### PR TITLE
Fixes and improvements in Commentaires

### DIFF
--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -82,7 +82,7 @@ class SupportController < ApplicationController
   end
 
   def direct_message?
-    user_signed_in? && params[:type] == Helpscout::FormAdapter::TYPE_INSTRUCTION && dossier.present? && !dossier.brouillon?
+    user_signed_in? && params[:type] == Helpscout::FormAdapter::TYPE_INSTRUCTION && dossier.present? && dossier.messagerie_available?
   end
 
   def dossier

--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -64,7 +64,7 @@ class SupportController < ApplicationController
       file: params[:file],
       body: "[#{params[:subject]}]<br><br>#{params[:text]}"
     }
-    commentaire = CommentaireService.build_with_email(email, dossier, attributes)
+    commentaire = CommentaireService.build(current_user, dossier, attributes)
     commentaire.save!
   end
 

--- a/app/helpers/commentaire_helper.rb
+++ b/app/helpers/commentaire_helper.rb
@@ -1,12 +1,12 @@
 module CommentaireHelper
   def commentaire_is_from_me_class(commentaire, connected_user)
-    if commentaire_is_from_me(commentaire, connected_user)
+    if commentaire.sent_by?(connected_user)
       "from-me"
     end
   end
 
   def commentaire_answer_action(commentaire, connected_user)
-    if commentaire_is_from_me(commentaire, connected_user)
+    if commentaire.sent_by?(connected_user)
       "Envoyer un message à l’instructeur"
     else
       "Répondre dans la messagerie"
@@ -21,11 +21,5 @@ module CommentaireHelper
     is_current_year = (commentaire.created_at.year == Date.current.year)
     template = is_current_year ? :message_date : :message_date_with_year
     I18n.l(commentaire.created_at, format: template)
-  end
-
-  private
-
-  def commentaire_is_from_me(commentaire, connected_user)
-    commentaire.email == connected_user.email
   end
 end

--- a/app/models/commentaire.rb
+++ b/app/models/commentaire.rb
@@ -25,12 +25,14 @@ class Commentaire < ApplicationRecord
   end
 
   def header
-    "#{sender}, #{I18n.l(created_at, format: '%d %b %Y %H:%M')}"
+    "#{redacted_email}, #{I18n.l(created_at, format: '%d %b %Y %H:%M')}"
   end
 
-  def sender
-    if email.present?
-      email.split('@').first
+  def redacted_email
+    if gestionnaire.present?
+      gestionnaire.email.split('@').first
+    else
+      email
     end
   end
 

--- a/app/models/commentaire.rb
+++ b/app/models/commentaire.rb
@@ -7,6 +7,7 @@ class Commentaire < ApplicationRecord
   mount_uploader :file, CommentaireFileUploader
   validates :file, file_size: { maximum: 20.megabytes, message: "La taille du fichier doit être inférieure à 20 Mo" }
   validate :is_virus_free?
+  validate :messagerie_available?, on: :create
   validates :body, presence: { message: "Votre message ne peut être vide" }
 
   default_scope { order(created_at: :asc) }
@@ -76,6 +77,13 @@ class Commentaire < ApplicationRecord
   def is_virus_free?
     if file.present? && file_changed? && !ClamavService.safe_file?(file.path)
       errors.add(:file, "Virus détecté dans le fichier joint, merci de changer de fichier")
+    end
+  end
+
+  def messagerie_available?
+    return if sent_by_system?
+    if dossier.present? && !dossier.messagerie_available?
+      errors.add(:dossier, "Il n’est pas possible d’envoyer un message sur un dossier archivé ou en brouillon")
     end
   end
 end

--- a/app/models/commentaire.rb
+++ b/app/models/commentaire.rb
@@ -14,10 +14,6 @@ class Commentaire < ApplicationRecord
 
   after_create :notify
 
-  def self.columns
-    super.reject { |c| c.name == "champ" }
-  end
-
   def email
     if user
       user.email

--- a/app/models/commentaire.rb
+++ b/app/models/commentaire.rb
@@ -36,6 +36,15 @@ class Commentaire < ApplicationRecord
     end
   end
 
