### PR TITLE
Suppression de colonnes dépréciées sur Procedure

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -3,8 +3,6 @@ require Rails.root.join('lib', 'percentile')
 class Procedure < ApplicationRecord
   MAX_DUREE_CONSERVATION = 36
 
-  self.ignored_columns = [:individual_with_siret]
-
   has_many :types_de_piece_justificative, -> { ordered }, inverse_of: :procedure, dependent: :destroy
   has_many :types_de_champ, -> { root.public_only.ordered }, inverse_of: :procedure, dependent: :destroy
   has_many :types_de_champ_private, -> { root.private_only.ordered }, class_name: 'TypeDeChamp', inverse_of: :procedure, dependent: :destroy

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -3,7 +3,7 @@ require Rails.root.join('lib', 'percentile')
 class Procedure < ApplicationRecord
   MAX_DUREE_CONSERVATION = 36
 
-  self.ignored_columns = [:individual_with_siret, :expects_multiple_submissions]
+  self.ignored_columns = [:individual_with_siret]
 
   has_many :types_de_piece_justificative, -> { ordered }, inverse_of: :procedure, dependent: :destroy
   has_many :types_de_champ, -> { root.public_only.ordered }, inverse_of: :procedure, dependent: :destroy

--- a/db/migrate/20190711135401_remove_expects_multiple_submissions_from_procedure.rb
+++ b/db/migrate/20190711135401_remove_expects_multiple_submissions_from_procedure.rb
@@ -1,0 +1,5 @@
+class RemoveExpectsMultipleSubmissionsFromProcedure < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :procedures, :expects_multiple_submissions, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20190711135457_remove_individual_with_siret_from_procedure.rb
+++ b/db/migrate/20190711135457_remove_individual_with_siret_from_procedure.rb
@@ -1,0 +1,5 @@
+class RemoveIndividualWithSiretFromProcedure < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :procedures, :individual_with_siret, :boolean, default: false
+  end
+end


### PR DESCRIPTION
Ces colonnes sont déjà ignorées en production. On peut donc les supprimer de la base.