### PR TITLE
manager: fix the deletion email not being sent

### DIFF
--- a/app/controllers/manager/dossiers_controller.rb
+++ b/app/controllers/manager/dossiers_controller.rb
@@ -22,9 +22,8 @@ module Manager
 
     def hide
       dossier = Dossier.find(params[:id])
-      deleted_dossier = dossier.hide!(current_administration)
+      dossier.hide!(current_administration)
 
-      DossierMailer.notify_deletion_to_user(deleted_dossier, dossier.user.email).deliver_later
       logger.info("Le dossier #{dossier.id} est supprimé par #{current_administration.email}")
       flash[:notice] = "Le dossier #{dossier.id} est supprimé"
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -412,7 +412,8 @@ class Dossier < ApplicationRecord
   def hide!(administration)
     update(hidden_at: Time.zone.now)
 
-    DeletedDossier.create_from_dossier(self)
+    deleted_dossier = DeletedDossier.create_from_dossier(self)
+    DossierMailer.notify_deletion_to_user(deleted_dossier, user.email).deliver_later
     log_dossier_operation(administration, :supprimer, self)
   end
 


### PR DESCRIPTION
When deleting a dossier from the manager, the deletion notification
email was not being sent. This is because the returned object from
`Dossier#hide!` was invalid.

Fix https://sentry.io/organizations/demarches-simplifiees/issues/1109732202/