### PR TITLE
no crash when q is missing on RechercheController::index

### DIFF
--- a/app/services/dossier_search_service.rb
+++ b/app/services/dossier_search_service.rb
@@ -38,7 +38,8 @@ class DossierSearchService
   end
 
   def self.to_tsquery(search_terms)
-    search_terms.strip
+    (search_terms || "")
+      .strip
       .gsub(/['?\\:&|!<>\(\)]/, "") # drop disallowed characters
       .split(/\s+/)           # split words
       .map { |x| "#{x}:*" }   # enable prefix matching

--- a/spec/controllers/gestionnaires/recherche_controller_spec.rb
+++ b/spec/controllers/gestionnaires/recherche_controller_spec.rb
@@ -48,5 +48,16 @@ describe Gestionnaires::RechercheController, type: :controller do
         end
       end
     end
+
+    context 'with no query param it does not crash' do
+      subject { get :index, params: {} }
+
+      it { is_expected.to have_http_status(200) }
+
+      it 'returns 0 dossier' do
+        subject
+        expect(assigns(:dossiers).count).to eq(0)
+      end
+    end
   end
 end


### PR DESCRIPTION
Résoud le problème de "NoMethodErrorGestionnaires::RechercheController#index: undefined method `strip' for nil:NilClass" lorsque q est absent