### PR TITLE
Filtre des dossiers par email de l’instructeur qui suit

### DIFF
--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -19,6 +19,7 @@ class ProcedurePresentation < ApplicationRecord
       field_hash('En construction le', 'self', 'en_construction_at'),
       field_hash('Mis à jour le', 'self', 'updated_at'),
       field_hash('Demandeur', 'user', 'email'),
+      field_hash('Email instructeur', 'followers_gestionnaires', 'email')
     ]
 
     if procedure.for_individual
@@ -92,7 +93,7 @@ class ProcedurePresentation < ApplicationRecord
           .where("champs.type_de_champ_id = #{column.to_i}")
           .order("champs.value #{order}")
           .pluck(:id)
-    when 'self', 'user', 'individual', 'etablissement'
+    when 'self', 'user', 'individual', 'etablissement', 'followers_gestionnaires'
       return (table == 'self' ? dossiers : dossiers.includes(table))
           .order("#{self.class.sanitized_column(table, column)} #{order}")
           .pluck(:id)
@@ -128,7 +129,7 @@ class ProcedurePresentation < ApplicationRecord
             .includes(table)
             .filter_ilike(table, column, values)
         end
-      when 'user', 'individual'
+      when 'user', 'individual', 'followers_gestionnaires'
         dossiers
           .includes(table)
           .filter_ilike(table, column, values)
@@ -201,6 +202,8 @@ class ProcedurePresentation < ApplicationRecord
       dossier.send(column)&.strftime('%d/%m/%Y')
     when 'user', 'individual', 'etablissement'
       dossier.send(table)&.send(column)
+    when 'followers_gestionnaires'
+      dossier.send(table)&.map { |g| g.send(column) }&.join(', ')
     when 'type_de_champ'
       dossier.champs.find { |c| c.type_de_champ_id == column.to_i }.value
     when 'type_de_champ_private'


### PR DESCRIPTION
fixes #3464

* léger refactor de ProcedurePresentation pour gérer les associations dont le nom est différent de la table (typiquement, les associations to-many)
* ajout d’un filtre `followers_gestionnaires`

(je suis un peu scolaire sur les tests, mais j’avais pas envie de tout réécrire)