### PR TITLE
Ajout d'un bouton de suppression des admin dans le manager

### DIFF
--- a/app/controllers/manager/administrateurs_controller.rb
+++ b/app/controllers/manager/administrateurs_controller.rb
@@ -33,6 +33,21 @@ module Manager
       head :ok
     end
 
+    def delete
+      administrateur = Administrateur.find(params[:id])
+
+      if !administrateur.can_be_deleted?
+        fail "Cannot delete this administrateur because it has dossiers or procedures"
+      end
+      administrateur.dossiers.each(&:delete_and_keep_track)
+      administrateur.destroy
+
+      logger.info("L'administrateur #{administrateur.id} est supprimé par #{current_user.id}")
+      flash[:notice] = "L'administrateur #{administrateur.id} est supprimé"
+
+      redirect_to manager_administrateurs_path
+    end
+
     private
 
     def create_administrateur_params

--- a/app/controllers/manager/administrateurs_controller.rb
+++ b/app/controllers/manager/administrateurs_controller.rb
@@ -37,7 +37,7 @@ module Manager
       administrateur = Administrateur.find(params[:id])
 
       if !administrateur.can_be_deleted?
-        fail "Cannot delete this administrateur because it has dossiers or procedures"
+        fail "Impossible de supprimer cet administrateur car il a des dossiers ou des procédures"
       end
       administrateur.dossiers.each(&:delete_and_keep_track)
       administrateur.destroy

--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -123,4 +123,8 @@ class Administrateur < ApplicationRecord
   def gestionnaire
     Gestionnaire.find_by(email: email)
   end
+
+  def can_be_deleted?
+    dossiers.state_instruction_commencee.none? && procedures.none?
+  end
 end

--- a/app/views/manager/administrateurs/show.html.erb
+++ b/app/views/manager/administrateurs/show.html.erb
@@ -33,6 +33,9 @@ as well as a link to its edit page.
   </div>
 
   <div>
+    <% if page.resource.can_be_deleted? %>
+      <%= link_to "supprimer", delete_manager_administrateur_path(page.resource), method: :delete, class: "button", data: { confirm: "Confirmez-vous la suppression de l'administrateur ?" } %>
+    <% end %>
     <% if page.resource.invitation_expired? %>
       <%= link_to "renvoyer l'invitation", reinvite_manager_administrateur_path(page.resource), method: :post, class: "button" %>
     <% end %>

--- a/app/views/manager/administrateurs/show.html.erb
+++ b/app/views/manager/administrateurs/show.html.erb
@@ -33,12 +33,10 @@ as well as a link to its edit page.
   </div>
 
   <div>
-    <% if page.resource.can_be_deleted? %>
-      <%= link_to "supprimer", delete_manager_administrateur_path(page.resource), method: :delete, class: "button", data: { confirm: "Confirmez-vous la suppression de l'administrateur ?" } %>
-    <% end %>
     <% if page.resource.invitation_expired? %>
       <%= link_to "renvoyer l'invitation", reinvite_manager_administrateur_path(page.resource), method: :post, class: "button" %>
     <% end %>
+    <%= button_to "supprimer", delete_manager_administrateur_path(page.resource), method: :delete, disabled: !page.resource.can_be_deleted?, class: "button", data: { confirm: "Confirmez-vous la suppression de l'administrateur ?" }, title: page.resource.can_be_deleted? ? "Supprimer" : "Cet administrateur a des dossiers ou des procédures et ne peut être supprimé" %>
   </div>
 
 </header>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
     resources :administrateurs, only: [:index, :show, :new, :create] do
       post 'reinvite', on: :member
       put 'enable_feature', on: :member
+      delete 'delete', on: :member
     end
 
     resources :users, only: [:index, :show] do


### PR DESCRIPTION
Comme le titre l'indique, un bouton permet de supprimer des administrateurs.
**Condition: ne pas avoir déposé de dossiers, ni de procédure.**
Je supprime seulement l'administrateur, pas l'instructeur ni l'utilisateur, ce qui est sans doute discutable…

![ajout-bouton-supprimer](https://user-images.githubusercontent.com/1223316/61636582-35407780-ac96-11e9-899b-5eb86d27fcb8.png)
![admin-notif](https://user-images.githubusercontent.com/1223316/61636584-35d90e00-ac96-11e9-8d19-71a9e5ad4d3d.png)
