### PR TITLE
Amélioration de formulations à la page "Suivi"

### DIFF
--- a/app/views/root/suivi.html.haml
+++ b/app/views/root/suivi.html.haml
@@ -21,7 +21,3 @@
   %h2.new-h2 Comment désactiver le suivi statistique sur mon navigateur ?
   %p.new-p
     Si vous souhaitez désactiver ce suivi statistique, il vous suffit d’activer la fonctionnalité « Ne pas me pister » de votre navigateur. Notre outil de suivi le prendra en compte, et cessera d’inclure vos visites dans les statistiques.
-
-  %h2.new-h2 Je contribue à enrichir vos données, puis-je y accéder ?
-  %p.new-p
-    Bien sûr ! Les statistiques d’usage sont en accès libre sur <a href="https://stats.data.gouv.fr/index.php?module=MultiSites&action=index&idSite=1&period=range&date=previous30&updated=1#?idSite=1&period=range&date=previous30&category=Dashboard_Dashboard&subcategory=1&module=MultiSites&action=index" target="_blank" rel="noopener">stats.data.gouv.fr</a>.

--- a/app/views/root/suivi.html.haml
+++ b/app/views/root/suivi.html.haml
@@ -18,6 +18,10 @@
     %br
     Nous utilisons pour cela <a href="https://matomo.org/" target="_blank" rel="noopener">Matomo</a>, un outil <a href="https://matomo.org/free-software/" target="_blank" rel="noopener">libre</a>, paramétré pour être en conformité avec la <a href="https://www.cnil.fr/fr/solutions-pour-la-mesure-daudience">recommandation « Cookies » </a>de la CNIL. Cela signifie que votre adresse IP, par exemple, est anonymisée avant d’être enregistrée. Il est donc impossible d’associer vos visites sur ce site à votre personne.
 
+  %h2.new-h2 Comment désactiver le suivi statistique sur mon navigateur ?
+  %p.new-p
+    Si vous souhaitez désactiver ce suivi statistique, il vous suffit d’activer la fonctionnalité « Ne pas me pister » de votre navigateur. Notre outil de suivi le prendra en compte, et cessera d’inclure vos visites dans les statistiques.
+
   %h2.new-h2 Je contribue à enrichir vos données, puis-je y accéder ?
   %p.new-p
     Bien sûr ! Les statistiques d’usage sont en accès libre sur <a href="https://stats.data.gouv.fr/index.php?module=MultiSites&action=index&idSite=1&period=range&date=previous30&updated=1#?idSite=1&period=range&date=previous30&category=Dashboard_Dashboard&subcategory=1&module=MultiSites&action=index" target="_blank" rel="noopener">stats.data.gouv.fr</a>.


### PR DESCRIPTION
## Ajout d'un paragraphe expliquant comment désactiver le suivi

Matomo est configuré pour respecter Do Not Track, donc on explique ça.

## Suppression du lien vers le dashboard Matomo

En ce moment le dashboard Matomo est privé. Ça ne sert donc à rien de mettre le lien.

J'ai regardé si on pourrait rendre le dashboard public (cc @maatinito). Il y a plusieurs éléments problématiques :

- Des tokens en query_params (j'ai ajouté un filtre pour les ignorer)
- Des emails en query_params (j'ai ajouté un filtre pour les ignorer)
- Des URLs de démarches en test
- Des emails dans les URL

Ignorer les query_params, c'est fait (mais pas rétroactif). Et ignorer des fragments d'URL, c'est plus compliqué, il faut le faire [côté client](https://matomo.org/faq/how-to/faq_89/) (y'a pas de support de ça côté serveur).

Bref, on a encore de la donnée sensible dans le dashboard, donc pas public pour l'instant.

