### PR TITLE
champs: show attachment actions only when the attachment is persisted

### DIFF
--- a/app/views/shared/attachment/_update.html.haml
+++ b/app/views/shared/attachment/_update.html.haml
@@ -5,8 +5,10 @@
       = link_to('le modèle suivant', url_for(template), target: '_blank', rel: 'noopener')
 
   - attachment_id = attachment ? attachment.id : SecureRandom.uuid
+  - persisted = attachment && attachment.persisted?
   - user_can_destroy = defined?(user_can_destroy) ? user_can_destroy : false
-  - if attachment
+
+  - if persisted
     .piece-justificative-actions{ id: "piece_justificative_#{attachment_id}" }
       .piece-justificative-action
         = render partial: "shared/attachment/show", locals: { attachment: attachment, user_can_upload: true }
@@ -18,5 +20,5 @@
 
   = form.file_field :piece_justificative_file,
     id: "piece_justificative_file_#{attachment_id}",
-    class: "piece-justificative-input #{'hidden' if attachment}",
+    class: "piece-justificative-input #{'hidden' if persisted}",
     direct_upload: true

--- a/spec/factories/champ.rb
+++ b/spec/factories/champ.rb
@@ -147,7 +147,7 @@ FactoryBot.define do
   factory :champ_piece_justificative, class: 'Champs::PieceJustificativeChamp' do
     type_de_champ { create(:type_de_champ_piece_justificative) }
 
-    after(:create) do |champ, _evaluator|
+    after(:build) do |champ, _evaluator|
       champ.piece_justificative_file.attach(io: StringIO.new("toto"), filename: "toto.txt", content_type: "text/plain")
     end
   end

--- a/spec/views/shared/attachment/_update.html.haml_spec.rb
+++ b/spec/views/shared/attachment/_update.html.haml_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+describe 'shared/attachment/_update.html.haml', type: :view do
+  let(:champ) { build(:champ_piece_justificative, dossier: create(:dossier)) }
+  let(:attachment) { nil }
+  let(:virus_scan_result) { nil }
+  let(:user_can_destroy) { false }
+
+  subject do
+    form_for(champ.dossier) do |form|
+      render 'shared/attachment/update', {
+        attachment: attachment,
+        user_can_destroy: user_can_destroy,
+        form: form
+      }
+    end
+  end
+
+  it 'renders a form field for uploading a file' do
+    expect(subject).to have_selector('input[type=file]:not(.hidden)')
+  end
+
+  context 'when there is a attached file' do
+    let(:attachment) { champ.piece_justificative_file.attachment }
+
+    it 'renders a form field for uploading a file' do
+      expect(subject).to have_selector('input[type=file]:not(.hidden)')
+    end
+
+    it 'does not renders a link to the unsaved file' do
+      expect(subject).not_to have_content(attachment.filename.to_s)
+    end
+
+    it 'doesn’t render action buttons' do
+      expect(subject).not_to have_link('Remplacer')
+      expect(subject).not_to have_link('Supprimer')
+    end
+
+    context 'and the attachment has been saved' do
+      before { champ.save! }
+
+      it 'renders a link to the file' do
+        expect(subject).to have_content(attachment.filename.to_s)
+      end
+
+      it 'renders action buttons' do
+        expect(subject).to have_button('Remplacer')
+      end
+
+      it 'hides the form field by default' do
+        expect(subject).to have_selector('input[type=file].hidden')
+      end
+
+      it 'hides the Delete button by default' do
+        is_expected.not_to have_link('Supprimer')
+      end
+
+      context 'and the user can delete the attachment' do
+        let(:user_can_destroy) { true }
+
+        it { is_expected.to have_link('Supprimer') }
+      end
+    end
+  end
+end


### PR DESCRIPTION
En ce moment, si on sauvegarde un brouillon mais qu'on échoue à cause d'une erreur de validation, on essaie quand même de présenter les contrôles pour modifier la pièce jointe nouvellement uploadée.

Comme la pièce jointe n'a pas été enregistrée (et n'a donc pas d'id), ça déclenche une exception.

Cette PR fait en sorte de ne montrer les contrôles de modification que si la PJ a réellement été sauvegardée.

Fix #3961