### PR TITLE
Corrige un crash quand l'email France Connect n'a pas la même casse que chez nous

### DIFF
--- a/app/controllers/france_connect/particulier_controller.rb
+++ b/app/controllers/france_connect/particulier_controller.rb
@@ -13,7 +13,7 @@ class FranceConnect::ParticulierController < ApplicationController
         fetched_fci.tap(&:save)
 
     if fci.user.nil?
-      user = User.find_or_create_by(email: fci.email_france_connect.downcase) do |new_user|
+      user = User.find_or_create_by!(email: fci.email_france_connect.downcase) do |new_user|
         new_user.password = Devise.friendly_token[0, 20]
         new_user.confirmed_at = Time.zone.now
       end

--- a/app/controllers/france_connect/particulier_controller.rb
+++ b/app/controllers/france_connect/particulier_controller.rb
@@ -13,7 +13,7 @@ class FranceConnect::ParticulierController < ApplicationController
         fetched_fci.tap(&:save)
 
     if fci.user.nil?
-      user = User.find_or_create_by(email: fci.email_france_connect) do |new_user|
+      user = User.find_or_create_by(email: fci.email_france_connect.downcase) do |new_user|
         new_user.password = Devise.friendly_token[0, 20]
         new_user.confirmed_at = Time.zone.now
       end

--- a/spec/controllers/france_connect/particulier_controller_spec.rb
+++ b/spec/controllers/france_connect/particulier_controller_spec.rb
@@ -71,11 +71,19 @@ describe FranceConnect::ParticulierController, type: :controller do
         end
 
         context 'when france_connect_particulier_id does not have an associate user' do
-          it { is_expected.to redirect_to(root_path) }
+          context 'when the email address is not used yet' do
+            it { expect { subject }.to change(User, :count).by(1) }
+            it { is_expected.to redirect_to(root_path) }
+          end
 
-          it do
-            subject
-            expect(User.find_by(email: email)).not_to be_nil
+          context 'when the email address is already used' do
+            let!(:user) { create(:user, email: email, france_connect_information: nil) }
+
+            it 'associates the france_connect infos with the existing user' do
+              expect { subject }.not_to change(User, :count)
+              expect(user.reload.loged_in_with_france_connect).to eq(User.loged_in_with_france_connects.fetch(:particulier))
+              expect(subject).to redirect_to(root_path)
+            end
           end
         end
       end

--- a/spec/controllers/france_connect/particulier_controller_spec.rb
+++ b/spec/controllers/france_connect/particulier_controller_spec.rb
@@ -85,6 +85,17 @@ describe FranceConnect::ParticulierController, type: :controller do
               expect(subject).to redirect_to(root_path)
             end
           end
+
+          context 'when a differently cased email address is already used' do
+            let(:email) { 'TEST@test.com' }
+            let!(:user) { create(:user, email: email.downcase, france_connect_information: nil) }
+
+            it 'associates the france_connect infos with the existing user' do
+              expect { subject }.not_to change(User, :count)
+              expect(user.reload.loged_in_with_france_connect).to eq(User.loged_in_with_france_connects.fetch(:particulier))
+              expect(subject).to redirect_to(root_path)
+            end
+          end
         end
       end
 


### PR DESCRIPTION
Cette PR corrige un crash quand France Connect renvoie un email `TEST@exemple.fr`, alors qu'on a un utilisateur existant `test@exemple.fr` en base.

La PR :

- Corrige le crash, en faisant une recherche insensible à la casse ;
- Fait en sorte de remonter une erreur plus tôt si jamais un problème similaire se reproduit dans le futur.

Fix #4053