### PR TITLE
Clear the “add admin” field after submit

### DIFF
--- a/app/views/new_administrateur/procedure_administrateurs/_add_admin_form.html.haml
+++ b/app/views/new_administrateur/procedure_administrateurs/_add_admin_form.html.haml
@@ -1,0 +1,9 @@
+= form_for procedure.administrateurs.new,
+  url: { controller: 'procedure_administrateurs' },
+  html: { class: 'form', id:  "procedure-#{procedure.id}-new_administrateur" } ,
+  remote: true do |f|
+  = f.label :email do
+    Ajouter un administrateur
+    %span.notice= "Renseignez l’email d’un administrateur déjà enregistré sur demarches-simplifiees.fr pour lui permettre de modifier « #{procedure.libelle} »."
+  = f.email_field :email, placeholder: 'marie.dupont@exemple.fr', required: true
+  = f.submit 'Ajouter comme administrateur', class: 'button primary send'

--- a/app/views/new_administrateur/procedure_administrateurs/create.js.haml
+++ b/app/views/new_administrateur/procedure_administrateurs/create.js.haml
@@ -3,4 +3,7 @@
   = append_to_element("#procedure-#{@procedure.id}-administrateurs",
     partial: 'administrateur',
     locals: { administrateur: @administrateur })
-  document.getElementById('procedure-#{@procedure.id}-new_administrateur').reset()
+  = render_to_element("#procedure-#{@procedure.id}-new_administrateur",
+    partial: 'add_admin_form',
+    outer: true,
+    locals: { procedure: @procedure })

--- a/app/views/new_administrateur/procedure_administrateurs/index.html.haml
+++ b/app/views/new_administrateur/procedure_administrateurs/index.html.haml
@@ -15,12 +15,4 @@
     %tfoot
       %tr
         %th{ colspan: 4 }
-          = form_for @procedure.administrateurs.new,
-            url: { controller: 'procedure_administrateurs' },
-            html: { class: 'form', id:  "procedure-#{@procedure.id}-new_administrateur" } ,
-            remote: true do |f|
-            = f.label :email do
-              Ajouter un administrateur
-              %span.notice= "Renseignez l’email d’un administrateur déjà enregistré sur demarches-simplifiees.fr pour lui permettre de modifier « #{@procedure.libelle} »."
-            = f.email_field :email, placeholder: 'marie.dupont@exemple.fr', required: true
-            = f.submit 'Ajouter comme administrateur', class: 'button primary send'
+          = render 'add_admin_form', procedure: @procedure


### PR DESCRIPTION
Extract the add_admin form to its own partial and re-render it when an admin is successfully added.

This is #3845, done according to discussion.