### PR TITLE
Affiche la description de la démarche sur les petits écrans

### DIFF
--- a/app/assets/stylesheets/new_design/auth.scss
+++ b/app/assets/stylesheets/new_design/auth.scss
@@ -3,6 +3,19 @@
 @import "placeholders";
 @import "mixins";
 
+#auth {
+  // On small screens, hide the procedure description text on auth pages.
+  // It avoids pushing the sign-in/sign-up form out of the viewport.
+  //
+  // The procedure description can still be read from the /commencer
+  // pages.
+  @media (max-width: $two-columns-breakpoint) {
+    .procedure-description {
+      display: none;
+    }
+  }
+}
+
 .auth-form {
   .auth-options {
     display: flex;

--- a/app/assets/stylesheets/new_design/commencer.scss
+++ b/app/assets/stylesheets/new_design/commencer.scss
@@ -1,8 +1,10 @@
 @import "constants";
 
 .commencer {
-  .button:first-of-type {
-    margin-top: 4 * $default-spacer;
+  @media (min-width: $two-columns-breakpoint) {
+    .button:first-of-type {
+      margin-top: 4 * $default-spacer;
+    }
   }
 
   .button {

--- a/app/assets/stylesheets/new_design/forms.scss
+++ b/app/assets/stylesheets/new_design/forms.scss
@@ -7,7 +7,7 @@
     margin-bottom: 20px;
 
     @media (max-width: $two-columns-breakpoint) {
-      font-size: 28px;
+      font-size: 26px;
     }
   }
 

--- a/app/assets/stylesheets/new_design/procedure_context.scss
+++ b/app/assets/stylesheets/new_design/procedure_context.scss
@@ -2,6 +2,7 @@
 @import "constants";
 
 $procedure-context-breakpoint: $two-columns-breakpoint;
+$procedure-description-line-height: 22px;
 
 .procedure-preview {
   font-size: 24px;
@@ -25,12 +26,13 @@ $procedure-context-breakpoint: $two-columns-breakpoint;
   }
 
   .procedure-title {
-    font-size: 30px;
+    font-size: 26px;
     margin: 0 0 20px 0;
     text-align: center;
 
     @media (min-width: $procedure-context-breakpoint) {
       margin: 50px 0 32px;
+      font-size: 30px;
       text-align: left;
     }
   }
@@ -39,11 +41,40 @@ $procedure-context-breakpoint: $two-columns-breakpoint;
     font-size: 16px;
 
     p:not(:last-of-type) {
-      margin-bottom: 2 * $default-spacer;
+      // Space the paragraphs by exactly one line height,
+      // so that the text always is truncated in the middle of a line,
+      // regarless of the number of paragraphs.
+      margin-bottom: 3 * $default-spacer;
     }
+  }
 
-    @media (max-width: $procedure-context-breakpoint) {
-      display: none; // TO FIX : make this description available for small devices
+  .read-more-button {
+    display: none;
+  }
+
+  @media (max-width: $procedure-context-breakpoint) {
+    // Truncate description and display the "Read more" UI if the text is too long
+    .procedure-description-body.read-more-collapsed {
+      // Setting the description at 25% of the viewport height:
+      // - displays more text on screens having more vertical space (like small tablets);
+      // - is enough for the action buttons to be visible on the bottom (even on mobiles).
+      max-height: 25vh;
+
+      // If the text exceeds the max-height,
+      // truncate it and displays the "Read more" button.
+      &.read-more-enabled {
+        overflow: hidden;
+        border-bottom: 1px solid $border-grey;
+
+        + .read-more-button {
+          display: block;
+          position: relative;
+          margin-left: auto;
+          margin-right: auto;
+          top: -19px;
+          margin-bottom: -19px;
+        }
+      }
     }
   }
 

--- a/app/javascript/new_design/procedure-context.js
+++ b/app/javascript/new_design/procedure-context.js
@@ -1,0 +1,20 @@
+import { delegate } from '@utils';
+
+function updateReadMoreVisibility() {
+  const descBody = document.querySelector('.procedure-description-body');
+  if (descBody) {
+    // If the description text overflows, display a "Read more" button.
+    const isOverflowing = descBody.scrollHeight > descBody.clientHeight;
+    descBody.classList.toggle('read-more-enabled', isOverflowing);
+  }
+}
+
+function expandProcedureDescription() {
+  const descBody = document.querySelector('.procedure-description-body');
+  descBody.classList.remove('read-more-collapsed');
+}
+
+addEventListener('turbolinks:load', updateReadMoreVisibility);
+addEventListener('resize', updateReadMoreVisibility);
+
+delegate('click', '.read-more-button', expandProcedureDescription);

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -18,6 +18,7 @@ import '../shared/toggle-target';
 
 import '../new_design/dropdown';
 import '../new_design/form-validation';
+import '../new_design/procedure-context';
 import '../new_design/select2';
 import '../new_design/spinner';
 import '../new_design/support';

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -23,7 +23,7 @@
     - if Rails.env.development?
       = stylesheet_link_tag :xray
 
-  %body{ class: browser.platform.ios? ? 'ios' : nil }
+  %body{ id: content_for(:page_id), class: browser.platform.ios? ? 'ios' : nil }
     .page-wrapper
       = render partial: "layouts/outdated_browser_banner"
       = render partial: 'layouts/pre_maintenance'

--- a/app/views/layouts/commencer/_procedure_description.html.haml
+++ b/app/views/layouts/commencer/_procedure_description.html.haml
@@ -5,4 +5,6 @@
 %h2.procedure-title
   = procedure.libelle
 .procedure-description
-  = h string_to_html(procedure.description)
+  .procedure-description-body.read-more-enabled.read-more-collapsed
+    = h string_to_html(procedure.description)
+  = button_tag "Afficher la description complète", class: 'button read-more-button'

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -1,3 +1,5 @@
+= content_for(:page_id, 'auth')
+
 .auth-form
   = devise_error_messages!
   = form_for resource, url: user_registration_path, html: { class: "form" } do |f|

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -1,3 +1,5 @@
+= content_for(:page_id, 'auth')
+
 .auth-form.sign-in-form
   - if resource_name == :user
     %p.register


### PR DESCRIPTION
Fix #3658

Aujourd'hui on masque la description entière de la démarche dès que l'écran est un peu petit (téléphones, tablettes).

Avec cette PR, la description de la démarche est affichée. Si elle est trop longue pour que les boutons d'actions soient visible, elle est tronquée, et un bouton "Afficher tout" permet de la déplier.

![Texte long](https://user-images.githubusercontent.com/179923/55331460-9b10b580-5493-11e9-9b77-5c7d774e7267.gif)