### PR TITLE
Fix “nearing_end_of_retention” test

### DIFF
--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -31,7 +31,7 @@ describe Dossier do
     let(:procedure) { create(:procedure, duree_conservation_dossiers_dans_ds: 6) }
     let!(:young_dossier) { create(:dossier, procedure: procedure) }
     let!(:expiring_dossier) { create(:dossier, :en_instruction, en_instruction_at: 170.days.ago, procedure: procedure) }
-    let!(:just_expired_dossier) { create(:dossier, :en_instruction, en_instruction_at: (6.months + 1.second).ago, procedure: procedure) }
+    let!(:just_expired_dossier) { create(:dossier, :en_instruction, en_instruction_at: (6.months + 1.hour + 1.second).ago, procedure: procedure) }
     let!(:long_expired_dossier) { create(:dossier, :en_instruction, en_instruction_at: 1.year.ago, procedure: procedure) }
 
     context 'with default delay to end of retention' do


### PR DESCRIPTION
The `nearing_end_of_retention` test creates a `just_expired_dossier` “six months ago”, which is 29 Oct 2018. The autumn DST change was on October 28; this is the first time this test runs under these conditions. We workaround the time offset by creating the dossier one hour earlier.

This is technically a workaround, not a fix: the date arithmetics in `nearing_end_of_retention` are probably wrong. It looks like it’s comparing intervals, which seems error-prone, while it should be comparing dates. For now, I’m just making the tests pass.