### PR TITLE
locales: remove unused carrierwave localisation

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -187,7 +187,6 @@ fr:
       etablissement_fail: 'Désolé, nous n’avons pas réussi à enregistrer l’établissement correspondant à ce numéro SIRET'
       france_connect:
         connexion: "Erreur lors de la connexion à France Connect."
-      extension_white_list_error: "Le format de fichier de la pièce jointe n'est pas valide."
       procedure_archived: "Cette démarche en ligne a été fermée, il n'est plus possible de déposer de dossier."
       procedure_not_draft: "Cette démarche n’est maintenant plus en brouillon."
       cadastres_empty:


### PR DESCRIPTION
- It was broken since the renaming of `extension_white_list` to  `extension_whitelist` (f0ed61cce8e7faae90a3b3923eedc17a27118023);
- The localisation is already included in the `carrierwave-i18n` gem;
- The localisation included in the gem is better than ours (it mentions
  which extensions are allowed).