### PR TITLE
Ignore `:expects_multiple_submissions` on the correct model

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1,8 +1,6 @@
 class Dossier < ApplicationRecord
   include DossierFilteringConcern
 
-  self.ignored_columns = [:expects_multiple_submissions]
-
   enum state: {
     brouillon:       'brouillon',
     en_construction: 'en_construction',

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -3,7 +3,7 @@ require Rails.root.join('lib', 'percentile')
 class Procedure < ApplicationRecord
   MAX_DUREE_CONSERVATION = 36
 
-  self.ignored_columns = [:individual_with_siret]
+  self.ignored_columns = [:individual_with_siret, :expects_multiple_submissions]
 
   has_many :types_de_piece_justificative, -> { ordered }, inverse_of: :procedure, dependent: :destroy
   has_many :types_de_champ, -> { root.public_only.ordered }, inverse_of: :procedure, dependent: :destroy


### PR DESCRIPTION
On ignorait la colonne sur "Dossiers", alors qu'elle est sur "Procédure" 🤦‍♂ 

(On a besoin de ça pour supprimer la colonne ensuite.)