### PR TITLE
Improve numeric field validation errors

### DIFF
--- a/app/models/champs/decimal_number_champ.rb
+++ b/app/models/champs/decimal_number_champ.rb
@@ -1,5 +1,11 @@
 class Champs::DecimalNumberChamp < Champ
-  validates :value, numericality: { allow_nil: true, allow_blank: true }
+  validates :value, numericality: {
+    allow_nil: true,
+    allow_blank: true,
+    message: -> (object, data) {
+      "« #{object.libelle} » " + object.errors.generate_message(data[:attribute].downcase, :not_a_number)
+    }
+  }
 
   def for_export
     processed_value

--- a/app/models/champs/integer_number_champ.rb
+++ b/app/models/champs/integer_number_champ.rb
@@ -1,5 +1,12 @@
 class Champs::IntegerNumberChamp < Champ
-  validates :value, numericality: { only_integer: true, allow_nil: true, allow_blank: true }
+  validates :value, numericality: {
+    only_integer: true,
+    allow_nil: true,
+    allow_blank: true,
+    message: -> (object, data) {
+      "« #{object.libelle} » " + object.errors.generate_message(data[:attribute].downcase, :not_an_integer)
+    }
+  }
 
   def for_export
     processed_value

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -128,6 +128,7 @@ fr:
       messages:
         blank: "doit être rempli"
         not_a_number: 'doit être un nombre'
+        not_an_integer: 'doit être un nombre entier (sans chiffres après la virgule)'
         greater_than: "doit être supérieur à %{count}"
         greater_than_or_equal_to: "doit être supérieur ou égal à %{count}"
         less_than: "doit être inférieur à %{count}"

--- a/config/locales/models/champs/fr.yml
+++ b/config/locales/models/champs/fr.yml
@@ -1,0 +1,5 @@
+fr:
+  activerecord:
+    attributes:
+      champs:
+        value: La valeur du champ

--- a/spec/models/champs/decimal_number_champ_spec.rb
+++ b/spec/models/champs/decimal_number_champ_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Champs::DecimalNumberChamp do
-  subject { Champs::DecimalNumberChamp.new(value: value) }
+  subject { build(:champ_decimal_number, value: value).tap(&:valid?) }
 
   describe '#valid?' do
     context 'when the value is integer number' do
@@ -20,6 +20,7 @@ describe Champs::DecimalNumberChamp do
       let(:value) { 'toto' }
 
       it { is_expected.to_not be_valid }
+      it { expect(subject.errors[:value]).to eq(["« #{subject.libelle} » doit être un nombre"]) }
     end
 
     context 'when the value is blank' do

--- a/spec/models/champs/integer_number_champ_spec.rb
+++ b/spec/models/champs/integer_number_champ_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Champs::IntegerNumberChamp do
-  subject { Champs::IntegerNumberChamp.new(value: value) }
+  subject { build(:champ_integer_number, value: value).tap(&:valid?) }
 
   describe '#valid?' do
     context 'when the value is integer number' do
@@ -14,12 +14,14 @@ describe Champs::IntegerNumberChamp do
       let(:value) { 2.6 }
 
       it { is_expected.to_not be_valid }
+      it { expect(subject.errors[:value]).to eq(["« #{subject.libelle} » doit être un nombre entier (sans chiffres après la virgule)"]) }
     end
 
     context 'when the value is not a number' do
       let(:value) { 'toto' }
 
       it { is_expected.to_not be_valid }
+      it { expect(subject.errors[:value]).to eq(["« #{subject.libelle} » doit être un nombre entier (sans chiffres après la virgule)"]) }
     end
 
     context 'when the value is blank' do


### PR DESCRIPTION
Quand un Usager enregistre un **brouillon** avec :

- une valeur décimale dans un champ "IntegerNumber",
- ou une valeur non numérique dans un champ "DecimalNumber",

La validation du navigateur est désactivée (normal), mais l'enregistrement des champs en Rails renvoie une erreur de validation.

<img width="1104" alt="Capture d’écran 2019-07-10 à 17 20 00" src="https://user-images.githubusercontent.com/179923/60981632-0097fc00-a337-11e9-90e5-dc67b73c90a3.png">

## Problème


- Le message d'erreur n'indique pas du tout de quel champ il s'agit.
- L'enregistrement du brouillon échoue : les données des champs sont conservées – mais on perd, par exemple, les pièces jointes envoyées.

## Correctif

Cette PR :

- Améliore le message d'erreur, pour mentionner explicitement les chiffres après la virgule
- Fait en sorte d'afficher le nom du champ dans le message d'erreur

_À terme, on voudra aussi :_

- _Ne pas perdre les pièces jointes lors d'erreurs de ce genre_
- _Peut-être uploader les pièces jointes en asyncrone dès qu'elles sont attachées ?_

## Après

<img width="1103" alt="Capture d’écran 2019-07-10 à 17 19 24" src="https://user-images.githubusercontent.com/179923/60981572-e2320080-a336-11e9-8410-c0385305de61.png">
