### PR TITLE
Rend plus facile de créer un autre dossier

### DIFF
--- a/app/controllers/admin/procedures_controller.rb
+++ b/app/controllers/admin/procedures_controller.rb
@@ -265,7 +265,7 @@ class Admin::ProceduresController < AdminController
   end
 
   def procedure_params
-    editable_params = [:libelle, :description, :organisation, :direction, :lien_site_web, :cadre_juridique, :deliberation, :notice, :expects_multiple_submissions, :web_hook_url, :euro_flag, :logo, :auto_archive_on]
+    editable_params = [:libelle, :description, :organisation, :direction, :lien_site_web, :cadre_juridique, :deliberation, :notice, :web_hook_url, :euro_flag, :logo, :auto_archive_on]
     if @procedure&.locked?
       params.require(:procedure).permit(*editable_params)
     else

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1,6 +1,8 @@
 class Dossier < ApplicationRecord
   include DossierFilteringConcern
 
+  self.ignored_columns = [:expects_multiple_submissions]
+
   enum state: {
     brouillon:       'brouillon',
     en_construction: 'en_construction',

--- a/app/views/admin/procedures/_informations.html.haml
+++ b/app/views/admin/procedures/_informations.html.haml
@@ -127,15 +127,6 @@
   .col-md-6
     %h4 Options avancées
 
-    = f.label :expects_multiple_submissions do
-      = f.check_box :expects_multiple_submissions
-      Ajuster pour le dépôt récurrent de dossiers
-    %p.help-block
-      %i.fa.fa-info-circle
-      Si cette démarche est conçue pour qu’une même personne y dépose régulièrement plusieurs
-      dossiers, l’interface est ajustée pour rendre plus facile la création de plusieurs dossiers
-      à la suite.
-
     - if Flipflop.web_hook?
       %label{ for: :web_hook_url } Lien de rappel HTTP (webhook)
       = f.text_field :web_hook_url, class: 'form-control', placeholder: 'https://callback.exemple.fr/'

--- a/app/views/users/dossiers/_dossier_actions.html.haml
+++ b/app/views/users/dossiers/_dossier_actions.html.haml
@@ -1,5 +1,5 @@
 - has_delete_action = dossier.can_be_deleted_by_user?
-- has_new_dossier_action = dossier.procedure.expects_multiple_submissions? && dossier.procedure.accepts_new_dossiers?
+- has_new_dossier_action = dossier.procedure.accepts_new_dossiers?
 
 - has_actions = has_delete_action || has_new_dossier_action
 

--- a/app/views/users/dossiers/merci.html.haml
+++ b/app/views/users/dossiers/merci.html.haml
@@ -20,4 +20,6 @@
       et
       %b échanger avec un instructeur.
 
-    = link_to 'Accéder à votre dossier', dossier_path(@dossier), class: 'button large primary'
+    .flex.column.align-center
+      = link_to 'Accéder à votre dossier', dossier_path(@dossier), class: 'button large primary'
+      = link_to 'Déposer un autre dossier', procedure_lien(@dossier.procedure)

--- a/spec/views/users/dossiers/_dossier_actions.html.haml_spec.rb
+++ b/spec/views/users/dossiers/_dossier_actions.html.haml_spec.rb
@@ -1,5 +1,5 @@
 describe 'users/dossiers/dossier_actions.html.haml', type: :view do
-  let(:procedure) { create(:procedure, :published, expects_multiple_submissions: true) }
+  let(:procedure) { create(:procedure, :published) }
   let(:dossier) { create(:dossier, :en_construction, procedure: procedure) }
 
   subject { render 'users/dossiers/dossier_actions.html.haml', dossier: dossier }
@@ -12,18 +12,13 @@ describe 'users/dossiers/dossier_actions.html.haml', type: :view do
     it { is_expected.not_to have_link('Supprimer le dossier') }
   end
 
-  context 'when the procedure doesn’t expect multiple submissions' do
-    let(:procedure) { create(:procedure, :published, expects_multiple_submissions: false) }
-    it { is_expected.not_to have_link('Commencer un autre dossier') }
-  end
-
   context 'when the procedure is closed' do
-    let(:procedure) { create(:procedure, :archived, expects_multiple_submissions: true) }
+    let(:procedure) { create(:procedure, :archived) }
     it { is_expected.not_to have_link('Commencer un autre dossier') }
   end
 
   context 'when there are no actions to display' do
-    let(:procedure) { create(:procedure, :published, expects_multiple_submissions: false) }
+    let(:procedure) { create(:procedure, :archived) }
     let(:dossier) { create(:dossier, :accepte, procedure: procedure) }
 
     it 'doesn’t render the menu at all' do


### PR DESCRIPTION
@benjaminhenkel me dit qu'on reçoit des messages au support de gens qui cherchent à créer un nouveau dossier sur la même démarche – mais qui ne trouvent pas l'option "Commencer un autre dossier".

De fait, cette option n'est visible que pour les démarches sur lesquelles l'Admin a explicitement dit "Cette démarche est faite pour le dépôt récurrent de dossiers". Mais la formulation n'est pas si claire, et les Admins oublient souvent de la cocher.

Résultat : dans la liste des dossiers, les Usagers voient parfois l'item "Commencer un autre dossier", et parfois pas, ça dépend de la démarche. Apparemment c'est perturbant.

## Proposition

Cette PR :

- **Affiche l'item "Commencer un autre dossier" pour toutes les démarches**

<img width="833" alt="Capture d’écran 2019-07-09 à 14 49 00" src="https://user-images.githubusercontent.com/179923/60889169-b6404d80-a258-11e9-809d-a8c4401c6333.png">

- **Affiche un lien "Déposer un autre dossier"** sur la page "Merci"

<img width="1068" alt="Capture d’écran 2019-07-09 à 14 40 02" src="https://user-images.githubusercontent.com/179923/60889182-c2c4a600-a258-11e9-8ea6-8f83ba1144d3.png">

- **Supprime le support de `Procedure#expects_multiple_submissions`**, qui est juste perturbant

Vous en pensez quoi ?