### PR TITLE
Remove possibility to use node 6.*

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,6 @@
     "lint:js": "eslint ./app/javascript ./app/assets/javascripts ./config/webpack"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "8.* || >= 10.*"
   }
 }


### PR DESCRIPTION
Some users reported that using `node 6.*` does not work since our dependencies require `node > 7.*` 

We use `node 8.10` in production, so it makes sense to get rid of this clause.