### PR TITLE
Améliore l'estimation des délais de traitement

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -346,14 +346,6 @@ class Procedure < ApplicationRecord
     percentile_time(:en_construction_at, :processed_at, 90)
   end
 
-  def usual_verification_time
-    percentile_time(:en_construction_at, :en_instruction_at, 90)
-  end
-
-  def usual_instruction_time
-    percentile_time(:en_instruction_at, :processed_at, 90)
-  end
-
   PATH_AVAILABLE = :available
   PATH_AVAILABLE_PUBLIEE = :available_publiee
   PATH_NOT_AVAILABLE = :not_available

--- a/app/views/users/dossiers/show/_estimated_delay.html.haml
+++ b/app/views/users/dossiers/show/_estimated_delay.html.haml
@@ -1,0 +1,9 @@
+/ FIXME: remove the custom procedure switch at some point
+- procedure_id_for_which_we_hide_the_estimated_delay = 6547
+- procedure_path_for_which_we_hide_the_estimated_delay = 'deposer-une-offre-de-stage'
+- show_time_means = procedure.id != procedure_id_for_which_we_hide_the_estimated_delay && procedure.path != procedure_path_for_which_we_hide_the_estimated_delay
+
+- if procedure.usual_traitement_time && show_time_means
+  - cache(procedure, expires_in: 1.day) do
+    %p
+      Habituellement, les dossiers de cette démarche sont traités dans un délai de #{distance_of_time_in_words(procedure.usual_traitement_time)}.

--- a/app/views/users/dossiers/show/_estimated_delay.html.haml
+++ b/app/views/users/dossiers/show/_estimated_delay.html.haml
@@ -3,7 +3,7 @@
 - procedure_path_for_which_we_hide_the_estimated_delay = 'deposer-une-offre-de-stage'
 - show_time_means = procedure.id != procedure_id_for_which_we_hide_the_estimated_delay && procedure.path != procedure_path_for_which_we_hide_the_estimated_delay
 
-- if procedure.usual_traitement_time && show_time_means
-  - cache(procedure, expires_in: 1.day) do
+- cache(procedure.id, expires_in: 1.day) do
+  - if procedure.usual_traitement_time && show_time_means
     %p
       Habituellement, les dossiers de cette démarche sont traités dans un délai de #{distance_of_time_in_words(procedure.usual_traitement_time)}.

--- a/app/views/users/dossiers/show/_status_overview.html.haml
+++ b/app/views/users/dossiers/show/_status_overview.html.haml
@@ -32,7 +32,7 @@
 
         / FIXME: remove the custom procedure switch at some point
         - if dossier.procedure.usual_verification_time && show_time_means
-          - cache(dossier.procedure, expires_in: 1.week) do
+          - cache(dossier.procedure, expires_in: 1.day) do
             %p
               Habituellement, les dossiers de cette démarche sont vérifiés dans un délai de #{distance_of_time_in_words(dossier.procedure.usual_verification_time)}.
 
@@ -47,7 +47,7 @@
 
         / FIXME: remove the custom procedure switch at some point
         - if dossier.procedure.usual_instruction_time && show_time_means
-          - cache(dossier.procedure, expires_in: 1.week) do
+          - cache(dossier.procedure, expires_in: 1.day) do
             %p
               Habituellement, les dossiers de cette démarche sont traités dans un délai de #{distance_of_time_in_words(dossier.procedure.usual_instruction_time)}.
 

--- a/app/views/users/dossiers/show/_status_overview.html.haml
+++ b/app/views/users/dossiers/show/_status_overview.html.haml
@@ -1,6 +1,4 @@
-- procedure_id_for_which_we_hide_the_time_means = 6547
-- procedure_path_for_which_we_hide_the_time_means = 'deposer-une-offre-de-stage'
-- show_time_means = dossier.procedure.id != procedure_id_for_which_we_hide_the_time_means && dossier.procedure.path != procedure_path_for_which_we_hide_the_time_means
+
 
 .status-overview
   - if !dossier.termine?
@@ -24,17 +22,11 @@
     - elsif dossier.en_construction?
       .en-construction
         %p Un instructeur de l’administration est en train de vérifier que votre dossier est bien complet. Si des modifications sont nécessaires, vous recevrez un message avec les modifications à effectuer.
-
         %p
           Sinon,
           = succeed '.' do
             %strong votre dossier passera directement en instruction
-
-        / FIXME: remove the custom procedure switch at some point
-        - if dossier.procedure.usual_verification_time && show_time_means
-          - cache(dossier.procedure, expires_in: 1.day) do
-            %p
-              Habituellement, les dossiers de cette démarche sont vérifiés dans un délai de #{distance_of_time_in_words(dossier.procedure.usual_verification_time)}.
+        = render partial: 'users/dossiers/show/estimated_delay', locals: { procedure: dossier.procedure }
 
     - elsif dossier.en_instruction?
       .en-instruction
