### PR TITLE
Améliore la rapidité et la fiabilité des tests d'intégration

### DIFF
--- a/spec/features/users/brouillon_spec.rb
+++ b/spec/features/users/brouillon_spec.rb
@@ -14,7 +14,7 @@ feature 'The user' do
     allow(Champs::RegionChamp).to receive(:regions).and_return(['region1', 'region2']).at_least(:once)
     allow(Champs::DepartementChamp).to receive(:departements).and_return(['dep1', 'dep2']).at_least(:once)
 
-    log_in(user.email, password, procedure)
+    log_in(user, procedure)
 
     fill_individual
 
@@ -93,7 +93,7 @@ feature 'The user' do
   end
 
   scenario 'fill a dossier with repetition', js: true do
-    log_in(user.email, password, procedure_with_repetition)
+    log_in(user, procedure_with_repetition)
 
     fill_individual
 
@@ -127,7 +127,7 @@ feature 'The user' do
   end
 
   scenario 'save an incomplete dossier as draft but cannot not submit it', js: true do
-    log_in(user.email, password, simple_procedure)
+    log_in(user, simple_procedure)
     fill_individual
 
     # Check an incomplete dossier can be saved as a draft, even when mandatory fields are missing
@@ -156,7 +156,7 @@ feature 'The user' do
   end
 
   scenario 'adding, replacing and removing attachments', js: true do
-    log_in(user.email, password, procedure_with_pj)
+    log_in(user, procedure_with_pj)
     fill_individual
 
     # Add an attachment
@@ -194,14 +194,10 @@ feature 'The user' do
 
   private
 
-  def log_in(email, password, procedure)
+  def log_in(user, procedure)
+    login_as user, scope: :user
+
     visit "/commencer/#{procedure.path}"
-    click_on 'J’ai déjà un compte'
-
-    expect(page).to have_current_path(new_user_session_path)
-    sign_in_with(email, password)
-
-    expect(page).to have_current_path("/commencer/#{procedure.path}")
     click_on 'Commencer la démarche'
 
     expect(page).to have_content("Données d'identité")

--- a/spec/features/users/brouillon_spec.rb
+++ b/spec/features/users/brouillon_spec.rb
@@ -75,11 +75,11 @@ feature 'The user' do
     expect(page).to have_field('email', with: 'loulou@yopmail.com')
     expect(page).to have_field('phone', with: '1234567890')
     expect(page).to have_checked_field('Non')
-    expect(page).to have_select('simple_drop_down_list', selected: 'val2')
-    expect(page).to have_select('multiple_drop_down_list', selected: ['val1', 'val3'])
-    expect(page).to have_select('pays', selected: 'AUSTRALIE')
-    expect(page).to have_select('regions', selected: 'region2')
-    expect(page).to have_select('departement', selected: 'dep2')
+    expect(page).to have_selected_value('simple_drop_down_list', selected: 'val2')
+    expect(page).to have_selected_value('multiple_drop_down_list', selected: ['val1', 'val3'])
+    expect(page).to have_selected_value('pays', selected: 'AUSTRALIE')
+    expect(page).to have_selected_value('regions', selected: 'region2')
+    expect(page).to have_selected_value('departement', selected: 'dep2')
     expect(page).to have_checked_field('engagement')
     expect(page).to have_field('dossier_link', with: '123')
     expect(page).to have_text('file.pdf')
@@ -229,10 +229,10 @@ feature 'The user' do
   end
 
   def check_date_and_time(date, field)
-    expect(page).to have_select("#{field}_1i", selected: date.strftime('%Y'))
-    expect(page).to have_select("#{field}_2i", selected: I18n.l(date, format: '%B'))
-    expect(page).to have_select("#{field}_3i", selected: date.strftime('%-d'))
-    expect(page).to have_select("#{field}_4i", selected: date.strftime('%H'))
-    expect(page).to have_select("#{field}_5i", selected: date.strftime('%M'))
+    expect(page).to have_selected_value("#{field}_1i", selected: date.strftime('%Y'))
+    expect(page).to have_selected_value("#{field}_2i", selected: I18n.l(date, format: '%B'))
+    expect(page).to have_selected_value("#{field}_3i", selected: date.strftime('%-d'))
+    expect(page).to have_selected_value("#{field}_4i", selected: date.strftime('%H'))
+    expect(page).to have_selected_value("#{field}_5i", selected: date.strftime('%M'))
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -167,4 +167,22 @@ RSpec.configure do |config|
       actual.attributes.with_indifferent_access.except(*ignored) == expected.attributes.with_indifferent_access.except(*ignored)
     end
   end
+
+  # Asserts that a given select element exists in the page,
+  # and that the option(s) with the given value(s) are selected.
+  #
+  # Usage: expect(page).to have_selected_value('Country', selected: 'Australia')
+  #
+  # For large lists, this is much faster than `have_select(location, selected: value)`,
+  # as it doesn’t check that every other options are not selected.
+  RSpec::Matchers.define(:have_selected_value) do |select_locator, options|
+    match do |page|
+      values = options[:selected].is_a?(String) ? [options[:selected]] : options[:selected]
+
+      select_element = page.first(:select, select_locator)
+      select_element && values.all? do |value|
+        select_element.first(:option, value).selected?
+      end
+    end
+  end
 end


### PR DESCRIPTION
Les tests d'intégration des brouillons (`features/user/brouillon_spec.rb`) sont en ce moment instables.

À priori il y a deux raisons :

1. Le test principal qui remplit tous les champs est lent ;
2. Le chargement des cartes peut faire timeouter le test (#3913).

Cette PR corrige le 1er point :

- La séquence de login est plus rapide ;
- La vérification que les bonnes valeurs sont sélectionnées dans les menus déroulants est plus rapide.

Ça permet d'aider le test à passer sous la barre du timeout en condition normales (mais ça n'aidera pas dans le cas où la carto bloque).