### PR TITLE
fix csp rule for crisp websocket

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -14,7 +14,7 @@ Rails.application.config.content_security_policy do |policy|
   # c'est trop compliqué pour être rectifié immédiatement (et sans valeur ajoutée:
   # c'est hardcodé dans les vues, donc pas injectable).
   policy.style_src :self, :unsafe_inline, "*.crisp.chat", "crisp.chat"
-  policy.connect_src "wss:client.relay.crisp.chat"
+  policy.connect_src "wss://*.crisp.chat"
   # Pour tout le reste, par défaut on accepte uniquement ce qui vient de chez nous
   # et dans la notification on inclue la source de l'erreur
   policy.default_src :self, :data, :report_sample, "fonts.gstatic.com", "in-automate.sendinblue.com", "player.vimeo.com", "app.franceconnect.gouv.fr", "sentry.io", "static.demarches-simplifiees.fr", "*.crisp.chat", "crisp.chat", "*.sibautomation.com", "sibautomation.com", "data"


### PR DESCRIPTION
Fix de typo et avec ça on respecte bien les préconisations de crisp, ce qui va nous éviter de futurs problèmes
https://help.crisp.chat/en/article/how-to-adjust-my-csp-policy-for-crisp-content-security-policy-bs2jjq/