### PR TITLE
Fix irb_context in rails console

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,7 +101,7 @@ group :development, :test do
   gem 'mina', git: 'https://github.com/mina-deploy/mina.git', require: false # Deploy
   gem 'pry-byebug'
   gem 'rspec-rails'
-  gem 'rspec_junit_formatter'
+  gem 'rspec_junit_formatter', require: false
   gem 'ruby-debug-ide', require: false
   gem 'spring' # Spring speeds up development by keeping your application running in the background
   gem 'spring-commands-rspec'


### PR DESCRIPTION
Don’t require the `rspec_junit_formatter` gem, it’s only needed when running tests (for circleci).

It messes with the console, when running `rails c` it causes this warning:
```
irb: warn: can't alias context from irb_context
```
This is related to rspec monkey patching a `context` method on `Object` (rspec/rspec-rails#1645)