### PR TITLE
Ajoute des boutons d'actions à tous les emails

### DIFF
--- a/app/controllers/new_administrateur/mail_templates_controller.rb
+++ b/app/controllers/new_administrateur/mail_templates_controller.rb
@@ -3,12 +3,14 @@ module NewAdministrateur
     include ActionView::Helpers::SanitizeHelper
 
     def preview
-      @procedure = procedure
+      mail_template = find_mail_template_by_slug(params[:id])
+      dossier = Dossier.new(id: '1', procedure: procedure)
+
+      @dossier = dossier
       @logo_url = procedure.logo.url
       @service = procedure.service
-
-      mail_template = find_mail_template_by_slug(params[:id])
       @rendered_template = sanitize(mail_template.body)
+      @actions = mail_template.actions_for_dossier(dossier)
 
       render(template: 'notification_mailer/send_notification', layout: 'mailers/notifications_layout')
     end
@@ -16,16 +18,16 @@ module NewAdministrateur
     private
 
     def procedure
-      @procedure = current_administrateur.procedures.find(params[:procedure_id])
+      @procedure ||= current_administrateur.procedures.find(params[:procedure_id])
     end
 
     def mail_templates
       [
-        @procedure.initiated_mail_template,
-        @procedure.received_mail_template,
-        @procedure.closed_mail_template,
-        @procedure.refused_mail_template,
-        @procedure.without_continuation_mail_template
+        procedure.initiated_mail_template,
+        procedure.received_mail_template,
+        procedure.closed_mail_template,
+        procedure.refused_mail_template,
+        procedure.without_continuation_mail_template
       ]
     end
 

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -1,5 +1,24 @@
 module MailerHelper
-  def round_button(text, url)
-    render 'shared/mailer_round_button', text: text, url: url
+  def round_button(text, url, variant)
+    render 'shared/mailer_round_button', text: text, url: url, theme: theme(variant)
+  end
+
+  private
+
+  def theme(variant)
+    case variant
+    when :primary
+      { color: white, bg_color: blue, border_color: blue }
+    when :secondary
+      { color: blue, bg_color: white, border_color: blue }
+    end
+  end
+
+  def blue
+    '#0069CC'
+  end
+
+  def white
+    '#FFFFFF'
   end
 end

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -1,4 +1,8 @@
 module MailerHelper
+  def vertical_margin(height)
+    render 'shared/mailer_vertical_margin', height: height
+  end
+
   def round_button(text, url, variant)
     render 'shared/mailer_round_button', text: text, url: url, theme: theme(variant)
   end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -9,6 +9,7 @@ class NotificationMailer < ApplicationMailer
   include ActionView::Helpers::SanitizeHelper
 
   helper ServiceHelper
+  helper MailerHelper
 
   layout 'mailers/notifications_layout'
 
@@ -46,6 +47,7 @@ class NotificationMailer < ApplicationMailer
     @service = dossier.procedure.service
     @logo_url = attach_logo(dossier.procedure)
     @rendered_template = sanitize(body)
+    @actions = mail_template.actions_for_dossier(dossier)
 
     mail(subject: subject, to: email, template_name: 'send_notification')
   end

--- a/app/models/concerns/mail_template_concern.rb
+++ b/app/models/concerns/mail_template_concern.rb
@@ -3,12 +3,22 @@ module MailTemplateConcern
 
   include TagsSubstitutionConcern
 
+  module Actions
+    SHOW         = :show
+    ASK_QUESTION = :ask_question
+    REPLY        = :reply
+  end
+
   def subject_for_dossier(dossier)
     replace_tags(subject, dossier)
   end
 
   def body_for_dossier(dossier)
     replace_tags(body, dossier)
+  end
+
+  def actions_for_dossier(dossier)
+    [MailTemplateConcern::Actions::SHOW, MailTemplateConcern::Actions::ASK_QUESTION]
   end
 
   def update_rich_body

--- a/app/models/mails/initiated_mail.rb
+++ b/app/models/mails/initiated_mail.rb
@@ -7,7 +7,7 @@ module Mails
     SLUG = "initiated_mail"
     DEFAULT_TEMPLATE_NAME = "notification_mailer/default_templates/initiated_mail"
     DISPLAYED_NAME = 'Accusé de réception'
-    DEFAULT_SUBJECT = 'Votre dossier nº --numéro du dossier-- a bien été reçu (--libellé démarche--)'
+    DEFAULT_SUBJECT = 'Votre dossier nº --numéro du dossier-- a bien été déposé (--libellé démarche--)'
     DOSSIER_STATE = Dossier.states.fetch(:en_construction)
   end
 end

