### PR TITLE
#4137 - Ajout d'un confirm à la suppression d'un champ

### DIFF
--- a/app/javascript/components/TypesDeChampEditor/components/TypeDeChamp.js
+++ b/app/javascript/components/TypesDeChampEditor/components/TypeDeChamp.js
@@ -68,9 +68,13 @@ const TypeDeChamp = sortableElement(
           <div className="flex justify-start delete">
             <button
               className="button small icon-only danger"
-              onClick={() =>
-                dispatch({ type: 'removeTypeDeChamp', params: { typeDeChamp } })
-              }
+              onClick={() => {
+                if (confirm('Êtes vous sûr de vouloir supprimer ce champ ?'))
+                  dispatch({
+                    type: 'removeTypeDeChamp',
+                    params: { typeDeChamp }
+                  });
+              }}
             >
               <FontAwesomeIcon icon="trash" title="Supprimer" />
             </button>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_17_132452) do
+ActiveRecord::Schema.define(version: 2019_07_17_151228) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -430,6 +430,7 @@ ActiveRecord::Schema.define(version: 2019_07_17_132452) do
     t.integer "user_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.text "message"
   end
 
   create_table "module_api_cartos", id: :serial, force: :cascade do |t|
@@ -500,6 +501,7 @@ ActiveRecord::Schema.define(version: 2019_07_17_132452) do
     t.boolean "durees_conservation_required", default: true
     t.string "path"
     t.string "declarative_with_state"
+    t.text "monavis"
     t.text "monavis_embed"
     t.index ["declarative_with_state"], name: "index_procedures_on_declarative_with_state"
     t.index ["hidden_at"], name: "index_procedures_on_hidden_at"

--- a/spec/features/new_administrateur/types_de_champ_spec.rb
+++ b/spec/features/new_administrateur/types_de_champ_spec.rb
@@ -11,7 +11,9 @@ feature 'As an administrateur I can edit types de champ', js: true do
   end
 
   it "Add a new champ" do
-    click_on 'Supprimer'
+    page.accept_alert do
+      click_on 'Supprimer'
+    end
 
     within '.buttons' do
       click_on 'Ajouter un champ'
@@ -48,7 +50,9 @@ feature 'As an administrateur I can edit types de champ', js: true do
     expect(page).to have_selector('#champ-3-libelle')
 
     within '.type-de-champ[data-index="2"]' do
-      click_on 'Supprimer'
+      page.accept_alert do
+        click_on 'Supprimer'
+      end
     end
 
     expect(page).not_to have_selector('#champ-3-libelle')
@@ -68,8 +72,9 @@ feature 'As an administrateur I can edit types de champ', js: true do
     blur
     expect(page).to have_content('Formulaire enregistré')
     page.refresh
-
-    click_on 'Supprimer'
+    page.accept_alert do
+      click_on 'Supprimer'
+    end
     expect(page).to have_content('Formulaire enregistré')
     expect(page).to have_content('Supprimer', count: 1)
     page.refresh


### PR DESCRIPTION
Fix #4137 
Par ailleurs, niveau UX il est un peu facile de supprimer trop de champs sans le vouloir sans cette confirmation