### PR TITLE
carte: disable tiles layer during tests

### DIFF
--- a/app/javascript/shared/carte.js
+++ b/app/javascript/shared/carte.js
@@ -13,10 +13,13 @@ export function initMap(element, position, editable = false) {
       scrollWheelZoom: false
     }).setView([position.lat, position.lon], editable ? 18 : position.zoom);
 
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      attribution:
-        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-    }).addTo(map);
+    const loadTilesLayer = process.env.RAILS_ENV != 'test';
+    if (loadTilesLayer) {
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution:
+          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+      }).addTo(map);
+    }
 
     if (editable) {
       const freeDraw = new FreeDraw({


### PR DESCRIPTION
During integration tests, we don't want to load the tiles from OSM:

- It hits OSM servers during every test run;
- It it slow (Capybara waits for the tiles to be loaded to proceed);
- It makes test time out when tiles cannot be loaded for some reason.

Fix #3913