### PR TITLE
[Emails] Améliore les emails de nouveau brouillon et de nouveau message

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -1,0 +1,5 @@
+module MailerHelper
+  def round_button(text, url)
+    render 'shared/mailer_round_button', text: text, url: url
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -2,4 +2,22 @@ class ApplicationMailer < ActionMailer::Base
   helper :application # gives access to all helpers defined within `application_helper`.
   default from: "demarches-simplifiees.fr <#{CONTACT_EMAIL}>"
   layout 'mailer'
+
+  # Attach the procedure logo to the email (if any).
+  # Returns the attachment url.
+  def attach_logo(procedure)
+    return nil if !procedure.logo?
+
+    begin
+      logo_filename = procedure.logo.filename
+      attachments.inline[logo_filename] = procedure.logo.read
+      attachments[logo_filename].url
+
+    rescue StandardError => e
+      # A problem occured when reading logo, maybe the logo is missing and we should clean the procedure to remove logo reference ?
+      Raven.extra_context(procedure_id: procedure.id)
+      Raven.capture_exception(e)
+      nil
+    end
+  end
 end

--- a/app/mailers/dossier_mailer.rb
+++ b/app/mailers/dossier_mailer.rb
@@ -1,5 +1,7 @@
 # Preview all emails at http://localhost:3000/rails/mailers/dossier_mailer
 class DossierMailer < ApplicationMailer
+  helper ServiceHelper
+
   layout 'mailers/layout'
 
   def notify_new_draft(dossier)

--- a/app/mailers/dossier_mailer.rb
+++ b/app/mailers/dossier_mailer.rb
@@ -6,13 +6,21 @@ class DossierMailer < ApplicationMailer
 
   def notify_new_draft(dossier)
     @dossier = dossier
+    @service = dossier.procedure.service
+    @logo_url = attach_logo(dossier.procedure)
+
     subject = "Retrouvez votre brouillon pour la démarche « #{dossier.procedure.libelle} »"
 
-    mail(to: dossier.user.email, subject: subject)
+    mail(to: dossier.user.email, subject: subject) do |format|
+      format.html { render layout: 'mailers/notification' }
+    end
   end
 
   def notify_new_answer(dossier)
     @dossier = dossier
+    @service = dossier.procedure.service
+    @logo_url = attach_logo(dossier.procedure)
+
     subject = "Nouveau message pour votre dossier nº #{dossier.id} (#{dossier.procedure.libelle})"
 
     mail(to: dossier.user.email, subject: subject) do |format|

--- a/app/mailers/dossier_mailer.rb
+++ b/app/mailers/dossier_mailer.rb
@@ -1,6 +1,7 @@
 # Preview all emails at http://localhost:3000/rails/mailers/dossier_mailer
 class DossierMailer < ApplicationMailer
   helper ServiceHelper
+  helper MailerHelper
 
   layout 'mailers/layout'
 

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -38,20 +38,9 @@ class NotificationMailer < ApplicationMailer
 
     create_commentaire_for_notification(dossier, subject, body)
 
-    if dossier.procedure.logo?
-      begin
-        logo_filename = dossier.procedure.logo.filename
-        attachments.inline[logo_filename] = dossier.procedure.logo.read
-        @logo_url = attachments[logo_filename].url
-      rescue StandardError => e
-        # A problem occured when reading logo, maybe the logo is missing and we should clean the procedure to remove logo reference ?
-        Raven.extra_context(procedure_id: dossier.procedure.id)
-        Raven.capture_exception(e)
-      end
-    end
-
     @dossier = dossier
     @service = dossier.procedure.service
+    @logo_url = attach_logo(dossier.procedure)
 
     mail(subject: subject, to: email) do |format|
       # rubocop:disable Rails/OutputSafety

--- a/app/views/dossier_mailer/notify_new_answer.html.haml
+++ b/app/views/dossier_mailer/notify_new_answer.html.haml
@@ -2,10 +2,12 @@
   Bonjour,
 
 %p
