### PR TITLE
#4015 - Pré-remplir nom/prénom/civilité à partir des infos France Connect

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -223,6 +223,10 @@ module Users
       dossier = Dossier.create!(procedure: procedure, user: current_user, state: Dossier.states.fetch(:brouillon))
 
       if dossier.procedure.for_individual
+        if current_user.france_connect_information.present?
+          dossier.update_with_france_connect(current_user.france_connect_information)
+        end
+
         redirect_to identite_dossier_path(dossier)
       else
         redirect_to siret_dossier_path(id: dossier.id)

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -478,11 +478,7 @@ class Dossier < ApplicationRecord
   end
 
   def update_with_france_connect(fc_information)
-    self.individual = Individual.create(
-      nom: fc_information.family_name,
-      prenom: fc_information.given_name,
-      gender: fc_information.gender == 'female' ? 'Mme' : 'M.'
-    )
+    self.individual = Individual.create_from_france_connect(fc_information)
   end
 
   private

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -479,8 +479,8 @@ class Dossier < ApplicationRecord
 
   def update_with_france_connect(fc_information)
     self.individual = Individual.create(
-      nom: fc_information.given_name,
-      prenom: fc_information.family_name,
+      nom: fc_information.family_name,
+      prenom: fc_information.given_name,
       gender: fc_information.gender == 'female' ? 'Mme' : 'M.'
     )
   end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -477,6 +477,14 @@ class Dossier < ApplicationRecord
     !PiecesJustificativesService.liste_pieces_justificatives(self).empty? && PiecesJustificativesService.pieces_justificatives_total_size(self) < Dossier::TAILLE_MAX_ZIP
   end
 
+  def update_with_france_connect(fc_information)
+    self.individual = Individual.create(
+      nom: fc_information.given_name,
+      prenom: fc_information.family_name,
+      gender: fc_information.gender == 'female' ? 'Mme' : 'M.'
+    )
+  end
+
   private
 
   def log_dossier_operation(author, operation, subject = nil)

--- a/app/models/individual.rb
+++ b/app/models/individual.rb
@@ -5,4 +5,15 @@ class Individual < ApplicationRecord
   validates :gender, presence: true, allow_nil: false, on: :update
   validates :nom, presence: true, allow_blank: false, allow_nil: false, on: :update
   validates :prenom, presence: true, allow_blank: false, allow_nil: false, on: :update
+
+  GENDER_MALE = 'M.'
+  GENDER_FEMALE = 'Mme'
+
+  def self.create_from_france_connect(fc_information)
+    create(
+      nom: fc_information.family_name,
+      prenom: fc_information.given_name,
+      gender: fc_information.gender == 'female' ? GENDER_FEMALE : GENDER_MALE
+    )
+  end
 end

--- a/app/views/shared/dossiers/editable_champs/_civilite.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_civilite.html.haml
@@ -1,8 +1,8 @@
 .radios
   %label
-    = form.radio_button :value, 'M.'
+    = form.radio_button :value, Individual::GENDER_MALE
     Monsieur
 
   %label
-    = form.radio_button :value, 'Mme.'
+    = form.radio_button :value, Individual::GENDER_FEMALE
     Madame

--- a/app/views/users/dossiers/identite.html.haml
+++ b/app/views/users/dossiers/identite.html.haml
@@ -13,7 +13,7 @@
       champs requis
 
     = f.label :gender, class: "required"
-    = f.select :gender, ['M.', 'Mme'], {}, class: "small"
+    = f.select :gender, [Individual::GENDER_MALE, Individual::GENDER_FEMALE], {}, class: "small"
 
     .flex
       .inline-champ

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -886,8 +886,6 @@ describe Users::DossiersController, type: :controller do
 
             it { is_expected.to redirect_to dossiers_path }
           end
-
-
         end
         context 'when user is not logged' do
           it { is_expected.to have_http_status(302) }

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -871,15 +871,23 @@ describe Users::DossiersController, type: :controller do
           end
 
           it { is_expected.to have_http_status(302) }
-          it { is_expected.to redirect_to siret_dossier_path(id: Dossier.last) }
-
           it { expect { subject }.to change(Dossier, :count).by 1 }
+          context 'when procedure is for entreprise' do
+            it { is_expected.to redirect_to siret_dossier_path(id: Dossier.last) }
+          end
+
+          context 'when procedure is for particulier' do
+            let(:procedure) { create(:procedure, :published, :for_individual) }
+            it { is_expected.to redirect_to identite_dossier_path(id: Dossier.last) }
+          end
 
           context 'when procedure is archived' do
             let(:procedure) { create(:procedure, :archived) }
 
             it { is_expected.to redirect_to dossiers_path }
           end
+
+
         end
         context 'when user is not logged' do
           it { is_expected.to have_http_status(302) }

--- a/spec/factories/france_connect_information.rb
+++ b/spec/factories/france_connect_information.rb
@@ -1,7 +1,8 @@
 FactoryBot.define do
   factory :france_connect_information do
-    given_name { 'plop' }
-    family_name { 'plip' }
+    given_name { 'Angela Claire Louise' }
+    family_name { 'DUBOIS' }
+    gender { 'female' }
     birthdate { '1976-02-24' }
     france_connect_particulier_id { '1234567' }
     email_france_connect { 'plip@octo.com' }

--- a/spec/features/users/brouillon_spec.rb
+++ b/spec/features/users/brouillon_spec.rb
@@ -50,7 +50,7 @@ feature 'The user' do
     expect(champ_value_for('datetime')).to eq('06/01/1985 07:05')
     expect(champ_value_for('number')).to eq('42')
     expect(champ_value_for('checkbox')).to eq('on')
-    expect(champ_value_for('civilite')).to eq('Mme.')
+    expect(champ_value_for('civilite')).to eq('Mme')
     expect(champ_value_for('email')).to eq('loulou@yopmail.com')
     expect(champ_value_for('phone')).to eq('1234567890')
     expect(champ_value_for('yes_no')).to eq('false')

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -997,4 +997,16 @@ describe Dossier do
       }
     end
   end
+
+  describe '#update_with_france_connect' do
+    let(:dossier) { create(:dossier, user: user) }
+    let(:user_info) { create(:france_connect_information) }
+
+    it {
+      dossier.update_with_france_connect(user_info)
+      expect(dossier.individual.gender).to eq 'Mme'
+      expect(dossier.individual.nom).to eq user_info.family_name
+      expect(dossier.individual.prenom).to eq user_info.given_name
+    }
+  end
 end


### PR DESCRIPTION
Cf #4015, on remplit dossier.individual à partir des infos france-connect si on les a.
Je suis peut-être passé à coté de quelque chose (j'ai pas tout l'historique, et ya eu des refactos depuis) mais j'ai fait plus simple que la PR https://github.com/betagouv/demarches-simplifiees.fr/pull/2720/files qui supprimait cette fonctionnalité.