### PR TITLE
mailers: fix last_week_overview crash when the overview is missing

### DIFF
--- a/app/mailers/gestionnaire_mailer.rb
+++ b/app/mailers/gestionnaire_mailer.rb
@@ -21,11 +21,13 @@ class GestionnaireMailer < ApplicationMailer
 
   def last_week_overview(gestionnaire)
     email = gestionnaire.email
-    @overview = gestionnaire.last_week_overview
-    headers['X-mailjet-campaign'] = 'last_week_overview'
     @subject = 'Votre activité hebdomadaire'
+    @overview = gestionnaire.last_week_overview
 
-    mail(to: email, subject: @subject)
+    if @overview.present?
+      headers['X-mailjet-campaign'] = 'last_week_overview'
+      mail(to: email, subject: @subject)
+    end
   end
 
   def send_dossier(sender, dossier, recipient)

--- a/spec/mailers/gestionnaire_mailer_spec.rb
+++ b/spec/mailers/gestionnaire_mailer_spec.rb
@@ -35,5 +35,15 @@ RSpec.describe GestionnaireMailer, type: :mailer do
     subject { described_class.last_week_overview(gestionnaire) }
 
     it { expect(subject.body).to include('Votre activité hebdomadaire') }
+
+    context 'when the gestionnaire has no active procedures' do
+      let(:procedure) { nil }
+      let(:last_week_overview) { nil }
+
+      it 'doesn’t send the email' do
+        expect(subject.message).to be_kind_of(ActionMailer::Base::NullMail)
+        expect(subject.body).to be_blank
+      end
+    end
   end
 end


### PR DESCRIPTION
This is because procedures may be unpublished between the time where
the job is enqueued and the time the mailer is run

Fix #3745