--- a/app/models/mails/received_mail.rb
+++ b/app/models/mails/received_mail.rb
@@ -7,7 +7,7 @@ module Mails
     SLUG = "received_mail"
     DEFAULT_TEMPLATE_NAME = "notification_mailer/default_templates/received_mail"
     DISPLAYED_NAME = 'Accusé de passage en instruction'
-    DEFAULT_SUBJECT = 'Votre dossier nº --numéro du dossier-- va être instruit (--libellé démarche--)'
+    DEFAULT_SUBJECT = 'Votre dossier nº --numéro du dossier-- va être examiné (--libellé démarche--)'
     DOSSIER_STATE = Dossier.states.fetch(:en_instruction)
   end
 end

--- a/app/models/mails/refused_mail.rb
+++ b/app/models/mails/refused_mail.rb
@@ -9,5 +9,9 @@ module Mails
     DISPLAYED_NAME = 'Accusé de rejet du dossier'
     DEFAULT_SUBJECT = 'Votre dossier nº --numéro du dossier-- a été refusé (--libellé démarche--)'
     DOSSIER_STATE = Dossier.states.fetch(:refuse)
+
+    def actions_for_dossier(dossier)
+      [MailTemplateConcern::Actions::REPLY, MailTemplateConcern::Actions::SHOW]
+    end
   end
 end

--- a/app/views/dossier_mailer/notify_new_answer.html.haml
+++ b/app/views/dossier_mailer/notify_new_answer.html.haml
@@ -11,7 +11,7 @@
 %p
   Pour le consulter et y répondre, cliquez sur le bouton ci-dessous :
 
-= round_button('Lire le message', messagerie_dossier_url(@dossier))
+= round_button('Lire le message', messagerie_dossier_url(@dossier), :primary)
 
 = render 'layouts/mailers/signature', service: @service
 

--- a/app/views/dossier_mailer/notify_new_answer.html.haml
+++ b/app/views/dossier_mailer/notify_new_answer.html.haml
@@ -5,11 +5,12 @@
   Bonjour,
 
 %p
-  L’administration en charge de votre dossier vous a
-  %strong envoyé un nouveau message.
+  Vous avez reçu un
+  %strong nouveau message
+  de la part du service en charge de votre dossier.
 
 %p
-  Pour le consulter et y répondre, cliquez sur le bouton ci-dessous :
+  Pour consulter le message et y répondre, cliquez sur le bouton ci-dessous :
 
 = round_button('Lire le message', messagerie_dossier_url(@dossier), :primary)
 

--- a/app/views/dossier_mailer/notify_new_draft.html.haml
+++ b/app/views/dossier_mailer/notify_new_draft.html.haml
@@ -5,13 +5,16 @@
   Bonjour,
 
 %p
-  Vous avez commencé à remplir un dossier pour la démarche « #{@dossier.procedure.libelle} ».
+  Vous avez commencé à remplir un dossier pour la démarche
+  = succeed '.' do
+    %strong « #{@dossier.procedure.libelle} »
 
 %p
   Vous pouvez
   %strong retrouver et compléter votre dossier
-  à l’adresse suivante :
-  = link_to dossier_url(@dossier), dossier_url(@dossier), target: '_blank', rel: 'noopener'
+  en cliquant sur le bouton ci-dessous:
+
+= round_button('Afficher votre dossier', dossier_url(@dossier), :primary)
 
 = render 'layouts/mailers/signature'
 

--- a/app/views/notification_mailer/_actions.html.haml
+++ b/app/views/notification_mailer/_actions.html.haml
@@ -1,0 +1,13 @@
+= vertical_margin(15)
+
+- actions.each_with_index do |action, index|
+  - variant = (index == 0 ? :primary : :secondary)
+  - case action
+  - when MailTemplateConcern::Actions::SHOW
+    = round_button('Consulter mon dossier', dossier_url(@dossier), variant)
+  - when MailTemplateConcern::Actions::ASK_QUESTION
+    = round_button('J’ai une question', messagerie_dossier_url(@dossier), variant)
+  - when MailTemplateConcern::Actions::REPLY
+    = round_button('Répondre à ce message', messagerie_dossier_url(@dossier), variant)
+
+= vertical_margin(8)

