### PR TITLE
Améliorations de robustesse à la tâche de migration des PR

### DIFF
--- a/app/services/piece_justificative_to_champ_piece_jointe_migration_service.rb
+++ b/app/services/piece_justificative_to_champ_piece_jointe_migration_service.rb
@@ -37,7 +37,7 @@ class PieceJustificativeToChampPieceJointeMigrationService
     procedure.types_de_champ += types_de_champ_pj
 
     # Unscope to make sure all dossiers are migrated, even the soft-deleted ones
-    procedure.dossiers.unscope(where: :hidden_at).find_each do |dossier|
+    procedure.dossiers.unscope(where: :hidden_at).includes(:champs).find_each do |dossier|
       champs_pj = types_de_champ_pj.map(&:build_champ)
       dossier.champs += champs_pj
 

--- a/app/services/piece_justificative_to_champ_piece_jointe_migration_service.rb
+++ b/app/services/piece_justificative_to_champ_piece_jointe_migration_service.rb
@@ -1,3 +1,5 @@
+require Rails.root.join("lib", "tasks", "task_helper")
+
 class PieceJustificativeToChampPieceJointeMigrationService
   def initialize(**params)
     params.each do |key, value|
@@ -86,6 +88,7 @@ class PieceJustificativeToChampPieceJointeMigrationService
 
     else
       make_empty_blob(pj)
+      rake_puts "Notice: attached file for champ #{champ.id} not found. An empty blob has been attached instead."
     end
 
     # By reloading, we force ActiveStorage to look at the attachment again, and see

--- a/app/services/piece_justificative_to_champ_piece_jointe_migration_service.rb
+++ b/app/services/piece_justificative_to_champ_piece_jointe_migration_service.rb
@@ -64,7 +64,8 @@ class PieceJustificativeToChampPieceJointeMigrationService
         yield if block_given?
       end
     end
-  rescue
+
+  rescue StandardError, SignalException
     # If anything goes wrong, we roll back the migration by destroying the newly created
     # types de champ, champs blobs and attachments.
     types_de_champ_pj.each do |type_champ|
@@ -95,7 +96,7 @@ class PieceJustificativeToChampPieceJointeMigrationService
     # that one exists now. We do this so that, if we need to roll back and destroy the champ,
     # the blob, the attachment and the actual file on OpenStack also get deleted.
     champ.reload
-  rescue
+  rescue StandardError, SignalException
     # Destroy partially attached object that the more general rescue in `populate_champs_pjs!`
     # might not be able to handle.
 

--- a/lib/tasks/task_helper.rb
+++ b/lib/tasks/task_helper.rb
@@ -60,7 +60,7 @@ class ProgressReport
 
   def format_duration(seconds)
     if seconds.finite?
-      Time.zone.at(seconds).strftime('%H:%M:%S')
+      Time.zone.at(seconds).utc.strftime('%H:%M:%S')
     else
       '--:--:--'
     end

--- a/lib/tasks/task_helper.rb
+++ b/lib/tasks/task_helper.rb
@@ -37,6 +37,8 @@ class ProgressReport
     rake_puts
   end
 
+  private
+
   def set_progress(total: nil, count: nil)
     if total.present?
       @total = total

--- a/spec/lib/tasks/task_helper_spec.rb
+++ b/spec/lib/tasks/task_helper_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe ProgressReport, lib: true do
+  context 'when the count pass above 100%' do
+    let(:total) { 2 }
+
+    subject(:progress) { ProgressReport.new(total) }
+
+    it 'doesn’t raise errors' do
+      expect do
+        (total + 2).times { progress.inc }
+        progress.finish
+      end.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
#### PJ migration task

- reduce the number of queries by preloading champs
- print a notice when migrating missing files
- handle signal interrupts
- add comments and notices 

#### Rake task_helper

- fix duration formatting
- mark private methods
- ensure that incrementing above 100% doesn’t raise an error