### PR TITLE
#3609 - Déplacement de l'URL qui envoie vers la procédure

### DIFF
--- a/app/controllers/admin/procedures_controller.rb
+++ b/app/controllers/admin/procedures_controller.rb
@@ -107,19 +107,20 @@ class Admin::ProceduresController < AdminController
 
   def publish
     path = params[:path]
+    lien_site_web = params[:lien_site_web]
     procedure = current_administrateur.procedures.find(params[:procedure_id])
 
     procedure.path = path
-    procedure.lien_site_web = params[:lien_site_web]
+    procedure.lien_site_web = lien_site_web
 
     if !procedure.validate
-      flash.alert = 'Lien de la démarche invalide'
+      flash.alert = 'Lien de la démarche invalide ou lien vers la démarche manquant'
       return redirect_to admin_procedures_path
     else
       procedure.path = nil
     end
 
-    if procedure.publish_or_reopen!(current_administrateur, path)
+    if procedure.publish_or_reopen!(current_administrateur, path, lien_site_web)
       flash.notice = "Démarche publiée"
       redirect_to admin_procedures_path
     else

--- a/app/controllers/admin/procedures_controller.rb
+++ b/app/controllers/admin/procedures_controller.rb
@@ -110,6 +110,8 @@ class Admin::ProceduresController < AdminController
     procedure = current_administrateur.procedures.find(params[:procedure_id])
 
     procedure.path = path
+    procedure.lien_site_web = params[:lien_site_web]
+
     if !procedure.validate
       flash.alert = 'Lien de la démarche invalide'
       return redirect_to admin_procedures_path

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -107,12 +107,12 @@ class Procedure < ApplicationRecord
     end
   end
 
-  def publish_or_reopen!(administrateur, path)
-    if archivee? && may_reopen?(administrateur, path)
-      reopen!(administrateur, path)
-    elsif may_publish?(administrateur, path)
+  def publish_or_reopen!(administrateur, path, lien_site_web)
+    if archivee? && may_reopen?(administrateur, path, lien_site_web)
+      reopen!(administrateur, path, lien_site_web)
+    elsif may_publish?(administrateur, path, lien_site_web)
       reset!
-      publish!(administrateur, path)
+      publish!(administrateur, path, lien_site_web)
     end
   end
 
@@ -488,21 +488,17 @@ class Procedure < ApplicationRecord
     update!(path: path)
   end
 
-  def can_publish?(administrateur, path)
-    path_availability(administrateur, path).in?(PATH_CAN_PUBLISH)
+  def can_publish?(administrateur, path, lien_site_web)
+    path_availability(administrateur, path).in?(PATH_CAN_PUBLISH) && lien_site_web.present?
   end
 
-  def can_reopen?(administrateur, path)
-    path_availability(administrateur, path).in?(PATH_CAN_PUBLISH)
-  end
-
-  def after_publish(administrateur, path)
+  def after_publish(administrateur, path, lien_site_web)
     update!(published_at: Time.zone.now)
 
     claim_path_ownership!(path)
   end
 
-  def after_reopen(administrateur, path)
+  def after_reopen(administrateur, path, lien_site_web)
     update!(published_at: Time.zone.now, archived_at: nil)
 
     claim_path_ownership!(path)

--- a/app/views/admin/procedures/_informations.html.haml
+++ b/app/views/admin/procedures/_informations.html.haml
@@ -19,7 +19,7 @@
     = f.label :duree_conservation_dossiers_hors_ds, "Hors demarches-simplifiees.fr* (durée en mois après la fin de l'instruction)"
     = f.number_field :duree_conservation_dossiers_hors_ds, class: 'form-control', placeholder: '6', required: true
 
-- if @procedure.new?
+- if @procedure.created_at.present?
   .form-group
     %h4 Où les usagers trouveront-ils le lien vers la démarche ?
     = f.text_field :lien_site_web, class: 'form-control', placeholder: 'https://exemple.gouv.fr/ma_demarche'

--- a/app/views/admin/procedures/_informations.html.haml
+++ b/app/views/admin/procedures/_informations.html.haml
@@ -19,9 +19,10 @@
     = f.label :duree_conservation_dossiers_hors_ds, "Hors demarches-simplifiees.fr* (durée en mois après la fin de l'instruction)"
     = f.number_field :duree_conservation_dossiers_hors_ds, class: 'form-control', placeholder: '6', required: true
 
-.form-group
-  %h4 Où les usagers trouveront-ils le lien vers la démarche ?
-  = f.text_field :lien_site_web, class: 'form-control', placeholder: 'https://exemple.gouv.fr/ma_demarche'
+- if @procedure.locked?
+  .form-group
+    %h4 Où les usagers trouveront-ils le lien vers la démarche ?
+    = f.text_field :lien_site_web, class: 'form-control', placeholder: 'https://exemple.gouv.fr/ma_demarche'
 
 .form-group
   %h4 Cadre juridique *