--- a/app/views/notification_mailer/_actions.html.haml
+++ b/app/views/notification_mailer/_actions.html.haml
@@ -1,4 +1,4 @@
-= vertical_margin(15)
+= vertical_margin(12)
 
 - actions.each_with_index do |action, index|
   - variant = (index == 0 ? :primary : :secondary)
@@ -10,4 +10,4 @@
   - when MailTemplateConcern::Actions::REPLY
     = round_button('Répondre à ce message', messagerie_dossier_url(@dossier), variant)
 
-= vertical_margin(8)
+= vertical_margin(5)

--- a/app/views/notification_mailer/default_templates/closed_mail.html.haml
+++ b/app/views/notification_mailer/default_templates/closed_mail.html.haml
@@ -2,7 +2,9 @@
   Bonjour,
 
 %p
-  Votre dossier nº --numéro du dossier-- a été accepté le --date de décision--.
+  Votre dossier nº --numéro du dossier--
+  %strong a été accepté
+  le --date de décision--.
 
 %p
   À tout moment, vous pouvez consulter votre dossier et les éventuels messages de l'administration à cette adresse : --lien dossier--

--- a/app/views/notification_mailer/default_templates/closed_mail_with_attestation.html.haml
+++ b/app/views/notification_mailer/default_templates/closed_mail_with_attestation.html.haml
@@ -2,12 +2,11 @@
   Bonjour,
 
 %p
-  Votre dossier nº --numéro du dossier-- a été accepté le --date de décision--.
+  Votre dossier nº --numéro du dossier--
+  %strong a été accepté
+  le --date de décision--.
 
 %p
   Vous pouvez télécharger votre attestation à l'adresse suivante : --lien attestation--
-
-%p
-  À tout moment, vous pouvez consulter votre dossier et les éventuels messages de l'administration à cette adresse : --lien dossier--
 
 = render partial: "notification_mailer/default_templates/signature"

--- a/app/views/notification_mailer/default_templates/initiated_mail.html.haml
+++ b/app/views/notification_mailer/default_templates/initiated_mail.html.haml
@@ -2,9 +2,9 @@
   Bonjour,
 
 %p
-  Votre administration vous confirme la bonne réception de votre dossier nº --numéro du dossier--.
-
-%p
-  À tout moment, vous pouvez consulter votre dossier et les éventuels messages de l'administration à cette adresse : --lien dossier--
+  Votre dossier nº --numéro du dossier--
+  = succeed '.' do
+    %strong a bien été déposé
+  Si besoin est, vous pouvez encore y apporter des modifications.
 
 = render partial: "notification_mailer/default_templates/signature"

--- a/app/views/notification_mailer/default_templates/received_mail.html.haml
+++ b/app/views/notification_mailer/default_templates/received_mail.html.haml
@@ -2,6 +2,10 @@
   Bonjour,
 
 %p
-  Votre administration vous confirme la bonne réception de votre dossier nº --numéro du dossier--. Celui-ci sera instruit dans le délai légal déclaré par votre interlocuteur.
+  Votre dossier nº --numéro du dossier--
+  a bien été reçu et
+  = succeed '.' do
+    %strong pris en charge
+  Il va maintenant être examiné par le service.
 
 = render partial: "notification_mailer/default_templates/signature"

--- a/app/views/notification_mailer/default_templates/refused_mail.html.haml
+++ b/app/views/notification_mailer/default_templates/refused_mail.html.haml
@@ -2,10 +2,12 @@
   Bonjour,
 
 %p
-  Votre dossier nº --numéro du dossier-- a été refusé le --date de décision--.
+  Votre dossier nº --numéro du dossier--
+  %strong a été refusé
+  le --date de décision--.
 
 %p
-  Le motif de refus est le suivant : --motivation--.
+  Le motif de refus est le suivant : « <i>--motivation--</i> ».
 
 %p
   Pour en savoir plus sur le motif du refus, vous pouvez consulter votre dossier et les éventuels messages de l'administration à cette adresse : --lien dossier--

--- a/app/views/notification_mailer/default_templates/without_continuation_mail.html.haml
+++ b/app/views/notification_mailer/default_templates/without_continuation_mail.html.haml
@@ -2,7 +2,9 @@
   Bonjour,
 
 %p
-  Votre dossier nº --numéro du dossier-- a été classé sans suite le --date de décision--.
+  Votre dossier nº --numéro du dossier--
+  %strong a été classé sans suite
+  le --date de décision--.
 
 %p
   Le motif est le suivant : --motivation--.

