### PR TITLE
Gemfile: fix an 'insecure connection' Bundler warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'aasm'
-gem 'actiontext', github: 'kobaltz/actiontext', branch: 'archive', require: 'action_text'
+gem 'actiontext', git: 'https://github.com/kobaltz/actiontext.git', branch: 'archive', require: 'action_text' # Port of ActionText to Rails 5
 gem 'active_link_to' # Automatically set a class on active links
 gem 'active_model_serializers'
 gem 'activestorage-openstack', git: 'https://github.com/fredZen/activestorage-openstack.git', branch: 'frederic/fix_upload_signature'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: git://github.com/kobaltz/actiontext.git
-  revision: ef59c4ba99d1b7614dd47f5a294eef553224db88
-  branch: archive
-  specs:
-    actiontext (0.1.0)
-      nokogiri
-      rails (>= 5.2.0)
-
-GIT
   remote: https://github.com/fredZen/activestorage-openstack.git
   revision: c71d5107a51701eab9d9267dd0000e6c1cf3e39a
   branch: frederic/fix_upload_signature
@@ -17,6 +8,15 @@ GIT
       marcel
       mime-types
       rails (~> 5.2.0)
+
+GIT
+  remote: https://github.com/kobaltz/actiontext.git
+  revision: ef59c4ba99d1b7614dd47f5a294eef553224db88
+  branch: archive
+  specs:
+    actiontext (0.1.0)
+      nokogiri
+      rails (>= 5.2.0)
 
 GIT
   remote: https://github.com/mina-deploy/mina.git


### PR DESCRIPTION
This fixes the following warning when running `bundler install`:

> $ bundle install
> The git source `git://github.com/kobaltz/actiontext.git` uses the `git` protocol, which transmits data without encryption. Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
