### PR TITLE
Put devtools behind feature flags

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,7 +24,7 @@ class ApplicationController < ActionController::Base
   end
 
   def authorize_request_for_profiler
-    if administration_signed_in?
+    if Flipflop.mini_profiler_enabled?
       Rack::MiniProfiler.authorize_request
     end
   end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -21,7 +21,7 @@
 
     = Gon::Base.render_data(camel_case: true, init: true, nonce:  request.content_security_policy_nonce)
 
-    - if Rails.env.development?
+    - if Flipflop.xray_enabled?
       = stylesheet_link_tag :xray
 
   %body{ id: content_for(:page_id), class: browser.platform.ios? ? 'ios' : nil }
@@ -39,7 +39,7 @@
       - if content_for?(:footer)
         = content_for(:footer)
 
-      - if Rails.env.development?
+      - if Flipflop.xray_enabled?
         = javascript_include_tag :xray
 
       = yield :charts_js

--- a/config/features.rb
+++ b/config/features.rb
@@ -18,6 +18,13 @@ Flipflop.configure do
 
   feature :operation_log_serialize_subject
 
+  group :development do
+    feature :mini_profiler_enabled,
+      default: Rails.env.development?
+    feature :xray_enabled,
+      default: Rails.env.development?
+  end
+
   group :production do
     feature :remote_storage,
       default: ENV['FOG_ENABLED'] == 'enabled'

--- a/config/initializers/rack_mini_profiler.rb
+++ b/config/initializers/rack_mini_profiler.rb
@@ -1,0 +1,1 @@
+Rack::MiniProfiler.config.authorization_mode = :whitelist


### PR DESCRIPTION
C'est utile pour debug le js sans les dev tools qui polluent la console avec des requêtes