### PR TITLE
Rend le bouton "Archiver" visible dès la validation du dossier

### DIFF
--- a/app/assets/stylesheets/new_design/instructeur.scss
+++ b/app/assets/stylesheets/new_design/instructeur.scss
@@ -19,7 +19,7 @@
   margin-bottom: 2 * $default-padding;
 }
 
-.mixed-buttons-bar {
+.header-actions {
   flex-shrink: 0;
 
   .button {

--- a/app/views/instructeurs/dossiers/_header.html.haml
+++ b/app/views/instructeurs/dossiers/_header.html.haml
@@ -10,29 +10,7 @@
         %li
           = "Dossier nº #{dossier.id}"
       .mixed-buttons-bar
-        %span.dropdown.print-menu-opener
-          %button.button.dropdown-button.icon-only
-            %span.icon.printer
-          %ul.print-menu.dropdown-content
-            %li
-              = link_to "Tout le dossier", print_instructeur_dossier_path(dossier.procedure, dossier), target: "_blank", rel: "noopener", class: "menu-item menu-link"
-            %li
-              = link_to "Uniquement cet onglet", "#", onclick: "window.print()", class: "menu-item menu-link"
-        - if Flipflop.download_as_zip_enabled? && !PiecesJustificativesService.liste_pieces_justificatives(dossier).empty?
-          %span.dropdown.print-menu-opener
-            %button.button.dropdown-button.icon-only
-              %span.icon.attachment
-            %ul.print-menu.dropdown-content
-              %li
-                - if PiecesJustificativesService.pieces_justificatives_total_size(dossier) < Dossier::TAILLE_MAX_ZIP
-                  = link_to "Télécharger toutes les pièces jointes", telecharger_pjs_instructeur_dossier_path(dossier.procedure, dossier), target: "_blank", rel: "noopener", class: "menu-item menu-link"
-                - else
-                  %p.menu-item Le téléchargement des pièces jointes est désactivé pour les dossiers de plus de #{number_to_human_size Dossier::TAILLE_MAX_ZIP}.
-
-
-        = render partial: "instructeurs/procedures/dossier_actions", locals: { procedure: dossier.procedure, dossier: dossier, dossier_is_followed: current_instructeur&.follow?(dossier) }
-        %span.state-button
-          = render partial: "state_button", locals: { dossier: dossier }
+        = render partial: 'instructeurs/dossiers/header_actions', locals: { dossier: dossier }
 
     %ul.tabs
       - notifications_summary = current_instructeur.notifications_for_dossier(dossier)

--- a/app/views/instructeurs/dossiers/_header.html.haml
+++ b/app/views/instructeurs/dossiers/_header.html.haml
@@ -9,7 +9,7 @@
             = dossier.procedure.libelle.truncate_words(10)
         %li
           = "Dossier nº #{dossier.id}"
-      .mixed-buttons-bar
+      .header-actions
         = render partial: 'instructeurs/dossiers/header_actions', locals: { dossier: dossier }
 
     %ul.tabs

--- a/app/views/instructeurs/dossiers/_header_actions.html.haml
+++ b/app/views/instructeurs/dossiers/_header_actions.html.haml
@@ -1,0 +1,24 @@
+%span.dropdown.print-menu-opener
+  %button.button.dropdown-button.icon-only
+    %span.icon.printer
+  %ul.print-menu.dropdown-content
+    %li
+      = link_to "Tout le dossier", print_instructeur_dossier_path(dossier.procedure, dossier), target: "_blank", rel: "noopener", class: "menu-item menu-link"
+    %li
+      = link_to "Uniquement cet onglet", "#", onclick: "window.print()", class: "menu-item menu-link"
+
+- if Flipflop.download_as_zip_enabled? && !PiecesJustificativesService.liste_pieces_justificatives(dossier).empty?
+  %span.dropdown.print-menu-opener
+    %button.button.dropdown-button.icon-only
+      %span.icon.attachment
+    %ul.print-menu.dropdown-content
+      %li
+        - if PiecesJustificativesService.pieces_justificatives_total_size(dossier) < Dossier::TAILLE_MAX_ZIP
+          = link_to "Télécharger toutes les pièces jointes", telecharger_pjs_instructeur_dossier_path(dossier.procedure, dossier), target: "_blank", rel: "noopener", class: "menu-item menu-link"
+        - else
+          %p.menu-item Le téléchargement des pièces jointes est désactivé pour les dossiers de plus de #{number_to_human_size Dossier::TAILLE_MAX_ZIP}.
+
+= render partial: "instructeurs/procedures/dossier_actions", locals: { procedure: dossier.procedure, dossier: dossier, dossier_is_followed: current_instructeur&.follow?(dossier) }
+
+%span.state-button
+  = render partial: "state_button", locals: { dossier: dossier }

--- a/app/views/instructeurs/dossiers/_state_button_refresh.js.erb
+++ b/app/views/instructeurs/dossiers/_state_button_refresh.js.erb
@@ -1,5 +1,5 @@
 <%= render_flash %>
-<%= render_to_element('.state-button', partial: "state_button", locals: { dossier: dossier }) %>
+<%= render_to_element('.header-actions', partial: 'header_actions', locals: { dossier: dossier }) %>
 
 <% attachment = dossier.justificatif_motivation.attachment %>
 <% if attachment && attachment.virus_scanner.pending? %>

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -117,7 +117,7 @@ describe Instructeurs::DossiersController, type: :controller do
     it { expect(dossier.reload.state).to eq(Dossier.states.fetch(:en_instruction)) }
     it { expect(instructeur.follow?(dossier)).to be true }
     it { expect(response).to have_http_status(:ok) }
-    it { expect(response.body).to include('.state-button') }
+    it { expect(response.body).to include('.header-actions') }
 
     context 'when the dossier has already been put en_instruction' do
       let(:dossier) { create(:dossier, :en_instruction, procedure: procedure) }
@@ -141,7 +141,7 @@ describe Instructeurs::DossiersController, type: :controller do
 
     it { expect(dossier.reload.state).to eq(Dossier.states.fetch(:en_construction)) }
     it { expect(response).to have_http_status(:ok) }
-    it { expect(response.body).to include('.state-button') }
+    it { expect(response.body).to include('.header-actions') }
 
     context 'when the dossier has already been put en_construction' do
       let(:dossier) { create(:dossier, :en_construction, procedure: procedure) }
@@ -166,7 +166,7 @@ describe Instructeurs::DossiersController, type: :controller do
 
     it { expect(dossier.reload.state).to eq(Dossier.states.fetch(:en_instruction)) }
     it { expect(response).to have_http_status(:ok) }
-    it { expect(response.body).to include('.state-button') }
+    it { expect(response.body).to include('.header-actions') }
 
     context 'when the dossier has already been put en_instruction' do
       let(:dossier) { create(:dossier, :en_instruction, procedure: procedure) }
@@ -239,7 +239,7 @@ describe Instructeurs::DossiersController, type: :controller do
           expect(dossier.justificatif_motivation).to be_attached
         end
 
-        it { expect(subject.body).to include('.state-button') }
+        it { expect(subject.body).to include('.header-actions') }
       end
     end
 
@@ -267,7 +267,7 @@ describe Instructeurs::DossiersController, type: :controller do
           subject
         end
 
-        it { expect(subject.body).to include('.state-button') }
+        it { expect(subject.body).to include('.header-actions') }
       end
 
       context 'with attachment' do
@@ -281,7 +281,7 @@ describe Instructeurs::DossiersController, type: :controller do
           expect(dossier.justificatif_motivation).to be_attached
         end
 
-        it { expect(subject.body).to include('.state-button') }
+        it { expect(subject.body).to include('.header-actions') }
       end
     end
 
@@ -322,14 +322,14 @@ describe Instructeurs::DossiersController, type: :controller do
         end
 
         it 'The instructeur is sent back to the dossier page' do
-          expect(subject.body).to include('.state-button')
+          expect(subject.body).to include('.header-actions')
         end
 
         context 'and the dossier has already an attestation' do
           it 'should not crash' do
             dossier.attestation = Attestation.new
             dossier.save
-            expect(subject.body).to include('.state-button')
+            expect(subject.body).to include('.header-actions')
           end
         end
       end
@@ -372,7 +372,7 @@ describe Instructeurs::DossiersController, type: :controller do
           expect(dossier.justificatif_motivation).to be_attached
         end
 
-        it { expect(subject.body).to include('.state-button') }
+        it { expect(subject.body).to include('.header-actions') }
       end
     end
 

--- a/spec/features/instructeurs/instructeur_spec.rb
+++ b/spec/features/instructeurs/instructeur_spec.rb
@@ -67,6 +67,7 @@ feature 'The instructeur part' do
     end
 
     expect(page).to have_text('Dossier traité avec succès.')
+    expect(page).to have_link('Archiver le dossier')
 
     dossier.reload
     expect(dossier.state).to eq(Dossier.states.fetch(:accepte))


### PR DESCRIPTION
En ce moment, quand un Instructeur change un dossier d'état, on ne rafraîchit que le bouton d'action – mais pas les autres boutons.

Ça veut dire notamment que quand un Instructeur accepte un dossier, le bouton d'à côté reste "Suivre le dossier" tant que la page n'est pas entièrement rechargée (alors qu'on devrait à la place avoir un bouton "Archiver").

Cette PR fait en sorte de recharger tous les boutons, pour que les bons statuts soient pris en compte, et qu'un Instructeur puisse archiver un dossier immédiatement après l'avoir terminé.

Fix #4186 (cc @benjaminhenkel)