### PR TITLE
Brouillon : clarifie les explications sur l'enregistrement et la reprise

### DIFF
--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -11,10 +11,12 @@
   = form_for dossier, form_options do |f|
 
     .prologue
-      .mandatory-explanation
+      %p.mandatory-explanation
         Les champs avec un astérisque (
         %span.mandatory> *
-        ) sont obligatoires. Pour enregistrer les informations saisies, cliquez sur le bouton « enregistrer le brouillon » en bas à gauche du formulaire.
+        ) sont obligatoires.
+      %p.mandatory-explanation
+        Pour enregistrer votre dossier et le reprendre plus tard, cliquez sur le bouton « Enregistrer le brouillon » en bas à gauche du formulaire.
 
       - if notice_url(dossier.procedure).present?
         = link_to notice_url(dossier.procedure), target: '_blank', rel: 'noopener', class: 'button notice', title: "Pour vous aider à remplir votre dossier, vous pouvez consulter le guide de cette démarche." do


### PR DESCRIPTION
Petite amélioration à la formulation :

- On saute une ligne ;
- On explique le cas d'usage ("reprendre plus tard").

## Avant

<img width="1110" alt="Capture d’écran 2019-06-13 à 11 22 00" src="https://user-images.githubusercontent.com/179923/59420725-ae15ff00-8dcd-11e9-9701-3d350d9c883f.png">

## Après

<img width="1108" alt="Capture d’écran 2019-06-13 à 11 21 17" src="https://user-images.githubusercontent.com/179923/59420772-c0903880-8dcd-11e9-8755-b5af194aee62.png">
