### PR TITLE
Ajout d'une tâche pour migrer les pièces justificatives de plusieurs démarches

### DIFF
--- a/app/services/piece_justificative_to_champ_piece_jointe_migration_service.rb
+++ b/app/services/piece_justificative_to_champ_piece_jointe_migration_service.rb
@@ -9,6 +9,11 @@ class PieceJustificativeToChampPieceJointeMigrationService
     storage_service.ensure_openstack_copy_possible!(PieceJustificativeUploader)
   end
 
+  def procedures_with_pjs_in_range(ids_range)
+    procedures_with_pj = Procedure.unscope(where: :hidden_at).joins(:types_de_piece_justificative).distinct
+    procedures_with_pj.where(id: ids_range)
+  end
+
   def convert_procedure_pjs_to_champ_pjs(procedure)
     types_de_champ_pj = PiecesJustificativesService.types_pj_as_types_de_champ(procedure)
     populate_champs_pjs!(procedure, types_de_champ_pj)

--- a/app/services/piece_justificative_to_champ_piece_jointe_migration_service.rb
+++ b/app/services/piece_justificative_to_champ_piece_jointe_migration_service.rb
@@ -14,9 +14,13 @@ class PieceJustificativeToChampPieceJointeMigrationService
     procedures_with_pj.where(id: ids_range)
   end
 
-  def convert_procedure_pjs_to_champ_pjs(procedure)
+  def number_of_champs_to_migrate(procedure)
+    (procedure.types_de_piece_justificative.count + 1) * procedure.dossiers.unscope(where: :hidden_at).count
+  end
+
+  def convert_procedure_pjs_to_champ_pjs(procedure, &progress)
     types_de_champ_pj = PiecesJustificativesService.types_pj_as_types_de_champ(procedure)
-    populate_champs_pjs!(procedure, types_de_champ_pj)
+    populate_champs_pjs!(procedure, types_de_champ_pj, &progress)
 
     # Only destroy the old types PJ once everything has been safely migrated to
     # champs PJs. Destroying the types PJ will cascade and destroy the PJs,
@@ -29,7 +33,7 @@ class PieceJustificativeToChampPieceJointeMigrationService
     @storage_service ||= CarrierwaveActiveStorageMigrationService.new
   end
 
-  def populate_champs_pjs!(procedure, types_de_champ_pj)
+  def populate_champs_pjs!(procedure, types_de_champ_pj, &progress)
     procedure.types_de_champ += types_de_champ_pj
 
     # Unscope to make sure all dossiers are migrated, even the soft-deleted ones
@@ -54,6 +58,8 @@ class PieceJustificativeToChampPieceJointeMigrationService
             created_at: dossier.created_at
           )
         end
+
+        yield if block_given?
       end
     end
   rescue

--- a/lib/tasks/2019_03_13_migrate_pjs_to_champs.rake
+++ b/lib/tasks/2019_03_13_migrate_pjs_to_champs.rake
@@ -1,8 +1,0 @@
-namespace :'2019_03_13_migrate_pjs_to_champs' do
-  task run: :environment do
-    procedure_id = ENV['PROCEDURE_ID']
-    service = PieceJustificativeToChampPieceJointeMigrationService.new
-    service.ensure_correct_storage_configuration!
-    service.convert_procedure_pjs_to_champ_pjs(Procedure.find(procedure_id))
-  end
-end

--- a/lib/tasks/pieces_justificatives.rake
+++ b/lib/tasks/pieces_justificatives.rake
@@ -1,0 +1,28 @@
+require Rails.root.join("lib", "tasks", "task_helper")
+
+namespace :pieces_justificatives do
+  task migrate_procedure_to_champs: :environment do
+    procedure_id = ENV['PROCEDURE_ID']
+    service = PieceJustificativeToChampPieceJointeMigrationService.new
+    service.ensure_correct_storage_configuration!
+    service.convert_procedure_pjs_to_champ_pjs(Procedure.find(procedure_id))
+  end
+
+  task migrate_procedures_range_to_champs: :environment do
+    if ENV['RANGE_START'].nil? || ENV['RANGE_END'].nil?
+      fail "RANGE_START and RANGE_END must be specified"
+    end
+    procedures_range = ENV['RANGE_START']..ENV['RANGE_END']
+
+    service = PieceJustificativeToChampPieceJointeMigrationService.new
+    service.ensure_correct_storage_configuration!
+    procedures_to_migrate = service.procedures_with_pjs_in_range(procedures_range)
+
+    procedures_to_migrate.find_each do |procedure|
+      rake_puts ''
+      rake_puts "Migrating procedure #{procedure.id}…"
+
+      service.convert_procedure_pjs_to_champ_pjs(procedure)
+    end
+  end
+end

