### PR TITLE
Passer la bibliothèque de procédures au nouveau design

### DIFF
--- a/app/assets/stylesheets/new_design/new_procedure_from_existing.scss
+++ b/app/assets/stylesheets/new_design/new_procedure_from_existing.scss
@@ -1,0 +1,12 @@
+.table.vertical.procedure-library-list th {
+  padding-top: 32px;
+}
+
+.table.vertical.procedure-library-list td {
+  padding-top: 0;
+  padding-bottom: 4px;
+}
+
+.procedure-library-list .button {
+  margin: 0 2px;
+}

--- a/app/controllers/admin/procedures_controller.rb
+++ b/app/controllers/admin/procedures_controller.rb
@@ -199,6 +199,7 @@ class Admin::ProceduresController < AdminController
       .where(id: significant_procedure_ids)
       .group_by(&:organisation_name)
       .sort_by { |_, procedures| procedures.first.created_at }
+    render layout: 'application'
   end
 
   def active_class

--- a/app/views/admin/procedures/new_from_existing.html.haml
+++ b/app/views/admin/procedures/new_from_existing.html.haml
@@ -1,30 +1,34 @@
-- if current_administrateur.procedures.brouillons.count == 0
-  %h4{ style: 'padding: 20px; margin: 20px !important;' }
-    Bienvenue, vous allez pouvoir créer une première démarche de test. Celle-ci sera visible uniquement par vous et ne sera publiée nulle part, alors pas de crainte à avoir.
+.container
+  - if current_administrateur.procedures.brouillons.count == 0
+    .card.feedback
+      .card-title
+        Bienvenue,
+      vous allez pouvoir créer une première démarche de test.
+      Celle-ci sera visible uniquement par vous et ne sera publiée nulle part, alors pas de crainte à avoir.
 
-.row{ style: 'padding: 20px; margin: 20px !important;' }
-  %a#from-scratch{ href: new_admin_procedure_path, class: 'btn-lg btn-primary' }
-    Créer une nouvelle démarche de zéro
+  .form
+    .send-wrapper
+      %a#from-scratch.button.primary{ href: new_admin_procedure_path }
+        Créer une nouvelle démarche de zéro
 
-.row.white-back
-  %h3
-    Créer une nouvelle démarche à partir d'une démarche existante
+    .card
+      %h2.header-section
+        Créer une nouvelle démarche à partir d'une démarche existante
 
-  .section.section-label
-    Pour rechercher dans cette liste, utilisez la fonction "Recherche" de votre navigateur (CTRL+F ou command+F)
-    %br
-    %br
-    - @grouped_procedures.each do |_, procedures|
-      %b
-        = procedures.first.organisation_name
-      %table{ style: 'margin-bottom: 40px;' }
-        - procedures.sort_by(&:id).each do |procedure|
-          %tr{ style: 'height: 36px;' }
-            %td{ style: 'width: 750px;' }
-              = procedure.libelle
-            %td{ style: 'padding-right: 10px; padding-left: 10px; width: 60px;' }
-              = link_to('Consulter', apercu_procedure_path(id: procedure.id), target: "_blank", rel: "noopener")
-            %td
-              = link_to('Cloner', admin_procedure_clone_path(procedure.id, from_new_from_existing: true), 'data-method' => :put, class: 'btn-sm btn-primary clone-btn')
-            %td{ style: 'padding-left: 10px;' }
-              = link_to('Contacter', "mailto:#{procedure.administrateurs.pluck(:email) * ","}")
+      %label
+        .notice
+          Pour rechercher dans cette liste, utilisez la fonction "Recherche" de votre navigateur (CTRL+F ou command+F)
+
+      %table.table.vertical.procedure-library-list
+        - @grouped_procedures.each do |_, procedures|
+          %tr
+            %th
+              = procedures.first.organisation_name
+          - procedures.sort_by(&:id).each do |procedure|
+            %tr
+              %td
+                = procedure.libelle
+              %td.flex
+                = link_to('Consulter', apercu_procedure_path(id: procedure.id), target: "_blank", rel: "noopener", class: 'button small')
+                = link_to('Cloner', admin_procedure_clone_path(procedure.id, from_new_from_existing: true), 'data-method' => :put, class: 'button small primary')
+                = link_to('Contacter', "mailto:#{procedure.administrateurs.pluck(:email) * ","}", class: 'button small')


### PR DESCRIPTION
Passe la bibliothèque de procédures sous la nouvelle UI.

Ainsi, on récupère un bouton de changement de rôle potable, ce qui permettra de reverter #3513

# Avant

## nouvel admin
![Screenshot from 2019-03-27 18-32-14](https://user-images.githubusercontent.com/356570/55099328-cbd1a300-50bf-11e9-85e4-72359e0accb2.png)

## admin existant
![Screenshot from 2019-03-27 18-35-15](https://user-images.githubusercontent.com/356570/55099341-d0965700-50bf-11e9-9f11-2f29ffbc6ec2.png)

# Après

## nouvel admin
![Screenshot from 2019-03-27 18-29-43](https://user-images.githubusercontent.com/356570/55146568-206b3180-5145-11e9-975d-1b874fcbc55c.png)

## admin existant
![Screenshot from 2019-03-27 18-30-33](https://user-images.githubusercontent.com/356570/55099369-db50ec00-50bf-11e9-9eb0-89d04ae4eeb5.png)

## avec menu de changement de rôle
![Screenshot from 2019-03-27 18-30-38](https://user-images.githubusercontent.com/356570/55099372-de4bdc80-50bf-11e9-933f-0ee29bd5a5b1.png)

