### PR TITLE
[fix #3975] set buttons floating in dossier page

### DIFF
--- a/app/assets/stylesheets/new_design/dossier_edit.scss
+++ b/app/assets/stylesheets/new_design/dossier_edit.scss
@@ -57,16 +57,16 @@
     border-top-left-radius: 5px;
     border-top-right-radius: 5px;
     border-bottom: none;
-    padding: 30px;
-    padding-bottom: 5px;
-    padding-top: 5px;
+    padding-top: 0px;
+    padding-bottom: $default-spacer;
+    padding-right: 30px;
+    padding-left: 30px;
     margin: 0 auto;
     margin-left: -30px;
     max-width: 1100px;
 
     .button {
-      margin-top: $default-padding;
-      margin-bottom: 0;
+      margin-top: $default-spacer;
     }
 
     @media(max-width: 1100px) {

--- a/app/assets/stylesheets/new_design/dossier_edit.scss
+++ b/app/assets/stylesheets/new_design/dossier_edit.scss
@@ -47,59 +47,49 @@
   }
 
   .send-dossier-actions-bar {
+    // scss-lint:disable VendorPrefix
+    position: -webkit-sticky;  // This is needed on Safari (tested on 12.1)
+    // scss-lint:enable VendorPrefix
+    position: sticky;
+    bottom: 0;
+
     display: flex;
-    width: 100%;
+    flex-direction: row;
+    align-items: center;
     margin-top: $default-padding;
+    margin-left: -$default-padding;
+    margin-right: -$default-padding;
+    margin-bottom: 0;
+    padding-top: 0;
+    padding-bottom: $default-spacer;
+    padding-right: $default-padding;
+    padding-left: $default-padding;
     background: #FFFFFF;
-    position: fixed;
-    bottom: 0px;
     border: 1px solid #CCCCCC;
     border-top-left-radius: 5px;
     border-top-right-radius: 5px;
     border-bottom: none;
-    padding-top: 0px;
-    padding-bottom: $default-spacer;
-    padding-right: 30px;
-    padding-left: 30px;
-    margin: 0 auto;
-    margin-left: -30px;
-    max-width: 1100px;
 
     .button {
-      margin-top: $default-spacer;
+      min-height: 38px;
+      line-height: 16px;
     }
 
-    @media(max-width: 1100px) {
-      margin-left: -16px;
+    // If there are more than one button, align the "Send" button to the right
+    .button:not(:first-of-type).send {
+      margin-left: auto;
     }
 
-    // Wide layout: align buttons on a single row
-    @media (min-width: 550px) {
-      flex-direction: row;
-
-      .button:not(:first-of-type) {
-        margin-left: $default-spacer;
-      }
-
-      // If there are more than one button, align the "Send" button to the right
-      .button:not(:first-of-type).send {
-        margin-left: auto;
-      }
+    // Normal layout
+    @media (min-width: 500px) {
+      padding-top: $default-spacer * 2;
+      padding-bottom: $default-spacer * 2;
     }
 
-    // Narrow layout: stack buttons vertically
-    @media (max-width: 550px) {
-      flex-direction: column-reverse;
-      align-items: center;
-      margin-left: -16px;
-
-      .button {
-        width: 100%;
-        max-width: 350px;
-        line-height: 30px;
-        margin-left: none;
-        margin-right: none;
-      }
+    // Compact layout
+    @media (max-width: 500px) {
+      padding-top: $default-spacer;
+      padding-bottom: $default-spacer;
     }
   }
 }

--- a/app/assets/stylesheets/new_design/dossier_edit.scss
+++ b/app/assets/stylesheets/new_design/dossier_edit.scss
@@ -45,4 +45,61 @@
     padding: 20px;
     border-radius: 4px;
   }
+
+  .send-dossier-actions-bar {
+    display: flex;
+    width: 100%;
+    margin-top: $default-padding;
+    background: #FFFFFF;
+    position: fixed;
+    bottom: 0px;
+    border: 1px solid #CCCCCC;
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+    border-bottom: none;
+    padding: 30px;
+    padding-bottom: 5px;
+    padding-top: 5px;
+    margin: 0 auto;
+    margin-left: -30px;
+    max-width: 1100px;
+
+    .button {
+      margin-top: $default-padding;
+      margin-bottom: 0;
+    }
+
+    @media(max-width: 1100px) {
+      margin-left: -16px;
+    }
+
+    // Wide layout: align buttons on a single row
+    @media (min-width: 550px) {
+      flex-direction: row;
+
+      .button:not(:first-of-type) {
+        margin-left: $default-spacer;
+      }
+
+      // If there are more than one button, align the "Send" button to the right
+      .button:not(:first-of-type).send {
+        margin-left: auto;
+      }
+    }
+
+    // Narrow layout: stack buttons vertically
+    @media (max-width: 550px) {
+      flex-direction: column-reverse;
+      align-items: center;
+      margin-left: -16px;
+
+      .button {
+        width: 100%;
+        max-width: 350px;
+        line-height: 30px;
+        margin-left: none;
+        margin-right: none;
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/new_design/forms.scss
+++ b/app/assets/stylesheets/new_design/forms.scss
@@ -361,6 +361,57 @@
     }
   }
 
+  .send-dossier-wrapper {
+    display: flex;
+    width: 100%;
+    margin-top: $default-padding;
+    background: #FFFFFF;
+    position: fixed;
+    bottom: 0px;
+    border: 1px solid #CCCCCC;
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+    border-bottom: none;
+    padding: 30px;
+    padding-bottom: 5px;
+    padding-top: 5px;
+    left: 0px;
+    margin: 0 auto;
+
+    .button {
+      margin-top: $default-padding;
+      margin-bottom: 0;
+    }
+
+    // Wide layout: align buttons on a single row
+    @media (min-width: 550px) {
+      flex-direction: row;
+
+      .button:not(:first-of-type) {
+        margin-left: $default-spacer;
+      }
+
+      // If there are more than one button, align the "Send" button to the right
+      .button:not(:first-of-type).send {
+        margin-left: auto;
+      }
+    }
+
+    // Narrow layout: stack buttons vertically
+    @media (max-width: 550px) {
+      flex-direction: column-reverse;
+      align-items: center;
+
+      .button {
+        width: 100%;
+        max-width: 350px;
+        line-height: 30px;
+        margin-left: none;
+        margin-right: none;
+      }
+    }
+  }
+
   .send-notice {
     @include notice-text-style;
     margin-bottom: $default-padding;

--- a/app/assets/stylesheets/new_design/forms.scss
+++ b/app/assets/stylesheets/new_design/forms.scss
@@ -361,63 +361,6 @@
     }
   }
 
-  .send-dossier-wrapper {
-    display: flex;
-    width: 100%;
-    margin-top: $default-padding;
-    background: #FFFFFF;
-    position: fixed;
-    bottom: 0px;
-    border: 1px solid #CCCCCC;
-    border-top-left-radius: 5px;
-    border-top-right-radius: 5px;
-    border-bottom: none;
-    padding: 30px;
-    padding-bottom: 5px;
-    padding-top: 5px;
-    margin: 0 auto;
-    margin-left: -30px;
-    max-width: 1100px;
-
-    .button {
-      margin-top: $default-padding;
-      margin-bottom: 0;
-    }
-
-    @media(max-width: 1100px) {
-      margin-left: -16px;
-    }
-
-    // Wide layout: align buttons on a single row
-    @media (min-width: 550px) {
-      flex-direction: row;
-
-      .button:not(:first-of-type) {
-        margin-left: $default-spacer;
-      }
-
-      // If there are more than one button, align the "Send" button to the right
-      .button:not(:first-of-type).send {
-        margin-left: auto;
-      }
-    }
-
-    // Narrow layout: stack buttons vertically
-    @media (max-width: 550px) {
-      flex-direction: column-reverse;
-      align-items: center;
-      margin-left: -16px;
-
-      .button {
-        width: 100%;
-        max-width: 350px;
-        line-height: 30px;
-        margin-left: none;
-        margin-right: none;
-      }
-    }
-  }
-
   .send-notice {
     @include notice-text-style;
     margin-bottom: $default-padding;

--- a/app/assets/stylesheets/new_design/forms.scss
+++ b/app/assets/stylesheets/new_design/forms.scss
@@ -375,12 +375,17 @@
     padding: 30px;
     padding-bottom: 5px;
     padding-top: 5px;
-    left: 0px;
     margin: 0 auto;
+    margin-left: -30px;
+    max-width: 1100px;
 
     .button {
       margin-top: $default-padding;
       margin-bottom: 0;
+    }
+
+    @media(max-width: 1100px) {
+      margin-left: -16px;
     }
 
     // Wide layout: align buttons on a single row
@@ -401,6 +406,7 @@
     @media (max-width: 550px) {
       flex-direction: column-reverse;
       align-items: center;
+      margin-left: -16px;
 
       .button {
         width: 100%;

--- a/app/assets/stylesheets/new_design/new_footer.scss
+++ b/app/assets/stylesheets/new_design/new_footer.scss
@@ -108,10 +108,6 @@ footer {
 .footer-row {
   margin-bottom: 30px;
 
-  &:last-child {
-    margin-bottom: 35px;
-  }
-
   // In this case, the bottom margin is defined directly on each individual column
   &.footer-columns {
     margin-bottom: 0;

--- a/app/assets/stylesheets/new_design/new_footer.scss
+++ b/app/assets/stylesheets/new_design/new_footer.scss
@@ -109,7 +109,7 @@ footer {
   margin-bottom: 30px;
 
   &:last-child {
-    margin-bottom: 0;
+    margin-bottom: 35px;
   }
 
   // In this case, the bottom margin is defined directly on each individual column

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -32,7 +32,7 @@
         locals: { champ: champ, form: champ_form }
 
     - if !apercu
-      .send-wrapper
+      .send-dossier-wrapper
         - if dossier.brouillon?
           = f.button 'Enregistrer le brouillon',
             formnovalidate: true,

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -32,7 +32,7 @@
         locals: { champ: champ, form: champ_form }
 
     - if !apercu
-      .send-dossier-wrapper
+      .send-dossier-actions-bar
         - if dossier.brouillon?
           = f.button 'Enregistrer le brouillon',
             formnovalidate: true,

--- a/spec/views/users/dossiers/brouillon.html.haml_spec.rb
+++ b/spec/views/users/dossiers/brouillon.html.haml_spec.rb
@@ -21,7 +21,7 @@ describe 'users/dossiers/brouillon.html.haml', type: :view do
   end
 
   it 'affiche les boutons de validation' do
-    expect(rendered).to have_selector('.send-wrapper')
+    expect(rendered).to have_selector('.send-dossier-wrapper')
   end
 
   it 'prépare le footer' do

--- a/spec/views/users/dossiers/brouillon.html.haml_spec.rb
+++ b/spec/views/users/dossiers/brouillon.html.haml_spec.rb
@@ -21,7 +21,7 @@ describe 'users/dossiers/brouillon.html.haml', type: :view do
   end
 
   it 'affiche les boutons de validation' do
-    expect(rendered).to have_selector('.send-dossier-wrapper')
+    expect(rendered).to have_selector('.send-dossier-actions-bar')
   end
 
   it 'prépare le footer' do


### PR DESCRIPTION
J'ai crée une classe CSS ".send-dossier-wrapper" pour n'ai pas impact sur les autres pages ex: Demander un avis. 
Je n'ai pas pu faire rentrer les boutons horizontalement, j'ai laissé par défaut empiler les boutons.

Fix #3975