### PR TITLE
Ajout d'un feature-flag pour désactiver l'API INSEE v3

### DIFF
--- a/app/lib/api_entreprise/api.rb
+++ b/app/lib/api_entreprise/api.rb
@@ -42,7 +42,11 @@ class ApiEntreprise::API
   def self.url(resource_name, siret_or_siren)
     base_url = [API_ENTREPRISE_URL, resource_name, siret_or_siren].join("/")
 
-    "#{base_url}?with_insee_v3=true"
+    if Flipflop.insee_api_v3?
+      base_url += "?with_insee_v3=true"
+    end
+
+    base_url
   end
 
   def self.params(siret_or_siren, procedure_id)

--- a/app/lib/api_entreprise/api.rb
+++ b/app/lib/api_entreprise/api.rb
@@ -40,7 +40,9 @@ class ApiEntreprise::API
   end
 
   def self.url(resource_name, siret_or_siren)
-    [API_ENTREPRISE_URL, resource_name, siret_or_siren].join("/")
+    base_url = [API_ENTREPRISE_URL, resource_name, siret_or_siren].join("/")
+
+    "#{base_url}?with_insee_v3=true"
   end
 
   def self.params(siret_or_siren, procedure_id)

--- a/config/features.rb
+++ b/config/features.rb
@@ -20,6 +20,8 @@ Flipflop.configure do
   group :production do
     feature :remote_storage,
       default: ENV['FOG_ENABLED'] == 'enabled'
+    feature :insee_api_v3,
+      default: true
     feature :weekly_overview,
       default: ENV['APP_NAME'] == 'tps'
     feature :pre_maintenance_mode


### PR DESCRIPTION
Comme ça quand l'API Entreprise v3 tombe, on peut facilement repasser en API v2 (qui a un fallback).

<img width="1106" alt="Capture d’écran 2019-04-30 à 17 30 26" src="https://user-images.githubusercontent.com/179923/56973694-a972ef80-6b6d-11e9-96e2-6f7f3299b317.png">

@LeSim tu peux relire ?