### PR TITLE
[A merger/proder le 11/04] Brander les emails transactionnels moins avec "DS", et plus avec la démarche

### DIFF
--- a/app/controllers/admin/mail_templates_controller.rb
+++ b/app/controllers/admin/mail_templates_controller.rb
@@ -12,7 +12,8 @@ class Admin::MailTemplatesController < AdminController
   def update
     mail_template = find_mail_template_by_slug(params[:id])
     mail_template.update(update_params)
-    redirect_to admin_procedure_mail_templates_path
+    flash.notice = "Email mis à jour"
+    redirect_to edit_admin_procedure_mail_template_path(mail_template.procedure_id, params[:id])
   end
 
   private

--- a/app/controllers/new_administrateur/mail_templates_controller.rb
+++ b/app/controllers/new_administrateur/mail_templates_controller.rb
@@ -1,0 +1,33 @@
+module NewAdministrateur
+  class MailTemplatesController < AdministrateurController
+    include ActionView::Helpers::SanitizeHelper
+
+    def preview
+      @procedure = procedure
+      mail_template = find_mail_template_by_slug(params[:id])
+      @dossier = Dossier.new(id: 0)
+
+      render(html: sanitize(mail_template.body), layout: 'mailers/notification')
+    end
+
+    private
+
+    def procedure
+      @procedure = current_administrateur.procedures.find(params[:procedure_id])
+    end
+
+    def mail_templates
+      [
+        @procedure.initiated_mail_template,
+        @procedure.received_mail_template,
+        @procedure.closed_mail_template,
+        @procedure.refused_mail_template,
+        @procedure.without_continuation_mail_template
+      ]
+    end
+
+    def find_mail_template_by_slug(slug)
+      mail_templates.find { |template| template.class.const_get(:SLUG) == slug }
+    end
+  end
+end

--- a/app/controllers/new_administrateur/mail_templates_controller.rb
+++ b/app/controllers/new_administrateur/mail_templates_controller.rb
@@ -4,9 +4,10 @@ module NewAdministrateur
 
     def preview
       @procedure = procedure
-      @dossier = Dossier.new(id: 0)
-      mail_template = find_mail_template_by_slug(params[:id])
       @logo_url = procedure.logo.url
+      @service = procedure.service
+
+      mail_template = find_mail_template_by_slug(params[:id])
 
       render(html: sanitize(mail_template.body), layout: 'mailers/notification')
     end

--- a/app/controllers/new_administrateur/mail_templates_controller.rb
+++ b/app/controllers/new_administrateur/mail_templates_controller.rb
@@ -4,8 +4,9 @@ module NewAdministrateur
 
     def preview
       @procedure = procedure
-      mail_template = find_mail_template_by_slug(params[:id])
       @dossier = Dossier.new(id: 0)
+      mail_template = find_mail_template_by_slug(params[:id])
+      @logo_url = procedure.logo.url
 
       render(html: sanitize(mail_template.body), layout: 'mailers/notification')
     end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -38,6 +38,11 @@ class NotificationMailer < ApplicationMailer
 
     @dossier = dossier
 
+    if dossier.procedure.logo?
+      @logo_filename = dossier.procedure.logo.filename
+      attachments.inline[@logo_filename] = dossier.procedure.logo.read
+    end
+
     mail(subject: subject, to: email) do |format|
       # rubocop:disable Rails/OutputSafety
       format.html { render(html: body.html_safe, layout: 'mailers/notification') }

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -36,13 +36,14 @@ class NotificationMailer < ApplicationMailer
 
     create_commentaire_for_notification(dossier, subject, body)
 
-    @dossier = dossier
-
     if dossier.procedure.logo?
       logo_filename = dossier.procedure.logo.filename
       attachments.inline[logo_filename] = dossier.procedure.logo.read
       @logo_url = attachments[logo_filename].url
     end