+  def sent_by_system?
+    [CONTACT_EMAIL, OLD_CONTACT_EMAIL].include?(email) &&
+      user.nil? && gestionnaire.nil?
+  end
+
+  def sent_by?(someone)
+    email == someone.email
+  end
+
   def file_url
     if Flipflop.remote_storage?
       RemoteDownloader.new(file.path).url

--- a/app/views/shared/dossiers/_messagerie.html.haml
+++ b/app/views/shared/dossiers/_messagerie.html.haml
@@ -4,7 +4,7 @@
       %li.message{ class: commentaire_is_from_me_class(commentaire, connected_user) }
         = render partial: "shared/dossiers/messages/message", locals: { commentaire: commentaire, connected_user: connected_user, messagerie_seen_at: messagerie_seen_at }
 
-  - if dossier.archived?
-    = render partial: "shared/dossiers/messages/messagerie_disabled", locals: { service: dossier.procedure.service }
-  - else
+  - if dossier.messagerie_available?
     = render partial: "shared/dossiers/messages/form", locals: { commentaire: new_commentaire, form_url: form_url }
+  - else
+    = render partial: "shared/dossiers/messages/messagerie_disabled", locals: { service: dossier.procedure.service }

--- a/app/views/shared/dossiers/messages/_message_icon.html.haml
+++ b/app/views/shared/dossiers/messages/_message_icon.html.haml
@@ -1,8 +1,7 @@
-- case commentaire.email
-- when connected_user.email
-  = image_tag('icons/account-circle.svg', class: 'person-icon')
-- when OLD_CONTACT_EMAIL
-- when CONTACT_EMAIL
+- if commentaire.sent_by_system?
   = image_tag('icons/mail.svg', class: 'person-icon')
+- elsif commentaire.sent_by?(connected_user)
+  = image_tag('icons/account-circle.svg', class: 'person-icon')
 - else
   = image_tag('icons/blue-person.svg', class: 'person-icon')
+

--- a/app/views/shared/dossiers/messages/_message_issuer.html.haml
+++ b/app/views/shared/dossiers/messages/_message_issuer.html.haml
@@ -5,4 +5,4 @@
 - when CONTACT_EMAIL
   Email automatique
 - else
-  = commentaire.sender
+  = commentaire.redacted_email

--- a/app/views/shared/dossiers/messages/_message_issuer.html.haml
+++ b/app/views/shared/dossiers/messages/_message_issuer.html.haml
@@ -1,8 +1,6 @@
-- case commentaire.email
-- when connected_user.email
-  Vous
-- when OLD_CONTACT_EMAIL
-- when CONTACT_EMAIL
+- if commentaire.sent_by_system?
   Email automatique
+- elsif commentaire.sent_by?(connected_user)
+  Vous
 - else
   = commentaire.redacted_email

--- a/spec/factories/commentaire.rb
+++ b/spec/factories/commentaire.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
 
     before(:create) do |commentaire, _evaluator|
       if !commentaire.dossier
-        commentaire.dossier = create :dossier
+        commentaire.dossier = create :dossier, :en_construction
       end
     end
   end

--- a/spec/helpers/commentaire_helper_spec.rb
+++ b/spec/helpers/commentaire_helper_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe CommentaireHelper, type: :helper do
   end
 
   describe '.commentaire_is_from_guest' do
-    let(:dossier) { create(:dossier) }
+    let(:dossier) { create(:dossier, :en_instruction) }
     let!(:guest) { create(:invite, dossier: dossier) }
 
     subject { commentaire_is_from_guest(commentaire) }

--- a/spec/models/commentaire_spec.rb
+++ b/spec/models/commentaire_spec.rb
@@ -7,6 +7,18 @@ describe Commentaire do
   it { is_expected.to have_db_column(:updated_at) }
   it { is_expected.to belong_to(:dossier) }
 
+  describe "#is_sent_by_system?" do
+    subject { commentaire.is_sent_by_system? }
+
+    let(:commentaire) { build :commentaire, email: email }
+
+    context 'with a commentaire created by the DS system' do
+      let(:email) { CONTACT_EMAIL }
+
+      it { is_expected.to be_truthy }
+    end
+  end
+
   describe "#redacted_email" do
     subject { commentaire.redacted_email }
 

