### PR TITLE
Carrierwave: change the method name to extension_whitelist for filter

### DIFF
--- a/app/uploaders/attestation_template_logo_uploader.rb
+++ b/app/uploaders/attestation_template_logo_uploader.rb
@@ -20,7 +20,7 @@ class AttestationTemplateLogoUploader < BaseUploader
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  def extension_white_list
+  def extension_whitelist
     ['jpg', 'jpeg', 'png']
   end
 

--- a/app/uploaders/attestation_template_signature_uploader.rb
+++ b/app/uploaders/attestation_template_signature_uploader.rb
@@ -20,7 +20,7 @@ class AttestationTemplateSignatureUploader < BaseUploader
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  def extension_white_list
+  def extension_whitelist
     ['jpg', 'jpeg', 'png']
   end
 

--- a/app/uploaders/commentaire_file_uploader.rb
+++ b/app/uploaders/commentaire_file_uploader.rb
@@ -13,11 +13,11 @@ class CommentaireFileUploader < BaseUploader
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
-  def extension_white_list
+  def extension_whitelist
     ['pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'odt', 'ods', 'odp', 'jpg', 'jpeg', 'png', 'zip', 'txt']
   end
 
   def accept_extension_list
-    extension_white_list.map { |e| ".#{e}" }.join(",")
+    extension_whitelist.map { |e| ".#{e}" }.join(",")
   end
 end

--- a/app/uploaders/piece_justificative_uploader.rb
+++ b/app/uploaders/piece_justificative_uploader.rb
@@ -18,7 +18,7 @@ class PieceJustificativeUploader < BaseUploader
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  def extension_white_list
+  def extension_whitelist
     ['pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'odt', 'ods', 'odp', 'jpg', 'jpeg', 'png']
   end
 

--- a/app/uploaders/procedure_logo_uploader.rb
+++ b/app/uploaders/procedure_logo_uploader.rb
@@ -20,7 +20,7 @@ class ProcedureLogoUploader < BaseUploader
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  def extension_white_list
+  def extension_whitelist
     ['jpg', 'jpeg', 'png']
   end
 


### PR DESCRIPTION
Le nom de la méthode "extension_white_list " a été changé dans le Gem "Carrierwave" ~> "extension_whitelist", le filtrer d'extension dans l'uploader ne fonctionne plus, les fichiers non autorisé peut uploader avec ce bug, et sans ROLLBACK. 
Voir [https://github.com/carrierwaveuploader/carrierwave/issues/1896](url)

