### PR TITLE
changement de wording

### DIFF
--- a/app/views/avis_mailer/avis_invitation.html.haml
+++ b/app/views/avis_mailer/avis_invitation.html.haml
@@ -25,7 +25,7 @@
 
 - if @avis.gestionnaire.present?
   %p
-    = link_to "Connectez-vous pour donner votre avis", avis_link
+    = link_to "Cliquez ici pour donner votre avis", avis_link
 - else
   %p
     = link_to "Inscrivez-vous pour donner votre avis", avis_link


### PR DESCRIPTION
changement de wording "Connectez-vous pour donner votre avis" > "Cliquez ici pour donner votre avis", ça permet de clarifier (sinon les usagers peuvent penser que c'est le lien pour se connecter à ds (/sign_in).
c'est le fruit de discussion avec des admin :)