### PR TITLE
enable static + activate csp in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -110,7 +110,7 @@ Rails.application.configure do
   }
 
   # The Content-Security-Policy is NOT in Report-Only mode
-  config.content_security_policy_report_only = true
+  config.content_security_policy_report_only = false
 
   config.lograge.enabled = ENV['LOGRAGE_ENABLED'] == 'enabled'
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -14,7 +14,7 @@ Rails.application.config.content_security_policy do |policy|
   # c'est trop compliqué pour être rectifié immédiatement (et sans valeur ajoutée:
   # c'est hardcodé dans les vues, donc pas injectable).
   policy.style_src :self, "*.crisp.chat", "crisp.chat", :unsafe_inline
-  policy.connect_src :self, "wss://*.crisp.chat"
+  policy.connect_src :self, "wss://*.crisp.chat", "*.demarches-simplifiees.fr"
   # Pour tout le reste, par défaut on accepte uniquement ce qui vient de chez nous
   # et dans la notification on inclue la source de l'erreur
   policy.default_src :self, :data, :report_sample, "fonts.gstatic.com", "in-automate.sendinblue.com", "player.vimeo.com", "app.franceconnect.gouv.fr", "sentry.io", "static.demarches-simplifiees.fr", "*.crisp.chat", "crisp.chat", "*.sibautomation.com", "sibautomation.com", "data"


### PR DESCRIPTION
Yesterday's issue was due to the new presence of connect-src (thus bypassing the settings in default-src) that did not include the static subdomain
So we can (hopefully safely) reactivate the CSPs with these settings