### PR TITLE
[#2180] Fix updated_at for migration PJ champs

### DIFF
--- a/app/services/piece_justificative_to_champ_piece_jointe_migration_service.rb
+++ b/app/services/piece_justificative_to_champ_piece_jointe_migration_service.rb
@@ -37,12 +37,12 @@ class PieceJustificativeToChampPieceJointeMigrationService
         pj = dossier.retrieve_last_piece_justificative_by_type(type_pj_id)
 
         if pj.present?
+          convert_pj_to_champ!(pj, champ)
+
           champ.update(
             updated_at: pj.updated_at,
             created_at: pj.created_at
           )
-
-          convert_pj_to_champ!(pj, champ)
         else
           champ.update(
             updated_at: dossier.updated_at,


### PR DESCRIPTION
Corrige la mise à jour de `updated_at` pour éviter de générer une pastille orange sur les dossiers convertis. J’arrive à montrer en conditions réelles que ça corrige le problème, malheureusement je n’ai pas trouvé de moyen de le reproduire dans une spec :cry: 
 