### PR TITLE
commencer: fix redirection with invalid path

### DIFF
--- a/app/controllers/users/commencer_controller.rb
+++ b/app/controllers/users/commencer_controller.rb
@@ -4,38 +4,39 @@ module Users
 
     def commencer
       @procedure = Procedure.publiees.find_by(path: params[:path])
-
-      if @procedure.blank?
-        flash.alert = "La démarche est inconnue, ou la création de nouveaux dossiers pour cette démarche est terminée."
-        return redirect_to root_path
-      end
+      return procedure_not_found if @procedure.blank?
 
       render 'commencer/show'
     end
 
     def commencer_test
       @procedure = Procedure.brouillons.find_by(path: params[:path])
-
-      if @procedure.blank?
-        flash.alert = "La démarche est inconnue, ou cette démarche n’est maintenant plus en test."
-        return redirect_to root_path
-      end
+      return procedure_not_found if @procedure.blank?
 
       render 'commencer/show'
     end
 
     def sign_in
-      store_user_location!
+      @procedure = Procedure.find_by(path: params[:path])
+      return procedure_not_found if @procedure.blank?
+
+      store_user_location!(@procedure)
       redirect_to new_user_session_path
     end
 
     def sign_up
-      store_user_location!
+      @procedure = Procedure.find_by(path: params[:path])
+      return procedure_not_found if @procedure.blank?
+
+      store_user_location!(@procedure)
       redirect_to new_user_registration_path
     end
 
     def france_connect
-      store_user_location!
+      @procedure = Procedure.find_by(path: params[:path])
+      return procedure_not_found if @procedure.blank?
+
+      store_user_location!(@procedure)
       redirect_to france_connect_particulier_path
     end
 
@@ -45,8 +46,21 @@ module Users
 
     private
 
-    def store_user_location!
+    def procedure_not_found
       procedure = Procedure.find_by(path: params[:path])
+
+      if procedure&.archivee?
+        flash.alert = t('errors.messages.procedure_archived')
+      elsif procedure&.publiee?
+        flash.alert = t('errors.messages.procedure_not_draft')
+      else
+        flash.alert = t('errors.messages.procedure_not_found')
+      end
+
+      return redirect_to root_path
+    end
+
+    def store_user_location!(procedure)
       store_location_for(:user, helpers.procedure_lien(procedure))
     end
   end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -188,6 +188,7 @@ fr:
         connexion: "Erreur lors de la connexion à France Connect."
       extension_white_list_error: "Le format de fichier de la pièce jointe n'est pas valide."
       procedure_archived: "Cette démarche en ligne a été fermée, il n'est plus possible de déposer de dossier."
+      procedure_not_draft: "Cette démarche n’est maintenant plus en brouillon."
       cadastres_empty:
         one: "Aucune parcelle cadastrale sur la zone séléctionnée"
         other: "Aucune parcelle cadastrale sur les zones séléctionnées"

--- a/spec/controllers/users/commencer_controller_spec.rb
+++ b/spec/controllers/users/commencer_controller_spec.rb
@@ -87,6 +87,14 @@ describe Users::CommencerController, type: :controller do
 
       it { expect(subject).to redirect_to(new_user_session_path) }
     end
+
+    context 'when the path doesn’t exist' do
+      subject { get :sign_in, params: { path: 'hello' } }
+
+      it 'redirects with an error message' do
+        expect(subject).to redirect_to(root_path)
+      end
+    end
   end
 
   describe '#sign_up' do
@@ -111,6 +119,14 @@ describe Users::CommencerController, type: :controller do
 
       it { expect(subject).to redirect_to(new_user_registration_path) }
     end
+
+    context 'when the path doesn’t exist' do
+      subject { get :sign_up, params: { path: 'hello' } }
+
+      it 'redirects with an error message' do
+        expect(subject).to redirect_to(root_path)
+      end
+    end
   end
 
   describe '#france_connect' do
@@ -134,6 +150,14 @@ describe Users::CommencerController, type: :controller do
       end
 
       it { expect(subject).to redirect_to(france_connect_particulier_path) }
+    end
+
+    context 'when the path doesn’t exist' do
+      subject { get :france_connect, params: { path: 'hello' } }
+
+      it 'redirects with an error message' do
+        expect(subject).to redirect_to(root_path)
+      end
     end
   end
 end


### PR DESCRIPTION
Aujourd'hui, quand :

1. Un Usager visite la page /commencer d'une démarche,
2. La démarche change de chemin (publication, archivage, re-publication, etc),
3. L'Usager clique sur "Créer un compte" ou "Connexion",

la page plante (parce qu'elle ne trouve pas la démarche).

On a eu quelques cas de ça en prod ; je pense que ce sont des admins qui testent (avec un profil usager dans un navigateur, et leur page admin dans un autre).

Cette PR fait en sorte d'afficher un message d'erreur utile à la place. Et de corriger le crash dans Sentry.