### PR TITLE
Drop `types_de_piece_justificative` and `pieces_justificatives` tables

### DIFF
--- a/db/migrate/20190730153555_drop_deprecated_piece_justificative_tables.rb
+++ b/db/migrate/20190730153555_drop_deprecated_piece_justificative_tables.rb
@@ -1,0 +1,40 @@
+class DropDeprecatedPieceJustificativeTables < ActiveRecord::Migration[5.2]
+  def change
+    assert_empty_table!(:types_de_piece_justificative)
+    assert_empty_table!(:pieces_justificatives)
+
+    drop_table :types_de_piece_justificative do |t|
+      t.string "libelle"
+      t.string "description"
+      t.boolean "api_entreprise", default: false
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.integer "procedure_id"
+      t.integer "order_place"
+      t.string "lien_demarche"
+      t.boolean "mandatory", default: false
+      t.index ["procedure_id"], name: "index_types_de_piece_justificative_on_procedure_id"
+    end
+
+    drop_table :pieces_justificatives do |t|
+      t.string "content"
+      t.integer "dossier_id"
+      t.integer "type_de_piece_justificative_id"
+      t.datetime "created_at"
+      t.integer "user_id"
+      t.string "original_filename"
+      t.string "content_secure_token"
+      t.datetime "updated_at"
+      t.index ["dossier_id"], name: "index_pieces_justificatives_on_dossier_id"
+      t.index ["type_de_piece_justificative_id"], name: "index_pieces_justificatives_on_type_de_piece_justificative_id"
+    end
+  end
+
+  def assert_empty_table!(table)
+    results = ActiveRecord::Base.connection.exec_query("SELECT COUNT(*) FROM #{table}")
+    records_count = results.first['count']
+    if records_count > 0
+      raise "Abord dropping `#{table}` table: it still contains #{records_count} records."
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_17_151228) do
+ActiveRecord::Schema.define(version: 2019_07_30_153555) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -456,19 +456,6 @@ ActiveRecord::Schema.define(version: 2019_07_17_151228) do
     t.index ["procedure_id"], name: "index_module_api_cartos_on_procedure_id", unique: true
   end
 
-  create_table "pieces_justificatives", id: :serial, force: :cascade do |t|
-    t.string "content"
-    t.integer "dossier_id"
-    t.integer "type_de_piece_justificative_id"
-    t.datetime "created_at"
-    t.integer "user_id"
-    t.string "original_filename"
-    t.string "content_secure_token"
-    t.datetime "updated_at"
-    t.index ["dossier_id"], name: "index_pieces_justificatives_on_dossier_id"
-    t.index ["type_de_piece_justificative_id"], name: "index_pieces_justificatives_on_type_de_piece_justificative_id"
-  end
-
   create_table "procedure_presentations", id: :serial, force: :cascade do |t|
     t.integer "assign_to_id"
     t.jsonb "sort", default: {"order"=>"desc", "table"=>"notifications", "column"=>"notifications"}, null: false
@@ -585,19 +572,6 @@ ActiveRecord::Schema.define(version: 2019_07_17_151228) do
     t.index ["private"], name: "index_types_de_champ_on_private"
     t.index ["procedure_id"], name: "index_types_de_champ_on_procedure_id"
     t.index ["stable_id"], name: "index_types_de_champ_on_stable_id"
-  end
-
-  create_table "types_de_piece_justificative", id: :serial, force: :cascade do |t|
-    t.string "libelle"
-    t.string "description"
-    t.boolean "api_entreprise", default: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "procedure_id"
-    t.integer "order_place"
-    t.string "lien_demarche"
-    t.boolean "mandatory", default: false
-    t.index ["procedure_id"], name: "index_types_de_piece_justificative_on_procedure_id"
   end
 
   create_table "users", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
Maintenant que les pieces justificatives des dossiers sont migrées et que les modèles sont supprimés en production, on peut virer les tables.

(Pour être sympa avec les intégrateurs externes, on vérifie que les migrations sont bien passées et que les tables sont vides avant de migrer.)