### PR TITLE
Corrige l'erreur 500 après l'envoi d'un message via le formulaire de contact

### DIFF
--- a/app/lib/helpscout/api.rb
+++ b/app/lib/helpscout/api.rb
@@ -22,17 +22,6 @@ class Helpscout::API
     })
   end
 
-  def add_custom_fields(conversation_id, dossier_id, browser)
-    body = {
-      'Dossier ID': dossier_id,
-      'Browser': browser
-    }.compact.map do |key, value|
-      { id: custom_fields[key], value: value }
-    end
-
-    call_api(:put, "#{CONVERSATIONS}/#{conversation_id}/#{FIELDS}", { fields: body })
-  end
-
   def create_conversation(email, subject, text, file)
     body = {
       subject: subject,

--- a/app/lib/helpscout/form_adapter.rb
+++ b/app/lib/helpscout/form_adapter.rb
@@ -41,8 +41,6 @@ class Helpscout::FormAdapter
 
     if conversation_id.present?
       add_tags(conversation_id)
-      add_custom_fields(conversation_id)
-
       true
     else
       false
@@ -53,10 +51,6 @@ class Helpscout::FormAdapter
 
   def add_tags(conversation_id)
     @api.add_tags(conversation_id, params[:tags])
-  end
-
-  def add_custom_fields(conversation_id)
-    @api.add_custom_fields(conversation_id, params[:dossier_id], params[:browser])
   end
 
   def create_conversation

--- a/spec/lib/helpscout/form_adapter_spec.rb
+++ b/spec/lib/helpscout/form_adapter_spec.rb
@@ -62,8 +62,6 @@ describe Helpscout::FormAdapter do
           .with(email, subject, text, nil)
         expect(api).to have_received(:add_tags)
           .with(conversation_id, tags)
-        expect(api).to have_received(:add_custom_fields)
-          .with(conversation_id, nil, nil)
       end
     end
 
@@ -102,8 +100,6 @@ describe Helpscout::FormAdapter do
           .with(email, subject, text, nil)
         expect(api).to have_received(:add_phone_number)
           .with(email, phone)
-        expect(api).to have_received(:add_custom_fields)
-          .with(conversation_id, nil, nil)
       end
     end
   end


### PR DESCRIPTION
On n'a plus droit aux Custom Fields dans notre nouveau plan HelpScout.

On pourra décider plus tard si on veut ré-activer la feature en changeant de plan.

Fix #3857