### PR TITLE
#4278 - Changer le placeholder de la messagerie selon le type d'utilisateur

### DIFF
--- a/app/views/shared/dossiers/messages/_form.html.haml
+++ b/app/views/shared/dossiers/messages/_form.html.haml
@@ -1,5 +1,8 @@
 = form_for(commentaire, url: form_url, html: { class: 'form' }) do |f|
-  = f.text_area :body, rows: 5, placeholder: 'Écrivez votre message à l’administration ici', required: true, class: 'message-textarea'
+  - placeholder = 'Écrivez votre message à l’administration ici'
+  - if instructeur_signed_in? || administrateur_signed_in?
+    - placeholder = 'Écrivez votre message ici'
+  = f.text_area :body, rows: 5, placeholder: placeholder, required: true, class: 'message-textarea'
   .flex.justify-between.wrap
     %div
       = f.file_field :piece_jointe, id: 'piece_jointe', direct_upload: true


### PR DESCRIPTION
Le contexte est là : https://github.com/betagouv/demarches-simplifiees.fr/issues/4278

J'ai préféré avoir `Écrivez votre message ici` plutôt que `Écrivez votre message à l'usager ici` car pour les comptes multiprofil (ex: test@exemple.fr), on peut être instructeur et usager et se retrouver avec un message incohérent dans la messagerie.