### PR TITLE
🚒 Corrige les notifications Instructeur sur les dossiers migrés avant-hier

### DIFF
--- a/lib/tasks/2019_06_06_fix_timestamps_of_migrated_dossiers.rake
+++ b/lib/tasks/2019_06_06_fix_timestamps_of_migrated_dossiers.rake
@@ -1,0 +1,19 @@
+require Rails.root.join("lib", "tasks", "task_helper")
+
+namespace :fix_timestamps_of_migrated_dossiers do
+  desc 'Fix the timestamps of dossiers affected by the faulty PJ migration'
+  task run: :environment do
+    affected_time_range = Time.utc(2019, 6, 4, 8, 0)..Time.utc(2019, 6, 4, 18, 0)
+    dossiers = Dossier.unscoped.where(procedure_id: 0..1000).where(updated_at: affected_time_range)
+
+    progress = ProgressReport.new(dossiers.count)
+
+    dossiers.find_each do |dossier|
+      fixed_updated_at = dossier.processed_at || dossier.en_instruction_at || dossier.en_construction_at || dossier.champs.last.updated_at || nil
+      dossier.update_column(:updated_at, fixed_updated_at)
+
+      progress.inc
+    end
+    progress.finish
+  end
+end

--- a/spec/lib/tasks/2019_06_06_fix_timestamps_of_migrated_dossiers_spec.rb
+++ b/spec/lib/tasks/2019_06_06_fix_timestamps_of_migrated_dossiers_spec.rb
@@ -1,0 +1,48 @@
+describe '2019_06_06_fix_timestamps_of_migrated_dossiers' do
+  let(:affected_procedure) { create(:simple_procedure, id: 500) }
+  let(:procedure_outside_range) { create(:simple_procedure, id: 5000) }
+
+  let(:affected_dossier) { create(:dossier, procedure: affected_procedure) }
+  let(:dossier_outside_time_range) { create(:dossier, procedure: affected_procedure) }
+  let(:dossier_outside_procedure_range) { create(:dossier, procedure: procedure_outside_range) }
+
+  let(:creation_time) { Time.utc(2017, 1, 1, 12, 0) }
+  let(:en_construction_time) { Time.utc(2018, 1, 1, 12, 0) }
+  let(:pj_migration_time) { Time.utc(2019, 6, 4, 12, 0) }
+
+  let(:rake_task) { Rake::Task['fix_timestamps_of_migrated_dossiers:run'] }
+
+  before do
+    Timecop.freeze(creation_time) do
+      affected_dossier
+      dossier_outside_time_range
+      dossier_outside_procedure_range
+    end
+    Timecop.freeze(en_construction_time) do
+      affected_dossier.update_column(:en_construction_at, Time.zone.now)
+    end
+    Timecop.freeze(pj_migration_time.prev_week) do
+      dossier_outside_time_range.tap(&:touch).reload
+    end
+    Timecop.freeze(pj_migration_time) do
+      dossier_outside_procedure_range.tap(&:touch).reload
+      affected_dossier.tap(&:touch).reload
+    end
+
+    rake_task.invoke
+  end
+
+  after { rake_task.reenable }
+
+  it 'fix the updated_at of affected dossiers' do
+    expect(affected_dossier.reload.updated_at).to eq(en_construction_time)
+  end
+
+  it 'ignores dossiers with a procedure_id outside of the procedure range' do
+    expect(dossier_outside_procedure_range.reload.updated_at).to eq(pj_migration_time)
+  end
+
+  it 'ignores dossiers with an updated_at outside of the time range' do
+    expect(dossier_outside_time_range.reload.updated_at).to eq(pj_migration_time.prev_week)
+  end
+end


### PR DESCRIPTION
When running the PJ migration task on procedures 0..1000 in production, migrated dossiers had their `updated_at` attribute modified.

This means a yellow notification badge pops up on the Instructeurs pages.

This PR repairs the affected dossiers, by restoring an approximative updated_at from the latest workflow value (or the timestamp of the migrated champ).