### PR TITLE
Amélioration du changement d'adresse email

### DIFF
--- a/app/assets/stylesheets/new_design/card.scss
+++ b/app/assets/stylesheets/new_design/card.scss
@@ -21,6 +21,14 @@
     }
   }
 
+  &.warning {
+    border-top: 8px solid $orange;
+
+    .card-title {
+      color: $orange;
+    }
+  }
+
   &.feedback {
     max-width: 600px;
     margin: 30px auto;

--- a/app/assets/stylesheets/new_design/profil.scss
+++ b/app/assets/stylesheets/new_design/profil.scss
@@ -12,4 +12,8 @@
   p {
     margin: 16px auto;
   }
+
+  .email-address {
+    font-weight: bold;
+  }
 }

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -8,4 +8,12 @@ class UserMailer < ApplicationMailer
 
     mail(to: user.email, subject: @subject)
   end
+
+  def account_already_taken(user, requested_email)
+    @user = user
+    @requested_email = requested_email
+    @subject = "Changement d’adresse email"
+
+    mail(to: requested_email, subject: @subject)
+  end
 end

--- a/app/views/layouts/_account_dropdown.haml
+++ b/app/views/layouts/_account_dropdown.haml
@@ -26,11 +26,11 @@
           = link_to admin_procedures_path, class: "menu-item menu-link" do
             = image_tag "icons/switch-profile.svg"
             Passer en administrateur
-      %li
-        = link_to profil_path, class: "menu-item menu-link" do
-          = image_tag "icons/switch-profile.svg"
-          Voir mon profil
 
+    %li
+      = link_to profil_path, class: "menu-item menu-link" do
+        = image_tag "icons/switch-profile.svg"
+        Voir mon profil
     %li
       = link_to destroy_user_session_path, method: :delete, class: "menu-item menu-link" do
         = image_tag "icons/sign-out.svg"

--- a/app/views/root/patron.html.haml
+++ b/app/views/root/patron.html.haml
@@ -157,6 +157,11 @@
         Titre de la carte mise en avant
       %p Et voici le contenu de la carte
 
+    .card.warning
+      .card-title
+        Titre de la carte d’avertissement
+      %p Et voici le contenu de la carte
+
     .card.feedback
       .card-title
         Titre de la carte pour demander un avis

--- a/app/views/user_mailer/account_already_taken.haml
+++ b/app/views/user_mailer/account_already_taken.haml
@@ -1,0 +1,20 @@
+- content_for(:title, @subject)
+
+%p
+  Bonjour,
+
+%p
+  L’utilisateur « #{@user.email} » a demandé le changement de son adresse vers « #{@requested_email} ».
+
+%p
+  Malheureusement, votre compte « #{@requested_email} » existe déjà. Nous ne pouvons pas fusionner automatiquement vos comptes.
+
+%p
+  %strong Nous ne pouvons donc pas effectuer le changement d’adresse email.
+
+%p
+  Si vous n'êtes pas à l’origine de cette demande, vous pouvez ignorer ce message. Et si vous avez besoin d’assistance, n’hésitez pas à nous contacter à
+  = succeed '.' do
+    = mail_to CONTACT_EMAIL
+
+= render partial: "layouts/mailers/signature"

--- a/app/views/users/profil/show.html.haml
+++ b/app/views/users/profil/show.html.haml
@@ -7,12 +7,16 @@
 
   .card
     .card-title Coordonnées
-    %p Votre email est actuellement #{current_user.email}
+    %p
+      Votre email est actuellement
+      %span.email-address= current_user.email
     - if current_user.unconfirmed_email.present?
-      %p
-        Un email a été envoyé à #{current_user.unconfirmed_email}.
-        %br
-        Merci de vérifier vos emails et de cliquer sur le lien d’activation pour finaliser la validation de votre nouvelle adresse.
+      .card.warning
+        .card-title
+          Changement en attente :
+          %span.email-address= current_user.unconfirmed_email
+        %p
+          Pour finaliser votre changement d’adresse, vérifiez vos emails et cliquez sur le lien de confirmation.
 
     = form_for @current_user, url: update_email_path, method: :patch, html: { class: 'form' } do |f|
       = f.email_field :email, value: nil, placeholder: 'Nouvelle adresse email', required: true

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -42,7 +42,7 @@ fr:
       signed_up_but_inactive: "Vous êtes bien enregistré. Vous ne pouvez cependant pas vous connecter car votre compte n'est pas encore activé."
       signed_up_but_locked: "Vous êtes bien enregistré. Vous ne pouvez cependant pas vous connecter car votre compte est verrouillé."
       signed_up_but_unconfirmed: "Nous vous avons envoyé un email contenant un lien d'activation. Ouvrez ce lien pour activer votre compte."
