### PR TITLE
Amélioration de la fiabilité des tests de feature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,11 @@ jobs:
           command: bundle exec rake db:create db:schema:load db:migrate RAILS_ENV=test
       - run:
           environment:
+            RAILS_ENV: test
+          name: Precompile Webpack assets
+          command: bin/webpack
+      - run:
+          environment:
             DATABASE_URL: "postgres://tps_test@localhost:5432/tps_test"
           name: Run Tests, Splitted by Timings
           command: |

--- a/spec/features/new_administrateur/types_de_champ_spec.rb
+++ b/spec/features/new_administrateur/types_de_champ_spec.rb
@@ -121,14 +121,14 @@ feature 'As an administrateur I can edit types de champ', js: true do
 
   it "Add carte champ" do
     select('Carte', from: 'champ-0-type_champ')
-    fill_in 'champ-0-libelle', with: 'libellé de champ carte'
+    fill_in 'champ-0-libelle', with: 'Libellé de champ carte', fill_options: { clear: :backspace }
     blur
     check 'Quartiers prioritaires'
     expect(page).to have_content('Formulaire enregistré')
 
     preview_window = window_opened_by { click_on 'Prévisualiser le formulaire' }
     within_window(preview_window) do
-      expect(page).to have_content('libellé de champ carte')
+      expect(page).to have_content('Libellé de champ carte')
       expect(page).to have_content('Quartiers prioritaires')
       expect(page).not_to have_content('Cadastres')
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,7 +40,7 @@ end
 
 Capybara.register_driver :headless_chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: ['headless', 'disable-gpu', 'disable-dev-shm-usage', 'disable-software-rasterizer', 'mute-audio', 'window-size=1440,900'] }
+    chromeOptions: { args: ['headless', 'disable-dev-shm-usage', 'disable-software-rasterizer', 'mute-audio', 'window-size=1440,900'] }
   )
 
   Capybara::Selenium::Driver.new app,


### PR DESCRIPTION
## specs: remove 'disable-gpu' from chromedriver options

This option as only ever needed on Windows [1] (which we don't use),
and it shouldn't be required anymore, as the underlying bug has been
fixed [2].

- [1] https://developers.google.com/web/updates/2017/04/headless-chrome
- [2] https://bugs.chromium.org/p/chromium/issues/detail?id=737678

## specs: precompile Webpack assets before running the specs suite

This avoids the first feature spec stalling for a few dozens of seconds
because Webpack assets are compiling (and thus reduce the risk of the
spec timing out).

Pre-compilation takes ~ 10s.

## specs: clear the React champ before adding a new value

This is purely cosmetic: it prevents the value from being `Nouveau champ TexteLibellé de champ carte`.