### PR TITLE
api_entreprise: display better error message when SIRET is private

### DIFF
--- a/app/lib/api_entreprise/api.rb
+++ b/app/lib/api_entreprise/api.rb
@@ -34,7 +34,7 @@ class ApiEntreprise::API
 
     if response.success?
       JSON.parse(response.body, symbolize_names: true)
-    elsif response.code == 404 || response.code == 422
+    elsif response.code&.between?(401, 499)
       raise RestClient::ResourceNotFound
     else
       raise RestClient::RequestFailed

--- a/spec/fixtures/files/api_entreprise/entreprises_private.json
+++ b/spec/fixtures/files/api_entreprise/entreprises_private.json
@@ -1,0 +1,6 @@
+{
+  "errors": [
+    "Le SIREN ou SIRET est non diffusable"
+  ],
+  "gateway_error": true
+}

--- a/spec/lib/api_entreprise/api_spec.rb
+++ b/spec/lib/api_entreprise/api_spec.rb
@@ -31,7 +31,17 @@ describe ApiEntreprise::API do
       end
     end
 
-    context 'when siret exist' do
+    context 'when siren infos are private' do
+      let(:siren) { '111111111' }
+      let(:status) { 403 }
+      let(:body) { File.read('spec/fixtures/files/api_entreprise/entreprises_private.json') }
+
+      it 'raises RestClient::ResourceNotFound' do
+        expect { subject }.to raise_error(RestClient::ResourceNotFound)
+      end
+    end
+
+    context 'when siren exist' do
       let(:siren) { '418166096' }
       let(:status) { 200 }
       let(:body) { File.read('spec/fixtures/files/api_entreprise/entreprises.json') }


### PR DESCRIPTION
Quand les infos d'une entreprise associée à un SIRET sont privées, on affiche en ce moment un message

> Erreur réseau, réessayez plus tard.

Maintenant, on affiche à la place un message d'erreur :

> Désolé, nous n’avons pas trouvé d’établissement enregistré correspondant à ce numéro SIRET.

Ce n'est pas encore l'idéal – mais ça évite de laisser les gens croire que c'est un pépin temporaire.

`HS #17845`

@Keirua tu en penses quoi ?