### PR TITLE
#4103 - Ajout du tag 'lien document justificatif'

### DIFF
--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -72,7 +72,7 @@ module TagsSubstitutionConcern
           return "[l'instructeur n'a pas joint de document supplémentaire]"
         end
       },
-      available_for_states: Dossier::SOUMIS
+      available_for_states: Dossier::TERMINE
     }
   ]
 

--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -59,14 +59,20 @@ module TagsSubstitutionConcern
     {
       libelle: 'lien attestation',
       description: '',
-      lambda: -> (d) {
-        links = [external_link(attestation_dossier_url(d))]
-        if d.justificatif_motivation.attached?
-          links.push external_link("Télécharger le justificatif", url_for_justificatif_motivation(d))
-        end
-        links.join "<br />\n"
-      },
+      lambda: -> (d) { external_link(attestation_dossier_url(d)) },
       available_for_states: [Dossier.states.fetch(:accepte)]
+    },
+    {
+      libelle: 'lien document justificatif',
+      description: '',
+      lambda: -> (d) {
+        if d.justificatif_motivation.attached?
+          external_link(url_for_justificatif_motivation(d), "Télécharger le document justificatif")
+        else
+          return "[l'instructeur n'a pas joint de document supplémentaire]"
+        end
+      },
+      available_for_states: Dossier::SOUMIS
     }
   ]
 

--- a/spec/models/concern/mail_template_concern_spec.rb
+++ b/spec/models/concern/mail_template_concern_spec.rb
@@ -105,7 +105,7 @@ describe MailTemplateConcern do
       end
     end
 
-    describe '--lien document justificatif--' do
+    shared_examples 'inserting the --lien document justificatif-- tag' do
       let(:procedure) { create(:procedure) }
 
       subject { mail.body_for_dossier(dossier) }
@@ -114,50 +114,32 @@ describe MailTemplateConcern do
         mail.body = "--lien document justificatif--"
       end
 
-      describe "in closed mail" do
-        let(:mail) { create(:closed_mail, procedure: procedure) }
-        describe 'without justificatif' do
-          it { is_expected.to include("[l'instructeur n'a pas joint de document supplémentaire]") }
-        end
-
-        describe 'with justificatif' do
-          before do
-            dossier.justificatif_motivation.attach(justificatif)
-          end
-          it { expect(dossier.justificatif_motivation).to be_attached }
-          it { is_expected.to include("Télécharger le document justificatif") }
-        end
+      describe 'without justificatif' do
+        it { is_expected.to include("[l'instructeur n'a pas joint de document supplémentaire]") }
       end
 
-      describe "in refused mail" do
-        let(:mail) { create(:refused_mail, procedure: procedure) }
-        describe 'without justificatif' do
-          it { is_expected.to include("[l'instructeur n'a pas joint de document supplémentaire]") }
+      describe 'with justificatif' do
+        before do
+          dossier.justificatif_motivation.attach(justificatif)
         end
-
-        describe 'with justificatif' do
-          before do
-            dossier.justificatif_motivation.attach(justificatif)
-          end
-          it { expect(dossier.justificatif_motivation).to be_attached }
-          it { is_expected.to include("Télécharger le document justificatif") }
-        end
+        it { expect(dossier.justificatif_motivation).to be_attached }
+        it { is_expected.to include("Télécharger le document justificatif") }
       end
+    end
 
-      describe "in without continuation mail" do
-        let(:mail) { create(:without_continuation_mail, procedure: procedure) }
-        describe 'without justificatif' do
-          it { is_expected.to include("[l'instructeur n'a pas joint de document supplémentaire]") }
-        end
+    context 'in closed mail' do
+      let(:mail) { create(:closed_mail, procedure: procedure) }
+      it_behaves_like 'inserting the --lien document justificatif-- tag'
+    end
 
-        describe 'with justificatif' do
-          before do
-            dossier.justificatif_motivation.attach(justificatif)
-          end
-          it { expect(dossier.justificatif_motivation).to be_attached }
-          it { is_expected.to include("Télécharger le document justificatif") }
-        end
-      end
+    context 'in refused mail' do
+      let(:mail) { create(:refused_mail, procedure: procedure) }
+      it_behaves_like 'inserting the --lien document justificatif-- tag'
+    end
+
+    context 'in without continuation mail' do
+      let(:mail) { create(:without_continuation_mail, procedure: procedure) }
+      it_behaves_like 'inserting the --lien document justificatif-- tag'
     end
   end
 

--- a/spec/models/concern/mail_template_concern_spec.rb
+++ b/spec/models/concern/mail_template_concern_spec.rb
@@ -89,7 +89,7 @@ describe MailTemplateConcern do
 
         it { expect(dossier.justificatif_motivation).to be_attached }
         it { is_expected.to include("<a target=\"_blank\" rel=\"noopener\" href=\"http://localhost:3000/dossiers/#{dossier.id}/attestation\">http://localhost:3000/dossiers/#{dossier.id}/attestation</a>") }
-        it { is_expected.to include("Télécharger le justificatif") }
+        it { is_expected.to_not include("Télécharger le justificatif") }
       end
 
       describe "in refuse mail" do
@@ -102,6 +102,61 @@ describe MailTemplateConcern do
         let(:mail) { create(:without_continuation_mail, procedure: procedure) }
 
         it { is_expected.to eq("--lien attestation--") }
+      end
+    end
+
+    describe '--lien document justificatif--' do
+      let(:procedure) { create(:procedure) }
+
+      subject { mail.body_for_dossier(dossier) }
+
+      before do
+        mail.body = "--lien document justificatif--"
+      end
+
+      describe "in closed mail" do
+        let(:mail) { create(:closed_mail, procedure: procedure) }
+        describe 'without justificatif' do
+          it { is_expected.to include("[l'instructeur n'a pas joint de document supplémentaire]") }
+        end
+
+        describe 'with justificatif' do
+          before do
+            dossier.justificatif_motivation.attach(justificatif)
+          end
+          it { expect(dossier.justificatif_motivation).to be_attached }
+          it { is_expected.to include("Télécharger le document justificatif") }
+        end
+      end
+
+      describe "in refused mail" do
+        let(:mail) { create(:refused_mail, procedure: procedure) }
+        describe 'without justificatif' do
+          it { is_expected.to include("[l'instructeur n'a pas joint de document supplémentaire]") }
+        end
+
+        describe 'with justificatif' do
+          before do
+            dossier.justificatif_motivation.attach(justificatif)
+          end
+          it { expect(dossier.justificatif_motivation).to be_attached }
+          it { is_expected.to include("Télécharger le document justificatif") }
+        end
+      end
+
+      describe "in without continuation mail" do
+        let(:mail) { create(:without_continuation_mail, procedure: procedure) }
+        describe 'without justificatif' do
+          it { is_expected.to include("[l'instructeur n'a pas joint de document supplémentaire]") }
+        end
+
+        describe 'with justificatif' do
+          before do
+            dossier.justificatif_motivation.attach(justificatif)
+          end
+          it { expect(dossier.justificatif_motivation).to be_attached }
+          it { is_expected.to include("Télécharger le document justificatif") }
+        end
       end
     end
   end


### PR DESCRIPTION
PR qui fait suite à la discussion Slack récapitulée dans https://github.com/betagouv/demarches-simplifiees.fr/issues/4103

J'ai fait quelques aménagements sur le vocabulaire par rapport à ce qu'on évoquait, rien de définitif bien sûr, vous en pensez quoi ?