### PR TITLE
PJ Migration : ensure creating an empty champ doesn’t display a notification

### DIFF
--- a/app/services/piece_justificative_to_champ_piece_jointe_migration_service.rb
+++ b/app/services/piece_justificative_to_champ_piece_jointe_migration_service.rb
@@ -85,8 +85,10 @@ class PieceJustificativeToChampPieceJointeMigrationService
         )
       else
         champ.update_columns(
-          updated_at: dossier.updated_at,
-          created_at: dossier.created_at
+          created_at: dossier.created_at,
+          # Set an updated_at date that won't cause notifications to appear
+          # on gestionnaires' dashboard.
+          updated_at: dossier.created_at
         )
       end
 

--- a/spec/services/piece_justificative_to_champ_piece_jointe_migration_service_spec.rb
+++ b/spec/services/piece_justificative_to_champ_piece_jointe_migration_service_spec.rb
@@ -113,9 +113,9 @@ describe PieceJustificativeToChampPieceJointeMigrationService do
           dossier.reload
         end
 
-        it 'the champ has the same timestamps as the dossier' do
+        it 'the champ doesn’t trigger a notification' do
           expect(dossier.champs.last.created_at).to eq(initial_dossier_timestamps[:created_at])
-          expect(dossier.champs.last.updated_at).to eq(initial_dossier_timestamps[:updated_at])
+          expect(dossier.champs.last.updated_at).to eq(initial_dossier_timestamps[:created_at])
         end
 
         it 'does not change the dossier timestamps' do


### PR DESCRIPTION
Aujourd'hui, quand la tâche de migration des PJs tombe sur un champ sans PJ, elle crée un champ vide.

Le problème est qu'elle met comme `champ.update_at` la date de mise à jour du dossier. Et cette date peut être postérieure au `follows.demande_last_seen_at` – ce qui affiche une notification chez l'instructeur.

Cette PR fait en sorte de créer les champs vides avec une date par défaut, dont on est sûr qu'elle ne déclenchera pas de notification.