### PR TITLE
france_connect: fix for params entirely missing from the callback

### DIFF
--- a/app/controllers/france_connect/particulier_controller.rb
+++ b/app/controllers/france_connect/particulier_controller.rb
@@ -30,7 +30,7 @@ class FranceConnect::ParticulierController < ApplicationController
   private
 
   def redirect_to_login_if_fc_aborted
-    if params[:code].empty?
+    if params[:code].blank?
       redirect_to new_user_session_path
     end
   end

--- a/spec/controllers/france_connect/particulier_controller_spec.rb
+++ b/spec/controllers/france_connect/particulier_controller_spec.rb
@@ -25,6 +25,12 @@ describe FranceConnect::ParticulierController, type: :controller do
 
     subject { get :callback, params: { code: code } }
 
+    context 'when params are missing' do
+      subject { get :callback }
+
+      it { is_expected.to redirect_to(new_user_session_path) }
+    end
+
     context 'when param code is missing' do
       let(:code) { nil }
 


### PR DESCRIPTION
Petit correctif mineur pour corriger une exception remontée dans Sentry : un retour de France Connect sans params fait crasher l'app.

https://sentry.io/organizations/demarches-simplifiees/issues/1015126670/?environment=production&project=1429547