### PR TITLE
Fix a crash in the activate_before_expiration email

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,5 @@
 class ApplicationMailer < ActionMailer::Base
+  helper :application # gives access to all helpers defined within `application_helper`.
   default from: "demarches-simplifiees.fr <#{CONTACT_EMAIL}>"
   layout 'mailer'
 end


### PR DESCRIPTION
Include application_helper in ApplicationMailer. This is needed to use `try_format_date`.

This fixes a crash in activate_before_expiration.haml (sentry RAILS-40)