### PR TITLE
[Refactor] Unify dossier deletion  between manager and user

### DIFF
--- a/app/controllers/manager/dossiers_controller.rb
+++ b/app/controllers/manager/dossiers_controller.rb
@@ -22,10 +22,10 @@ module Manager
 
     def hide
       dossier = Dossier.find(params[:id])
-      dossier.hide!(current_administration)
+      dossier.delete_and_keep_track(current_administration)
 
       logger.info("Le dossier #{dossier.id} est supprimé par #{current_administration.email}")
-      flash[:notice] = "Le dossier #{dossier.id} est supprimé"
+      flash[:notice] = "Le dossier #{dossier.id} a été supprimé."
 
       redirect_to manager_dossier_path(dossier)
     end

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -193,7 +193,7 @@ module Users
       dossier = current_user.dossiers.includes(:user, procedure: :administrateurs).find(params[:id])
 
       if dossier.can_be_deleted_by_user?
-        dossier.delete_and_keep_track
+        dossier.delete_and_keep_track(current_user)
         flash.notice = 'Votre dossier a bien été supprimé.'
         redirect_to dossiers_path
       else

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -317,7 +317,7 @@ class Dossier < ApplicationRecord
     end
   end
 
-  def delete_and_keep_track
+  def delete_and_keep_track(author)
     deleted_dossier = DeletedDossier.create_from_dossier(self)
     update(hidden_at: deleted_dossier.deleted_at)
 
@@ -328,6 +328,8 @@ class Dossier < ApplicationRecord
       end
     end
     DossierMailer.notify_deletion_to_user(deleted_dossier, user.email).deliver_later
+
+    log_dossier_operation(author, :supprimer, self)
   end
 
   def after_passer_en_instruction(gestionnaire)
@@ -407,14 +409,6 @@ class Dossier < ApplicationRecord
     save!
     NotificationMailer.send_without_continuation_notification(self).deliver_later
     log_dossier_operation(gestionnaire, :classer_sans_suite, self)
-  end
-
-  def hide!(administration)
-    update(hidden_at: Time.zone.now)
-
-    deleted_dossier = DeletedDossier.create_from_dossier(self)
-    DossierMailer.notify_deletion_to_user(deleted_dossier, user.email).deliver_later
-    log_dossier_operation(administration, :supprimer, self)
   end
 
   def check_mandatory_champs


### PR DESCRIPTION
This is a follow-up of #4097.

Currently there are two code paths for deleting a dossier, depending on
whether the dossier was deleted by the user, or from the Manager.

This commit unifies the two code paths into one.

This has the effect of:

- An operation log is now recorded when an user deletes its own dossier;
- Gestionnaires are now notified even when the dossier is deleted from
  the Manager;
- The `support:delete_user_account` task now requires the email address
  of the author.