--- a/app/views/admin/procedures/_informations.html.haml
+++ b/app/views/admin/procedures/_informations.html.haml
@@ -19,7 +19,7 @@
     = f.label :duree_conservation_dossiers_hors_ds, "Hors demarches-simplifiees.fr* (durée en mois après la fin de l'instruction)"
     = f.number_field :duree_conservation_dossiers_hors_ds, class: 'form-control', placeholder: '6', required: true
 
-- if @procedure.locked?
+- if @procedure.new?
   .form-group
     %h4 Où les usagers trouveront-ils le lien vers la démarche ?
     = f.text_field :lien_site_web, class: 'form-control', placeholder: 'https://exemple.gouv.fr/ma_demarche'

--- a/app/views/admin/procedures/_modal_publish.html.haml
+++ b/app/views/admin/procedures/_modal_publish.html.haml
@@ -39,9 +39,12 @@
                 target: "_blank"
 
           .form-group
-            %h4 Où les usagers trouveront-ils le lien vers cette démarche ?
+            %h4 Où les usagers trouveront-ils le lien vers cette démarche ? *
             %p.center
-              = text_field_tag(:lien_site_web, @procedure.lien_site_web, class: 'form-control', placeholder: 'https://exemple.gouv.fr/ma_demarche')
+              = text_field_tag(:lien_site_web, @procedure.lien_site_web,
+                                required: true,
+                                class: 'form-control',
+                                placeholder: 'https://exemple.gouv.fr/ma_demarche')
 
             #path-messages
               #path_is_mine.text-warning.center.message

--- a/app/views/admin/procedures/_modal_publish.html.haml
+++ b/app/views/admin/procedures/_modal_publish.html.haml
@@ -38,6 +38,11 @@
                 "https://vimeo.com/334463514",
                 target: "_blank"
 
+          .form-group
+            %h4 Où les usagers trouveront-ils le lien vers cette démarche ?
+            %p.center
+              = text_field_tag(:lien_site_web, @procedure.lien_site_web, class: 'form-control', placeholder: 'https://exemple.gouv.fr/ma_demarche')
+
             #path-messages
               #path_is_mine.text-warning.center.message
                 Ce lien est déjà utilisé par une de vos démarche.

--- a/spec/controllers/admin/procedures_controller_spec.rb
+++ b/spec/controllers/admin/procedures_controller_spec.rb
@@ -334,10 +334,11 @@ describe Admin::ProceduresController, type: :controller do
     let(:procedure) { create(:procedure, administrateur: admin) }
     let(:procedure2) { create(:procedure, :published, administrateur: admin) }
     let(:procedure3) { create(:procedure, :published) }
+    let(:lien_site_web) { 'http://some.administration/' }
 
     context 'when admin is the owner of the procedure' do
       before do
-        put :publish, params: { procedure_id: procedure.id, path: path }
+        put :publish, params: { procedure_id: procedure.id, path: path, lien_site_web: lien_site_web }
         procedure.reload
         procedure2.reload
       end
@@ -348,6 +349,7 @@ describe Admin::ProceduresController, type: :controller do
         it 'publish the given procedure' do
           expect(procedure.publiee?).to be_truthy
           expect(procedure.path).to eq(path)
+          expect(procedure.lien_site_web).to eq(lien_site_web)
           expect(response.status).to eq 302
           expect(flash[:notice]).to have_content 'Démarche publiée'
         end
@@ -359,6 +361,7 @@ describe Admin::ProceduresController, type: :controller do
         it 'publish the given procedure' do
           expect(procedure.publiee?).to be_truthy
           expect(procedure.path).to eq(path)
+          expect(procedure.lien_site_web).to eq(lien_site_web)
           expect(response.status).to eq 302
           expect(flash[:notice]).to have_content 'Démarche publiée'
         end
@@ -375,6 +378,7 @@ describe Admin::ProceduresController, type: :controller do
         it 'does not publish the given procedure' do
           expect(procedure.publiee?).to be_falsey
           expect(procedure.path).not_to match(path)
+          expect(procedure.lien_site_web).not_to match(lien_site_web)
           expect(response.status).to eq 200
         end
 
@@ -391,6 +395,7 @@ describe Admin::ProceduresController, type: :controller do
         it 'does not publish the given procedure' do
           expect(procedure.publiee?).to be_falsey
           expect(procedure.path).not_to match(path)