--- a/spec/models/commentaire_spec.rb
+++ b/spec/models/commentaire_spec.rb
@@ -7,6 +7,24 @@ describe Commentaire do
   it { is_expected.to have_db_column(:updated_at) }
   it { is_expected.to belong_to(:dossier) }
 
+  describe "#redacted_email" do
+    subject { commentaire.redacted_email }
+
+    context 'with a commentaire created by a gestionnaire' do
+      let(:commentaire) { build :commentaire, gestionnaire: gestionnaire }
+      let(:gestionnaire) { build :gestionnaire, email: 'some_user@exemple.fr' }
+
+      it { is_expected.to eq 'some_user' }
+    end
+
+    context 'with a commentaire created by a user' do
+      let(:commentaire) { build :commentaire, user: user }
+      let(:user) { build :user, email: 'some_user@exemple.fr' }
+
+      it { is_expected.to eq 'some_user@exemple.fr' }
+    end
+  end
+
   describe "#notify" do
     let(:procedure) { create(:procedure) }
     let(:gestionnaire) { create(:gestionnaire) }

--- a/spec/models/commentaire_spec.rb
+++ b/spec/models/commentaire_spec.rb
@@ -7,8 +7,32 @@ describe Commentaire do
   it { is_expected.to have_db_column(:updated_at) }
   it { is_expected.to belong_to(:dossier) }
 
-  describe "#is_sent_by_system?" do
-    subject { commentaire.is_sent_by_system? }
+  describe 'messagerie_available validation' do
+    subject { commentaire.valid?(:create) }
+
+    context 'with a commentaire created by the DS system' do
+      let(:commentaire) { build :commentaire, email: CONTACT_EMAIL }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'on an archived dossier' do
+      let(:dossier) { create :dossier, :archived }
+      let(:commentaire) { build :commentaire, dossier: dossier }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'on a dossier en_construction' do
+      let(:dossier) { create :dossier, :en_construction }
+      let(:commentaire) { build :commentaire, dossier: dossier }
+
+      it { is_expected.to be_truthy }
+    end
+  end
+
+  describe "#sent_by_system?" do
+    subject { commentaire.sent_by_system? }
 
     let(:commentaire) { build :commentaire, email: email }
 
@@ -42,7 +66,7 @@ describe Commentaire do
     let(:gestionnaire) { create(:gestionnaire) }
     let(:assign_to) { create(:assign_to, gestionnaire: gestionnaire, procedure: procedure) }
     let(:user) { create(:user) }
-    let(:dossier) { create(:dossier, procedure: procedure, user: user) }
+    let(:dossier) { create(:dossier, :en_construction, procedure: procedure, user: user) }
     let(:commentaire) { Commentaire.new(dossier: dossier, body: "Mon commentaire") }
 
     context "with a commentaire created by a gestionnaire" do

--- a/spec/views/shared/dossiers/messages/message.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/messages/message.html.haml_spec.rb
@@ -3,7 +3,7 @@ describe 'shared/dossiers/messages/message.html.haml', type: :view do
 
   subject { render 'shared/dossiers/messages/message.html.haml', commentaire: commentaire, messagerie_seen_at: seen_at, connected_user: dossier.user }
 
-  let(:dossier) { create(:dossier) }
+  let(:dossier) { create(:dossier, :en_construction) }
   let(:commentaire) { create(:commentaire, dossier: dossier) }
   let(:seen_at) { commentaire.created_at + 1.hour }
 


### PR DESCRIPTION
Following #3979 and #4018:

- Actually respect `dossier.messagerie_available?` in `_messagerie.html.haml` (instead of `dossier.archived?`)
- Respect `dossier.messagerie_available?` in SupportController (`/contact`)
- Pass the signed-in user as the commentaire author from `/contact`
- Remove `Commentaire::columns` override
- Display the full `User` email in Commentaires (only redact the Gestionnaires emails)

And finally, 
- Validate messagerie_available? when creating a new Commentaire
Commentaires by Users and Gestionnaire need the messagerie to be available; Automatic system Commentaires can be created anytime.
This reintroduces Commentaire validation that was introduced in #3979 and disabled in #4018