### PR TITLE
app: mark the contact forms as not sensitive to trusted tokens

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -201,6 +201,8 @@ class ApplicationController < ActionController::Base
 
     if path == '/' ||
       path == '/users/sign_out' ||
+      path == '/contact' ||
+      path == '/contact-admin' ||
       path.start_with?('/connexion-par-jeton') ||
       path.start_with?('/api/') ||
       path.start_with?('/lien-envoye')


### PR DESCRIPTION
Instructeurs waiting for a confirmation token should be able to access the contact form (especially to ask for help).

Fix #4198 (cc @benjaminhenkel)