### PR TITLE
Add no-reply email to transactional emails

### DIFF
--- a/app/mailers/devise_user_mailer.rb
+++ b/app/mailers/devise_user_mailer.rb
@@ -7,4 +7,9 @@ class DeviseUserMailer < Devise::Mailer
   def template_paths
     ['devise_mailer']
   end
+
+  def confirmation_instructions(record, token, opts = {})
+    opts[:from] = NO_REPLY_EMAIL
+    super
+  end
 end

--- a/app/mailers/dossier_mailer.rb
+++ b/app/mailers/dossier_mailer.rb
@@ -12,7 +12,7 @@ class DossierMailer < ApplicationMailer
 
     subject = "Retrouvez votre brouillon pour la démarche « #{dossier.procedure.libelle} »"
 
-    mail(to: dossier.user.email, subject: subject) do |format|
+    mail(from: NO_REPLY_EMAIL, to: dossier.user.email, subject: subject) do |format|
       format.html { render layout: 'mailers/notifications_layout' }
     end
   end
@@ -24,7 +24,7 @@ class DossierMailer < ApplicationMailer
 
     subject = "Nouveau message pour votre dossier nº #{dossier.id} (#{dossier.procedure.libelle})"
 
-    mail(to: dossier.user.email, subject: subject) do |format|
+    mail(from: NO_REPLY_EMAIL, to: dossier.user.email, subject: subject) do |format|
       format.html { render layout: 'mailers/notifications_layout' }
     end
   end

--- a/app/mailers/dossier_mailer.rb
+++ b/app/mailers/dossier_mailer.rb
@@ -60,8 +60,13 @@ class DossierMailer < ApplicationMailer
 
   def notify_revert_to_instruction(dossier)
     @dossier = dossier
-    @subject = "Votre dossier nº #{@dossier.id} est en train d'être réexaminé"
+    @service = dossier.procedure.service
+    @logo_url = attach_logo(dossier.procedure)
 
-    mail(to: dossier.user.email, subject: @subject)
+    subject = "Votre dossier nº #{@dossier.id} est en train d'être réexaminé"
+
+    mail(from: NO_REPLY_EMAIL, to: dossier.user.email, subject: subject) do |format|
+      format.html { render layout: 'mailers/notifications_layout' }
+    end
   end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -12,6 +12,7 @@ class NotificationMailer < ApplicationMailer
   helper MailerHelper
 
   layout 'mailers/notifications_layout'
+  default from: NO_REPLY_EMAIL
 
   def send_dossier_received(dossier)
     send_notification(dossier, dossier.procedure.received_mail_template)

--- a/app/views/dossier_mailer/notify_revert_to_instruction.html.haml
+++ b/app/views/dossier_mailer/notify_revert_to_instruction.html.haml
@@ -1,3 +1,6 @@
+- content_for :procedure_logo do
+  = render 'layouts/mailers/logo', url: @logo_url
+
 %p
   Bonjour,
 
@@ -13,4 +16,7 @@
     email:
     = mail_to @dossier.procedure.service.email, @dossier.procedure.service.email
 
-= render partial: "layouts/mailers/signature"
+= render 'layouts/mailers/signature'
+
+- content_for :footer do
+  = render 'layouts/mailers/service_footer', service: @service, dossier: @dossier

--- a/config/initializers/contacts.rb
+++ b/config/initializers/contacts.rb
@@ -2,7 +2,7 @@ if !defined?(CONTACT_EMAIL)
   CONTACT_EMAIL = "contact@demarches-simplifiees.fr"
   EQUIPE_EMAIL = "equipe@demarches-simplifiees.fr"
   TECH_EMAIL = "tech@demarches-simplifiees.fr"
-
+  NO_REPLY_EMAIL = "Ne pas répondre <ne-pas-repondre@demarches-simplifiees.fr>"
   CONTACT_PHONE = "01 76 42 02 87"
 
   OLD_CONTACT_EMAIL = "contact@tps.apientreprise.fr"

--- a/spec/mailers/dossier_mailer_spec.rb
+++ b/spec/mailers/dossier_mailer_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe DossierMailer, type: :mailer do
   let(:to_email) { 'instructeur@exemple.gouv.fr' }
 
   shared_examples 'a dossier notification' do
+    it 'is sent from a no-reply address' do
+      expect(subject.from.first).to eq(Mail::Address.new(NO_REPLY_EMAIL).address)
+    end
+
     it 'includes the contact informations in the footer' do
       expect(subject.body).to include('ne pas répondre')
     end

--- a/spec/mailers/dossier_mailer_spec.rb
+++ b/spec/mailers/dossier_mailer_spec.rb
@@ -67,4 +67,16 @@ RSpec.describe DossierMailer, type: :mailer do
     it { expect(subject.body).to include("n'a pas pu être supprimé") }
     it { expect(subject.body).to include(dossier.procedure.libelle) }
   end
+
+  describe '.notify_revert_to_instruction' do
+    let(:dossier) { create(:dossier, procedure: build(:simple_procedure)) }
+
+    subject { described_class.notify_revert_to_instruction(dossier) }
+
+    it { expect(subject.subject).to include('réexaminé') }
+    it { expect(subject.body).to include(dossier.procedure.libelle) }
+    it { expect(subject.body).to include(dossier_url(dossier)) }
+
+    it_behaves_like 'a dossier notification'
+  end
 end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -56,5 +56,9 @@ RSpec.describe NotificationMailer, type: :mailer do
         expect(mail.body).not_to include('iframe')
       end
     end
+
+    it 'sends the mail from a no-reply address' do
+      expect(subject.from.first).to eq(Mail::Address.new(NO_REPLY_EMAIL).address)
+    end
   end
 end


### PR DESCRIPTION
Je n'ai pas fait le tour de TOUS les messages envoyés par DS aux usagers; juste ceux qui me semblaient les plus fréquents : création de comptes, changement d'email, accusés, nouveau message

<img width="810" alt="Capture d'écran 2019-08-29 17 19 34" src="https://user-images.githubusercontent.com/3593868/63953297-62482d00-ca81-11e9-99dc-6de247d69d36.png">
<img width="699" alt="Capture d'écran 2019-08-29 17 19 58" src="https://user-images.githubusercontent.com/3593868/63953299-62482d00-ca81-11e9-965b-a3b2cf751283.png">