+          expect(procedure.lien_site_web).not_to match(lien_site_web)
           expect(response).to redirect_to :admin_procedures
           expect(flash[:alert]).to have_content 'Lien de la démarche invalide'
         end

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     duree_conservation_dossiers_dans_ds { 3 }
     duree_conservation_dossiers_hors_ds { 6 }
     ask_birthday { false }
+    lien_site_web { "https://mon-site.gouv" }
 
     transient do
       administrateur {}
@@ -147,13 +148,13 @@ FactoryBot.define do
 
     trait :published do
       after(:build) do |procedure, _evaluator|
-        procedure.publish!(procedure.administrateurs.first, generate(:published_path))
+        procedure.publish!(procedure.administrateurs.first, generate(:published_path), procedure.lien_site_web)
       end
     end
 
     trait :archived do
       after(:build) do |procedure, _evaluator|
-        procedure.publish!(procedure.administrateurs.first, generate(:published_path))
+        procedure.publish!(procedure.administrateurs.first, generate(:published_path), procedure.lien_site_web)
         procedure.archive!
       end
     end
@@ -162,14 +163,14 @@ FactoryBot.define do
       # For now the behavior is the same than :archived
       # (it may be different in the future though)
       after(:build) do |procedure, _evaluator|
-        procedure.publish!(procedure.administrateurs.first, generate(:published_path))
+        procedure.publish!(procedure.administrateurs.first, generate(:published_path), procedure.lien_site_web)
         procedure.archive!
       end
     end
 
     trait :hidden do
       after(:build) do |procedure, _evaluator|
-        procedure.publish!(procedure.administrateurs.first, generate(:published_path))
+        procedure.publish!(procedure.administrateurs.first, generate(:published_path), procedure.lien_site_web)
         procedure.hide!
       end
     end

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -38,7 +38,7 @@ FactoryBot.define do
       after(:build) do |procedure, _evaluator|
         procedure.for_individual = true
         procedure.types_de_champ << create(:type_de_champ, libelle: 'Texte obligatoire', mandatory: true)
-        procedure.publish!(procedure.administrateurs.first, generate(:published_path))
+        procedure.publish!(procedure.administrateurs.first, generate(:published_path), procedure.lien_site_web)
       end
     end
 

--- a/spec/features/admin/procedure_creation_spec.rb
+++ b/spec/features/admin/procedure_creation_spec.rb
@@ -123,6 +123,7 @@ feature 'As an administrateur I wanna create a new procedure', js: true do
 
         within '#publish-modal' do
           expect(page).to have_field('procedure_path')
+          fill_in 'lien_site_web', with: 'http://some.website'
           click_on 'publish'
         end
 

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -554,7 +554,7 @@ describe Procedure do
 
     before do
       Timecop.freeze(now)
-      procedure.publish!(procedure.administrateurs.first, "example-path")
+      procedure.publish!(procedure.administrateurs.first, "example-path", procedure.lien_site_web)
     end
     after { Timecop.return }
 

--- a/spec/views/admin/procedures/edit.html.haml_spec.rb
+++ b/spec/views/admin/procedures/edit.html.haml_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'admin/procedures/edit.html.haml', type: :view, vcr: { cassette_name: 'admin_procedure_edit' } do
   let(:logo) { Rack::Test::UploadedFile.new("./spec/fixtures/files/logo_test_procedure.png", 'image/png') }
-  let(:procedure) { create(:procedure, logo: logo) }
+  let(:procedure) { create(:procedure, logo: logo, lien_site_web: 'http://some.website') }
 
   before do
     assign(:procedure, procedure)

--- a/spec/views/admin/procedures/show.html.haml_spec.rb
+++ b/spec/views/admin/procedures/show.html.haml_spec.rb
@@ -41,7 +41,7 @@ describe 'admin/procedures/show.html.haml', type: :view do
 
   describe 'procedure is published' do
     before do
-      procedure.publish!(procedure.administrateurs.first, 'fake_path')
+      procedure.publish!(procedure.administrateurs.first, 'fake_path', procedure.lien_site_web)
       procedure.reload
       render
     end
@@ -59,7 +59,7 @@ describe 'admin/procedures/show.html.haml', type: :view do
 
   describe 'procedure is archived' do
     before do
-      procedure.publish!(procedure.administrateurs.first, 'fake_path')
+      procedure.publish!(procedure.administrateurs.first, 'fake_path', procedure.lien_site_web)
       procedure.archive!
       procedure.reload
       render


### PR DESCRIPTION
https://github.com/betagouv/demarches-simplifiees.fr/issues/3609:

 - plus de lien à la création de la démarche
 - le lien est demandé lorsqu'on publie la démarche
 - on peut modifier ce lien dans l'onglet "description" si la démarche est publiée

![image](https://user-images.githubusercontent.com/1223316/61044465-fdede300-a3d8-11e9-92f4-39787dd924a6.png)
