### PR TITLE
Corrections sur le bouton "Modifier le dossier"

### DIFF
--- a/app/assets/stylesheets/new_design/dossier_show.scss
+++ b/app/assets/stylesheets/new_design/dossier_show.scss
@@ -38,10 +38,6 @@
     }
   }
 
-  .button.edit-form {
-    float: right;
-  }
-
   .messagerie-explanation {
     margin-bottom: $default-padding * 2;
   }

--- a/app/views/invites/_dropdown.html.haml
+++ b/app/views/invites/_dropdown.html.haml
@@ -1,4 +1,4 @@
-%span.dropdown.invite-user-action{ :style => "float:right;right: 10px;" }
+%span.dropdown.invite-user-action
   %button.button.dropdown-button
     %span.icon.person
     - if dossier.invites.count > 0

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -15,8 +15,9 @@
         Les champs avec un astérisque (
         %span.mandatory> *
         ) sont obligatoires.
-      %p.mandatory-explanation
-        Pour enregistrer votre dossier et le reprendre plus tard, cliquez sur le bouton « Enregistrer le brouillon » en bas à gauche du formulaire.
+      - if dossier.brouillon?
+        %p.mandatory-explanation
+          Pour enregistrer votre dossier et le reprendre plus tard, cliquez sur le bouton « Enregistrer le brouillon » en bas à gauche du formulaire.
 
       - if notice_url(dossier.procedure).present?
         = link_to notice_url(dossier.procedure), target: '_blank', rel: 'noopener', class: 'button notice', title: "Pour vous aider à remplir votre dossier, vous pouvez consulter le guide de cette démarche." do

--- a/app/views/users/dossiers/show/_header.html.haml
+++ b/app/views/users/dossiers/show/_header.html.haml
@@ -11,7 +11,8 @@
           = "- Déposé le #{l(dossier.en_construction_at, format: '%d %B %Y')}"
 
     - if current_user.owns?(dossier)
-      = link_to "Modifier mon dossier", modifier_dossier_path(dossier.id), class: 'button accepted edit-form', 'title'=> "Vous pouvez modifier votre dossier tant qu'il n'est passé en instruction"
+      - if dossier.can_be_updated_by_user?
+        = link_to "Modifier mon dossier", modifier_dossier_path(dossier.id), class: 'button accepted edit-form', 'title'=> "Vous pouvez modifier votre dossier tant qu'il n'est passé en instruction"
       = render partial: 'invites/dropdown', locals: { dossier: dossier }
       .clearfix
 

--- a/app/views/users/dossiers/show/_header.html.haml
+++ b/app/views/users/dossiers/show/_header.html.haml
@@ -13,8 +13,8 @@
     - if current_user.owns?(dossier)
       .header-actions
         = render partial: 'invites/dropdown', locals: { dossier: dossier }
-        - if dossier.can_be_updated_by_user?
-          = link_to "Modifier mon dossier", modifier_dossier_path(dossier.id), class: 'button accepted edit-form', 'title'=> "Vous pouvez modifier votre dossier tant qu'il n'est passé en instruction"
+        - if dossier.can_be_updated_by_user? && !current_page?(modifier_dossier_path(dossier))
+          = link_to "Modifier mon dossier", modifier_dossier_path(dossier), class: 'button accepted edit-form', 'title'=> "Vous pouvez modifier votre dossier tant qu'il n'est passé en instruction"
 
     %ul.tabs
       = dynamic_tab_item('Résumé', dossier_path(dossier))

--- a/app/views/users/dossiers/show/_header.html.haml
+++ b/app/views/users/dossiers/show/_header.html.haml
@@ -11,10 +11,10 @@
           = "- Déposé le #{l(dossier.en_construction_at, format: '%d %B %Y')}"
 
     - if current_user.owns?(dossier)
-      - if dossier.can_be_updated_by_user?
-        = link_to "Modifier mon dossier", modifier_dossier_path(dossier.id), class: 'button accepted edit-form', 'title'=> "Vous pouvez modifier votre dossier tant qu'il n'est passé en instruction"
-      = render partial: 'invites/dropdown', locals: { dossier: dossier }
-      .clearfix
+      .header-actions
+        = render partial: 'invites/dropdown', locals: { dossier: dossier }
+        - if dossier.can_be_updated_by_user?
+          = link_to "Modifier mon dossier", modifier_dossier_path(dossier.id), class: 'button accepted edit-form', 'title'=> "Vous pouvez modifier votre dossier tant qu'il n'est passé en instruction"
 
     %ul.tabs
       = dynamic_tab_item('Résumé', dossier_path(dossier))


### PR DESCRIPTION
- Le bouton n'est plus affiché sur les dossiers que l'usager ne peut pas modifier (fix #4143)
- La mise en page du bouton est corrigée (il manquait une marge dans certains cas)
- Le bouton "Modifier" est masqué sur la page de modification d'un dossier (pour qu'on évite de le confondre avec le bouton "Enregistrer).

Bonus :

- Le texte "Vous pouvez enregistrer un brouillon" n'apparaît plus sur la page "Modifier le dossier" quand le dossier est déjà en instruction ;)