### PR TITLE
Corrige la tâche de migration des PJ

### DIFF
--- a/app/services/piece_justificative_to_champ_piece_jointe_migration_service.rb
+++ b/app/services/piece_justificative_to_champ_piece_jointe_migration_service.rb
@@ -25,9 +25,16 @@ class PieceJustificativeToChampPieceJointeMigrationService
     populate_champs_pjs!(procedure, types_de_champ_pj, &progress)
 
     # Only destroy the old types PJ once everything has been safely migrated to
-    # champs PJs. Destroying the types PJ will cascade and destroy the PJs,
-    # and delete the linked objects from remote storage. This means that no other
-    # cleanup action is required.
+    # champs PJs.
+
+    # First destroy the individual PJ champs on all dossiers.
+    # It will cascade and destroy the PJs, and delete the linked objects from remote storage.
+    procedure.dossiers.unscope(where: :hidden_at).includes(:champs).find_each do |dossier|
+      destroy_pieces_justificatives(dossier)
+    end
+
+    # Now we can destroy the type de champ themselves,
+    # without cascading the timestamp update on all attached dossiers.
     procedure.types_de_piece_justificative.destroy_all
   end
 
@@ -49,8 +56,11 @@ class PieceJustificativeToChampPieceJointeMigrationService
     rake_puts "Error received. Rolling back migration of procedure #{procedure.id}…"
 
     types_de_champ_pj.each do |type_champ|
-      type_champ.champ.each { |c| c.piece_justificative_file.purge }
-      type_champ.destroy
+      # First destroy all the individual champs on dossiers
+      type_champ.champ.each { |c| destroy_champ_pj(c.dossier.reload, c) }
+      # Now we can destroy the type de champ itself,
+      # without cascading the timestamp update on all attached dossiers.
+      type_champ.reload.destroy
     end
 
     rake_puts "Migration of procedure #{procedure.id} rolled back."
@@ -62,7 +72,9 @@ class PieceJustificativeToChampPieceJointeMigrationService
   def migrate_dossier!(dossier, types_de_champ_pj)
     # Add the new pieces justificatives champs to the dossier
     champs_pj = types_de_champ_pj.map(&:build_champ)
-    dossier.champs += champs_pj
+    preserving_updated_at(dossier) do
+      dossier.champs += champs_pj
+    end
 
     # Copy the dossier old pieces jointes to the new champs
     # (even if the champs already existed, so that we ensure a clean state)
@@ -71,7 +83,9 @@ class PieceJustificativeToChampPieceJointeMigrationService
       pj = dossier.retrieve_last_piece_justificative_by_type(type_pj_id)
 
       if pj.present?
-        convert_pj_to_champ!(pj, champ)
+        preserving_updated_at(dossier) do
+          convert_pj_to_champ!(pj, champ)
+        end
 
         champ.update_columns(
           updated_at: pj.updated_at,
@@ -136,5 +150,27 @@ class PieceJustificativeToChampPieceJointeMigrationService
 
   def make_empty_blob(pj)
     storage_service.make_empty_blob(pj.content, pj.updated_at.iso8601, filename: pj.original_filename)
+  end
+
+  def preserving_updated_at(model)
+    original_modification_date = model.updated_at
+    begin
+      yield
+    ensure
+      model.update_column(:updated_at, original_modification_date)
+    end
+  end
+
+  def destroy_pieces_justificatives(dossier)
+    preserving_updated_at(dossier) do
+      dossier.pieces_justificatives.destroy_all
+    end
+  end
+
+  def destroy_champ_pj(dossier, champ)
+    preserving_updated_at(dossier) do
+      champ.piece_justificative_file.purge
+      champ.destroy
+    end
   end
 end


### PR DESCRIPTION
Aujourd'hui la tâche de migration des pièces jointes modifie le `Dossier#updated_at` des dossiers concernés.

Concrètement, ça veut dire que les Instructeurs voient une pastille orange de notification apparaitre sur tous les dossiers migrés, même les plus anciens.

Cette PR fait en sorte que le `Dossier#updated_at` ne change pas pendant la migration – même en cas de rollback.

## Implémentation

Les `Dossier#updated_at` sont essentiellement modifiés automagiquement par des relations `belongs_to :dossier, touch: true` sur des éléments enfants (champs, etc). Et dans Rails, il n'y a pas moyen de dire à un `save` sur un modèle de ne pas toucher les relations parentes.

À la place, on wrappe donc toutes les opérations sur des dossiers dans un :

```
preserving_updated_at(dossier) do
  # do the stuff
end
```

Le helper `preserving_updated_at` lit la date, effectue l'opération, et restore le `updated_at` initial. Et ça marche aussi si une exception est levée pendant le traitement.

Ce wrapper est ajouté autour des opérations :

- de création de champ,
- de suppression du champ précédent (en cas de succès),
- de suppression du nouveau champ (en cas de rollback).

C'est moche. On est obligé de faire ça à cause des `updated_at` automagiques de Rails ; comme quoi y'a du pour et du contre. Mais ça fonctionne bien. Et c'est testé à donf.