### PR TITLE
mailers: prevent the signature from being auto-linked

### DIFF
--- a/app/views/layouts/mailers/_signature.html.haml
+++ b/app/views/layouts/mailers/_signature.html.haml
@@ -4,4 +4,5 @@
   - if defined?(service) && service && service.nom.present?
     = service.nom
   - else
-    L’équipe demarches-simplifiees.fr
+    -# The WORD JOINER unicode entity prevents email clients from auto-linking the signature
+    L’équipe demarches-simplifiees&#8288;.fr


### PR DESCRIPTION
Some emails clients (Gmail or Mail.app) may turn the signature into
a clickable link.

This can distract users, and make them think we are a good point of
contact (where they should contact their administration or use the
website directly instead).

_Replaces #4276_