### PR TITLE
Redirige les réponses aux emails de notification vers l'adresse email du service

### DIFF
--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -2,4 +2,10 @@ module ServiceHelper
   def formatted_horaires(horaires)
     horaires.sub(/\S/, &:downcase)
   end
+
+  def email_for_reply_to(service)
+    if service && service&.email =~ URI::MailTo::EMAIL_REGEXP
+      [service.email, CONTACT_EMAIL]
+    end
+  end
 end

--- a/app/mailers/dossier_mailer.rb
+++ b/app/mailers/dossier_mailer.rb
@@ -1,5 +1,7 @@
 # Preview all emails at http://localhost:3000/rails/mailers/dossier_mailer
 class DossierMailer < ApplicationMailer
+  include ServiceHelper
+
   layout 'mailers/layout'
 
   def notify_new_draft(dossier)
@@ -11,9 +13,11 @@ class DossierMailer < ApplicationMailer
 
   def notify_new_answer(dossier)
     @dossier = dossier
+    email = dossier.user.email
+    reply_to = email_for_reply_to(dossier.procedure.service)
     subject = "Nouveau message pour votre dossier nº #{dossier.id}"
 
-    mail(to: dossier.user.email, subject: subject) do |format|
+    mail(to: email, subject: subject, reply_to: reply_to) do |format|
       format.html { render layout: 'mailers/notification' }
     end
   end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -6,6 +6,7 @@
 # The subject and body of a Notification can be customized by each demarche.
 #
 class NotificationMailer < ApplicationMailer
+  include ServiceHelper
   helper ServiceHelper
 
   def send_dossier_received(dossier)
@@ -32,7 +33,7 @@ class NotificationMailer < ApplicationMailer
 
   def send_notification(dossier, mail_template)
     email = dossier.user.email
-
+    reply_to = email_for_reply_to(dossier.procedure.service)
     subject = mail_template.subject_for_dossier(dossier)
     body = mail_template.body_for_dossier(dossier)
 
@@ -53,7 +54,7 @@ class NotificationMailer < ApplicationMailer
     @dossier = dossier
     @service = dossier.procedure.service
 
-    mail(subject: subject, to: email) do |format|
+    mail(to: email, subject: subject, reply_to: reply_to) do |format|
       # rubocop:disable Rails/OutputSafety
       format.html { render(html: body.html_safe, layout: 'mailers/notification') }
       # rubocop:enable Rails/OutputSafety

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe ServiceHelper, type: :helper do
+  describe '#email_for_reply_to' do
+    let(:email) { 'administration@example.fr' }
+    let(:service) { create(:service, email: email) }
+
+    subject { email_for_reply_to(service) }
+
+    context 'when the service email is valid' do
+      let(:email) { 'contact@prefecture.gouv.fr' }
+      it { is_expected.to eq [email, CONTACT_EMAIL] }
+    end
+
+    context 'when the service email is invalid' do
+      let(:email) { 'ne-pas-repondre' }
+      it { is_expected.to be_nil }
+    end
+
+    context 'when the service service does not exist' do
+      let(:service) { nil }
+      it { is_expected.to be_nil }
+    end
+  end
+end


### PR DESCRIPTION
Cette PR implémente la discussion dans #3715 : quand un usager reçoit un email transactionnel sur un dossier, s'il clique sur "Répondre", l'adresse de réponse est l'adresse de contact du Service de la démarche.

**Spam**

Le `Reply-To` n'a pas l'air de changer le spam-score (testé sur https://www.mail-tester.com/). Faudra surveiller, quand même.

**Opportunité**

Comme discuté dans #3715, je me demande si c'est une bonne idée.

Vous en pensez quoi, vous ? (On peut discuter dans l'issue, pour le contexte de la discussion, au besoin).

Fix #3715