### PR TITLE
#4242 - Removed ask_birthday for new procedures & dossiers

### DIFF
--- a/app/controllers/admin/procedures_controller.rb
+++ b/app/controllers/admin/procedures_controller.rb
@@ -284,7 +284,7 @@ class Admin::ProceduresController < AdminController
     permited_params = if @procedure&.locked?
       params.require(:procedure).permit(*editable_params)
     else
-      params.require(:procedure).permit(*editable_params, :duree_conservation_dossiers_dans_ds, :duree_conservation_dossiers_hors_ds, :for_individual, :ask_birthday, :path)
+      params.require(:procedure).permit(*editable_params, :duree_conservation_dossiers_dans_ds, :duree_conservation_dossiers_hors_ds, :for_individual, :path)
     end
     permited_params[:logo_active_storage] = permited_params.delete(:logo)
     permited_params

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -236,6 +236,7 @@ class Procedure < ApplicationRecord
     procedure.closed_mail = closed_mail&.dup
     procedure.refused_mail = refused_mail&.dup
     procedure.without_continuation_mail = without_continuation_mail&.dup
+    procedure.ask_birthday = false # see issue #4242
 
     procedure.cloned_from_library = from_library
     procedure.parent_procedure = self

--- a/app/views/admin/procedures/_informations.html.haml
+++ b/app/views/admin/procedures/_informations.html.haml
@@ -121,12 +121,6 @@
       %b
         Si votre démarche s’adresse indifféremment à une personne morale ou un particulier choisissez l'option "particuliers". Vous pourrez utilisez le champ SIRET directement dans le formulaire.
 
-      %ul#individual-with-siret
-        %li
-          .checkbox
-            %label
-              = f.check_box :ask_birthday
-              Demander la date de naissance.
 .row
   .col-md-6
     %h4 Options avancées

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -448,6 +448,18 @@ describe Procedure do
       it 'should have one administrateur' do
         expect(subject.administrateurs).to eq([administrateur])
       end
+
+      it 'should set ask_birthday to false' do
+        expect(subject.ask_birthday?).to eq(false)
+      end
+    end
+
+    context 'when the procedure is cloned from the library' do
+      let(:procedure) { create(:procedure, received_mail: received_mail, service: service, ask_birthday: true) }
+
+      it 'should set ask_birthday to false' do
+        expect(subject.ask_birthday?).to eq(false)
+      end
     end
 
     it 'should keep service_id' do


### PR DESCRIPTION
Pour la rétro compatibilité, on doit garder `ask_birthday` (qui sert sur le premier écran de dépot d'un dossier, et bien sur en base). Par contre, on doit le virer lors du clonage, sinon on a les problèmes évoqués dans #4242.