### PR TITLE
enable csp

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,7 +59,7 @@ Rails.application.configure do
     port: 3000
   }
 
-  # Use Content-Security-Policy-Report-Only instead of Content-Security-Policy
+  # Use Content-Security-Policy-Report-Only headers
   config.content_security_policy_report_only = true
 
   # Raises error for missing translations

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -109,7 +109,8 @@ Rails.application.configure do
     host: ENV['APP_HOST']
   }
 
-  config.content_security_policy_report_only = true
+  # The Content-Security-Policy is NOT in Report-Only mode
+  config.content_security_policy_report_only = false
 
   config.lograge.enabled = ENV['LOGRAGE_ENABLED'] == 'enabled'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
     protocol: :http
   }
 
-  # Use Content-Security-Policy-Report-Only instead of Content-Security-Policy
+  # Use Content-Security-Policy-Report-Only headers
   config.content_security_policy_report_only = true
 
   config.active_job.queue_adapter = :test

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -13,8 +13,8 @@ Rails.application.config.content_security_policy do |policy|
   # Pour les CSS, on a beaucoup de style inline et quelques balises <style>
   # c'est trop compliqué pour être rectifié immédiatement (et sans valeur ajoutée:
   # c'est hardcodé dans les vues, donc pas injectable).
-  policy.style_src :self, :unsafe_inline, "*.crisp.chat", "crisp.chat"
-  policy.connect_src "wss://*.crisp.chat"
+  policy.style_src :self, "*.crisp.chat", "crisp.chat", :unsafe_inline
+  policy.connect_src :self, "wss://*.crisp.chat"
   # Pour tout le reste, par défaut on accepte uniquement ce qui vient de chez nous
   # et dans la notification on inclue la source de l'erreur
   policy.default_src :self, :data, :report_sample, "fonts.gstatic.com", "in-automate.sendinblue.com", "player.vimeo.com", "app.franceconnect.gouv.fr", "sentry.io", "static.demarches-simplifiees.fr", "*.crisp.chat", "crisp.chat", "*.sibautomation.com", "sibautomation.com", "data"


### PR DESCRIPTION
Should be fine (#confidence)

My only concern is that we have some reports that use an old policy, like this one yesterday (only happens for crisp.chat, on style-src). Not sure why.

```
{
    "csp-report": {
        "blocked-uri": "https://client.crisp.chat",
        "document-uri": "https://www.demarches-simplifiees.fr/procedures/18178/dossiers/545705/annotations-privees",
        "original-policy": "report-uri https://demarchessimplifieestest.report-uri.com/r/d/csp/reportOnly; img-src https://www.demarches-simplifiees.fr https://*.openstreetmap.org https://static.demarches-simplifiees.fr https://*.cloud.ovh.net https://stats.data.gouv.fr * data:; script-src https://www.demarches-simplifiees.fr https://stats.data.gouv.fr https://*.sendinblue.com https://*.crisp.chat https://crisp.chat https://*.sibautomation.com https://sibautomation.com 'unsafe-eval' 'unsafe-inline' blob:; style-src https://www.demarches-simplifiees.fr 'unsafe-inline'; default-src https://www.demarches-simplifiees.fr data: https://fonts.gstatic.com https://in-automate.sendinblue.com https://player.vimeo.com https://app.franceconnect.gouv.fr https://sentry.io https://static.demarches-simplifiees.fr https://*.crisp.chat https://crisp.chat https://*.sibautomation.com https://sibautomation.com https://data",
        "violated-directive": "style-src https://www.demarches-simplifiees.fr 'unsafe-inline'"
    }
}
```