### PR TITLE
Do not check for path availability when in the “new procedure” form

### DIFF
--- a/app/views/admin/procedures/new.html.haml
+++ b/app/views/admin/procedures/new.html.haml
@@ -6,7 +6,4 @@
     = form_for @procedure, url: { controller: 'admin/procedures', action: :create }, multipart: true do |f|
       = render partial: 'informations', locals: { f: f }
       .text-right
-        - if @availability.in?(Procedure::PATH_CAN_PUBLISH)
-          = f.button 'Valider', class: 'btn btn-info', id: 'save-procedure'
-        - else
-          = f.button 'Valider', class: 'btn btn-info', id: 'save-procedure', disabled: true
+        = f.button 'Valider', class: 'btn btn-info', id: 'save-procedure'


### PR DESCRIPTION
The user can’t even enter the path here, it’s nil.

fixes #3918

The `@availability` was always `PATH_NOT_AVAILABLE` when the form was reloaded after an error, because `Procedure::path_availability` always found an (archived) procedure with a `nil` path. It got confused and concluded its path was conflicting.

🤷🏻‍♂️