--- a/spec/lib/tasks/pieces_justificatives_spec.rb
+++ b/spec/lib/tasks/pieces_justificatives_spec.rb
@@ -1,4 +1,23 @@
 describe 'pieces_justificatives' do
+  describe 'migrate_procedure_to_champs' do
+    let(:rake_task) { Rake::Task['pieces_justificatives:migrate_procedure_to_champs'] }
+    let(:procedure) { create(:procedure, :with_two_type_de_piece_justificative) }
+
+    before do
+      ENV['PROCEDURE_ID'] = procedure.id.to_s
+
+      allow_any_instance_of(PieceJustificativeToChampPieceJointeMigrationService).to receive(:ensure_correct_storage_configuration!)
+
+      rake_task.invoke
+    end
+
+    after { rake_task.reenable }
+
+    it 'migrates the procedure' do
+      expect(procedure.reload.types_de_piece_justificative).to be_empty
+    end
+  end
+
   describe 'migrate_procedures_range_to_champs' do
     let(:rake_task) { Rake::Task['pieces_justificatives:migrate_procedures_range_to_champs'] }
     let(:procedure_in_range_1) { create(:procedure, :with_two_type_de_piece_justificative) }

--- a/spec/lib/tasks/pieces_justificatives_spec.rb
+++ b/spec/lib/tasks/pieces_justificatives_spec.rb
@@ -1,0 +1,32 @@
+describe 'pieces_justificatives' do
+  describe 'migrate_procedures_range_to_champs' do
+    let(:rake_task) { Rake::Task['pieces_justificatives:migrate_procedures_range_to_champs'] }
+    let(:procedure_in_range_1) { create(:procedure, :with_two_type_de_piece_justificative) }
+    let(:procedure_in_range_2) { create(:procedure, :with_two_type_de_piece_justificative) }
+    let(:procedure_out_of_range) { create(:procedure, :with_two_type_de_piece_justificative) }
+
+    before do
+      procedure_in_range_1
+      procedure_in_range_2
+      procedure_out_of_range
+
+      ENV['RANGE_START'] = procedure_in_range_1.id.to_s
+      ENV['RANGE_END'] = procedure_in_range_2.id.to_s
+
+      allow_any_instance_of(PieceJustificativeToChampPieceJointeMigrationService).to receive(:ensure_correct_storage_configuration!)
+
+      rake_task.invoke
+    end
+
+    after { rake_task.reenable }
+
+    it 'migrates procedures in the ids range' do
+      expect(procedure_in_range_1.reload.types_de_piece_justificative).to be_empty
+      expect(procedure_in_range_2.reload.types_de_piece_justificative).to be_empty
+    end
+
+    it 'doesn’t migrate procedures not in the range' do
+      expect(procedure_out_of_range.reload.types_de_piece_justificative).to be_present
+    end
+  end
+end


### PR DESCRIPTION
On a déjà une tâche pour migrer les PJs d'une démarche spécifique (merci @fredZen ❤️). Mais pour industrialiser, ce qu'on voudrait, c'est pouvoir migrer les démarches en bloc (idéalement même dans plusieurs shells en parallèle).

Cette PR introduit une tâche qui permet de **migrer une série de démarches d'un coup**. Elle prend un intervalle d'ids (par exemple `[500..1000]`).

_Bonus_ : la tâche comporte aussi un indicateur de progression, incrémenté pour chaque champ migré. Ça permet d'estimer le temps que va prendre la migration.