### PR TITLE
Replacement du endpoint api-carto

### DIFF
--- a/config/initializers/urls.rb
+++ b/config/initializers/urls.rb
@@ -1,6 +1,6 @@
 # API URLs
 API_ADRESSE_URL = ENV.fetch("API_ADRESSE_URL", "https://api-adresse.data.gouv.fr")
-API_CARTO_URL = ENV.fetch("API_CARTO_URL", "https://apicarto.sgmap.fr")
+API_CARTO_URL = ENV.fetch("API_CARTO_URL", "https://sandbox.geo.api.gouv.fr/apicarto")
 API_ENTREPRISE_URL = ENV.fetch("API_ENTREPRISE_URL", "https://entreprise.api.gouv.fr/v2")
 API_GEO_URL = ENV.fetch("API_GEO_URL", "https://geo.api.gouv.fr")
 API_GEO_SANDBOX_URL = ENV.fetch("API_GEO_SANDBOX_URL", "https://sandbox.geo.api.gouv.fr")

--- a/spec/lib/api_carto/api_spec.rb
+++ b/spec/lib/api_carto/api_spec.rb
@@ -5,7 +5,7 @@ describe ApiCarto::API do
     subject { described_class.search_qp(geojson) }
 
     before do
-      stub_request(:post, "https://apicarto.sgmap.fr/quartiers-prioritaires/search")
+      stub_request(:post, "https://sandbox.geo.api.gouv.fr/apicarto/quartiers-prioritaires/search")
         .with(:body => /.*/,
           :headers => { 'Content-Type' => 'application/json' })
         .to_return(status: status, body: body)
@@ -53,7 +53,7 @@ describe ApiCarto::API do
     subject { described_class.search_cadastre(geojson) }
 
     before do
-      stub_request(:post, "https://apicarto.sgmap.fr/cadastre/geometrie")
+      stub_request(:post, "https://sandbox.geo.api.gouv.fr/apicarto/cadastre/geometrie")
         .with(:body => /.*/,
           :headers => { 'Content-Type' => 'application/json' })
         .to_return(status: status, body: body)

--- a/spec/lib/api_carto/cadastre_adapter_spec.rb
+++ b/spec/lib/api_carto/cadastre_adapter_spec.rb
@@ -4,7 +4,7 @@ describe ApiCarto::CadastreAdapter do
   subject { described_class.new(coordinates).results }
 
   before do
-    stub_request(:post, "https://apicarto.sgmap.fr/cadastre/geometrie")
+    stub_request(:post, "https://sandbox.geo.api.gouv.fr/apicarto/cadastre/geometrie")
       .with(:body => /.*/,
         :headers => { 'Content-Type' => 'application/json' })
       .to_return(status: status, body: body)

--- a/spec/lib/api_carto/quartiers_prioritaires_adapter_spec.rb
+++ b/spec/lib/api_carto/quartiers_prioritaires_adapter_spec.rb
@@ -4,7 +4,7 @@ describe ApiCarto::QuartiersPrioritairesAdapter do
   subject { described_class.new(coordinates).results }
 
   before do
-    stub_request(:post, "https://apicarto.sgmap.fr/quartiers-prioritaires/search")
+    stub_request(:post, "https://sandbox.geo.api.gouv.fr/apicarto/quartiers-prioritaires/search")
       .with(:body => /.*/,
         :headers => { 'Content-Type' => 'application/json' })
       .to_return(status: status, body: body)


### PR DESCRIPTION
Première étape de https://github.com/betagouv/demarches-simplifiees.fr/issues/814:
Changer le endpoint utilisé pour la carto, ce qui permet(tra) de décommissionner un serveur en face.
Les données restent moins à jour que dans API géo mais on ne peut pas migrer immédiatement dessus.

Cela utilise https://github.com/etalab/apicarto#docker que nous pourrions éventuellement faire tourner nous même si jamais il n'est pas possible d'utiliser Api géo, mais une réflexion sur la refonte de l'utilisation de la carto est à mener: utilisation de leaflet qui ne permet pas d'afficher beaucoup de données à remplacer par mapbox gl ou OpenLayers, remplacement des requêtes d'intersection qui ont lieu actuellement.
