### PR TITLE
Renomme « Soumettre le dossier » en « Déposer le dossier »

### DIFF
--- a/app/views/invites/_form.html.haml
+++ b/app/views/invites/_form.html.haml
@@ -6,7 +6,7 @@
         %li= invite.email
     %p Ces personnes peuvent modifier ce dossier.
     - if dossier.brouillon?
-      %p Une fois le dossier complet, vous devez le soumettre vous-même.
+      %p Une fois le dossier complet, vous devez le déposer vous-même.
 
   - else
     %p Vous pouvez inviter quelqu’un à remplir ce dossier avec vous.

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -80,7 +80,7 @@
             data: { 'disable-with': "Envoi en cours…" }
 
           - if dossier.can_transition_to_en_construction?
-            = f.button 'Soumettre le dossier',
+            = f.button 'Déposer le dossier',
               class: 'button send primary',
               disabled: !current_user.owns?(dossier),
               data: { 'disable-with': "Envoi en cours…" }
@@ -92,6 +92,6 @@
 
       - if dossier.brouillon? && !current_user.owns?(dossier)
         .send-notice.invite-cannot-submit
-          En tant qu’invité, vous pouvez remplir ce formulaire – mais le titulaire du dossier doit le soumettre lui-même.
+          En tant qu’invité, vous pouvez remplir ce formulaire – mais le titulaire du dossier doit le déposer lui-même.
 
       = render partial: "shared/dossiers/submit_is_over", locals: { dossier: dossier }

--- a/app/views/users/dossiers/show/_status_overview.html.haml
+++ b/app/views/users/dossiers/show/_status_overview.html.haml
@@ -15,7 +15,7 @@
     - if dossier.brouillon?
       .brouillon
         %p Votre dossier n’est pas encore visible par l’administration.
-        %p Vous pouvez « Soumettre votre dossier » afin de le transmettre à l’administration. Une fois soumis, vous pourrez toujours modifier votre dossier.
+        %p Vous pouvez déposer votre dossier afin de le transmettre à l’administration. Une fois soumis, vous pourrez toujours modifier votre dossier.
 
     - elsif dossier.en_construction?
       .en-construction

--- a/spec/features/users/brouillon_spec.rb
+++ b/spec/features/users/brouillon_spec.rb
@@ -137,14 +137,14 @@ feature 'The user' do
     expect(page).to have_current_path(brouillon_dossier_path(user_dossier))
 
     # Check an incomplete dossier cannot be submitted when mandatory fields are missing
-    click_on 'Soumettre le dossier'
+    click_on 'Déposer le dossier'
     expect(user_dossier.reload.brouillon?).to be(true)
     expect(page).to have_current_path(brouillon_dossier_path(user_dossier))
 
     # Check a dossier can be submitted when all mandatory fields are filled
     fill_in('texte obligatoire', with: 'super texte')
 
-    click_on 'Soumettre le dossier'
+    click_on 'Déposer le dossier'
     expect(user_dossier.reload.en_construction?).to be(true)
     expect(champ_value_for('texte obligatoire')).to eq('super texte')
     expect(page).to have_current_path(merci_dossier_path(user_dossier))

--- a/spec/features/users/invite_spec.rb
+++ b/spec/features/users/invite_spec.rb
@@ -63,7 +63,7 @@ feature 'Invitations' do
       navigate_to_invited_dossier(invite)
       expect(page).to have_current_path(brouillon_dossier_path(dossier))
 
-      expect(page).to have_button('Soumettre le dossier', disabled: true)
+      expect(page).to have_button('Déposer le dossier', disabled: true)
       expect(page).to have_selector('.invite-cannot-submit')
     end
   end


### PR DESCRIPTION
- J'ai l'impression que « Soumettre » c'est un anglicisme (pour "Submit");
- "Soumettre", en soi, ça peut vouloir dire plusieurs choses, c'est pas très clair;
- Dans la vie on va **déposer** un dossier, pas le soumettre.

Ça vous va ?