### PR TITLE
Rename “Passé en construction le” to 'Déposé le' for clarity

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -454,7 +454,7 @@ class Dossier < ApplicationRecord
       ['Archivé', :archived],
       ['État du dossier', I18n.t(state, scope: [:activerecord, :attributes, :dossier, :state])],
       ['Dernière mise à jour le', :updated_at],
-      ['Passé en construction le', :en_construction_at],
+      ['Déposé le', :en_construction_at],
       ['Passé en instruction le', :en_instruction_at],
       ['Traité le', :processed_at],
       ['Motivation de la décision', :motivation],

--- a/spec/services/procedure_export_v2_service_spec.rb
+++ b/spec/services/procedure_export_v2_service_spec.rb
@@ -45,7 +45,7 @@ describe ProcedureExportV2Service do
           "Archivé",
           "État du dossier",
           "Dernière mise à jour le",
-          "Passé en construction le",
+          "Déposé le",
           "Passé en instruction le",
           "Traité le",
           "Motivation de la décision",


### PR DESCRIPTION
Dans l'ancien format nous avons `created_at` que certains instructeurs pensent être "Déposé le" mais qui est en réalité "Brouillon crée le" qui n'a aucun intérêt. “Passé en construction le” – personne ne sait ce que ça veut dire :)
