### PR TITLE
tasks: populate Procedure.administrateurs even for hidden procedures

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -1,8 +1,6 @@
 require Rails.root.join('lib', 'percentile')
 
 class Procedure < ApplicationRecord
-  self.ignored_columns = [:administrateur_id]
-
   MAX_DUREE_CONSERVATION = 36
 
   has_many :types_de_piece_justificative, -> { ordered }, dependent: :destroy

--- a/lib/tasks/deployment/20190429103024_add_procedure_administrateur_to_administrateurs_for_hidden_procedures.rake
+++ b/lib/tasks/deployment/20190429103024_add_procedure_administrateur_to_administrateurs_for_hidden_procedures.rake
@@ -1,0 +1,19 @@
+namespace :after_party do
+  desc 'Deployment task: add_procedure_administrateur_to_administrateurs_for_hidden_procedures'
+  task add_procedure_administrateur_to_administrateurs_for_hidden_procedures: :environment do
+    rake_puts "Running deploy task: 'add_procedure_administrateur_to_administrateurs_for_hidden_procedures'"
+    hidden_procedures = Procedure.unscoped.hidden.includes(:administrateurs)
+    progress = ProgressReport.new(hidden_procedures.count)
+
+    hidden_procedures.find_each do |procedure|
+      deprecated_administrateur = Administrateur.find_by(id: procedure.administrateur_id)
+      if deprecated_administrateur && !procedure.administrateurs.include?(deprecated_administrateur)
+        procedure.administrateurs << deprecated_administrateur
+      end
+      progress.inc
+    end
+
+    progress.finish
+    AfterParty::TaskRecord.create version: '20190429103024'
+  end
+end


### PR DESCRIPTION
Part of #1626.

The previous procedure migration (created in f7af01e0dc7c38b598a849f062b181b3f8c55a62) worked fine, but didn't run on hidden procedures (due to the default scope).

Practically it has no consequences (as it only affects hidden Procedures), but this fixes some bad data.

We'll be able to drop the `administrateur_id` column after this.

@n-b please review