### PR TITLE
gestionnaire: ignore when the gestionnaire already follows the dossier

### DIFF
--- a/app/models/gestionnaire.rb
+++ b/app/models/gestionnaire.rb
@@ -31,7 +31,18 @@ class Gestionnaire < ApplicationRecord
       return
     end
 
-    followed_dossiers << dossier
+    begin
+      followed_dossiers << dossier
+    rescue ActiveRecord::RecordNotUnique
+      # Altough we checked before the insertion that the gestionnaire wasn't
+      # already following this dossier, this was done at the Rails level:
+      # at the database level, the dossier was already followed, and a
+      # "invalid constraint" exception is raised.
+      #
+      # We can ignore this safely, as it means the goal is already reached:
+      # the gestionnaire follows the dossier.
+      return
+    end
   end
 
   def unfollow(dossier)


### PR DESCRIPTION
Corrige :

- https://sentry.io/organizations/demarches-simplifiees/issues/971606988/?environment=production&project=1429550&query=is%3Aunresolved+index_follows_on_gestionnaire_id_and_dossier_id&statsPeriod=14d&utc=false
- https://sentry.io/organizations/demarches-simplifiees/issues/973415114/?environment=production&project=1429550&query=is%3Aunresolved+index_follows_on_gestionnaire_id_and_dossier_id&statsPeriod=14d&utc=false

Fix #3720 (voir l'issue pour les commentaires)