### PR TITLE
Disable Messagerie in archived Dossiers and procedures

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -177,7 +177,7 @@ class Dossier < ApplicationRecord
   end
 
   def messagerie_available?
-    !brouillon? && !archived
+    !brouillon? && !archived && !procedure.archivee?
   end
 
   def retention_end_date

--- a/app/services/commentaire_service.rb
+++ b/app/services/commentaire_service.rb
@@ -12,6 +12,9 @@ class CommentaireService
     end
 
     def build_with_email(email, dossier, params)
+      if !dossier.messagerie_available?
+        raise ArgumentError, "Commentaires cannot be added to brouillons or archived Dossiers"
+      end
       attributes = params.merge(email: email, dossier: dossier)
       Commentaire.new(attributes)
     end

--- a/app/views/shared/dossiers/_messagerie.html.haml
+++ b/app/views/shared/dossiers/_messagerie.html.haml
@@ -4,4 +4,7 @@
       %li.message{ class: commentaire_is_from_me_class(commentaire, connected_user) }
         = render partial: "shared/dossiers/messages/message", locals: { commentaire: commentaire, connected_user: connected_user, messagerie_seen_at: messagerie_seen_at }
 
-  = render partial: "shared/dossiers/messages/form", locals: { commentaire: new_commentaire, form_url: form_url }
+  - if dossier.archived?
+    = render partial: "shared/dossiers/messages/messagerie_disabled", locals: { service: dossier.procedure.service }
+  - else
+    = render partial: "shared/dossiers/messages/form", locals: { commentaire: new_commentaire, form_url: form_url }

--- a/app/views/shared/dossiers/messages/_messagerie_disabled.html.haml
+++ b/app/views/shared/dossiers/messages/_messagerie_disabled.html.haml
@@ -1,0 +1,14 @@
+.card.feedback
+  .card-title
+    La messagerie est désormais désactivée.
+  %p
+    Pour poser une question sur ce dossier, contactez :
+  %p
+    = service.nom
+    %br
+    = service.organisme
+    %br
+    - horaires = "Horaires : #{formatted_horaires(service.horaires)}"
+    = simple_format(horaires)
+  %p
+    = link_to service.email, "mailto:#{service.email}"

--- a/app/views/users/_procedure_footer.html.haml
+++ b/app/views/users/_procedure_footer.html.haml
@@ -27,7 +27,9 @@
             %a{ href: "tel:#{service.telephone}" }= service.telephone
 
           %p
-            Horaires : #{formatted_horaires(service.horaires)}
+            - horaires = "Horaires : #{formatted_horaires(service.horaires)}"
+            = simple_format(horaires)
+
 
         - politiques = politiques_conservation_de_donnees(procedure)
         - if politiques.present?

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe NotificationMailer, type: :mailer do
   end
 
   let(:user) { create(:user) }
-  let(:dossier) { create(:dossier, :with_service, user: user) }
+  let(:dossier) { create(:dossier, :with_service, :en_construction, user: user) }
 
   describe '.send_notification' do
     let(:email_template) { instance_double('email_template', subject_for_dossier: 'subject', body_for_dossier: 'body') }

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -736,6 +736,37 @@ describe Dossier do
     end
   end
 
+  describe "#messagerie_available?" do
+    let(:procedure) { create(:procedure) }
+    let(:dossier) { create(:dossier, procedure: procedure) }
+
+    subject { dossier.messagerie_available? }
+
+    context "dossier is brouillon" do
+      before { dossier.state = Dossier.states.fetch(:brouillon) }
+
+      it { is_expected.to be false }
+    end
+
+    context "dossier is archived" do
+      before { dossier.archived = true }
+
+      it { is_expected.to be false }
+    end
+
+    context "procedure is archived" do
+      before { procedure.archived_at = Date.today }
+
+      it { is_expected.to be false }
+    end
+
+    context "procedure is not archived, dossier is not archived" do
+      before { dossier.state = Dossier.states.fetch(:en_instruction) }
+
+      it { is_expected.to be true }
+    end
+  end
+
   context "retention date" do
     let(:procedure) { create(:procedure, duree_conservation_dossiers_dans_ds: 6) }
     let(:uninstructed_dossier) { create(:dossier, :en_construction, procedure: procedure) }

--- a/spec/services/commentaire_service_spec.rb
+++ b/spec/services/commentaire_service_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe CommentaireService do
   describe '.create' do
-    let(:dossier) { create :dossier }
+    let(:dossier) { create :dossier, :en_construction }
     let(:sender) { dossier.user }
     let(:body) { 'Contenu du message.' }
     let(:file) { nil }


### PR DESCRIPTION
* Use the existing `Dossier#messagerie_available?` method
* Raise when attempting to build a `Commentaire` if not `messagerie_available?`
* Disable the `Messagerie` form if not `messagerie_available?`
* Add tests :)
* Tweak the Horaires formatting while we’re here.

Screenshot:
<img width="677" alt="Capture d’écran 2019-06-20 à 12 03 32" src="https://user-images.githubusercontent.com/139391/59840828-73731000-9353-11e9-8bba-6d11affaac69.png">
