### PR TITLE
Remove placeholder on textarea champ

### DIFF
--- a/app/views/shared/dossiers/editable_champs/_textarea.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_textarea.html.haml
@@ -1,5 +1,4 @@
 ~ form.text_area :value,
   row: 6,
-  placeholder: champ.description,
   required: champ.mandatory?,
   value: html_to_string(champ.value)


### PR DESCRIPTION
Avant
![Capture d’écran 2019-04-04 à 17 33 00](https://user-images.githubusercontent.com/847942/55568580-3e660280-5700-11e9-9b7e-9e3caba9111f.png)

Après
![Capture d’écran 2019-04-04 à 17 35 14](https://user-images.githubusercontent.com/847942/55568584-402fc600-5700-11e9-9dcb-ec3828940099.png)

Fix #3682