### PR TITLE
Migration PJ : corrige le rollback dans le cas où les dossiers sont cachés

### DIFF
--- a/app/services/piece_justificative_to_champ_piece_jointe_migration_service.rb
+++ b/app/services/piece_justificative_to_champ_piece_jointe_migration_service.rb
@@ -141,7 +141,7 @@ class PieceJustificativeToChampPieceJointeMigrationService
       # First destroy all the individual champs on dossiers
       type_champ.champ.each do |champ|
         begin
-          destroy_champ_pj(champ.dossier.reload, champ)
+          destroy_champ_pj(Dossier.unscope(where: :hidden_at).find(champ.dossier_id), champ)
         rescue => e
           rake_puts e
           rake_puts "Rolling back of champ #{champ.id} failed. Continuing to roll back…"

--- a/spec/services/piece_justificative_to_champ_piece_jointe_migration_service_spec.rb
+++ b/spec/services/piece_justificative_to_champ_piece_jointe_migration_service_spec.rb
@@ -265,6 +265,22 @@ describe PieceJustificativeToChampPieceJointeMigrationService do
         .not_to change { ActiveStorage::Attachment.count }
     end
 
+    context 'when some dossiers to roll back are hidden' do
+      before do
+        dossier.update_column(:hidden_at, Time.zone.now)
+      end
+
+      it 'does not create champs' do
+        expect { try_convert(procedure) }
+          .not_to change { dossier.champs.count }
+      end
+
+      it 'does not change the hidden dossier timestamps' do
+        try_convert(procedure)
+        expect(dossier.updated_at).to eq(initial_dossier_timestamps[:updated_at])
+      end
+    end
+
     context 'when receiving a Signal interruption (like Ctrl+C)' do
       let(:exception) { Interrupt }
 


### PR DESCRIPTION
Quand un modèle a un `default_scope`, si un autre modèle fait un `belongs_to :model`, le default_scope est hérité.

Ça veut par exemple dire que si on a un Dossier `hidden_at`, `champ.dossier` va renvoyer nil.

Cette PR corrige le rollback des dossiers en cas d'erreur de la migration des PJ, pour ne pas échouer si le dossier est hidden.