### PR TITLE
bin: run after_party tasks on bin/update

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -21,6 +21,9 @@ chdir APP_ROOT do
   puts "\n== Updating database =="
   system! 'bin/rails db:migrate'
 
+  puts "\n== Running after_party tasks =="
+  system! 'bin/rails after_party:run'
+
   puts "\n== Removing old logs =="
   system! 'bin/rails log:clear'
 


### PR DESCRIPTION
Cette PR fait en sorte que les tâches after_party soient jouées quand on lance `bin/update` en local. Ça permet de maintenir son environnement de dev à jour plus facilement.

/cc @mmagn @pengfeidong 