### PR TITLE
Champ Siret: Fix siret-champ save

### DIFF
--- a/app/controllers/champs/siret_controller.rb
+++ b/app/controllers/champs/siret_controller.rb
@@ -13,9 +13,9 @@ class Champs::SiretController < ApplicationController
       etablissement = find_etablisement_with_siret
       if etablissement.present?
         @etablissement = etablissement
-        if @champ.present?
-          etablissement.champ = @champ
-          etablissement.save!
+
+        if !@champ.nil?
+          @champ.update!(value: etablissement.siret, etablissement: etablissement)
         end
       else
         @champ&.update!(value: '')

--- a/spec/controllers/champs/siret_controller_spec.rb
+++ b/spec/controllers/champs/siret_controller_spec.rb
@@ -6,7 +6,7 @@ describe Champs::SiretController, type: :controller do
 
   describe '#show' do
     let(:dossier) { create(:dossier, user: user, procedure: procedure) }
-    let(:champ) { create(:champ_siret, dossier: dossier) }
+    let(:champ) { create(:champ_siret, dossier: dossier, value: nil, etablissement: nil) }
     let(:params) do
       {
         champ_id: champ.id,


### PR DESCRIPTION
When a user enters a siret, it calls siret_controller in ajax. The champ value is stil nil, so champ.present? is false because champ.blank is redefined to focus on value. Thus the champ is not updated.