+
+    @dossier = dossier
+    @service = dossier.procedure.service
 
     mail(subject: subject, to: email) do |format|
       # rubocop:disable Rails/OutputSafety

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -39,8 +39,9 @@ class NotificationMailer < ApplicationMailer
     @dossier = dossier
 
     if dossier.procedure.logo?
-      @logo_filename = dossier.procedure.logo.filename
-      attachments.inline[@logo_filename] = dossier.procedure.logo.read
+      logo_filename = dossier.procedure.logo.filename
+      attachments.inline[logo_filename] = dossier.procedure.logo.read
+      @logo_url = attachments[logo_filename].url
     end
 
     mail(subject: subject, to: email) do |format|

--- a/app/views/admin/mail_templates/edit.html.haml
+++ b/app/views/admin/mail_templates/edit.html.haml
@@ -15,6 +15,7 @@
     .text-right
       = link_to "Annuler", admin_procedure_mail_templates_path(@procedure), class: "btn btn-default"
       = f.button :submit, 'Mettre à jour', class: "btn-success"
+      = link_to "Prévisualiser", preview_procedure_mail_template_path(@procedure, @mail_template.class.const_get(:SLUG)), class: "btn btn-primary", target: "_blank"
 
   .row
     .col-md-12

--- a/app/views/layouts/mailers/notification.html.haml
+++ b/app/views/layouts/mailers/notification.html.haml
@@ -4,4 +4,4 @@
     = succeed '.' do
       = link_to 'messagerie', messagerie_dossier_url(@dossier), target: '_blank', rel: 'noopener'
 
-= render template: 'layouts/mailers/layout'
+= render template: 'layouts/mailers/notifications_layout'

--- a/app/views/layouts/mailers/notification.html.haml
+++ b/app/views/layouts/mailers/notification.html.haml
@@ -1,3 +1,10 @@
+- if @logo_filename.present?
+  - content_for :procedure_logo do
+    %table{ width: "100%", border: "0", cellspacing: "0", cellpadding: "0" }
+      %tr
+        %td{ align: "center" }
+          = image_tag attachments[@logo_filename].url, style: "height: 150px;"
+
 - content_for :footer do
   %strong
     Merci de ne pas répondre à cet email. Pour vous adresser à votre administration, passez directement par votre

--- a/app/views/layouts/mailers/notification.html.haml
+++ b/app/views/layouts/mailers/notification.html.haml
@@ -3,7 +3,7 @@
     %table{ width: "100%", border: "0", cellspacing: "0", cellpadding: "0" }
       %tr
         %td{ align: "center" }
-          = image_tag @logo_url, style: "height: 150px;"
+          = image_tag @logo_url, height: "150", style: "display:block; max-height: 150px; max-width: 150px;"
 
 - content_for :footer do
   - if @dossier.present?

--- a/app/views/layouts/mailers/notification.html.haml
+++ b/app/views/layouts/mailers/notification.html.haml
@@ -1,14 +1,18 @@
-- if @logo_filename.present?
+- if @logo_url.present?
   - content_for :procedure_logo do
     %table{ width: "100%", border: "0", cellspacing: "0", cellpadding: "0" }
       %tr
         %td{ align: "center" }
-          = image_tag attachments[@logo_filename].url, style: "height: 150px;"
+          = image_tag @logo_url, style: "height: 150px;"
 
 - content_for :footer do
+  - if @dossier.present?
+    - messagerie_url = messagerie_dossier_url(@dossier)
+  - else
+    - messagerie_url = "#"
   %strong
     Merci de ne pas répondre à cet email. Pour vous adresser à votre administration, passez directement par votre
     = succeed '.' do
-      = link_to 'messagerie', messagerie_dossier_url(@dossier), target: '_blank', rel: 'noopener'
+      = link_to 'messagerie', messagerie_url, target: '_blank', rel: 'noopener'
 
 = render template: 'layouts/mailers/notifications_layout'

--- a/app/views/layouts/mailers/notification.html.haml
+++ b/app/views/layouts/mailers/notification.html.haml
@@ -15,4 +15,28 @@
     = succeed '.' do
       = link_to 'messagerie', messagerie_url, target: '_blank', rel: 'noopener'
 
