### PR TITLE
stylesheets: fix font of dropdown items on Firefox

### DIFF
--- a/app/assets/stylesheets/new_design/_typography.scss
+++ b/app/assets/stylesheets/new_design/_typography.scss
@@ -1,6 +1,6 @@
 @import "colors";
 
 %new-type {
-  font-family: "Muli";
+  font-family: "Muli", system-ui, -apple-system, sans-serif;
   color: $black;
 }


### PR DESCRIPTION
Styling `<select>` elements is notoriously hard. Here, it seems that Firefox doesn't handle custom fonts on `<option>` elements. As we have no fallback font, the browser uses its default font, Times.

Having fallback fonts is good practice anyway.

## Before

<img width="553" alt="Capture d’écran 2019-06-03 à 18 09 37" src="https://user-images.githubusercontent.com/179923/58816956-df9f0580-862a-11e9-8260-362eb2ae6bd2.png">

## After

<img width="544" alt="Capture d’écran 2019-06-03 à 18 06 38" src="https://user-images.githubusercontent.com/179923/58816965-e3cb2300-862a-11e9-92d3-5f055e3fba50.png">
