### PR TITLE
models: fix touch not propagating when using nested attributes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -726,7 +726,7 @@ Rails/HttpStatus:
   Enabled: false
 
 Rails/InverseOf:
-  Enabled: false
+  Enabled: true
 
 Rails/LexicallyScopedActionFilter:
   Enabled: false

--- a/app/models/avis.rb
+++ b/app/models/avis.rb
@@ -1,7 +1,7 @@
 class Avis < ApplicationRecord
   include EmailSanitizableConcern
 
-  belongs_to :dossier, touch: true
+  belongs_to :dossier, inverse_of: :avis, touch: true
   belongs_to :gestionnaire
   belongs_to :claimant, class_name: 'Gestionnaire'
 

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -1,5 +1,5 @@
 class Champ < ApplicationRecord
-  belongs_to :dossier, touch: true
+  belongs_to :dossier, inverse_of: :champs, touch: true
   belongs_to :type_de_champ, inverse_of: :champ
   belongs_to :parent, class_name: 'Champ'
   has_many :commentaires

--- a/app/models/champs/repetition_champ.rb
+++ b/app/models/champs/repetition_champ.rb
@@ -1,5 +1,5 @@
 class Champs::RepetitionChamp < Champ
-  has_many :champs, -> { ordered }, foreign_key: :parent_id, dependent: :destroy
+  has_many :champs, -> { ordered }, foreign_key: :parent_id, inverse_of: :parent, dependent: :destroy
 
   accepts_nested_attributes_for :champs, allow_destroy: true
 

--- a/app/models/commentaire.rb
+++ b/app/models/commentaire.rb
@@ -1,5 +1,5 @@
 class Commentaire < ApplicationRecord
-  belongs_to :dossier, touch: true
+  belongs_to :dossier, inverse_of: :commentaires, touch: true
   belongs_to :piece_justificative
 
   belongs_to :user

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -19,18 +19,18 @@ class Dossier < ApplicationRecord
   has_one :individual, dependent: :destroy
   has_one :attestation, dependent: :destroy
 
-  has_many :pieces_justificatives, dependent: :destroy
+  has_many :pieces_justificatives, inverse_of: :dossier, dependent: :destroy
   has_one_attached :justificatif_motivation
 
-  has_many :champs, -> { root.public_only.ordered }, dependent: :destroy
-  has_many :champs_private, -> { root.private_only.ordered }, class_name: 'Champ', dependent: :destroy
-  has_many :commentaires, dependent: :destroy
+  has_many :champs, -> { root.public_only.ordered }, inverse_of: :dossier, dependent: :destroy
+  has_many :champs_private, -> { root.private_only.ordered }, class_name: 'Champ', inverse_of: :dossier, dependent: :destroy
+  has_many :commentaires, inverse_of: :dossier, dependent: :destroy
   has_many :invites, dependent: :destroy
   has_many :follows, -> { active }
   has_many :previous_follows, -> { inactive }, class_name: 'Follow'
   has_many :followers_gestionnaires, through: :follows, source: :gestionnaire
   has_many :previous_followers_gestionnaires, -> { distinct }, through: :previous_follows, source: :gestionnaire
-  has_many :avis, dependent: :destroy
+  has_many :avis, inverse_of: :dossier, dependent: :destroy
 
   has_many :dossier_operation_logs, dependent: :destroy
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -26,8 +26,8 @@ class Dossier < ApplicationRecord
   has_many :champs_private, -> { root.private_only.ordered }, class_name: 'Champ', inverse_of: :dossier, dependent: :destroy
   has_many :commentaires, inverse_of: :dossier, dependent: :destroy
   has_many :invites, dependent: :destroy
-  has_many :follows, -> { active }
-  has_many :previous_follows, -> { inactive }, class_name: 'Follow'
+  has_many :follows, -> { active }, inverse_of: :dossier
+  has_many :previous_follows, -> { inactive }, class_name: 'Follow', inverse_of: :dossier
   has_many :followers_gestionnaires, through: :follows, source: :gestionnaire
   has_many :previous_followers_gestionnaires, -> { distinct }, through: :previous_follows, source: :gestionnaire
   has_many :avis, inverse_of: :dossier, dependent: :destroy