--- a/app/views/notification_mailer/send_notification.html.haml
+++ b/app/views/notification_mailer/send_notification.html.haml
@@ -3,5 +3,8 @@
 
 = @rendered_template
 
+- if @actions.present?
+  = render 'notification_mailer/actions', actions: @actions, dossier: @dossier
+
 - content_for :footer do
   = render 'layouts/mailers/service_footer', service: @service, dossier: @dossier

--- a/app/views/shared/_mailer_round_button.html.haml
+++ b/app/views/shared/_mailer_round_button.html.haml
@@ -1,9 +1,10 @@
 /# From https://litmus.com/blog/a-guide-to-bulletproof-buttons-in-email-design
-%table{ width: "100%", border: "0", cellspacing:"0", cellpadding:"0" }
+%table{ width: "100%", border: "0", cellspacing:"0", cellpadding:"5" }
   %tr
-    %td
-      %table{ border:"0", cellspacing:"0", cellpadding:"0", style:"margin: auto" }
+    %td{ align: "center" }
+      %table{ border:"0", cellspacing:"0", cellpadding:"0" }
         %tr
-          %td{ align:"center", style:"border-radius: 5px;", bgcolor:"#0069cc" }
-            %a{ href: url, target:"_blank", rel: "noopener", style:"font-size: 16px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; text-decoration: none; border-radius: 5px; padding: 12px 25px; border: 1px solid #0069cc; display: inline-block;" }
+          %td{ align:"center", style:"border-radius: 5px;", color: theme[:color], bgcolor: theme[:bg_color] }
+            %a{ href: url, target:"_blank", rel: "noopener", style:"font-size: 16px; font-family: Helvetica, Arial, sans-serif; color: #{theme[:color]}; text-decoration: none; text-decoration: none; border-radius: 5px; padding: 12px 25px; border: 1px solid #{theme[:border_color]}; display: inline-block; min-width: 250px" }
               = text
+

--- a/app/views/shared/_mailer_round_button.html.haml
+++ b/app/views/shared/_mailer_round_button.html.haml
@@ -5,5 +5,5 @@
       %table{ border:"0", cellspacing:"0", cellpadding:"0", style:"margin: auto" }
         %tr
           %td{ align:"center", style:"border-radius: 5px;", bgcolor:"#0069cc" }
-            %a{ href: url, target:"_blank", style:"font-size: 16px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; text-decoration: none; border-radius: 5px; padding: 12px 25px; border: 1px solid #0069cc; display: inline-block;" }
+            %a{ href: url, target:"_blank", rel: "noopener", style:"font-size: 16px; font-family: Helvetica, Arial, sans-serif; color: #ffffff; text-decoration: none; text-decoration: none; border-radius: 5px; padding: 12px 25px; border: 1px solid #0069cc; display: inline-block;" }
               = text

--- a/app/views/shared/_mailer_vertical_margin.html.haml
+++ b/app/views/shared/_mailer_vertical_margin.html.haml
@@ -1,0 +1,4 @@
+%table{ cellspacing: "0", cellpadding: (height / 2), border: "0" }
+  %tr
+    %td
+      %div

--- a/spec/controllers/new_administrateur/mail_templates_controller_spec.rb
+++ b/spec/controllers/new_administrateur/mail_templates_controller_spec.rb
@@ -13,9 +13,17 @@ describe NewAdministrateur::MailTemplatesController, type: :controller do
 
     it { expect(response).to have_http_status(:ok) }
 
-    it { expect(response.body).to have_css("img[src*='#{procedure.logo.filename}']") }
+    it 'displays the procedure logo' do
+      expect(response.body).to have_css("img[src*='#{procedure.logo.filename}']")
+    end
 
-    it { expect(response.body).to include(procedure.service.nom) }
-    it { expect(response.body).to include(procedure.service.telephone) }
+    it 'displays the action buttons' do
+      expect(response.body).to have_link('Consulter mon dossier')
+    end
+
+    it 'displays the service in the footer' do
+      expect(response.body).to include(procedure.service.nom)
+      expect(response.body).to include(procedure.service.telephone)
+    end
   end
 end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -28,6 +28,11 @@ RSpec.describe NotificationMailer, type: :mailer do
       expect(mail.body).to have_link('messagerie')
     end
 
+    it 'renders the actions' do
+      expect(mail.body).to have_link('Consulter mon dossier', href: dossier_url(dossier))
+      expect(mail.body).to have_link('J’ai une question', href: messagerie_dossier_url(dossier))
+    end
+
     context 'when the template body contains tags' do
       let(:email_template) { create(:received_mail, subject: 'Email subject', body: 'Hello --nom--, your dossier --lien dossier-- was processed.') }
 

