### PR TITLE
dossier: make messagerie available on archived procedures

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -225,7 +225,7 @@ class Dossier < ApplicationRecord
   end
 
   def messagerie_available?
-    !brouillon? && !archived && !procedure.archivee?
+    !brouillon? && !archived
   end
 
   def retention_end_date

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -747,22 +747,16 @@ describe Dossier do
       it { is_expected.to be false }
     end
 
+    context "dossier is submitted" do
+      before { dossier.state = Dossier.states.fetch(:en_instruction) }
+
+      it { is_expected.to be true }
+    end
+
     context "dossier is archived" do
       before { dossier.archived = true }
 
       it { is_expected.to be false }
-    end
-
-    context "procedure is archived" do
-      before { procedure.archived_at = Date.today }
-
-      it { is_expected.to be false }
-    end
-
-    context "procedure is not archived, dossier is not archived" do
-      before { dossier.state = Dossier.states.fetch(:en_instruction) }
-
-      it { is_expected.to be true }
     end
   end
 


### PR DESCRIPTION
An Admin may archive a procedure to make it unavailable to
the general public, but before all dossiers are handled. In this case,
the messagerie needs to be available.

Fix #4089