### PR TITLE
Fix/ameliorations cosmetiques monavis

### DIFF
--- a/app/assets/stylesheets/new_design/merci.scss
+++ b/app/assets/stylesheets/new_design/merci.scss
@@ -30,4 +30,10 @@
   a {
     margin-top: 40px;
   }
+
+  .monavis {
+    img {
+      margin-top: 2*$default-padding;
+    }
+  }
 }

--- a/app/assets/stylesheets/new_design/merci.scss
+++ b/app/assets/stylesheets/new_design/merci.scss
@@ -33,7 +33,7 @@
 
   .monavis {
     img {
-      margin-top: 2*$default-padding;
+      margin-top: 2 * $default-padding;
     }
   }
 }

--- a/app/views/admin/procedures/monavis.html.haml
+++ b/app/views/admin/procedures/monavis.html.haml
@@ -1,6 +1,6 @@
 .row.white-back
   #procedure_new.section.section-label
-    = form_for @procedure, url: url_for({ controller: 'admin/procedures', action: :update_monavis, id: @procedure.id }), multipart: true do |f|
+    = form_for @procedure, url: url_for({ controller: 'admin/procedures', action: :update_monavis }), multipart: true do |f|
       = render partial: 'monavis', locals: { f: f }
       .text-right
         = f.button 'Enregistrer', class: 'btn btn-success'

--- a/app/views/layouts/left_panels/_left_panel_admin_procedurescontroller_update_monavis.html.haml
+++ b/app/views/layouts/left_panels/_left_panel_admin_procedurescontroller_update_monavis.html.haml
@@ -1,0 +1,1 @@
+= render partial: 'layouts/left_panels/left_panel_admin_procedurescontroller_navbar', locals: { active: 'MonAvis' }

--- a/app/views/layouts/navbars/_navbar_admin_procedurescontroller_monavis.html.haml
+++ b/app/views/layouts/navbars/_navbar_admin_procedurescontroller_monavis.html.haml
@@ -1,0 +1,1 @@
+= render partial: 'layouts/navbars/navbar_admin_procedurescontroller_index'

--- a/app/views/layouts/navbars/_navbar_admin_procedurescontroller_update_monavis.html.haml
+++ b/app/views/layouts/navbars/_navbar_admin_procedurescontroller_update_monavis.html.haml
@@ -1,0 +1,1 @@
+= render partial: 'layouts/navbars/navbar_admin_procedurescontroller_index'

--- a/app/views/users/dossiers/merci.html.haml
+++ b/app/views/users/dossiers/merci.html.haml
@@ -23,5 +23,5 @@
     .flex.column.align-center
       = link_to 'Accéder à votre dossier', dossier_path(@dossier), class: 'button large primary'
       = link_to 'Déposer un autre dossier', procedure_lien(@dossier.procedure)
-      %div.monavis
+      .monavis
         != @dossier.procedure.monavis_embed

--- a/app/views/users/dossiers/merci.html.haml
+++ b/app/views/users/dossiers/merci.html.haml
@@ -23,4 +23,5 @@
     .flex.column.align-center
       = link_to 'Accéder à votre dossier', dossier_path(@dossier), class: 'button large primary'
       = link_to 'Déposer un autre dossier', procedure_lien(@dossier.procedure)
-      != @dossier.procedure.monavis_embed
+      %div.monavis
+        != @dossier.procedure.monavis_embed


### PR DESCRIPTION
 - réduction de la marge sur le bouton « MonAvis » dans la page de remerciements
 - on garde le bandeau bleu de navigation lors d'une mise à jour réussie/échouée.

![marges-monavis](https://user-images.githubusercontent.com/1223316/61469727-02d60800-a980-11e9-9c85-ccac478b5b85.png)
