### PR TITLE
tasks: fix the commentaires migration task to work with hidden dossiers

### DIFF
--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -39,6 +39,10 @@ FactoryBot.define do
       archived { false }
     end
 
+    trait :hidden do
+      hidden_at { Time.zone.now }
+    end
+
     trait :with_dossier_link do
       after(:create) do |dossier, _evaluator|
         linked_dossier = create(:dossier)


### PR DESCRIPTION
By default `commentaire.dossier` doesn't return the dossier if it is hidden.