### PR TITLE
Améliorations de la page /stats

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -162,7 +162,9 @@ class StatsController < ApplicationController
   end
 
   def contact_percentage
-    from = Date.new(2018, 1)
+    number_of_months = 13
+
+    from = Date.today.prev_month(number_of_months)
     to = Date.today.prev_month
 
     adapter = Helpscout::UserConversationsAdapter.new(from, to)

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -132,7 +132,7 @@ class StatsController < ApplicationController
       Feedback.ratings.fetch(:happy)   => "Satisfaits"
     }
 
-    number_of_weeks = 6
+    number_of_weeks = 12
     totals = Feedback
       .group_by_week(:created_at, last: number_of_weeks, current: false)
       .count

--- a/spec/controllers/stats_controller_spec.rb
+++ b/spec/controllers/stats_controller_spec.rb
@@ -228,20 +228,17 @@ describe StatsController, type: :controller do
 
     it 'returns weekly ratios between a given feedback and all feedback' do
       happy_data = stats.find { |g| g[:name] == 'Satisfaits' }[:data]
-      expect(happy_data.values[0]).to eq 0
-      expect(happy_data.values[1]).to eq 0
-      expect(happy_data.values[2]).to eq 0
-      expect(happy_data.values[3]).to eq 25.0
-      expect(happy_data.values[4]).to eq 50.0
-      expect(happy_data.values[5]).to eq 75.0
+
+      expect(happy_data.values[-4]).to eq 0
+      expect(happy_data.values[-3]).to eq 25.0
+      expect(happy_data.values[-2]).to eq 50.0
+      expect(happy_data.values[-1]).to eq 75.0
 
       unhappy_data = stats.find { |g| g[:name] == 'Mécontents' }[:data]
-      expect(unhappy_data.values[0]).to eq 0
-      expect(unhappy_data.values[1]).to eq 0
-      expect(unhappy_data.values[2]).to eq 0
-      expect(unhappy_data.values[3]).to eq 75.0
-      expect(unhappy_data.values[4]).to eq 50.0
-      expect(unhappy_data.values[5]).to eq 25.0
+      expect(unhappy_data.values[-4]).to eq 0
+      expect(unhappy_data.values[-3]).to eq 75.0
+      expect(unhappy_data.values[-2]).to eq 50.0
+      expect(unhappy_data.values[-1]).to eq 25.0
     end
 
     it 'excludes values still in the current week' do


### PR DESCRIPTION
- Le **graphique de satisfactions** ne couvre que six semaines. C'est court pour mesurer une évolution. Cette PR le passe à 12 semaines.
- Le **graphique du taux de contact** est calculé depuis janvier 2018. C'est long pour mesurer une évolution. Cette PR le passe à 13 mois (pour faire par exemple de mars 2018 à mars 2019).