-  Un nouveau message est disponible dans votre espace demarches-simplifiees.fr.
+  L’administration en charge de votre dossier vous a
+  %strong envoyé un nouveau message.
 
 %p
-  Pour le consulter, merci de vous rendre sur
-  = link_to messagerie_dossier_url(@dossier), messagerie_dossier_url(@dossier), target: '_blank', rel:'noopener'
+  Pour le consulter et y répondre, cliquez sur le bouton ci-dessous :
+
+= round_button('Lire le message', messagerie_dossier_url(@dossier))
 
 = render partial: "layouts/mailers/signature", locals: { service: @service }

--- a/app/views/dossier_mailer/notify_new_answer.html.haml
+++ b/app/views/dossier_mailer/notify_new_answer.html.haml
@@ -8,4 +8,4 @@
   Pour le consulter, merci de vous rendre sur
   = link_to messagerie_dossier_url(@dossier), messagerie_dossier_url(@dossier), target: '_blank', rel:'noopener'
 
-= render partial: "layouts/mailers/signature"
+= render partial: "layouts/mailers/signature", locals: { service: @service }

--- a/app/views/dossier_mailer/notify_new_draft.html.haml
+++ b/app/views/dossier_mailer/notify_new_draft.html.haml
@@ -2,9 +2,12 @@
   Bonjour,
 
 %p
-  Vous pouvez retrouver et compléter le brouillon que vous avez créé pour la démarche
-  %strong= @dossier.procedure.libelle
-  à l'adresse suivante :
+  Vous avez commencé à remplir un dossier pour la démarche « #{@dossier.procedure.libelle} ».
+
+%p
+  Vous pouvez
+  %strong retrouver et compléter votre dossier
+  à l’adresse suivante :
   = link_to dossier_url(@dossier), dossier_url(@dossier), target: '_blank', rel: 'noopener'
 
 = render partial: "layouts/mailers/signature"

--- a/app/views/layouts/mailers/_signature.html.haml
+++ b/app/views/layouts/mailers/_signature.html.haml
@@ -1,4 +1,7 @@
 %p
   Bonne journée,
   %br
-  L’équipe demarches-simplifiees.fr
+  - if defined?(service) && service && service.nom.present?
+    = service.nom
+  - else
+    L’équipe demarches-simplifiees.fr

--- a/app/views/layouts/mailers/notification.html.haml
+++ b/app/views/layouts/mailers/notification.html.haml
@@ -9,9 +9,9 @@
   %strong
     Merci de ne pas répondre à cet email.
     - if @dossier.present? && @dossier.messagerie_available?
-      Pour vous adresser à votre administration, passez directement par votre
+      Pour vous adresser à votre administration, passez directement par la
       = succeed '.' do
-        = link_to 'messagerie', messagerie_dossier_url(@dossier), target: '_blank', rel: 'noopener'
+        = link_to 'messagerie du dossier', messagerie_dossier_url(@dossier), target: '_blank', rel: 'noopener'
 
   - if @service.present?
     %table{ width: "100%", border: "0", cellspacing: "0", cellpadding: "0", style: "cursor:auto;color:#55575d;font-family:Helvetica, Arial, sans-serif;font-size:11px;line-height:22px;text-align:left;" }

--- a/app/views/layouts/mailers/notification.html.haml
+++ b/app/views/layouts/mailers/notification.html.haml
@@ -6,14 +6,12 @@
           = image_tag @logo_url, height: "150", style: "display:block; max-height: 150px; max-width: 150px;"
 
 - content_for :footer do
-  - if @dossier.present?
-    - messagerie_url = messagerie_dossier_url(@dossier)
-  - else
-    - messagerie_url = "#"
   %strong
