### PR TITLE
Corrige l'affichage du radio-button "Personne morale"

### DIFF
--- a/app/controllers/admin/procedures_controller.rb
+++ b/app/controllers/admin/procedures_controller.rb
@@ -62,7 +62,7 @@ class Admin::ProceduresController < AdminController
   end
 
   def new
-    @procedure ||= Procedure.new
+    @procedure ||= Procedure.new(for_individual: true)
     @availability = Procedure::PATH_AVAILABLE
   end
 

--- a/app/views/admin/procedures/_informations.html.haml
+++ b/app/views/admin/procedures/_informations.html.haml
@@ -100,7 +100,7 @@
       %h4 À qui s’adresse ma démarche ?
       .checkbox
         %label
-          = f.radio_button :for_individual, 1, :checked => true
+          = f.radio_button :for_individual, true
           %b Ma démarche s’adresse à un particulier
 
         %p
@@ -108,7 +108,7 @@
 
       .checkbox
         %label
-          = f.radio_button :for_individual, 0, :checked => false
+          = f.radio_button :for_individual, false
           %b Ma démarche s’adresse à une personne morale
 
         %p

--- a/spec/features/admin/procedure_creation_spec.rb
+++ b/spec/features/admin/procedure_creation_spec.rb
@@ -36,6 +36,8 @@ feature 'As an administrateur I wanna create a new procedure', js: true do
         click_on 'from-scratch'
 
         expect(page).to have_current_path(new_admin_procedure_path)
+        expect(find('#procedure_for_individual_true')).to be_checked
+        expect(find('#procedure_for_individual_false')).not_to be_checked
         fill_in 'procedure_duree_conservation_dossiers_dans_ds', with: '3'
         fill_in 'procedure_duree_conservation_dossiers_hors_ds', with: '6'
         click_on 'save-procedure'


### PR DESCRIPTION
Previously `checked: true` forced the checked status, disregarding the
actual value of the model.

Fix #4080