### PR TITLE
Utiliser un unique compte pipedrive

### DIFF
--- a/app/lib/biz_dev.rb
+++ b/app/lib/biz_dev.rb
@@ -1,38 +1,12 @@
 module BizDev
-  BIZ_DEV_MAPPING = {
-    9 =>
-      {
-        full_name: "Philippe Vrignaud",
-        pipedrive_id: 2753338
-      },
-    10 =>
-      {
-        full_name: "Benjamin Doberset",
-        pipedrive_id: 4223834
-      }
-  }
-
-  BIZ_DEV_IDS = BIZ_DEV_MAPPING.keys
+  NAME = "Équipe DS"
+  PIPEDRIVE_ID = 6019737
 
   def self.full_name(administration_id)
-    id = ensure_proper_administration_id(administration_id)
-
-    BIZ_DEV_MAPPING[id][:full_name]
+    NAME
   end
 
   def self.pipedrive_id(administration_id)
-    id = ensure_proper_administration_id(administration_id)
-
-    BIZ_DEV_MAPPING[id][:pipedrive_id]
-  end
-
-  private
-
-  def self.ensure_proper_administration_id(administration_id)
-    if administration_id.in?(BIZ_DEV_IDS)
-      administration_id
-    else
-      BIZ_DEV_IDS[administration_id % BIZ_DEV_IDS.length]
-    end
+    PIPEDRIVE_ID
   end
 end

--- a/spec/lib/biz_dev_spec.rb
+++ b/spec/lib/biz_dev_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe BizDev, lib: true do
-  let(:first_biz_dev_id) { BizDev::BIZ_DEV_IDS.first }
+  let(:first_biz_dev_id) { BizDev::PIPEDRIVE_ID }
   let(:non_biz_dev_id) { first_biz_dev_id - 1 }
 
-  it { expect(BizDev::BIZ_DEV_MAPPING).not_to include(non_biz_dev_id) }
+  it { expect(BizDev::PIPEDRIVE_ID).not_to eq(non_biz_dev_id) }
 
   describe '#full_name' do
     subject { described_class.full_name(administration_id) }

--- a/spec/mailers/administration_mailer_spec.rb
+++ b/spec/mailers/administration_mailer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe AdministrationMailer, type: :mailer do
   describe '#invite_admin' do
     let(:admin) { create(:administrateur) }
     let(:token) { "Toc toc toc" }
-    let(:administration_id) { BizDev::BIZ_DEV_IDS.first }
+    let(:administration_id) { BizDev::PIPEDRIVE_ID }
 
     subject { described_class.invite_admin(admin, token, administration_id) }
 


### PR DESCRIPTION
Suite aux cleanups de comptes pipedrive, on a des erreurs pipedrive car le mapping actuel ne reflète pas l'état des comptes dispo (on avait déja eu le problème au départ de camille).
Après discussion avec @chaibax , on a vu qu'à terme il n'y aurait plus que le compte "équipe" qui serait utilisé, donc c'est ce qu'il faut utiliser.

J'ai laissé l'API frontale en l'état (on continue à appeler les méthodes `full_name` et `pipedrive_id`). On peut envisager de supprimer ces méthodes et appeler directement les constantes aux 2 endroits où c'est le cas.