### PR TITLE
RFC: Reset the form and untouch the input after adding an admin

### DIFF
--- a/app/views/new_administrateur/procedure_administrateurs/create.js.haml
+++ b/app/views/new_administrateur/procedure_administrateurs/create.js.haml
@@ -3,4 +3,9 @@
   = append_to_element("#procedure-#{@procedure.id}-administrateurs",
     partial: 'administrateur',
     locals: { administrateur: @administrateur })
-  document.getElementById('procedure-#{@procedure.id}-new_administrateur').reset()
+
+  let form = document.getElementById('procedure-#{@procedure.id}-new_administrateur');
+  form.reset();
+  let inputs = form.querySelectorAll('input, textarea');
+  inputs.forEach(blur)
+  inputs.forEach(input => { input.classList.remove('touched') })


### PR DESCRIPTION
This works and solves the [discussion](https://github.com/betagouv/demarches-simplifiees.fr/pull/3786#pullrequestreview-233972944) in #3786:

> Le required a l'air de faire des trucs chelous quand on ajoute un admin : le champ devient rouge.
> <img width="614" alt="Capture d’écran 2019-05-06 à 15 16 33" src="https://user-images.githubusercontent.com/179923/57227576-078e4f80-7012-11e9-9685-223bff354a71.png">

---

I believe this isn’t the right place to put this code, should it be a function in `form-validation.js`? That’s where the `touched` class is set initially.