### PR TITLE
notification_mailer: send procedure id when reporting a missing logo

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -45,6 +45,7 @@ class NotificationMailer < ApplicationMailer
         @logo_url = attachments[logo_filename].url
       rescue StandardError => e
         # A problem occured when reading logo, maybe the logo is missing and we should clean the procedure to remove logo reference ?
+        Raven.extra_context(procedure_id: dossier.procedure.id)
         Raven.capture_exception(e)
       end
     end


### PR DESCRIPTION
Quand on envoie un email de notification et que la démarche dit qu'elle a un logo, mais qu'on n'arrive pas à récupérer le fichier du logo, on remonte manuellement une erreur à Sentry, pour signaler qu'il faudrait nettoyer la démarche en question.

Mais aujourd'hui quand on [regarde ces erreurs dans Sentry](https://sentry.io/organizations/demarches-simplifiees/issues/982657454/?environment=production&project=1429547), on n'a pas accès à l'id de la démarche en question. Du coup on ne peut pas la nettoyer.

Cette PR fait en sorte de remonter l'id de la démarche, pour qu'on puisse faire du nettoyage à la main, et fermer l'exception dans Sentry.