### PR TITLE
Service : suppression du champ SIRET obligatoire

### DIFF
--- a/app/views/new_administrateur/services/_form.html.haml
+++ b/app/views/new_administrateur/services/_form.html.haml
@@ -10,16 +10,6 @@
     %span.mandatory *
   = f.text_field :organisme, placeholder: "mairie de Mours, préfecture de l'Oise, ministère de la Culture", required: true
 
-  = f.label :siret do
-    SIRET
-    %span.mandatory *
-  %p
-    Pour trouver votre numéro SIRET, utilisez
-    %a{ href: 'https://entreprise.data.gouv.fr/', target: '_blank', rel: 'noopener' }
-      entreprise.data.gouv.fr
-    ou renseignez-vous auprès de votre service comptable
-  = f.number_field :siret, required: true
-
   = f.label :type_organisme do
     Type d’organisme
     %span.mandatory *


### PR DESCRIPTION
Cette PR supprime le champ SIRET obligatoire lors de la création d'un service.

**Raisonnement :**

- Trouver le SIRET est pénible pour les admins ;
- C'est un frein à l'adoption ;
- En ce moment on ne s'en sert même pas.

L'idée était d'un jour dé-dupliquer les services en fonction du SIRET, mais est-ce qu'on va vraiment faire ça un jour ?

_NB: le SIRET est déjà optionnel en base, donc pas besoin de modifications supplémentaire._