+  - if @service.present?
+    %table{ width: "100%", border: "0", cellspacing: "0", cellpadding: "0", style: "cursor:auto;color:#55575d;font-family:Helvetica, Arial, sans-serif;font-size:11px;line-height:22px;text-align:left;" }
+      %tr
+        %td{ width: "50%", valign: "top" }
+          %p
+            %strong Cette démarche est gérée par :
+            %br
+            = @service.nom
+            %br
+            = @service.organisme
+            %br
+            = @service.adresse
+        %td{ width: "50%", valign: "top" }
+          %p
+            %strong Poser une question sur votre dossier :
+            %br
+            = link_to 'Par la messagerie', messagerie_url, target: '_blank', rel: 'noopener'
+            %br
+            Par téléphone :
+            = link_to @service.telephone, "tel:#{@service.telephone}"
+            %br
+            Horaires : #{ formatted_horaires(@service.horaires) }
+
+
 = render template: 'layouts/mailers/notifications_layout'

--- a/app/views/layouts/mailers/notifications_layout.html.erb
+++ b/app/views/layouts/mailers/notifications_layout.html.erb
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  <head>
+    <title><%= yield(:title) %></title>
+    <!--[if !mso]>
+      <!-- -->
+      <meta http-equiv="X-UA-Compatible" content="IE=edge">
+      <!--<![endif]-->
+      <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <style type="text/css">  #outlook a { padding: 0; }  .ReadMsgBody { width: 100%; }  .ExternalClass { width: 100%; }  .ExternalClass * { line-height:100%; }  body { margin: 0; padding: 0; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; }  table, td { border-collapse:collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; }  img { border: 0; height: auto; line-height: 100%; outline: none; text-decoration: none; -ms-interpolation-mode: bicubic; }  p { display: block; margin: 13px 0; }</style>
+      <!--[if !mso]>
+        <!-->
+          <style type="text/css">  @media only screen and (max-width:480px) {    @-ms-viewport { width:320px; }    @viewport { width:320px; }  }</style>
+          <!--<![endif]-->
+          <!--[if mso]>
+            <xml>
+            <o:OfficeDocumentSettings>
+            <o:AllowPNG/>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+            </o:OfficeDocumentSettings>
+            </xml>
+          <![endif]-->
+          <!--[if lte mso 11]>
+            <style type="text/css">  .outlook-group-fix {    width:100% !important;  }</style>
+          <![endif]-->
+          <style type="text/css">  @media only screen and (min-width:480px) {    .mj-column-per-66 { width:66.66666666666666%!important; }.mj-column-per-33 { width:33.33333333333333%!important; }.mj-column-per-100 { width:100%!important; }  }</style>
+  </head>
+  <body style="background: #F4F4F4;">
+    <div style="background-color:#F4F4F4;">
+      <!--[if mso | IE]>
+        <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="600" align="center" style="width:600px;">
+        <tr>
+        <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
+      <![endif]-->
+      <div style="margin:0px auto;max-width:600px;">
+        <table role="presentation" cellpadding="0" cellspacing="0" style="font-size:0px;width:100%;" align="center" border="0">
+          <tbody>
+            <tr>
+              <td style="text-align:center;vertical-align:top;direction:ltr;font-size:0px;padding:20px 0px 20px 0px;">
+                <div class="mj-column-per-33 outlook-group-fix" style="vertical-align:top;display:inline-block;direction:ltr;font-size:13px;text-align:left;width:100%;">
+                  <table role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                    <tbody>
+                      <tr>
+                        <td style="word-wrap:break-word;font-size:0px;padding:0px 25px 0px 0px;padding-top:0px;padding-bottom:0px;" align="right">
+                          <div class="" style="cursor:auto;color:#55575d;font-family:Helvetica, Arial, sans-serif;font-size:11px;line-height:22px;text-align:right;">
+                            <p style="margin: 10px 0;">
+                            </p>
+                          </div>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <!--[if mso | IE]>
+                  </td>
+                  </tr>
+                  </table>
+                <![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <!--[if mso | IE]>
+        </td>
+        </tr>
+        </table>
+      <![endif]-->
+      <!--[if mso | IE]>
+        <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="600" align="center" style="width:600px;">
+        <tr>
+        <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
+      <![endif]-->
+      <div style="margin:0px auto;max-width:600px;background:#ffffff;">
+        <table role="presentation" cellpadding="0" cellspacing="0" style="font-size:0px;width:100%;background:#ffffff;" align="center" border="0">
+          <tbody>
+            <tr>
+              <td style="text-align:center;vertical-align:top;direction:ltr;font-size:0px;padding:20px 0px 20px 0px;">
+                <!--[if mso | IE]>
+                  <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                  <tr>
+                  <td style="vertical-align:top;width:600px;">
+                <![endif]-->
+                <div class="mj-column-per-100 outlook-group-fix" style="vertical-align:top;display:inline-block;direction:ltr;font-size:13px;text-align:left;width:100%;">
+                  <table role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                    <tbody>
+                      <tr>
+                        <td style="word-wrap:break-word;font-size:0px;padding:0px 25px 0px 25px;padding-top:0px;padding-bottom:0px;" align="left">
+                          <div class="" style="cursor:auto;color:#55575d;font-family:Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;text-align:left;">
+                            <h1 style="font-size: 30px; text-align: center; font-weight: 300; max-width: 300px; margin: 30px auto 40px; line-height: 1.2;"><%= yield(:title) %></h1>
+                            <%= yield %>
+                          </div>
+                        </td>
+                      </tr>
+                      <% if content_for?(:footer) %>
+                        <tr>
+                          <td style="word-wrap:break-word;font-size:0px;padding:0px 25px 0px 25px;padding-top:0px;padding-bottom:0px;" align="left">
+                            <p style="font-size:13px;text-align:left;">
+                              —
+                            </p>
+                            <p style="cursor:auto;color:#55575d;font-family:Helvetica, Arial, sans-serif;font-size:12px;font-weight:bold;line-height:22px;text-align:left;">
+                              <%= yield(:footer) %>
+                            </p>
+                          </td>
+                        </tr>
+                      <% end %>
+                    </tbody>
+                  </table>
+                </div>
+                <!--[if mso | IE]>
+                  </td>
+                  </tr>
+                  </table>
+                <![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <!--[if mso | IE]>
+        </td>
+        </tr>
+        </table>
+      <![endif]-->
+      <!--[if mso | IE]>
+        <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="600" align="center" style="width:600px;">
+        <tr>
+        <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
+      <![endif]-->
+      <div style="margin:0px auto;max-width:600px;">
+        <table role="presentation" cellpadding="0" cellspacing="0" style="font-size:0px;width:100%;" align="center" border="0">
+          <tbody>
+            <tr>
+              <td style="text-align:center;vertical-align:top;direction:ltr;font-size:0px;padding:20px 0px 20px 0px;">
+                <!--[if mso | IE]>
+                  <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                  <tr>
+                  <td style="vertical-align:top;width:600px;">
+                <![endif]-->
+                <div class="mj-column-per-100 outlook-group-fix" style="vertical-align:top;display:inline-block;direction:ltr;font-size:13px;text-align:left;width:100%;">
+                  <table role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
+                    <tbody>
+                      <tr>
+                        <td style="word-wrap:break-word;font-size:0px;padding:0px 20px 0px 20px;padding-top:0px;padding-bottom:0px;" align="center">
+                          <div class="" style="cursor:auto;color:#55575d;font-family:Helvetica, Arial, sans-serif;font-size:11px;line-height:22px;text-align:center;">
+                            demarches-simplifiees.fr est un service fourni par la DINSIC et incubé par beta.gouv.fr
+                          </div>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td style="word-wrap:break-word;font-size:0px;padding:0px 20px 0px 20px;padding-top:0px;padding-bottom:0px;" align="center">
+                          <div class="" style="cursor:auto;color:#55575d;font-family:Helvetica, Arial, sans-serif;font-size:11px;line-height:22px;text-align:center;">
+                            <p style="margin: 10px 0;">
+                            </p>
+                          </div>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <!--[if mso | IE]>
+                  </td>
+                  </tr>
+                  </table>
+                <![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <!--[if mso | IE]>
+        </td>
+        </tr>
+        </table>
+        <in![endif]-->
+    </div>
+  </body>
+</html>

--- a/app/views/layouts/mailers/notifications_layout.html.erb
+++ b/app/views/layouts/mailers/notifications_layout.html.erb
@@ -86,10 +86,10 @@
                 <div class="mj-column-per-100 outlook-group-fix" style="vertical-align:top;display:inline-block;direction:ltr;font-size:13px;text-align:left;width:100%;">
                   <table role="presentation" cellpadding="0" cellspacing="0" width="100%" border="0">
                     <tbody>
+                      <%= yield(:procedure_logo) %>
                       <tr>
                         <td style="word-wrap:break-word;font-size:0px;padding:0px 25px 0px 25px;padding-top:0px;padding-bottom:0px;" align="left">
                           <div class="" style="cursor:auto;color:#55575d;font-family:Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;text-align:left;">
-                            <h1 style="font-size: 30px; text-align: center; font-weight: 300; max-width: 300px; margin: 30px auto 40px; line-height: 1.2;"><%= yield(:title) %></h1>
                             <%= yield %>
                           </div>
                         </td>

--- a/app/views/notification_mailer/_signature.html.haml
+++ b/app/views/notification_mailer/_signature.html.haml
@@ -1,0 +1,4 @@
+%p
+  Bonne journée,
+
+%p --nom du service--

--- a/app/views/notification_mailer/closed_mail.html.haml
+++ b/app/views/notification_mailer/closed_mail.html.haml
@@ -7,4 +7,4 @@
 %p
   À tout moment, vous pouvez consulter votre dossier et les éventuels messages de l'administration à cette adresse : --lien dossier--
 
-= render partial: "layouts/mailers/signature"
+= render partial: "notification_mailer/signature"

--- a/app/views/notification_mailer/closed_mail_with_attestation.html.haml
+++ b/app/views/notification_mailer/closed_mail_with_attestation.html.haml
@@ -10,4 +10,4 @@
 %p
   À tout moment, vous pouvez consulter votre dossier et les éventuels messages de l'administration à cette adresse : --lien dossier--
 
-= render partial: "layouts/mailers/signature"
+= render partial: "notification_mailer/signature"

--- a/app/views/notification_mailer/initiated_mail.html.haml
+++ b/app/views/notification_mailer/initiated_mail.html.haml
@@ -7,4 +7,4 @@
 %p
   À tout moment, vous pouvez consulter votre dossier et les éventuels messages de l'administration à cette adresse : --lien dossier--
 
-= render partial: "layouts/mailers/signature"
+= render partial: "notification_mailer/signature"

--- a/app/views/notification_mailer/received_mail.html.haml
+++ b/app/views/notification_mailer/received_mail.html.haml
@@ -4,4 +4,4 @@
 %p
   Votre administration vous confirme la bonne réception de votre dossier nº --numéro du dossier--. Celui-ci sera instruit dans le délai légal déclaré par votre interlocuteur.
 
-= render partial: "layouts/mailers/signature"
+= render partial: "notification_mailer/signature"

--- a/app/views/notification_mailer/refused_mail.html.haml
+++ b/app/views/notification_mailer/refused_mail.html.haml
@@ -10,4 +10,4 @@
 %p
   Pour en savoir plus sur le motif du refus, vous pouvez consulter votre dossier et les éventuels messages de l'administration à cette adresse : --lien dossier--
 
-= render partial: "layouts/mailers/signature"
+= render partial: "notification_mailer/signature"

--- a/app/views/notification_mailer/without_continuation_mail.html.haml
+++ b/app/views/notification_mailer/without_continuation_mail.html.haml
@@ -10,4 +10,4 @@
 %p
   Pour en savoir plus sur les raisons de ce classement sans suite, vous pouvez consulter votre dossier et les éventuels messages de l'administration à cette adresse : --lien dossier--
 
-= render partial: "layouts/mailers/signature"
+= render partial: "notification_mailer/signature"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -378,6 +378,10 @@ Rails.application.routes.draw do
           patch :move
         end
       end
+
+      resources :mail_templates, only: [] do
+        get 'preview', on: :member
+      end
     end
 
     resources :services, except: [:show] do

--- a/spec/controllers/admin/mail_templates_controller_spec.rb
+++ b/spec/controllers/admin/mail_templates_controller_spec.rb
@@ -31,7 +31,7 @@ describe Admin::MailTemplatesController, type: :controller do
         }
     end
 
-    it { expect(response).to redirect_to admin_procedure_mail_templates_path(procedure) }
+    it { expect(response).to redirect_to edit_admin_procedure_mail_template_path(procedure, initiated_mail.class.const_get(:SLUG)) }
 
     context 'the mail template' do
       subject { procedure.reload; procedure.initiated_mail_template }

--- a/spec/controllers/new_administrateur/mail_templates_controller_spec.rb
+++ b/spec/controllers/new_administrateur/mail_templates_controller_spec.rb
@@ -1,0 +1,21 @@
+describe NewAdministrateur::MailTemplatesController, type: :controller do
+  render_views
+
+  let(:admin) { create(:administrateur) }
+
+  describe '#preview' do
+    let(:procedure) { create(:procedure, :with_logo, :with_service, administrateur: admin) }
+
+    before do
+      sign_in admin
+      get :preview, params: { id: "initiated_mail", procedure_id: procedure.id }
+    end
+
+    it { expect(response).to have_http_status(:ok) }
+
+    it { expect(response.body).to have_css("img[src*='#{procedure.logo.filename}']") }
+
+    it { expect(response.body).to include(procedure.service.nom) }
+    it { expect(response.body).to include(procedure.service.telephone) }
+  end
+end

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -41,6 +41,10 @@ FactoryBot.define do
       end
     end
 
+    trait :with_logo do
+      logo { Rack::Test::UploadedFile.new("./spec/fixtures/files/logo_test_procedure.png", 'application/pdf') }
+    end
+
     trait :with_path do
       path { generate(:published_path) }
     end

--- a/spec/mailers/previews/notification_mailer_preview.rb
+++ b/spec/mailers/previews/notification_mailer_preview.rb
@@ -4,7 +4,8 @@ class NotificationMailerPreview < ActionMailer::Preview
   end
 
   def send_initiated_notification
-    NotificationMailer.send_initiated_notification(Dossier.last)
+    p = Procedure.where(id: Mails::InitiatedMail.where("body like ?", "%<img%").pluck(:procedure_id).uniq).order("RANDOM()").first
+    NotificationMailer.send_initiated_notification(p.dossiers.last)
   end
 
   def send_closed_notification

--- a/spec/views/admin/mail_templates/edit.html.haml_spec.rb
+++ b/spec/views/admin/mail_templates/edit.html.haml_spec.rb
@@ -10,6 +10,7 @@ describe 'admin/mail_templates/edit.html.haml', type: :view do
     allow(view).to receive(:admin_procedure_mail_templates_path).and_return("/toto")
 
     assign(:mail_template, mail_template)
+    assign(:procedure, procedure)
   end
 
   context "Champs are listed in the page" do


### PR DESCRIPTION
Fix #3064

<img width="631" alt="Capture d’écran 2019-03-20 à 18 16 17" src="https://user-images.githubusercontent.com/847942/54748247-5ce0df80-4bd1-11e9-942e-960658ccc331.png">
