### PR TITLE
Ajout d'un message lorsque le dossier fait plus de 50Mo

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -15,6 +15,8 @@ class Dossier < ApplicationRecord
   INSTRUCTION_COMMENCEE = TERMINE + [states.fetch(:en_instruction)]
   SOUMIS = EN_CONSTRUCTION_OU_INSTRUCTION + TERMINE
 
+  TAILLE_MAX_ZIP = 50.megabytes
+
   has_one :etablissement, dependent: :destroy
   has_one :individual, dependent: :destroy
   has_one :attestation, dependent: :destroy
@@ -461,7 +463,7 @@ class Dossier < ApplicationRecord
   end
 
   def attachments_downloadable?
-    !PiecesJustificativesService.liste_pieces_justificatives(self).empty? && PiecesJustificativesService.pieces_justificatives_total_size(self) < 50.megabytes
+    !PiecesJustificativesService.liste_pieces_justificatives(self).empty? && PiecesJustificativesService.pieces_justificatives_total_size(self) < Dossier::TAILLE_MAX_ZIP
   end
 
   private

--- a/app/views/gestionnaires/dossiers/_header.html.haml
+++ b/app/views/gestionnaires/dossiers/_header.html.haml
@@ -24,10 +24,10 @@
               %span.icon.attachment
             %ul.print-menu.dropdown-content
               %li
-                - if PiecesJustificativesService.pieces_justificatives_total_size(dossier) < 50.megabytes
+                - if PiecesJustificativesService.pieces_justificatives_total_size(dossier) < Dossier::TAILLE_MAX_ZIP
                   = link_to "Télécharger toutes les pièces jointes", telecharger_pjs_gestionnaire_dossier_path(dossier.procedure, dossier), target: "_blank", rel: "noopener", class: "menu-item menu-link"
                 - else
-                  %p.menu-item Le téléchargement des dossiers est désactivé pour les dossiers de plus de 50Mo.
+                  %p.menu-item Le téléchargement des pièces jointes est désactivé pour les dossiers de plus de #{number_to_human_size Dossier::TAILLE_MAX_ZIP}.
 
 
         = render partial: "gestionnaires/procedures/dossier_actions", locals: { procedure: dossier.procedure, dossier: dossier, dossier_is_followed: current_gestionnaire&.follow?(dossier) }

--- a/app/views/gestionnaires/dossiers/_header.html.haml
+++ b/app/views/gestionnaires/dossiers/_header.html.haml
@@ -18,13 +18,16 @@
               = link_to "Tout le dossier", print_gestionnaire_dossier_path(dossier.procedure, dossier), target: "_blank", rel: "noopener", class: "menu-item menu-link"
             %li
               = link_to "Uniquement cet onglet", "#", onclick: "window.print()", class: "menu-item menu-link"
-        - if Flipflop.download_as_zip_enabled? && dossier.attachments_downloadable?
+        - if Flipflop.download_as_zip_enabled? && !PiecesJustificativesService.liste_pieces_justificatives(dossier).empty?
           %span.dropdown.print-menu-opener
             %button.button.dropdown-button.icon-only
               %span.icon.attachment
             %ul.print-menu.dropdown-content
               %li
-                = link_to "Télécharger toutes les pièces jointes", telecharger_pjs_gestionnaire_dossier_path(dossier.procedure, dossier), target: "_blank", rel: "noopener", class: "menu-item menu-link"
+                - if PiecesJustificativesService.pieces_justificatives_total_size(dossier) < 50.megabytes
+                  = link_to "Télécharger toutes les pièces jointes", telecharger_pjs_gestionnaire_dossier_path(dossier.procedure, dossier), target: "_blank", rel: "noopener", class: "menu-item menu-link"
+                - else
+                  %p.menu-item Le téléchargement des dossiers est désactivé pour les dossiers de plus de 50Mo.
 
 
         = render partial: "gestionnaires/procedures/dossier_actions", locals: { procedure: dossier.procedure, dossier: dossier, dossier_is_followed: current_gestionnaire&.follow?(dossier) }


### PR DESCRIPTION
Ajout d'un message pour expliciter le comportement lorsque le téléchargement est désactivé du fait du dépassement de la limite des 50Mo.

![telechargement-desactive](https://user-images.githubusercontent.com/1223316/61438443-c2569a00-a93f-11e9-9124-5fa1bbc598d0.png)

![image](https://user-images.githubusercontent.com/1223316/61438500-eca85780-a93f-11e9-9262-e6d7521e8ca4.png)