@@ -44,12 +36,7 @@
           %strong
             vous recevrez un email
           avec le résultat.
-
-        / FIXME: remove the custom procedure switch at some point
-        - if dossier.procedure.usual_instruction_time && show_time_means
-          - cache(dossier.procedure, expires_in: 1.day) do
-            %p
-              Habituellement, les dossiers de cette démarche sont traités dans un délai de #{distance_of_time_in_words(dossier.procedure.usual_instruction_time)}.
+        = render partial: 'users/dossiers/show/estimated_delay', locals: { procedure: dossier.procedure }
 
     - elsif dossier.accepte?
       .accepte

--- a/spec/features/users/dossier_details_spec.rb
+++ b/spec/features/users/dossier_details_spec.rb
@@ -17,28 +17,24 @@ describe 'Dossier details:' do
   end
 
   describe "the user can see the mean time they are expected to wait" do
-    context "when the dossier is in construction" do
-      before do
-        other_dossier = create(:dossier, :accepte, :for_individual, procedure: procedure, en_construction_at: 10.days.ago, en_instruction_at: Time.zone.now)
-        visit dossier_path(dossier)
-      end
+    let(:other_dossier) { create(:dossier, :accepte, :for_individual, procedure: procedure, en_construction_at: 10.days.ago, en_instruction_at: 9.days.ago, processed_at: Time.zone.now) }
 
-      it { expect(page).to have_text("Habituellement, les dossiers de cette démarche sont vérifiés dans un délai de 10 jours.") }
+    context "when the dossier is in construction" do
+      it "displays the estimated wait duration" do
+        other_dossier
+        visit dossier_path(dossier)
+        expect(page).to have_text("Habituellement, les dossiers de cette démarche sont traités dans un délai de 10 jours.")
+      end
     end
 
     context "when the dossier is in instruction" do
       let(:dossier) { create(:dossier, :en_instruction, :for_individual, :with_commentaires, user: user, procedure: procedure) }
 
-      before do
-        Timecop.freeze(Time.zone.local(2012, 12, 20))
-
-        other_dossier = create(:dossier, :accepte, :for_individual, procedure: procedure, en_instruction_at: 60.days.ago, processed_at: Time.zone.now)
+      it "displays the estimated wait duration" do
+        other_dossier
         visit dossier_path(dossier)
+        expect(page).to have_text("Habituellement, les dossiers de cette démarche sont traités dans un délai de 10 jours.")
       end
-
-      after { Timecop.return }
-
-      it { expect(page).to have_text("Habituellement, les dossiers de cette démarche sont traités dans un délai de 2 mois.") }
     end
   end
 

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -727,59 +727,17 @@ describe Procedure do
     end
   end
 
-  describe '#usual_verification_time' do
+  describe '#usual_traitement_time' do
     let(:procedure) { create(:procedure) }
 
-    def create_dossier(construction_date:, instruction_date:)
-      dossier = create(:dossier, :en_instruction, procedure: procedure)
-      dossier.update!(en_construction_at: construction_date, en_instruction_at: instruction_date)
-    end
-
-    before do
-      delays.each do |delay|
-        create_dossier(construction_date: 1.week.ago - delay, instruction_date: 1.week.ago)
-      end
-    end
-
-    context 'when there are several dossiers in the time frame' do
-      let(:delays) { [1.day, 2.days, 2.days, 2.days, 2.days, 3.days, 3.days, 3.days, 3.days, 12.days] }
-
-      it 'returns a time representative of the dossier verification delay' do
-        expect(procedure.usual_verification_time).to be_between(3.days, 4.days)
-      end
-    end
-
-    context 'when there are very old dossiers' do
-      let(:delays) { [2.days, 2.days] }
-      let!(:old_dossier) { create_dossier(construction_date: 3.months.ago, instruction_date: 2.months.ago) }
-
-      it 'ignores dossiers older than 1 month' do
-        expect(procedure.usual_verification_time).to be_within(1.hour).of(2.days)
-      end
-    end
-
-    context 'when there is only one dossier in the time frame' do
-      let(:delays) { [1.day] }
-      it { expect(procedure.usual_verification_time).to be_within(1.hour).of(1.day) }
-    end
-
-    context 'where there are no dossiers' do
-      let(:delays) { [] }
-      it { expect(procedure.usual_verification_time).to be_nil }
-    end
-  end
-
-  describe '#usual_instruction_time' do
-    let(:procedure) { create(:procedure) }
-
-    def create_dossier(instruction_date:, processed_date:)
+    def create_dossier(construction_date:, instruction_date:, processed_date:)
       dossier = create(:dossier, :accepte, procedure: procedure)
-      dossier.update!(en_instruction_at: instruction_date, processed_at: processed_date)
+      dossier.update!(en_construction_at: construction_date, en_instruction_at: instruction_date, processed_at: processed_date)
     end
 
     before do
       delays.each do |delay|
