### PR TITLE
api_entreprise: revert to API v2

### DIFF
--- a/app/lib/api_entreprise/api.rb
+++ b/app/lib/api_entreprise/api.rb
@@ -40,9 +40,7 @@ class ApiEntreprise::API
   end
 
   def self.url(resource_name, siret_or_siren)
-    base_url = [API_ENTREPRISE_URL, resource_name, siret_or_siren].join("/")
-
-    "#{base_url}?with_insee_v3=true"
+    [API_ENTREPRISE_URL, resource_name, siret_or_siren].join("/")
   end
 
   def self.params(siret_or_siren, procedure_id)


### PR DESCRIPTION
Corrige un incident de production (en ce moment la v3 est down, mais la v2 fonctionne).

La PR qui passait en v3 (#3138) n'effectuait que ce changement ; ça a l'air safe.