### PR TITLE
dossier: fix flaky spec for `nearing_end_of_retention`

### DIFF
--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -31,7 +31,7 @@ describe Dossier do
     let(:procedure) { create(:procedure, duree_conservation_dossiers_dans_ds: 6) }
     let!(:young_dossier) { create(:dossier, procedure: procedure) }
     let!(:expiring_dossier) { create(:dossier, :en_instruction, en_instruction_at: 170.days.ago, procedure: procedure) }
-    let!(:just_expired_dossier) { create(:dossier, :en_instruction, en_instruction_at: (6.months + 1.hour + 1.second).ago, procedure: procedure) }
+    let!(:just_expired_dossier) { create(:dossier, :en_instruction, en_instruction_at: (6.months + 1.hour + 10.seconds).ago, procedure: procedure) }
     let!(:long_expired_dossier) { create(:dossier, :en_instruction, en_instruction_at: 1.year.ago, procedure: procedure) }
 
     context 'with default delay to end of retention' do


### PR DESCRIPTION
If the spec takes longer than 1s to run, the test fails.

Increase the delay.