### PR TITLE
sign_in: fix line breaks on form header

### DIFF
--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -4,7 +4,7 @@
   - if resource_name == :user
     %p.register
       %span
-        Nouveau sur demarches-simplifiees.fr ?
+        Nouveau sur demarches&#8209;simplifiees.fr ?
       = link_to "Créer un compte", new_registration_path(resource_name), class: "button primary auth-signup-button"
 
     %hr


### PR DESCRIPTION
## Avant

<img width="541" alt="Capture d’écran 2019-04-29 à 17 56 29" src="https://user-images.githubusercontent.com/179923/56909252-2d62a400-6aa8-11e9-9099-056716536cc2.png">

## Après

<img width="538" alt="Capture d’écran 2019-04-29 à 17 55 31" src="https://user-images.githubusercontent.com/179923/56909256-2f2c6780-6aa8-11e9-8ed6-70ef11e13656.png">