### PR TITLE
Correction de la suppression des démarches

### DIFF
--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -2,6 +2,6 @@ class GroupeInstructeur < ApplicationRecord
   DEFAULT_LABEL = 'défaut'
   belongs_to :procedure
   has_many :assign_tos
-  has_many :instructeurs, through: :assign_tos
+  has_many :instructeurs, through: :assign_tos, dependent: :destroy
   has_many :dossiers
 end

--- a/spec/controllers/admin/procedures_controller_spec.rb
+++ b/spec/controllers/admin/procedures_controller_spec.rb
@@ -96,9 +96,9 @@ describe Admin::ProceduresController, type: :controller do
   end
 
   describe 'DELETE #destroy' do
-    let(:procedure_draft) { create :procedure_with_dossiers, administrateur: admin, published_at: nil, archived_at: nil }
-    let(:procedure_published) { create :procedure_with_dossiers, administrateur: admin, aasm_state: :publiee, published_at: Time.zone.now, archived_at: nil }
-    let(:procedure_archived) { create :procedure_with_dossiers, administrateur: admin, aasm_state: :archivee, published_at: nil, archived_at: Time.zone.now }
+    let(:procedure_draft)     { create :procedure_with_dossiers, administrateur: admin, instructeurs: [admin.instructeur], published_at: nil, archived_at: nil }
+    let(:procedure_published) { create :procedure_with_dossiers, administrateur: admin, instructeurs: [admin.instructeur], aasm_state: :publiee, published_at: Time.zone.now, archived_at: nil }
+    let(:procedure_archived)  { create :procedure_with_dossiers, administrateur: admin, instructeurs: [admin.instructeur], aasm_state: :archivee, published_at: nil, archived_at: Time.zone.now }
 
     subject { delete :destroy, params: { id: procedure.id } }
 


### PR DESCRIPTION
Supprimer une démarche supprime maintenant le groupe d'instructeurs associé (au lieu de planter).

Fix #4282