### PR TITLE
[#479] Ajout d'un bouton pour télécharger toutes les pièces d'un dossier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ yarn-debug.log*
 /public/packs
 /public/packs-test
 /node_modules
+vendor/*
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity

--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ gem 'turbolinks' # Turbolinks makes following links in your web application fast
 gem 'typhoeus'
 gem 'warden'
 gem 'webpacker'
+gem 'zipline'
 gem 'zxcvbn-ruby', require: 'zxcvbn'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,7 @@ GEM
     crass (1.0.4)
     css_parser (1.6.0)
       addressable
+    curb (0.9.10)
     daemons (1.3.1)
     database_cleaner (1.7.0)
     datetime_picker_rails (0.0.7)
@@ -674,6 +675,11 @@ GEM
       nokogiri (~> 1.8)
     xray-rails (0.3.1)
       rails (>= 3.1.0)
+    zip_tricks (4.7.4)
+    zipline (1.1.0)
+      curb (>= 0.8.0, < 0.10)
+      rails (>= 3.2.1, < 6.1)
+      zip_tricks (>= 4.2.1, <= 5.0.0)
     zxcvbn-ruby (0.1.2)
 
 PLATFORMS
@@ -779,6 +785,7 @@ DEPENDENCIES
   webmock
   webpacker
   xray-rails
+  zipline
   zxcvbn-ruby
 
 BUNDLED WITH

--- a/app/lib/active_storage/downloadable_file.rb
+++ b/app/lib/active_storage/downloadable_file.rb
@@ -1,0 +1,29 @@
+class ActiveStorage::DownloadableFile
+  def initialize(attached)
+    if using_local_backend?
+      @url = 'file://' + ActiveStorage::Blob.service.path_for(attached.key)
+    else
+      @url = attached.service_url
+    end
+  end
+
+  def url
+    @url
+  end
+
+  def self.create_list_from_dossier(dossier)
+    pjs = PiecesJustificativesService.liste_pieces_justificatives(dossier)
+    pjs.map do |pj|
+      [
+        ActiveStorage::DownloadableFile.new(pj.piece_justificative_file),
+        pj.piece_justificative_file.filename.to_s
+      ]
+    end
+  end
+
+  private
+
+  def using_local_backend?
+    [:local, :local_test, :test].include?(Rails.application.config.active_storage.service)
+  end
+end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -466,6 +466,10 @@ class Dossier < ApplicationRecord
     end
   end
 
+  def attachments_downloadable?
+    !PiecesJustificativesService.liste_pieces_justificatives(self).empty? && PiecesJustificativesService.pieces_justificatives_total_size(self) < 50.megabytes
+  end
+
   private
 
   def log_dossier_operation(author, operation, subject = nil)

--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -70,6 +70,17 @@ class PiecesJustificativesService
     end
   end
 
+  def self.liste_pieces_justificatives(dossier)
+    dossier.champs
+      .select { |c| c.type_champ == TypeDeChamp.type_champs.fetch(:piece_justificative) }
+      .filter { |pj| pj.piece_justificative_file.attached? }
+  end
+
+  def self.pieces_justificatives_total_size(dossier)
+    liste_pieces_justificatives(dossier)
+      .sum { |pj| pj.piece_justificative_file.byte_size }
+  end
+
   def self.serialize_types_de_champ_as_type_pj(procedure)
     tdcs = procedure.types_de_champ.select { |type_champ| type_champ.old_pj.present? }
     tdcs.map.with_index do |type_champ, order_place|

--- a/app/views/gestionnaires/dossiers/_header.html.haml
+++ b/app/views/gestionnaires/dossiers/_header.html.haml
@@ -18,6 +18,14 @@
               = link_to "Tout le dossier", print_gestionnaire_dossier_path(dossier.procedure, dossier), target: "_blank", rel: "noopener", class: "menu-item menu-link"
             %li
               = link_to "Uniquement cet onglet", "#", onclick: "window.print()", class: "menu-item menu-link"
+        - if Flipflop.download_as_zip_enabled? && dossier.attachments_downloadable?
+          %span.dropdown.print-menu-opener
+            %button.button.dropdown-button.icon-only
+              %span.icon.attachment
+            %ul.print-menu.dropdown-content
+              %li
+                = link_to "Télécharger toutes les pièces jointes", telecharger_pjs_gestionnaire_dossier_path(dossier.procedure, dossier), target: "_blank", rel: "noopener", class: "menu-item menu-link"
+
 
         = render partial: "gestionnaires/procedures/dossier_actions", locals: { procedure: dossier.procedure, dossier: dossier, dossier_is_followed: current_gestionnaire&.follow?(dossier) }
         %span.state-button

--- a/config/features.rb
+++ b/config/features.rb
@@ -18,6 +18,8 @@ Flipflop.configure do
 
   feature :procedure_export_v2_enabled
   feature :operation_log_serialize_subject
+  feature :download_as_zip_enabled,
+    default: false
 
   group :development do
     feature :mini_profiler_enabled,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -335,6 +335,7 @@ Rails.application.routes.draw do
             post 'send-to-instructeurs' => 'dossiers#send_to_instructeurs'
             post 'avis' => 'dossiers#create_avis'
             get 'print' => 'dossiers#print'
+            get 'telecharger_pjs' => 'dossiers#telecharger_pjs'
           end
         end
       end

--- a/spec/controllers/gestionnaires/dossiers_controller_spec.rb
+++ b/spec/controllers/gestionnaires/dossiers_controller_spec.rb
@@ -524,4 +524,24 @@ describe Gestionnaires::DossiersController, type: :controller do
     it { expect(champ_repetition.champs.first.value).to eq('text') }
     it { expect(response).to redirect_to(annotations_privees_gestionnaire_dossier_path(dossier.procedure, dossier)) }
   end
+
+  describe "#telecharger_pjs" do
+    subject do
+      get :telecharger_pjs, params: {
+        procedure_id: procedure.id,
+        dossier_id: dossier.id
+      }
+    end
+
+    context 'when zip download is disabled through flipflop' do
+      before do
+        Flipflop::FeatureSet.current.test!.switch!(:download_as_zip_enabled, false)
+      end
+
+      it 'is forbidden' do
+        subject
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
 end

--- a/spec/lib/active_storage/downloadable_file_spec.rb
+++ b/spec/lib/active_storage/downloadable_file_spec.rb
@@ -1,0 +1,26 @@
+describe ActiveStorage::DownloadableFile do
+  let(:tpjs) { [tpj_not_mandatory] }
+  let!(:tpj_not_mandatory) do
+    TypeDePieceJustificative.create(libelle: 'not mandatory', mandatory: false)
+  end
+  let(:procedure) { Procedure.create(types_de_piece_justificative: tpjs) }
+  let(:dossier) { Dossier.create(procedure: procedure) }
+  let(:procedure) { Procedure.create(types_de_piece_justificative: tpjs) }
+  let(:dossier) { Dossier.create(procedure: procedure) }
+  let(:list) { ActiveStorage::DownloadableFile.create_list_from_dossier(dossier) }
+
+  describe 'create_list_from_dossier' do
+    context 'when no piece_justificative is present' do
+      it { expect(list).to match([]) }
+    end
+
+    context 'when there is a piece_justificative' do
+      let (:pj) { create(:champ, :piece_justificative, :with_piece_justificative_file) }
+      before do
+        dossier.champs = [pj]
+      end
+
+      it { expect(list.length).to be 1 }
+    end
+  end
+end

--- a/spec/services/pieces_justificatives_service_spec.rb
+++ b/spec/services/pieces_justificatives_service_spec.rb
@@ -20,6 +20,9 @@ describe PiecesJustificativesService do
   let(:errors) { PiecesJustificativesService.upload!(dossier, user, hash) }
   let(:tpjs) { [tpj_not_mandatory] }
 
+  let(:attachment_list) { PiecesJustificativesService.liste_pieces_justificatives(dossier) }
+  let(:poids_total) { PiecesJustificativesService.pieces_justificatives_total_size(dossier) }
+
   describe 'self.upload!' do
     context 'when no params are given' do
       it { expect(errors).to eq([]) }
@@ -81,12 +84,30 @@ describe PiecesJustificativesService do
       before :each do
         # we are messing around piece_justificative
         # because directly doubling carrierwave params seems complicated
-
         piece_justificative_double = double(type_de_piece_justificative: tpj_mandatory)
         expect(dossier).to receive(:pieces_justificatives).and_return([piece_justificative_double])
       end
 
-      it { expect(errors).to match([]) }
+      it {
+        expect(errors).to match([])
+      }
+    end
+  end
+
+  describe '#attachment_list' do
+    context 'when no piece_justificative is present' do
+      it { expect(attachment_list).to match([]) }
+      it { expect(poids_total).to be 0 }
+    end
+
+    context 'when there is a piece_justificative' do
+      let (:pj) { create(:champ, :piece_justificative, :with_piece_justificative_file) }
+      before do
+        dossier.champs = [pj]
+      end
+
+      it { expect(attachment_list).not_to be_empty }
+      it { expect(poids_total).to be pj.piece_justificative_file.byte_size }
     end
   end
 


### PR DESCRIPTION
Ajout d'un bouton pour permettre à l'instructeur de télécharger toutes les PJ, comme vu dans #479 

![image](https://user-images.githubusercontent.com/1223316/54934560-ffc19280-4f1e-11e9-8306-7f71f61f3186.png)

Comme vu lors de notre rencontre, le téléchargement se fait via [zipline](https://github.com/fringd/zipline).
Zipline dépend de [curb](https://github.com/taf2/curb). Ce sont les binding ruby pour curl, il faut donc que les librairies nécessaires soient présentes sur le serveur (cf install de curb pour les détails, mais rien d'original).

Cette fonctionnalité pose des questions de monitoring mais je ne sais pas là non plus ce qui est dispo pour surveiller la conso en bande passante, le temps d'exécution, etc.

Bref, je suis preneur de vos retours sur cette fonctionnalité !