--- a/spec/mailers/previews/notification_mailer_preview.rb
+++ b/spec/mailers/previews/notification_mailer_preview.rb
@@ -1,11 +1,11 @@
 class NotificationMailerPreview < ActionMailer::Preview
-  def send_dossier_received
-    NotificationMailer.send_dossier_received(Dossier.last)
-  end
-
   def send_initiated_notification
     p = Procedure.where(id: Mails::InitiatedMail.where("body like ?", "%<img%").pluck(:procedure_id).uniq).order("RANDOM()").first
     NotificationMailer.send_initiated_notification(p.dossiers.last)
+  end
+
+  def send_dossier_received
+    NotificationMailer.send_dossier_received(Dossier.last)
   end
 
   def send_closed_notification
@@ -13,7 +13,8 @@ class NotificationMailerPreview < ActionMailer::Preview
   end
 
   def send_refused_notification
-    NotificationMailer.send_refused_notification(Dossier.last)
+    dossier = Dossier.last.tap { |d| d.assign_attributes(motivation: 'Le montant demandé dépasse le plafond autorisé') }
+    NotificationMailer.send_refused_notification(dossier)
   end
 
   def send_without_continuation_notification


### PR DESCRIPTION
Fix #4060

Cette PR :

- Reformule le texte par défaut des emails pour utiliser un langage plus clair ;
- Met en gras et en avant l'information principale de l'email, pour qu'elle soit accessible même en lisant en diagonale ;
- Ajoute de gros boutons d'action aux emails de notification.

L'objectif est de permettre aux usagers de savoir quoi faire – et surtout de cliquer sur les boutons plutôt que de répondre à l'email.

## Nouveau brouillon

**Avant / Après**

<span>
<img width="49%" alt="01 - draft" src="https://user-images.githubusercontent.com/179923/61721426-b9fbc600-ad68-11e9-9a55-6849b6e9e4e6.png">
<img width="49%" alt="01 NEW" src="https://user-images.githubusercontent.com/179923/61721429-bbc58980-ad68-11e9-8c02-73f41091e712.png"></span>

## Dossier déposé

**Avant / Après**

<span>
<img width="49%" alt="02 - dépôt" src="https://user-images.githubusercontent.com/179923/61721551-ed3e5500-ad68-11e9-8d6c-abb597daf210.png">
<img width="49%" alt="02 NEW" src="https://user-images.githubusercontent.com/179923/61721555-ee6f8200-ad68-11e9-9991-0620f2b9758c.png"></span>

## Dossier en instruction

**Avant / Après**

<span>
<img width="49%" alt="03 - instruction" src="https://user-images.githubusercontent.com/179923/61721678-28d91f00-ad69-11e9-9151-949501549ec6.png">
<img width="49%" alt="03 NEW" src="https://user-images.githubusercontent.com/179923/61721679-2aa2e280-ad69-11e9-80b4-ced553c9101f.png"></span>

## Nouveau message reçu

**Avant / Après**

<span>
<img width="49%" alt="04 - nouveau message" src="https://user-images.githubusercontent.com/179923/61721716-38586800-ad69-11e9-95e1-24446259b08a.png">
<img width="49%" alt="04 NEW" src="https://user-images.githubusercontent.com/179923/61721719-39899500-ad69-11e9-9379-aa189fdfe387.png"></span>

## Dossier accepté

**Avant / Après**

<span>
<img width="49%" alt="05 - accepté" src="https://user-images.githubusercontent.com/179923/61721734-4312fd00-ad69-11e9-8ea5-eb019dd8a5a0.png">
<img width="49%" alt="05 NEW" src="https://user-images.githubusercontent.com/179923/61721744-44dcc080-ad69-11e9-926f-3e0841a495b1.png"></span>

## Remarques

- Les boutons sont normalement suffisamment génériques pour avoir du sens même si l'admin a beaucoup modifié le texte par défaut de l'email.
- Dans un second temps, on mettra le contenu des messages directement dans l'email (mais pas tout de suite).
- On pourra aussi ajouter un bouton "Télécharger l'attestation" si le dossier en comporte une.

## Questions ouvertes

- Faut-il des boutons "Consulter mon dossier" lorsque l'usager n'a pas d'action à effectuer ? Est-ce que ce n'est pas perturbant ?
- Est-ce qu'on augmente la taille du texte des emails, qui est un peu petite ?