-        create_dossier(instruction_date: 1.week.ago - delay, processed_date: 1.week.ago)
+        create_dossier(construction_date: 1.week.ago - delay, instruction_date: 1.week.ago - delay + 12.hours, processed_date: 1.week.ago)
       end
     end
 
@@ -787,36 +745,36 @@ describe Procedure do
       let(:delays) { [1.day, 2.days, 2.days, 2.days, 2.days, 3.days, 3.days, 3.days, 3.days, 12.days] }
 
       it 'returns a time representative of the dossier instruction delay' do
-        expect(procedure.usual_instruction_time).to be_between(3.days, 4.days)
+        expect(procedure.usual_traitement_time).to be_between(3.days, 4.days)
       end
     end
 
     context 'when there are very old dossiers' do
       let(:delays) { [2.days, 2.days] }
-      let!(:old_dossier) { create_dossier(instruction_date: 3.months.ago, processed_date: 2.months.ago) }
+      let!(:old_dossier) { create_dossier(construction_date: 3.months.ago, instruction_date: 2.months.ago, processed_date: 2.months.ago) }
 
       it 'ignores dossiers older than 1 month' do
-        expect(procedure.usual_instruction_time).to be_within(1.hour).of(2.days)
+        expect(procedure.usual_traitement_time).to be_within(1.hour).of(2.days)
       end
     end
 
     context 'when there is a dossier with bad data' do
       let(:delays) { [2.days, 2.days] }
-      let!(:bad_dossier) { create_dossier(instruction_date: nil, processed_date: 10.days.ago) }
+      let!(:bad_dossier) { create_dossier(construction_date: nil, instruction_date: nil, processed_date: 10.days.ago) }
 
       it 'ignores bad dossiers' do
-        expect(procedure.usual_instruction_time).to be_within(1.hour).of(2.days)
+        expect(procedure.usual_traitement_time).to be_within(1.hour).of(2.days)
       end
     end
 
     context 'when there is only one processed dossier' do
       let(:delays) { [1.day] }
-      it { expect(procedure.usual_instruction_time).to be_within(1.hour).of(1.day) }
+      it { expect(procedure.usual_traitement_time).to be_within(1.hour).of(1.day) }
     end
 
     context 'where there is no processed dossier' do
       let(:delays) { [] }
-      it { expect(procedure.usual_instruction_time).to be_nil }
+      it { expect(procedure.usual_traitement_time).to be_nil }
     end
   end
 

--- a/spec/views/users/dossiers/show/_status_overview.html.haml_spec.rb
+++ b/spec/views/users/dossiers/show/_status_overview.html.haml_spec.rb
@@ -1,4 +1,6 @@
 describe 'users/dossiers/show/_status_overview.html.haml', type: :view do
+  before { allow(dossier.procedure).to receive(:usual_traitement_time).and_return(1.day) }
+
   subject! { render 'users/dossiers/show/status_overview.html.haml', dossier: dossier }
 
   matcher :have_timeline_item do |selector|
@@ -46,6 +48,7 @@ describe 'users/dossiers/show/_status_overview.html.haml', type: :view do
     end
 
     it { is_expected.to have_selector('.status-explanation .en-construction') }
+    it { is_expected.to have_text('Habituellement, les dossiers de cette démarche sont traités dans un délai de 1 jour') }
   end
 
   context 'when en instruction' do
@@ -59,6 +62,7 @@ describe 'users/dossiers/show/_status_overview.html.haml', type: :view do
     end
 
     it { is_expected.to have_selector('.status-explanation .en-instruction') }
+    it { is_expected.to have_text('Habituellement, les dossiers de cette démarche sont traités dans un délai de 1 jour') }
   end
 
   context 'when accepté' do


### PR DESCRIPTION
Une démarche nous a signalé que l'estimation de traitement des dossiers était beaucoup trop courte par rapport à la réalité.

Après investigation, il y avait deux problèmes :

- On affichait une valeur périmée, parce que le cache était trop long ;
- On affichait la valeur pour le délai de passage en instruction, que les usagers prenaient comme le délai de traitement complet.

De fait c'est pas très malin de ma part d'avoir séparé le délai d'instruction et le délai d'acceptation : si un dossier met 1 mois à passer en instruction, et ensuite 2 mois encore à être terminé, on affiche à l'usager "Habituellement les dossiers sont vérifiés en 1 mois". C'est techniquement vrai, mais l'important c'est que sa démarche va prendre trois mois.

**Cette PR :**

- Affiche l'estimation du délai de traitement pour l'ensemble du workflow (plutôt que de séparer les estimations pour l'étape de construction et l'étape d'instruction).
- Cache les données pendant un jour (plutôt qu'une semaine).
- Fait en sorte que le cache soit réellement utile (avant on calculait la valeur coûteuse en dehors du cache quoi qu'il arrive 😓)