### PR TITLE
4156 - draft d'un écran mailjet dans le manager

### DIFF
--- a/app/controllers/manager/users_controller.rb
+++ b/app/controllers/manager/users_controller.rb
@@ -6,5 +6,42 @@ module Manager
       flash[:notice] = "L'email d'activation de votre compte a été renvoyé."
       redirect_to manager_user_path(user)
     end
+
+    def sent_emails
+      @user = User.find(params[:id])
+
+      contactId = fetch_contact_id(@user.email)
+      @messages = fetch_messages(@contactId)
+    end
+    
+    def auth
+      "#{ENV['MAILJET_API_KEY']}:#{ENV['MAILJET_SECRET_KEY']}"
+    end
+
+    def fetch_contact_id(email)
+      response = Typhoeus.get(
+        "https://api.mailjet.com/v3/REST/contact/#{email}",
+        userpwd: auth
+      )
+
+      if response.success? 
+        contact = JSON.parse(response.body)
+        return contact.dig('Data', 0, 'ID')
+      end
+      return nil
+    end
+
+    def fetch_messages(contactId)
+      response = Typhoeus.get(
+        "https://api.mailjet.com/v3/REST/message/?ContactId=#{contactId}",
+        userpwd: auth
+      )
+
+      if response.success? 
+        messages = JSON.parse(response.body).dig('Data')
+        return messages
+      end
+      return []
+    end
   end
 end

--- a/app/views/manager/users/sent_emails.html.erb
+++ b/app/views/manager/users/sent_emails.html.erb
@@ -1,0 +1,18 @@
+<h1>Liste des messages envoyés à <%= @user.email %></h1>
+<table>
+  <thead>
+    <th>Id</th>
+    <th>ArrivedAt</th>
+    <th>Status</th>
+  </thead>
+  <tbody>
+  <% @messages.each do |message| %>
+    <tr>
+      <td><%= message['ID'] %></td>
+      <td><%= message['ArrivedAt'] %></td>
+      <td><%= message['Status'] %></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>
+

--- a/app/views/manager/users/show.html.erb
+++ b/app/views/manager/users/show.html.erb
@@ -52,5 +52,9 @@ as well as a link to its edit page.
       <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
           ><%= render_field attribute, page: page %></dd>
     <% end %>
+    <dd class="attribute-data">
+      <%= link_to('Voir les emails envoyés', sent_emails_manager_user_path(page.resource)) %>
+    </dd>
   </dl>
 </section>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
 
     resources :users, only: [:index, :show] do
       post 'resend_confirmation_instructions', on: :member
+      get 'sent_emails', on: :member
     end
 
     resources :gestionnaires, only: [:index, :show] do


### PR DESCRIPTION
brouillon dégueu pour avancer sur https://github.com/betagouv/demarches-simplifiees.fr/issues/4156 mais on voit l'esprit:
 - ajout d'une route /manager/user/123/sent_email que fait des appels API pour sortir les infos
 - ajout d'un bouton sur l'écran user#show pour s'y rendre

Le problème, c'est surtout qu'on a pas les titre des messages envoyés via l'API pour savoir à quoi cela correspond…

![test-recherche](https://user-images.githubusercontent.com/1223316/62330114-fe4d3b80-b4b7-11e9-8eae-5facda41804b.png)
