### PR TITLE
Fix belongs_to default scope

### DIFF
--- a/app/models/attestation.rb
+++ b/app/models/attestation.rb
@@ -1,5 +1,5 @@
 class Attestation < ApplicationRecord
-  belongs_to :dossier
+  belongs_to :dossier, -> { unscope(where: :hidden_at) }
 
   mount_uploader :pdf, AttestationUploader
 end

--- a/app/models/avis.rb
+++ b/app/models/avis.rb
@@ -1,7 +1,7 @@
 class Avis < ApplicationRecord
   include EmailSanitizableConcern
 
-  belongs_to :dossier, inverse_of: :avis, touch: true
+  belongs_to :dossier, -> { unscope(where: :hidden_at) }, inverse_of: :avis, touch: true
   belongs_to :gestionnaire
   belongs_to :claimant, class_name: 'Gestionnaire'
 

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -1,5 +1,5 @@
 class Champ < ApplicationRecord
-  belongs_to :dossier, inverse_of: :champs, touch: true
+  belongs_to :dossier, -> { unscope(where: :hidden_at) }, inverse_of: :champs, touch: true
   belongs_to :type_de_champ, inverse_of: :champ
   belongs_to :parent, class_name: 'Champ'
   has_many :commentaires

--- a/app/models/commentaire.rb
+++ b/app/models/commentaire.rb
@@ -1,5 +1,5 @@
 class Commentaire < ApplicationRecord
-  belongs_to :dossier, inverse_of: :commentaires, touch: true
+  belongs_to :dossier, -> { unscope(where: :hidden_at) }, inverse_of: :commentaires, touch: true
   belongs_to :piece_justificative
 
   belongs_to :user

--- a/app/models/dossier_operation_log.rb
+++ b/app/models/dossier_operation_log.rb
@@ -10,7 +10,7 @@ class DossierOperationLog < ApplicationRecord
     demander_un_avis: 'demander_un_avis'
   }
 
-  belongs_to :dossier
+  belongs_to :dossier, -> { unscope(where: :hidden_at) }
   has_one_attached :serialized
   belongs_to :bill_signature, optional: true
 

--- a/app/models/etablissement.rb
+++ b/app/models/etablissement.rb
@@ -1,5 +1,5 @@
 class Etablissement < ApplicationRecord
-  belongs_to :dossier
+  belongs_to :dossier, -> { unscope(where: :hidden_at) }
 
   has_one :champ, class_name: 'Champs::SiretChamp'
   has_many :exercices, dependent: :destroy

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -1,6 +1,6 @@
 class Follow < ApplicationRecord
   belongs_to :gestionnaire
-  belongs_to :dossier
+  belongs_to :dossier, -> { unscope(where: :hidden_at) }
 
   validates :gestionnaire_id, uniqueness: { scope: [:dossier_id, :unfollowed_at] }
 

--- a/app/models/individual.rb
+++ b/app/models/individual.rb
@@ -1,5 +1,5 @@
 class Individual < ApplicationRecord
-  belongs_to :dossier
+  belongs_to :dossier, -> { unscope(where: :hidden_at) }
 
   validates :dossier_id, uniqueness: true
   validates :gender, presence: true, allow_nil: false, on: :update

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -1,7 +1,7 @@
 class Invite < ApplicationRecord
   include EmailSanitizableConcern
 
-  belongs_to :dossier
+  belongs_to :dossier, -> { unscope(where: :hidden_at) }
   belongs_to :user
 
   before_validation -> { sanitize_email(:email) }

--- a/app/models/piece_justificative.rb
+++ b/app/models/piece_justificative.rb
@@ -1,5 +1,5 @@
 class PieceJustificative < ApplicationRecord
-  belongs_to :dossier, inverse_of: :pieces_justificatives, touch: true
+  belongs_to :dossier, -> { unscope(where: :hidden_at) }, inverse_of: :pieces_justificatives, touch: true
   belongs_to :type_de_piece_justificative
   has_one :commentaire
 

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -39,6 +39,10 @@ FactoryBot.define do
       archived { false }
     end
 
+    trait :hidden do
+      hidden_at { Time.zone.now }
+    end
+
     trait :with_dossier_link do
       after(:create) do |dossier, _evaluator|
         linked_dossier = create(:dossier)

--- a/spec/models/champ_spec.rb
+++ b/spec/models/champ_spec.rb
@@ -5,6 +5,15 @@ describe Champ do
 
   it_should_behave_like "champ_spec"
 
+  describe 'belongs_to :dossier' do
+    context 'when the parent dossier is hidden' do
+      let(:dossier) { create(:dossier, :hidden, procedure: nil) }
+      let(:champ) { build(:champ, dossier_id: dossier.id) }
+
+      it { expect(champ.dossier).to eq(dossier) }
+    end
+  end
+
   describe '#public?' do
     let(:type_de_champ) { build(:type_de_champ) }
     let(:champ) { type_de_champ.champ.build }

--- a/spec/services/piece_justificative_to_champ_piece_jointe_migration_service_spec.rb
+++ b/spec/services/piece_justificative_to_champ_piece_jointe_migration_service_spec.rb
@@ -265,6 +265,22 @@ describe PieceJustificativeToChampPieceJointeMigrationService do
         .not_to change { ActiveStorage::Attachment.count }
     end
 
+    context 'when some dossiers to roll back are hidden' do
+      before do
+        dossier.update_column(:hidden_at, Time.zone.now)
+      end
+
+      it 'does not create champs' do
+        expect { try_convert(procedure) }
+          .not_to change { dossier.champs.count }
+      end
+
+      it 'does not change the hidden dossier timestamps' do
+        try_convert(procedure)
+        expect(dossier.updated_at).to eq(initial_dossier_timestamps[:updated_at])
+      end
+    end
+
     context 'when receiving a Signal interruption (like Ctrl+C)' do
       let(:exception) { Interrupt }
 


### PR DESCRIPTION
Quand un modèle a un `default_scope`, si un autre modèle fait un `belongs_to :model`, le default_scope est hérité.

Ça veut par exemple dire que si on a un Dossier `hidden_at`, `champ.dossier` va renvoyer `nil`.

Cette PR unscope toutes les relations `belongs_to :dossier`, pour qu'elles renvoient le dossier même s'il est `hidden_at`.

_(Et à long terme, on devrait supprimer le `default_scope`, qui est vraiment trop trompeur.)_