--- a/app/models/gestionnaire.rb
+++ b/app/models/gestionnaire.rb
@@ -12,12 +12,12 @@ class Gestionnaire < ApplicationRecord
   has_many :assign_to, dependent: :destroy
   has_many :procedures, through: :assign_to
 
-  has_many :assign_to_with_email_notifications, -> { with_email_notifications }, class_name: 'AssignTo'
+  has_many :assign_to_with_email_notifications, -> { with_email_notifications }, class_name: 'AssignTo', inverse_of: :gestionnaire
   has_many :procedures_with_email_notifications, through: :assign_to_with_email_notifications, source: :procedure
 
   has_many :dossiers, -> { state_not_brouillon }, through: :procedures
-  has_many :follows, -> { active }
-  has_many :previous_follows, -> { inactive }, class_name: 'Follow'
+  has_many :follows, -> { active }, inverse_of: :gestionnaire
+  has_many :previous_follows, -> { inactive }, class_name: 'Follow', inverse_of: :gestionnaire
   has_many :followed_dossiers, through: :follows, source: :dossier
   has_many :previously_followed_dossiers, -> { distinct }, through: :previous_follows, source: :dossier
   has_many :avis

--- a/app/models/piece_justificative.rb
+++ b/app/models/piece_justificative.rb
@@ -1,5 +1,5 @@
 class PieceJustificative < ApplicationRecord
-  belongs_to :dossier, touch: true
+  belongs_to :dossier, inverse_of: :pieces_justificatives, touch: true
   belongs_to :type_de_piece_justificative
   has_one :commentaire
 

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -5,9 +5,9 @@ class Procedure < ApplicationRecord
 
   MAX_DUREE_CONSERVATION = 36
 
-  has_many :types_de_piece_justificative, -> { ordered }, dependent: :destroy
-  has_many :types_de_champ, -> { root.public_only.ordered }, dependent: :destroy
-  has_many :types_de_champ_private, -> { root.private_only.ordered }, class_name: 'TypeDeChamp', dependent: :destroy
+  has_many :types_de_piece_justificative, -> { ordered }, inverse_of: :procedure, dependent: :destroy
+  has_many :types_de_champ, -> { root.public_only.ordered }, inverse_of: :procedure, dependent: :destroy
+  has_many :types_de_champ_private, -> { root.private_only.ordered }, class_name: 'TypeDeChamp', inverse_of: :procedure, dependent: :destroy
   has_many :dossiers, dependent: :restrict_with_exception
   has_many :deleted_dossiers, dependent: :destroy
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -32,7 +32,7 @@ class TypeDeChamp < ApplicationRecord
   belongs_to :procedure
 
   belongs_to :parent, class_name: 'TypeDeChamp'
-  has_many :types_de_champ, -> { ordered }, foreign_key: :parent_id, class_name: 'TypeDeChamp', dependent: :destroy
+  has_many :types_de_champ, -> { ordered }, foreign_key: :parent_id, class_name: 'TypeDeChamp', inverse_of: :parent, dependent: :destroy
 
   store_accessor :options, :cadastres, :quartiers_prioritaires, :parcelles_agricoles, :old_pj
   delegate :tags_for_template, to: :dynamic_type

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -127,6 +127,14 @@ FactoryBot.define do
       end
     end
 
+    trait :with_piece_justificative do
+      after(:build) do |procedure, _evaluator|
+        type_de_champ = create(:type_de_champ_piece_justificative)
+        procedure.types_de_champ << type_de_champ
+      end
+    end
+
+    # Deprecated
     trait :with_two_type_de_piece_justificative do
       after(:build) do |procedure, _evaluator|
         rib = create(:type_de_piece_justificative, :rib, order_place: 1)


### PR DESCRIPTION
Sometimes, when using nested attributes, touch doesn’t propagate to parent relationships. (see https://github.com/rails/rails/issues/26726)

Specifically, this happens in our app when updating a dossier with only new attachements (but without changing the value of any fields).

To work around this, we need to define the parent relationship explicitely. This is good practice anyway.

Fix #3906

**Dependant on:**

- [x] #3935