### PR TITLE
add cookie session expiration

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_DS_session'
+Rails.application.config.session_store :cookie_store, key: '_DS_session', expire_after: 14.days


### PR DESCRIPTION

Ajout d'une durée limite pour la vie des cookie.

J'ai fait le test avec un TTL court (une minute, les armées suggèrent 30mn):
  - si on utilise l'appli avant l'expiration du cookie, il est régénéré à chaque refresh pour 30mn supplémentaires
  - si on n'utilise pas l'appli pendant la durée d'expiration du cookie, on est déconnecté

donc mettre une durée trop courte va déconnecter les gens qui n'utilisent pas l'appli, mais cela ne va pas déconnecter pour autant les utilisateurs toutes les 30mn s'ils naviguent dans l'app

Pour autant, je suis moyen chaud pour mettre un cookie aussi court. Les utilisateurs n'aiment pas qu'on leur demande souvent un mot de passe, ça peut vite les gonfler, donc je préfère mettre une durée bien supérieure (2 semaines) pour éviter de demander aux utilisateurs leurs mot de passe trop souvent.