### PR TITLE
add duplicate rules as fallback

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,10 +6,10 @@ Rails.application.config.content_security_policy do |policy|
     policy.report_uri "http://#{ENV['APP_HOST']}/csp/" # ne pas notifier report-uri en dev/test
   end
   # Whitelist image
-  policy.img_src :self, "*.openstreetmap.org", "static.demarches-simplifiees.fr", "*.cloud.ovh.net", "stats.data.gouv.fr", "*"
+  policy.img_src :self, "*.openstreetmap.org", "static.demarches-simplifiees.fr", "*.cloud.ovh.net", "stats.data.gouv.fr", "*", :data
   # Whitelist JS: nous, sendinblue et matomo
   # miniprofiler et nous avons quelques boutons inline :(
-  policy.script_src :self, "stats.data.gouv.fr", "*.sendinblue.com", :unsafe_eval, :unsafe_inline
+  policy.script_src :self, "stats.data.gouv.fr", "*.sendinblue.com", "*.crisp.chat", "crisp.chat", "*.sibautomation.com", "sibautomation.com", :unsafe_eval, :unsafe_inline, :blob
   # Pour les CSS, on a beaucoup de style inline et quelques balises <style>
   # c'est trop compliqué pour être rectifié immédiatement (et sans valeur ajoutée:
   # c'est hardcodé dans les vues, donc pas injectable).


### PR DESCRIPTION
bien qu'on ai déja ces règles dans `default-src` (qui, de ce que je comprends, est le fallback qu'on les règles ne matchen pas ailleurs), nous avons encore des erreurs sur script-src pour sibautomation, data et (parfois…) crisp

ajout aussi de `blob` parmi les règles

le caractère un peu aléatoir n'aide pas à comprendre la cause de ce genre de bugs, mais cela ne semble pas venire d'un navigateur vu que tout le monde est touché.