### PR TITLE
Rename Gestionnaire to Instructeur in seeds.rb

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -297,7 +297,7 @@ Rails.application.routes.draw do
   end
 
   #
-  # Gestionnaire
+  # Instructeur
   #
 
   scope module: 'instructeurs', as: 'instructeur' do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,5 +11,5 @@ default_password = "this is a very complicated password !"
 puts "Create test user '#{default_user}'"
 Administration.create!(email: default_user, password: default_password)
 Administrateur.create!(email: default_user, password: default_password)
-Gestionnaire.create!(email: default_user, password: default_password)
+Instructeur.create!(email: default_user, password: default_password)
 User.create!(email: default_user, password: default_password, confirmed_at: Time.zone.now)


### PR DESCRIPTION
If I’m not mistaken, the last remaining instances of “Gestionnaire” are:
* old rake tasks, that should be removed
* `DS_GESTIONNAIRE_ID` in the Sendinblue config, that would need to be renamed in sendinblue as well.