### PR TITLE
Migration des PJ : gestion des erreurs qui peuvent se produire pendant le rollback

### DIFF
--- a/app/services/piece_justificative_to_champ_piece_jointe_migration_service.rb
+++ b/app/services/piece_justificative_to_champ_piece_jointe_migration_service.rb
@@ -54,15 +54,7 @@ class PieceJustificativeToChampPieceJointeMigrationService
     # If anything goes wrong, we roll back the migration by destroying the newly created
     # types de champ, champs blobs and attachments.
     rake_puts "Error received. Rolling back migration of procedure #{procedure.id}…"
-
-    types_de_champ_pj.each do |type_champ|
-      # First destroy all the individual champs on dossiers
-      type_champ.champ.each { |c| destroy_champ_pj(c.dossier.reload, c) }
-      # Now we can destroy the type de champ itself,
-      # without cascading the timestamp update on all attached dossiers.
-      type_champ.reload.destroy
-    end
-
+    rollback_migration!(types_de_champ_pj)
     rake_puts "Migration of procedure #{procedure.id} rolled back."
 
     # Reraise the exception to abort the migration.
@@ -142,6 +134,16 @@ class PieceJustificativeToChampPieceJointeMigrationService
 
     # Reraise the exception to abort the migration.
     raise
+  end
+
+  def rollback_migration!(types_de_champ_pj)
+    types_de_champ_pj.each do |type_champ|
+      # First destroy all the individual champs on dossiers
+      type_champ.champ.each { |c| destroy_champ_pj(c.dossier.reload, c) }
+      # Now we can destroy the type de champ itself,
+      # without cascading the timestamp update on all attached dossiers.
+      type_champ.reload.destroy
+    end
   end
 
   def make_blob(pj)

--- a/app/services/piece_justificative_to_champ_piece_jointe_migration_service.rb
+++ b/app/services/piece_justificative_to_champ_piece_jointe_migration_service.rb
@@ -139,7 +139,14 @@ class PieceJustificativeToChampPieceJointeMigrationService
   def rollback_migration!(types_de_champ_pj)
     types_de_champ_pj.each do |type_champ|
       # First destroy all the individual champs on dossiers
-      type_champ.champ.each { |c| destroy_champ_pj(c.dossier.reload, c) }
+      type_champ.champ.each do |champ|
+        begin
+          destroy_champ_pj(champ.dossier.reload, champ)
+        rescue => e
+          rake_puts e
+          rake_puts "Rolling back of champ #{champ.id} failed. Continuing to roll back…"
+        end
+      end
       # Now we can destroy the type de champ itself,
       # without cascading the timestamp update on all attached dossiers.
       type_champ.reload.destroy

--- a/spec/services/piece_justificative_to_champ_piece_jointe_migration_service_spec.rb
+++ b/spec/services/piece_justificative_to_champ_piece_jointe_migration_service_spec.rb
@@ -276,5 +276,26 @@ describe PieceJustificativeToChampPieceJointeMigrationService do
         expect { try_convert(procedure) }.not_to change { dossier.champs.count }
       end
     end
+
+    context 'when rolling back a dossier fails' do
+      before do
+        allow(service).to receive(:destroy_champ_pj)
+          .with(having_attributes(id: dossier.id), anything)
+          .and_raise(StandardError)
+        allow(service).to receive(:destroy_champ_pj)
+          .with(any_args)
+          .and_call_original
+      end
+
+      it 'continues to roll back the other dossiers' do
+        expect { try_convert(procedure) }
+          .not_to change { failing_dossier.champs.count }
+      end
+
+      it 'does not creates types de champ on the procedure' do
+        expect { try_convert(procedure) }
+          .not_to change { procedure.types_de_champ.count }
+      end
+    end
   end
 end


### PR DESCRIPTION
Quand une erreur se produit lors de la migration des PJ d'une démarche, on rollback toute la démarche (pour que tous les dossiers soient cohérents).

Pour cela, le rollback se fait en deux phases :

1. On supprime les nouveaux champs PJ des dossiers (pour ne laisser que les anciens) ;
2. On supprime les nouveaux types de champs PJ de la démarche (pour ne laisser que les anciens).

En ce moment, si une erreur se produit pendant la suppression d'un champ d'un dossier, tout le rollback est laissé en carafe.

Maintenant, en cas d'erreur, cette PR fait en sorte de logger l'erreur, et de continuer à rollbacker des autres dossiers.