### PR TITLE
app: rename references to `betagouv/tps`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,13 +12,13 @@ Voici la marche à suivre recommandée pour effectuer une modification.
 
 La première étape est généralement de discuter de l’amélioration que vous proposez (s’il ne s’agit pas d’un changement trivial, comme la correction d’une coquille).
 
-Pour cela, [créez une nouvelle issue](https://github.com/betagouv/tps/issues/new) concernant votre proposition. Autant que possible, indiquez clairement votre besoin, votre cas d’usage – et éventuellement comment vous pensez déjà le résoudre.
+Pour cela, [créez une nouvelle issue](https://github.com/betagouv/demarches-simplifiees.fr/issues/new) concernant votre proposition. Autant que possible, indiquez clairement votre besoin, votre cas d’usage – et éventuellement comment vous pensez déjà le résoudre.
 
 Nous pouvons alors discuter, pour vérifier que le besoin exprimé correspond à l’usage de demarches-simplifiees.fr, proposer éventuellement des alternatives, et se mettre d’accord sur une implémentation technique pertinente.
 
 ## 2. Proposer du code
 
-Une fois que la discussion est établie, et que les éléments techniques sont dégrossis, vous pouvez proposer des changements au code. Pour cela, effectuez vos modifications en local, et [ouvrez une Pull Request](https://github.com/betagouv/tps/issues/new) avec les changements que vous souhaitez apporter.
+Une fois que la discussion est établie, et que les éléments techniques sont dégrossis, vous pouvez proposer des changements au code. Pour cela, effectuez vos modifications en local, et [ouvrez une Pull Request](https://github.com/betagouv/demarches-simplifiees.fr/issues/new) avec les changements que vous souhaitez apporter.
 
 Quelques conseils : pensez à bien décrire l’objectif et l’implémentation de votre PR au moment de la créer. Et si vos changements sont importants, découpez-les en plusieurs petites PRs successives, qui seront plus faciles à relire. N’oubliez pas d’ajouter des tests automatisés pour vous assurer que vos changements fonctionnent bien.
 

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ Afin d'initialiser l'environnement de développement, exécutez la commande suiv
 
     overmind start
 
-L'application tourne à l'adresse `http://localhost:3000`. 
+L'application tourne à l'adresse `http://localhost:3000`.
 
 ### Utilisateurs de test
 
-En local, un utilisateur de test est créé automatiquement, avec les identifiants `test@exemple.fr`/`this is a very complicated password !`. (voir [db/seeds.rb](https://github.com/betagouv/tps/blob/dev/db/seeds.rb))
+En local, un utilisateur de test est créé automatiquement, avec les identifiants `test@exemple.fr`/`this is a very complicated password !`. (voir [db/seeds.rb](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/db/seeds.rb))
 
 ### Programmation des jobs
 

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -3,7 +3,7 @@
     = link_to 'DINSIC', "http://etatplateforme.modernisation.gouv.fr"
     = Time.zone.now.year
     \-
-    = link_to 'Nouveautés', 'https://github.com/betagouv/tps/releases', target: '_blank'
+    = link_to 'Nouveautés', 'https://github.com/betagouv/demarches-simplifiees.fr/releases', target: '_blank'
     \-
     = link_to 'Statistiques', stats_path
     \-

--- a/app/views/root/_footer.html.haml
+++ b/app/views/root/_footer.html.haml
@@ -21,7 +21,7 @@
           %li.footer-link
             = link_to "Newsletter", "https://my.sendinblue.com/users/subscribe/js_id/3s2q1/id/1", :class => "footer-link", :target => "_blank", rel: "noopener"
           %li.footer-link
-            = link_to "Nouveautés", "https://github.com/betagouv/tps/releases", :class => "footer-link"
+            = link_to "Nouveautés", "https://github.com/betagouv/demarches-simplifiees.fr/releases", :class => "footer-link"
           %li.footer-link
             = link_to "Statistiques", stats_path, :class => "footer-link"
           %li.footer-link

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -26,7 +26,7 @@ shared_dirs = [
 
 set :domain, ENV.fetch('domain')
 set :deploy_to, deploy_to
-set :repository, 'https://github.com/betagouv/tps.git'
+set :repository, 'https://github.com/betagouv/demarches-simplifiees.fr.git'
 set :branch, ENV.fetch('branch')
 set :forward_agent, true
 set :user, 'ds'


### PR DESCRIPTION
We just renamed the repository from `betagouv/tps` to `betagouv/demarches-simplifiees.fr`.

Github has an automatic redirection, but better be clean.