### PR TITLE
Fix antivirus not running

### DIFF
--- a/app/jobs/virus_scanner_job.rb
+++ b/app/jobs/virus_scanner_job.rb
@@ -1,7 +1,11 @@
 class VirusScannerJob < ApplicationJob
   def perform(blob)
     metadata = extract_metadata_via_virus_scanner(blob)
-    blob.update!(metadata: blob.metadata.merge(metadata))
+    if blob.metadata.present?
+      blob.update!(metadata: blob.metadata.merge(metadata))
+    else
+      blob.update!(metadata: metadata)
+    end
   end
 
   def extract_metadata_via_virus_scanner(blob)

--- a/app/lib/active_storage/virus_scanner.rb
+++ b/app/lib/active_storage/virus_scanner.rb
@@ -23,12 +23,16 @@ class ActiveStorage::VirusScanner
     blob.metadata[:virus_scan_result] == SAFE
   end
 
-  def analyzed?
+  def done?
+    blob.metadata[:scanned_at].present?
+  end
+
+  def started?
     blob.metadata[:virus_scan_result].present?
   end
 
   def analyze_later
-    if !analyzed?
+    if !done?
       blob.update!(metadata: blob.metadata.merge(virus_scan_result: PENDING))
       VirusScannerJob.perform_later(blob)
     end

--- a/app/views/shared/piece_jointe/_pj_link.html.haml
+++ b/app/views/shared/piece_jointe/_pj_link.html.haml
@@ -1,10 +1,10 @@
 - if pj.attached?
   .pj-link
-    - if pj.virus_scanner.safe? || !pj.virus_scanner.analyzed?
+    - if pj.virus_scanner.safe? || !pj.virus_scanner.started?
       = link_to url_for(pj), target: '_blank', rel: 'noopener',  title: "Télécharger la pièce jointe" do
         %span.icon.attachment
         = pj.filename.to_s
-      - if !pj.virus_scanner.analyzed?
+      - if !pj.virus_scanner.started?
         (ce fichier n’a pas été analysé par notre antivirus, téléchargez-le avec précaution)
 
     - else

--- a/spec/models/champ_spec.rb
+++ b/spec/models/champ_spec.rb
@@ -388,7 +388,7 @@ describe Champ do
           champ.save
         end
 
-        it { expect(champ.piece_justificative_file.virus_scanner.analyzed?).to be_truthy }
+        it { expect(champ.piece_justificative_file.virus_scanner.started?).to be_truthy }
       end
 
       context 'and there is no blob' do


### PR DESCRIPTION
L'antivirus semble ne pas tourner sur certaines PJ, ou du moins les metadata ne sont pas mises à jour avec le status du scan + la date du scan.
Je soupçonne que le scan n'ai jamais lieu lorsque la méthode `analyze?` renvoit vrai, ce qui peut arriver si la valeur `pending` a été sauvegardée avant que le scan ne soit lancé.
L'hypothèse du scan qui ne se lance jamais est également confirmée par le fait qu'on a jamais d'erreurs de l'antivirus, et que les PJ bloquées en prod n'ont pas de date de scan (`scanned_at`)
Je n'ai pas reproduit le bug chez moi :( mais si ce fix n'améliore pas la situation, il ne la dégradera pas plus.