### PR TITLE
Respecte les sauts de lignes dans les avis

### DIFF
--- a/app/assets/stylesheets/new_design/avis.scss
+++ b/app/assets/stylesheets/new_design/avis.scss
@@ -105,6 +105,10 @@
       margin-top: $default-padding;
     }
 
+    .answer-body p:not(:last-of-type) {
+      margin-bottom: $default-padding;
+    }
+
     .avis-icon {
       margin-right: $default-spacer;
     }

--- a/app/views/gestionnaires/shared/avis/_list.html.haml
+++ b/app/views/gestionnaires/shared/avis/_list.html.haml
@@ -29,4 +29,5 @@
                 - else
                   %span.waiting En attente de réponse
               = render partial: 'shared/piece_jointe/pj_link', locals: { object: avis, pj: avis.piece_justificative_file }
-              %p= avis.answer
+              .answer-body
+                = simple_format(avis.answer)

--- a/spec/factories/avis.rb
+++ b/spec/factories/avis.rb
@@ -19,5 +19,9 @@ FactoryBot.define do
         avis.claimant = create :gestionnaire
       end
     end
+
+    trait :with_answer do
+      answer { "Mon avis se décompose en deux points :\n- La demande semble pertinente\n- Le demandeur remplit les conditions." }
+    end
   end
 end

--- a/spec/views/gestionnaire/shared/avis/list.html.haml_spec.rb
+++ b/spec/views/gestionnaire/shared/avis/list.html.haml_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe 'gestionnaires/shared/avis/_list.html.haml', type: :view do
   before { view.extend DossierHelper }
 
@@ -5,16 +7,22 @@ describe 'gestionnaires/shared/avis/_list.html.haml', type: :view do
 
   let(:gestionnaire) { create(:gestionnaire) }
   let(:avis) { [create(:avis, claimant: gestionnaire)] }
+  let(:seen_at) { avis.first.created_at + 1.hour }
 
-  context "with a seen_at after avis created_at" do
-    let(:seen_at) { avis.first.created_at + 1.hour }
+  it { is_expected.to have_text(avis.first.introduction) }
+  it { is_expected.not_to have_css(".highlighted") }
 
-    it { is_expected.not_to have_css(".highlighted") }
-  end
-
-  context "with a seen_at after avis created_at" do
+  context 'with a seen_at before avis created_at' do
     let(:seen_at) { avis.first.created_at - 1.hour }
 
     it { is_expected.to have_css(".highlighted") }
+  end
+
+  context 'with an answer' do
+    let(:avis) { [create(:avis, :with_answer, claimant: gestionnaire)] }
+
+    it 'renders the answer formatted with newlines' do
+      expect(subject).to include(simple_format(avis.first.answer))
+    end
   end
 end


### PR DESCRIPTION
Fix #3738

## Avant

<img width="855" alt="Capture d’écran 2019-04-04 à 10 14 00" src="https://user-images.githubusercontent.com/179923/55540134-98e06e00-56c2-11e9-80f3-31620cc8041a.png">

## Après


<img width="858" alt="Capture d’écran 2019-04-04 à 10 12 16" src="https://user-images.githubusercontent.com/179923/55540142-9d0c8b80-56c2-11e9-9033-2da204451b4c.png">