-    Merci de ne pas répondre à cet email. Pour vous adresser à votre administration, passez directement par votre
-    = succeed '.' do
-      = link_to 'messagerie', messagerie_url, target: '_blank', rel: 'noopener'
+    Merci de ne pas répondre à cet email.
+    - if @dossier.present? && @dossier.messagerie_available?
+      Pour vous adresser à votre administration, passez directement par votre
+      = succeed '.' do
+        = link_to 'messagerie', messagerie_dossier_url(@dossier), target: '_blank', rel: 'noopener'
 
   - if @service.present?
     %table{ width: "100%", border: "0", cellspacing: "0", cellpadding: "0", style: "cursor:auto;color:#55575d;font-family:Helvetica, Arial, sans-serif;font-size:11px;line-height:22px;text-align:left;" }
@@ -31,7 +29,11 @@
           %p
             %strong Poser une question sur votre dossier :
             %br
-            = link_to 'Par la messagerie', messagerie_url, target: '_blank', rel: 'noopener'
+            - if @dossier.present? && @dossier.messagerie_available?
+              = link_to 'Par la messagerie', messagerie_dossier_url(@dossier), target: '_blank', rel: 'noopener'
+            - else
+              Par email :
+              = link_to @service.email, "mailto:#{@service.email}"
             %br
             Par téléphone :
             = link_to @service.telephone, "tel:#{@service.telephone}"

--- a/app/views/shared/_mailer_round_button.html.haml
+++ b/app/views/shared/_mailer_round_button.html.haml
@@ -1,0 +1,9 @@
+/# From https://litmus.com/blog/a-guide-to-bulletproof-buttons-in-email-design
+%table{ width: "100%", border: "0", cellspacing:"0", cellpadding:"0" }
+  %tr
+    %td
+      %table{ border:"0", cellspacing:"0", cellpadding:"0", style:"margin: auto" }
+        %tr
+          %td{ align:"center", style:"border-radius: 5px;", bgcolor:"#0069cc" }
+            %a{ href: url, target:"_blank", style:"font-size: 16px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; text-decoration: none; border-radius: 5px; padding: 12px 25px; border: 1px solid #0069cc; display: inline-block;" }
+              = text


### PR DESCRIPTION
_Deuxième partie du chantier sur les emails (#4060)._

Cette PR améliore les emails transactionnels faciles à modifier : ceux que DS envoie lui-même, sans passer par des templates modifiables par l'administration. Ce sont donc les emails "Nouveau brouillon" et "Nouveau message dans la messagerie".

Le plan est de commencer par tester les gros boutons d'action sur ces emails – puis ensuite de voir comment rajouter les boutons aux emails à templates.

## "Nouveau brouillon"

Je pars du principe que c'est un email qui permet à la fois de retrouver son brouillon, mais aussi son dossier une fois que le dossier est déposé.

- Le logo de la démarche est maintenant affiché
- Le message est signé de la part de la démarche (et pas de DS)
- Clarification du texte

### Avant

<img width="708" alt="Capture d’écran 2019-07-17 à 16 51 15" src="https://user-images.githubusercontent.com/179923/61386815-3e57d000-a8b5-11e9-8bcb-1c1883779167.png">

### Après

<img width="709" alt="Capture d’écran 2019-07-17 à 16 51 55" src="https://user-images.githubusercontent.com/179923/61386827-41eb5700-a8b5-11e9-9109-eaf50eb34bcb.png">

## "Nouveau message"

- Le logo de la démarche est maintenant affiché
- Le message est signé de la part de la démarche (et pas de DS)
- Nouveau gros bouton "Lire le message"

- On affiche les infos de contact de la démarche

### Avant

<img width="865" alt="Capture d’écran 2019-07-17 à 12 35 40" src="https://user-images.githubusercontent.com/179923/61386501-b4a80280-a8b4-11e9-8edc-d887f4c71cd2.png">

### Après

<img width="802" alt="Capture d’écran 2019-07-17 à 16 50 21" src="https://user-images.githubusercontent.com/179923/61386584-d43f2b00-a8b4-11e9-9259-bc4017c3a086.png">