-      update_needs_confirmation: "Votre compte a bien été mis à jour mais nous devons vérifier votre nouvelle adresse email. Merci de vérifier vos emails et de cliquer sur le lien d’activation pour finaliser la validation de votre nouvelle adresse."
+      update_needs_confirmation: "Vous devez confirmer votre nouvelle adresse email. Vérifiez vos emails, et cliquez sur le lien de confirmation pour confirmer votre changement d’adresse."
       updated: "Votre compte a été modifié avec succès."
     sessions:
       signed_in: "Connecté."

--- a/spec/features/users/change_email_spec.rb
+++ b/spec/features/users/change_email_spec.rb
@@ -19,14 +19,15 @@ feature 'Changing an email' do
       click_button 'Changer mon adresse'
     end
 
-    user.reload
-    expect(user.email).to eq(old_email)
-    expect(user.unconfirmed_email).to eq(new_email)
+    expect(page).to have_content(I18n.t('devise.registrations.update_needs_confirmation'))
+    expect(page).to have_content(old_email)
+    expect(page).to have_content(new_email)
 
     click_confirmation_link_for(new_email)
 
-    user.reload
-    expect(user.email).to eq(new_email)
-    expect(user.unconfirmed_email).to be_nil
+    expect(page).to have_content(I18n.t('devise.confirmations.confirmed'))
+    expect(page).not_to have_content(old_email)
+    expect(page).to have_content(new_email)
+    expect(user.reload.email).to eq(new_email)
   end
 end

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -3,6 +3,10 @@ class UserMailerPreview < ActionMailer::Preview
     UserMailer.new_account_warning(user)
   end
 
+  def account_already_taken
+    UserMailer.account_already_taken(user, 'dircab@territoires.gouv.fr')
+  end
+
   private
 
   def user

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe UserMailer, type: :mailer do
+  let(:user) { build(:user) }
+
+  describe '.new_account_warning' do
+    subject { described_class.new_account_warning(user) }
+
+    it { expect(subject.to).to eq([user.email]) }
+    it { expect(subject.body).to include(user.email) }
+  end
+
+  describe '.account_already_taken' do
+    let(:requested_email) { 'new@exemple.fr' }
+
+    subject { described_class.account_already_taken(user, requested_email) }
+
+    it { expect(subject.to).to eq([requested_email]) }
+    it { expect(subject.body).to include(requested_email) }
+  end
+end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe Dossier do
   include ActiveJob::TestHelper
@@ -420,7 +420,6 @@ describe Dossier do
 
     it "send an email when the dossier is created for the very first time" do
       dossier = nil
-      ActiveJob::Base.queue_adapter = :test
       expect do
         perform_enqueued_jobs do
           dossier = Dossier.create(procedure: procedure, state: Dossier.states.fetch(:brouillon), user: user)


### PR DESCRIPTION
# Amélioration de la visibilité de l'adresse en cours de confirmation

- L'adresse en cours de confirmation est maintenant plus visible. La couleur orange devrait permettre aux gens de comprendre globalement ce qui se passe, même sans lire le texte.
- Le message de succès qui demande confirmation est légèrement plus clair (même si il sera sans doute peu lu de toute manière).

## Avant

![Avant](https://user-images.githubusercontent.com/179923/60901072-9a937200-a26d-11e9-8367-32202c03a871.png)

## Après

![Après](https://user-images.githubusercontent.com/179923/60901086-9ebf8f80-a26d-11e9-9da2-d150e13ea4e1.png)

# Envoi d'un email en cas d'adresse prise

Quand on demande à changer d'email pour une adresse qui existe déjà, il n'y a pas de message d'erreur spécifique.

Pour éviter que l'utilisateur se demande pourquoi il ne reçoit pas de confirmation, on envoie un email au compte demandé.

<img width="658" alt="Capture d’écran 2019-07-09 à 17 17 05" src="https://user-images.githubusercontent.com/179923/60901187-cf9fc480-a26d-11e9-88ca-3a1b5ad832b6.png">

@LeSim tu en penses quoi ?