### PR TITLE
Merge pull request #4300 from betagouv/fix-helpscout-stats

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -13,7 +13,6 @@ class StatsController < ApplicationController
     @satisfaction_usagers = satisfaction_usagers
 
     @contact_percentage = contact_percentage
-    @contact_percentage_excluded_tags = Helpscout::UserConversationsAdapter::EXCLUDED_TAGS
 
     @dossiers_states = dossiers_states
 
@@ -177,7 +176,7 @@ class StatsController < ApplicationController
       .map do |monthly_report|
         start_date = monthly_report[:start_date].to_time.localtime
         end_date = monthly_report[:end_date].to_time.localtime
-        replies_count = monthly_report[:conversations_count]
+        replies_count = monthly_report[:replies_sent]
 
         dossiers_count = Dossier.where(en_construction_at: start_date..end_date).count
 

--- a/app/views/stats/index.html.haml
+++ b/app/views/stats/index.html.haml
@@ -34,16 +34,15 @@
 
     .stat-card.stat-card-half.pull-left
       %span.stat-card-title
-        Pourcentage de contact usager
+        Pourcentage de contact utilisateur
 
       .chart-container
         .chart
           = line_chart @contact_percentage
 
       .stat-card-details
-        %abbr{ title: "À l’exception des conversations taggées #{@contact_percentage_excluded_tags.join(', ')}" }
-          Nombre de conversations actives dans HelpScout
-        %span / nombre de dossiers déposés
+        Nombre de réponses envoyées via HelpScout
+        \/ nombre de dossiers déposés
 
     .stat-card.stat-card-half.pull-left
       %span.stat-card-title

--- a/spec/fixtures/cassettes/helpscout_conversations_reports.yml
+++ b/spec/fixtures/cassettes/helpscout_conversations_reports.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.helpscout.net/v2/oauth2/token
     body:
       encoding: UTF-8
-      string: client_id&client_secret&grant_type=client_credentials
+      string: client_id=1234&client_secret=5678&grant_type=client_credentials
     headers:
       User-Agent:
       - demarches-simplifiees.fr
@@ -23,7 +23,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 13 Dec 2018 12:49:04 GMT
+      - Wed, 11 Sep 2019 15:02:24 GMT
       Pragma:
       - no-cache
       Content-Length:
@@ -32,14 +32,14 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"token_type":"bearer","access_token":"18mock9b","expires_in":7200}
+      string: '{"token_type":"bearer","access_token":"redacted","expires_in":7200}
 
 '
     http_version:
-  recorded_at: Thu, 13 Dec 2018 12:49:05 GMT
+  recorded_at: Wed, 11 Sep 2019 15:02:24 GMT
 - request:
     method: get
-    uri: https://api.helpscout.net/v2/reports/conversations?end=2017-12-01T00:00:00Z&start=2017-11-01T00:00:00Z
+    uri: https://api.helpscout.net/v2/reports/productivity?end=2017-12-01T00:00:00Z&mailboxes=9999&start=2017-11-01T00:00:00Z
     body:
       encoding: US-ASCII
       string: ''
@@ -47,7 +47,7 @@ http_interactions:
       User-Agent:
       - demarches-simplifiees.fr
       Authorization:
-      - Bearer 18mock9b
+      - Bearer redacted
       Content-Type:
       - application/json; charset=UTF-8
       Expect:
@@ -64,9 +64,9 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Correlation-Id:
-      - a6ee3949-ec16-4b39-92bc-3600adc3f671#144730730
+      - 23f037f4-3974-4c8f-b252-3a580e4400dc#3293935
       Date:
-      - Thu, 13 Dec 2018 12:49:05 GMT
+      - Wed, 11 Sep 2019 15:02:24 GMT
       Expires:
       - '0'
       Pragma:
@@ -77,24 +77,23 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Ratelimit-Limit-Minute:
-      - '200'
+      - '400'
       X-Ratelimit-Remaining-Minute:
-      - '199'
+      - '399'
       X-Xss-Protection:
       - 1; mode=block
       Content-Length:
-      - '5434'
+      - '2551'
       Connection:
       - keep-alive
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        eyJyZXBsaWVzIjp7ImNvdW50IjoyMTYsInRvcCI6W3sibmFtZSI6Ik1hdXZhaXMgaW50ZXJsb2N1dGV1ciIsImlkIjo3MjczOTYsIm1haWxib3hJZCI6MTI1OTI2LCJjb3VudCI6OSwicGVyY2VudCI6NC4xNjY2NjY2NjY2NjY2NjZ9LHsibmFtZSI6IkRlbWFuZGUgZGUgZMOpbW8sIHN0ZXAgMSIsImlkIjo3MzIxOTQsIm1haWxib3hJZCI6MTI1OTI2LCJjb3VudCI6NSwicGVyY2VudCI6Mi4zMTQ4MTQ4MTQ4MTQ4MTV9LHsibmFtZSI6IkRlbWFuZGUgY29tcHRlIGFkbWluIHBhcnRpY3VsaWVyIC8gZW50cmVwcmlzZSIsImlkIjo3NTExMzAsIm1haWxib3hJZCI6MTI1OTI2LCJjb3VudCI6MywicGVyY2VudCI6MS4zODg4ODg4ODg4ODg4ODg4fSx7Im5hbWUiOiJTdGVwIDIsIG5vdXZlbGxlIHByb2PDqWR1cmUiLCJpZCI6NzMyMTk1LCJtYWlsYm94SWQiOjEyNTkyNiwiY291bnQiOjIsInBlcmNlbnQiOjAuOTI1OTI1OTI1OTI1OTI1OH1dfSwid29ya2Zsb3dzIjp7ImNvdW50IjoyMTYsInRvcCI6W119LCJ0YWdzIjp7ImNvdW50IjoyMTYsInRvcCI6W3siaWQiOjEsImNvdW50IjoyMTYsInBlcmNlbnQiOjEwMC4wfV19LCJjdXN0b21lcnMiOnsiY291bnQiOjIxNiwidG9wIjpbeyJuYW1lIjoiQ29vY2hlIE1hcmllIiwiaWQiOjE1MDIyNDI5MiwiY291bnQiOjEzLCJwZXJjZW50Ijo2LjAxODUxODUxODUxODUxOH0seyJuYW1lIjoiVnJpZ25hdWQgUGhpbGlwcGUiLCJpZCI6MTQ3NjcwOTY2LCJjb3VudCI6MTIsInBlcmNlbnQiOjUuNTU1NTU1NTU1NTU1NTU1fSx7Im5hbWUiOiJDb3Jpbm5lIExhc25lIiwiaWQiOjE0OTY2NTIyNSwiY291bnQiOjcsInBlcmNlbnQiOjMuMjQwNzQwNzQwNzQwNzQwNX0seyJuYW1lIjoiU2VydmljZSBDbGllbnQgTWFpbGpldCIsImlkIjoxNDg0NTI1MjYsImNvdW50Ijo1LCJwZXJjZW50IjoyLjMxNDgxNDgxNDgxNDgxNX0seyJuYW1lIjoiVCZlYWN1dGU7bCZlYWN1dGU7cHJvYyZlYWN1dGU7ZHVyZXMgU2ltcGxpZmkmZWFjdXRlO2VzIiwiaWQiOjE0NzY2ODE0MSwiY291bnQiOjUsInBlcmNlbnQiOjIuMzE0ODE0ODE0ODE0ODE1fSx7Im5hbWUiOiJNb25iZXQtRHVmYXUgRnJhbiZjY2VkaWw7b2lzIChuYXYtR2VucyBEZSBNZXIpIC0gRGR0bSA2NC9kbWwvYW1sIiwiaWQiOjE1MzMwMzk4NiwiY291bnQiOjQsInBlcmNlbnQiOjEuODUxODUxODUxODUxODUxNn0seyJuYW1lIjoiUGhpbGlwcGUgVnJpZ25hdWQiLCJpZCI6MTQ4OTc0MTk5LCJjb3VudCI6MywicGVyY2VudCI6MS4zODg4ODg4ODg4ODg4ODg4fSx7Im5hbWUiOiJkb21pbmlxdWVAY29sbGFydC5mciIsImlkIjoxNDg4MTA4OTcsImNvdW50IjozLCJwZXJjZW50IjoxLjM4ODg4ODg4ODg4ODg4ODh9LHsibmFtZSI6IkxlYmFzdGFyZCBGcmFuY2sgKGFkam9pbnQgQXUgQ2hlZiBEZSBCdXJlYXUpIC0gRGdhbG4vc2FncC9zZHAvYmNzaSIsImlkIjoxNTI5NzA5ODMsImNvdW50IjozLCJwZXJjZW50IjoxLjM4ODg4ODg4ODg4ODg4ODh9LHsibmFtZSI6IkZyYW1hbGlzdGVzIiwiaWQiOjE1MDkwMTMyNCwiY291bnQiOjMsInBlcmNlbnQiOjEuMzg4ODg4ODg4ODg4ODg4OH0seyJuYW1lIjoiUnVmaW4gQXR0aW5nbGkiLCJpZCI6MTQ4ODM1MTAzLCJjb3VudCI6MywicGVyY2VudCI6MS4zODg4ODg4ODg4ODg4ODg4fSx7Im5hbWUiOiJIdW1hIExhdXRlcmZpbmciLCJpZCI6MTQ3ODE0Njc0LCJjb3VudCI6MywicGVyY2VudCI6MS4zODg4ODg4ODg4ODg4ODg4fSx7Im5hbWUiOiJDc2YtU29pc3NvbnMub3JnIiwiaWQiOjE1MzMzNDE5NiwiY291bnQiOjIsInBlcmNlbnQiOjAuOTI1OTI1OTI1OTI1OTI1OH0seyJuYW1lIjoic2FycmlxdWV0LmNocmlzdGlhbkBvcmFuZ2UuZnIiLCJpZCI6MTUxOTAxNDA5LCJjb3VudCI6MiwicGVyY2VudCI6MC45MjU5MjU5MjU5MjU5MjU4fSx7Im5hbWUiOiJmYWJpZW5uZS5jb3F1ZWxsZUBjYWZub3JkLmNuYWZtYWlsLmZyIiwiaWQiOjE1MDU5MzgzOSwiY291bnQiOjIsInBlcmNlbnQiOjAuOTI1OTI1OTI1OTI1OTI1OH0seyJuYW1lIjoiSiZlYWN1dGU7ciZvY2lyYzttZSBMYXVyZW50IiwiaWQiOjE1MDA3NDM4NywiY291bnQiOjIsInBlcmNlbnQiOjAuOTI1OTI1OTI1OTI1OTI1OH0seyJuYW1lIjoiQXVyJmVhY3V0ZTtsaWUgQ2hhYnJvbCIsImlkIjoxNTE1ODM4MjYsImNvdW50IjoyLCJwZXJjZW50IjowLjkyNTkyNTkyNTkyNTkyNTh9LHsibmFtZSI6IlBpZXJyZS1BbGV4aXMgQmFyYmllciIsImlkIjoxNTEyMzkzMTAsImNvdW50IjoyLCJwZXJjZW50IjowLjkyNTkyNTkyNTkyNTkyNTh9LHsibmFtZSI6IktoYWxlZCBLaGVsaWYiLCJpZCI6MTUwMzc0Mzk3LCJjb3VudCI6MiwicGVyY2VudCI6MC45MjU5MjU5MjU5MjU5MjU4fSx7Im5hbWUiOiJMZSBSaHVuIEVsb2RpZSAoY2hlZiBEZSBCdXJlYXUpIC0gRHJpZWEgSWYvc3N0L2RydHIvYmdjMiIsImlkIjoxNDk1NDcyOTEsImNvdW50IjoyLCJwZXJjZW50IjowLjkyNTkyNTkyNTkyNTkyNTh9LHsibmFtZSI6Ik1hcmluYSBMYXVyZSIsImlkIjoxNTQzMjU3MDUsImNvdW50IjoyLCJwZXJjZW50IjowLjkyNTkyNTkyNTkyNTkyNTh9LHsibmFtZSI6IlBsYW1vdWNoZSIsImlkIjoxNDk3MTQ0OTUsImNvdW50IjoyLCJwZXJjZW50IjowLjkyNTkyNTkyNTkyNTkyNTh9LHsibmFtZSI6IlRpcGhhbmllIFRoYXZhdWQiLCJpZCI6MTUyNDM4MDQ3LCJjb3VudCI6MiwicGVyY2VudCI6MC45MjU5MjU5MjU5MjU5MjU4fSx7Im5hbWUiOiJBenVyJmVhY3V0ZTtlbm5lIExvY2F0aW9uIiwiaWQiOjE1MTEzMjA4MywiY291bnQiOjIsInBlcmNlbnQiOjAuOTI1OTI1OTI1OTI1OTI1OH0seyJuYW1lIjoiSXNhYmVsbGUgUmVuYXJkIC8gU2VydmljZSBRdWFsaXQmZWFjdXRlOyIsImlkIjoxNTExMTI1MzcsImNvdW50IjoyLCJwZXJjZW50IjowLjkyNTkyNTkyNTkyNTkyNTh9LHsibmFtZSI6IkNhZmZpZXIgQXVyJmVhY3V0ZTtsaWVuIiwiaWQiOjE0OTY3NzE0OCwiY291bnQiOjIsInBlcmNlbnQiOjAuOTI1OTI1OTI1OTI1OTI1OH0seyJuYW1lIjoiSmFjcXVlbGluZSBHYXJjaWEiLCJpZCI6MTQ5MTk0NDcwLCJjb3VudCI6MSwicGVyY2VudCI6MC40NjI5NjI5NjI5NjI5NjI5fSx7Im5hbWUiOiJSZW5hcmQgTWFydGluZSIsImlkIjoxNDkwNDg0MDksImNvdW50IjoxLCJwZXJjZW50IjowLjQ2Mjk2Mjk2Mjk2Mjk2Mjl9LHsibmFtZSI6IkZsb3JlbmNlIENhbXBlbm9uIENvbW11bmljYXRpb24iLCJpZCI6MTQ5Mjc0NzA4LCJjb3VudCI6MSwicGVyY2VudCI6MC40NjI5NjI5NjI5NjI5NjI5fSx7Im5hbWUiOiJjZXNhcmluZS5ndWVpQGFycy5zYW50ZS5mciIsImlkIjoxNDg2Njc5NTgsImNvdW50IjoxLCJwZXJjZW50IjowLjQ2Mjk2Mjk2Mjk2Mjk2Mjl9LHsibmFtZSI6IlNlcmdlbnQgQmVydHJhbmQiLCJpZCI6MTQ3OTY3NzY3LCJjb3VudCI6MSwicGVyY2VudCI6MC40NjI5NjI5NjI5NjI5NjI5fSx7Im5hbWUiOiJDJmVhY3V0ZTtjaWxlIFRhbWJ1cmluaSIsImlkIjoxNDg0OTcxOTcsImNvdW50IjoxLCJwZXJjZW50IjowLjQ2Mjk2Mjk2Mjk2Mjk2Mjl9LHsibmFtZSI6IlBoaWxpcHBlIFNhbmNoZXoiLCJpZCI6MTQ5NDkwNjE5LCJjb3VudCI6MSwicGVyY2VudCI6MC40NjI5NjI5NjI5NjI5NjI5fSx7Im5hbWUiOiJKb2VsbGUgR3VlbHRvbiBKb2d1ZWx0b25AYXBvZ2VpOTQubmV0IiwiaWQiOjE0ODA0MDcxMywiY291bnQiOjEsInBlcmNlbnQiOjAuNDYyOTYyOTYyOTYyOTYyOX0seyJuYW1lIjoiRmxvcmVuY2UgRGV6aWVyZSIsImlkIjoxNDc4NDA5MjYsImNvdW50IjoxLCJwZXJjZW50IjowLjQ2Mjk2Mjk2Mjk2Mjk2Mjl9LHsibmFtZSI6IkJlbmphbWluIEhlbmtlbCIsImlkIjoxNDc3MDM2NzcsImNvdW50IjoxLCJwZXJjZW50IjowLjQ2Mjk2Mjk2Mjk2Mjk2Mjl9LHsibmFtZSI6Im1hbnVlbGEubW9udGF5QGNhZnBhcy1kZS1jYWxhaXMuY25hZm1haWwuZnIiLCJpZCI6MTQ4MTU2OTQ4LCJjb3VudCI6MSwicGVyY2VudCI6MC40NjI5NjI5NjI5NjI5NjI5fSx7Im5hbWUiOiJTZXJ2YW5lIENoYXV2ZWwiLCJpZCI6MTQ4ODUzMjEyLCJjb3VudCI6MSwicGVyY2VudCI6MC40NjI5NjI5NjI5NjI5NjI5fSx7Im5hbWUiOiJJdmFuIENvbGxvbWJldCIsImlkIjoxNDgxMjcyMTQsImNvdW50IjoxLCJwZXJjZW50IjowLjQ2Mjk2Mjk2Mjk2Mjk2Mjl9LHsibmFtZSI6IlNpJmVncmF2ZTtnZSIsImlkIjoxNDg2MjAzMjcsImNvdW50IjoxLCJwZXJjZW50IjowLjQ2Mjk2Mjk2Mjk2Mjk2Mjl9LHsibmFtZSI6IkJhIE91bWFyIiwiaWQiOjE0ODM1ODMxNCwiY291bnQiOjEsInBlcmNlbnQiOjAuNDYyOTYyOTYyOTYyOTYyOX0seyJuYW1lIjoiaXNhYmVsbGUubWFydGluQGRyanNjcy5nb3V2LmZyIiwiaWQiOjE0ODY1OTU4NywiY291bnQiOjEsInBlcmNlbnQiOjAuNDYyOTYyOTYyOTYyOTYyOX0seyJuYW1lIjoiY2xhdWRlLnJlbm91QGdhcmFudC1jbmRwLmZyIiwiaWQiOjE0OTMwOTM1NCwiY291bnQiOjEsInBlcmNlbnQiOjAuNDYyOTYyOTYyOTYyOTYyOX0seyJuYW1lIjoiSmVhbi1ZdmVzIENyZXVzb3QiLCJpZCI6MTQ3ODYwOTQxLCJjb3VudCI6MSwicGVyY2VudCI6MC40NjI5NjI5NjI5NjI5NjI5fSx7Im5hbWUiOiJBbGFpbiBBbmRyZSIsImlkIjoxNDgxMzkxODgsImNvdW50IjoxLCJwZXJjZW50IjowLjQ2Mjk2Mjk2Mjk2Mjk2Mjl9LHsibmFtZSI6IkhlcnYmZWFjdXRlOyBTaW9uIiwiaWQiOjE0NzgyMTk2NywiY291bnQiOjEsInBlcmNlbnQiOjAuNDYyOTYyOTYyOTYyOTYyOX0seyJuYW1lIjoiTWljaCZlZ3JhdmU7bGUgU3BhY2sgLyBTdCZlYWN1dGU7IFNpc3RyYSIsImlkIjoxNDg4Mzk4NjAsImNvdW50IjoxLCJwZXJjZW50IjowLjQ2Mjk2Mjk2Mjk2Mjk2Mjl9LHsibmFtZSI6IlJlbmFyZCBPbGl2aWVyIiwiaWQiOjE0ODQ4OTQ3OSwiY291bnQiOjEsInBlcmNlbnQiOjAuNDYyOTYyOTYyOTYyOTYyOX0seyJuYW1lIjoiU3lsdmllIEdhYnJpZWwiLCJpZCI6MTQ3ODUyMzI1LCJjb3VudCI6MSwicGVyY2VudCI6MC40NjI5NjI5NjI5NjI5NjI5fSx7Im5hbWUiOiJCb2lzc29uIFRob21hcyIsImlkIjoxNDc4MTQ3OTUsImNvdW50IjoxLCJwZXJjZW50IjowLjQ2Mjk2Mjk2Mjk2Mjk2Mjl9XX0sImJ1c2llc3REYXkiOnsiZGF5Ijo0LCJob3VyIjowLCJjb3VudCI6NDZ9LCJmaWx0ZXJUYWdzIjpbXSwiYnVzeVRpbWVFbmQiOjE1LCJidXN5VGltZVN0YXJ0IjoxMywidGFnSWRzIjpbIjEiXSwiY3VycmVudCI6eyJzdGFydERhdGUiOiIyMDE3LTExLTAxVDAwOjAwOjAwWiIsImVuZERhdGUiOiIyMDE3LTEyLTAxVDAwOjAwOjAwWiIsInRvdGFsQ29udmVyc2F0aW9ucyI6MjE2LCJjb252ZXJzYXRpb25zQ3JlYXRlZCI6MTc4LCJuZXdDb252ZXJzYXRpb25zIjoxNzgsImN1c3RvbWVycyI6MTUwLCJtZXNzYWdlc1JlY2VpdmVkIjoyOTMsImNvbnZlcnNhdGlvbnNQZXJEYXkiOjZ9LCJjdXN0b21GaWVsZHMiOnsiZmllbGRzIjpbXSwiY291bnQiOjB9fQ==
+      encoding: UTF-8
+      string: '{"filterTags":[{"name":"administration","id":3745889},{"name":"caf","id":4276799}],"current":{"startDate":"2017-11-01T00:00:00Z","endDate":"2017-12-01T00:00:00Z","totalConversations":96,"resolutionTime":182589.09375,"repliesToResolve":1.625,"responseTime":178804,"firstResponseTime":106231,"resolved":96,"resolvedOnFirstReply":64,"closed":181,"repliesSent":187,"handleTime":402,"percentResolvedOnFirstReply":66.66666666666666,"ratings":[],"newConversations":178,"messagesReceived":293,"createdInHS":11},"responseTime":{"count":113,"previousCount":0,"ranges":[{"id":10,"count":22,"percent":19.469026548672566},{"id":3,"count":13,"percent":11.504424778761061},{"id":9,"count":13,"percent":11.504424778761061},{"id":1,"count":12,"percent":10.619469026548673},{"id":7,"count":12,"percent":10.619469026548673},{"id":2,"count":11,"percent":9.734513274336283},{"id":6,"count":11,"percent":9.734513274336283},{"id":5,"count":7,"percent":6.1946902654867255},{"id":4,"count":6,"percent":5.3097345132743365},{"id":8,"count":6,"percent":5.3097345132743365}]},"handleTime":{"count":96,"previousCount":0,"ranges":[{"id":3,"count":32,"percent":33.33333333333333},{"id":1,"count":25,"percent":26.041666666666668},{"id":2,"count":18,"percent":18.75},{"id":4,"count":11,"percent":11.458333333333332},{"id":5,"count":10,"percent":10.416666666666668}]},"firstResponseTime":{"count":113,"previousCount":0,"ranges":[{"id":10,"count":18,"percent":15.929203539823009},{"id":2,"count":14,"percent":12.389380530973451},{"id":3,"count":13,"percent":11.504424778761061},{"id":8,"count":12,"percent":10.619469026548673},{"id":9,"count":12,"percent":10.619469026548673},{"id":1,"count":11,"percent":9.734513274336283},{"id":4,"count":11,"percent":9.734513274336283},{"id":6,"count":11,"percent":9.734513274336283},{"id":7,"count":7,"percent":6.1946902654867255},{"id":5,"count":4,"percent":3.5398230088495577}]},"resolutionTime":{"count":96,"previousCount":0,"ranges":[{"id":1,"count":43,"percent":44.79166666666667},{"id":2,"count":21,"percent":21.875},{"id":5,"count":12,"percent":12.5},{"id":3,"count":11,"percent":11.458333333333332},{"id":4,"count":9,"percent":9.375}]},"repliesToResolve":{"count":96,"previousCount":0,"ranges":[{"id":1,"count":64,"percent":66.66666666666666,"resolutionTime":127669},{"id":2,"count":20,"percent":20.833333333333336,"resolutionTime":331855},{"id":3,"count":5,"percent":5.208333333333334,"resolutionTime":267573},{"id":5,"count":4,"percent":4.166666666666666,"resolutionTime":42776},{"id":4,"count":3,"percent":3.125,"resolutionTime":403874}]}}'
     http_version:
-  recorded_at: Thu, 13 Dec 2018 12:49:05 GMT
+  recorded_at: Wed, 11 Sep 2019 15:02:24 GMT
 - request:
     method: get
-    uri: https://api.helpscout.net/v2/reports/conversations?end=2018-01-01T00:00:00Z&start=2017-12-01T00:00:00Z
+    uri: https://api.helpscout.net/v2/reports/productivity?end=2018-01-01T00:00:00Z&mailboxes=9999&start=2017-12-01T00:00:00Z
     body:
       encoding: US-ASCII
       string: ''
@@ -102,7 +101,7 @@ http_interactions:
       User-Agent:
       - demarches-simplifiees.fr
       Authorization:
-      - Bearer 18mock9b
+      - Bearer redacted
       Content-Type:
       - application/json; charset=UTF-8
       Expect:
@@ -119,9 +118,9 @@ http_interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Correlation-Id:
-      - 9b1a2413-9d2a-4605-9791-b191ea62b838#53820636
+      - aa56c5ae-9e2c-45c0-8af1-e344e6172af5#3277423
       Date:
-      - Thu, 13 Dec 2018 12:49:05 GMT
+      - Wed, 11 Sep 2019 15:02:24 GMT
       Expires:
       - '0'
       Pragma:
@@ -132,19 +131,18 @@ http_interactions:
       X-Frame-Options:
       - DENY
       X-Ratelimit-Limit-Minute:
-      - '200'
+      - '400'
       X-Ratelimit-Remaining-Minute:
-      - '198'
+      - '398'
       X-Xss-Protection:
       - 1; mode=block
       Content-Length:
-      - '5622'
+      - '2581'
       Connection:
       - keep-alive
     body:
-      encoding: ASCII-8BIT
-      string: !binary |-
-        eyJyZXBsaWVzIjp7ImNvdW50IjoxNDEsInRvcCI6W3sibmFtZSI6Ik1hdXZhaXMgaW50ZXJsb2N1dGV1ciIsImlkIjo3MjczOTYsIm1haWxib3hJZCI6MTI1OTI2LCJjb3VudCI6MTYsInBlcmNlbnQiOjExLjM0NzUxNzczMDQ5NjQ1NH0seyJuYW1lIjoiRGVtYW5kZSBjb21wdGUgYWRtaW4gcGFydGljdWxpZXIgLyBlbnRyZXByaXNlIiwiaWQiOjc1MTEzMCwibWFpbGJveElkIjoxMjU5MjYsImNvdW50Ijo4LCJwZXJjZW50Ijo1LjY3Mzc1ODg2NTI0ODIyN30seyJuYW1lIjoiRGVtYW5kZSBkZSBkw6ltbywgc3RlcCAxIiwiaWQiOjczMjE5NCwibWFpbGJveElkIjoxMjU5MjYsImNvdW50Ijo1LCJwZXJjZW50IjozLjU0NjA5OTI5MDc4MDE0Mn0seyJuYW1lIjoiVXNhZ2VyIGluc2NyaXQgbidhcnJpdmUgcGFzIMOgIGTDqXBvc2VyIGRlIGRvc3NpZXIgW09MRF0iLCJpZCI6NzgyODU2LCJtYWlsYm94SWQiOjEyNTkyNiwiY291bnQiOjUsInBlcmNlbnQiOjMuNTQ2MDk5MjkwNzgwMTQyfSx7Im5hbWUiOiJJbCBzZW1ibGVyYWl0IHF1ZSB2b3VzIGF5ZXogcmVuY29udHLDqSBkZXMgZXJyZXVycywgcHJvYmzDqG1lIHLDqXNvbHUiLCJpZCI6NzI2MTc3LCJtYWlsYm94SWQiOjEyNTkyNiwiY291bnQiOjIsInBlcmNlbnQiOjEuNDE4NDM5NzE2MzEyMDU2OH1dfSwid29ya2Zsb3dzIjp7ImNvdW50IjoxNDEsInRvcCI6W119LCJ0YWdzIjp7ImNvdW50IjoxNDEsInRvcCI6W3siaWQiOjEsImNvdW50IjoxNDEsInBlcmNlbnQiOjEwMC4wfV19LCJjdXN0b21lcnMiOnsiY291bnQiOjE0MSwidG9wIjpbeyJuYW1lIjoiQ29vY2hlIE1hcmllIiwiaWQiOjE1MDIyNDI5MiwiY291bnQiOjcsInBlcmNlbnQiOjQuOTY0NTM5MDA3MDkyMTk5fSx7Im5hbWUiOiJUJmVhY3V0ZTtsJmVhY3V0ZTtwcm9jJmVhY3V0ZTtkdXJlcyBTaW1wbGlmaSZlYWN1dGU7ZXMiLCJpZCI6MTQ3NjY4MTQxLCJjb3VudCI6NSwicGVyY2VudCI6My41NDYwOTkyOTA3ODAxNDJ9LHsibmFtZSI6IlNlcnZpY2UgQ2xpZW50IE1haWxqZXQiLCJpZCI6MTQ4NDUyNTI2LCJjb3VudCI6NCwicGVyY2VudCI6Mi44MzY4Nzk0MzI2MjQxMTM2fSx7Im5hbWUiOiJWcmlnbmF1ZCBQaGlsaXBwZSIsImlkIjoxNDc2NzA5NjYsImNvdW50Ijo0LCJwZXJjZW50IjoyLjgzNjg3OTQzMjYyNDExMzZ9LHsibmFtZSI6IkZyeWRtYW4gTGlvbmVsIC0gRGdpdG0vc2Fncy9hZzIiLCJpZCI6MTU0NjkwMTI2LCJjb3VudCI6MiwicGVyY2VudCI6MS40MTg0Mzk3MTYzMTIwNTY4fSx7Im5hbWUiOiJGaWNoaWVycyBGb25jaWVycyBEcmllYSAtIERyaWVhIElmL3NjZXAvIElmL3NjZXAvcGlkL2NpZyIsImlkIjoxNTY4MDMzNTUsImNvdW50IjoyLCJwZXJjZW50IjoxLjQxODQzOTcxNjMxMjA1Njh9LHsibmFtZSI6IkJsYW5jYXJkIERlIExlcnkgSm9oYW5uYSIsImlkIjoxNTYwMTUzNTUsImNvdW50IjoyLCJwZXJjZW50IjoxLjQxODQzOTcxNjMxMjA1Njh9LHsibmFtZSI6IkRhZ3VlcnJlIiwiaWQiOjE1NTQ1NzY1NiwiY291bnQiOjIsInBlcmNlbnQiOjEuNDE4NDM5NzE2MzEyMDU2OH0seyJuYW1lIjoiQXVyJmVhY3V0ZTtsaWUgQ2hhYnJvbCIsImlkIjoxNTE1ODM4MjYsImNvdW50IjoyLCJwZXJjZW50IjoxLjQxODQzOTcxNjMxMjA1Njh9LHsibmFtZSI6IkImZWFjdXRlO2F0cmljZSBQaWVyaSIsImlkIjoxNDk2OTIwMjYsImNvdW50IjoyLCJwZXJjZW50IjoxLjQxODQzOTcxNjMxMjA1Njh9LHsibmFtZSI6IkxlIFJodW4gRWxvZGllIChjaGVmIERlIEJ1cmVhdSkgLSBEcmllYSBJZi9zc3QvZHJ0ci9iZ2MyIiwiaWQiOjE0OTU0NzI5MSwiY291bnQiOjIsInBlcmNlbnQiOjEuNDE4NDM5NzE2MzEyMDU2OH0seyJuYW1lIjoiSXNzYW0gR2hhbmVtIiwiaWQiOjE1NTExOTE4NCwiY291bnQiOjIsInBlcmNlbnQiOjEuNDE4NDM5NzE2MzEyMDU2OH0seyJuYW1lIjoiTWFyaW5hIExhdXJlIiwiaWQiOjE1NDMyNTcwNSwiY291bnQiOjIsInBlcmNlbnQiOjEuNDE4NDM5NzE2MzEyMDU2OH0seyJuYW1lIjoiTGF1cmllIFBvaW50ZWF1IiwiaWQiOjE1NDY2NDA5NiwiY291bnQiOjIsInBlcmNlbnQiOjEuNDE4NDM5NzE2MzEyMDU2OH0seyJuYW1lIjoiRnJhbWFsaXN0ZXMiLCJpZCI6MTUwOTAxMzI0LCJjb3VudCI6MiwicGVyY2VudCI6MS40MTg0Mzk3MTYzMTIwNTY4fSx7Im5hbWUiOiJBbmRyaWV1IEFsZXhhbmRyZSIsImlkIjoxNTgwNzYxMzMsImNvdW50IjoyLCJwZXJjZW50IjoxLjQxODQzOTcxNjMxMjA1Njh9LHsibmFtZSI6IkNhZmZpZXIgQXVyJmVhY3V0ZTtsaWVuIiwiaWQiOjE0OTY3NzE0OCwiY291bnQiOjIsInBlcmNlbnQiOjEuNDE4NDM5NzE2MzEyMDU2OH0seyJuYW1lIjoiRmxhaGF1dCBTdCZlYWN1dGU7cGhhbmUgKGFkam9pbnQgQXUgRGlyZWN0ZXVyKSAgNzgvZGlyIiwiaWQiOjE1MTg0ODk2OSwiY291bnQiOjEsInBlcmNlbnQiOjAuNzA5MjE5ODU4MTU2MDI4NH0seyJuYW1lIjoicG9zdG1hc3RlckBvdXRsb29rLmNvbSIsImlkIjoxNDg4MTI1NzQsImNvdW50IjoxLCJwZXJjZW50IjowLjcwOTIxOTg1ODE1NjAyODR9LHsibmFtZSI6Im5icmlhdWx0QHZpbGxlLW1lcnUuZnIiLCJpZCI6MTQ3OTg3MDkxLCJjb3VudCI6MSwicGVyY2VudCI6MC43MDkyMTk4NTgxNTYwMjg0fSx7Im5hbWUiOiJNaWNoYWVsIE1hZ2FsaGFlcyIsImlkIjoxNTQ2OTU1NzgsImNvdW50IjoxLCJwZXJjZW50IjowLjcwOTIxOTg1ODE1NjAyODR9LHsibmFtZSI6IlNlcmdlbnQgQmVydHJhbmQiLCJpZCI6MTQ3OTY3NzY3LCJjb3VudCI6MSwicGVyY2VudCI6MC43MDkyMTk4NTgxNTYwMjg0fSx7Im5hbWUiOiJNYWlyaWUgRGUgUHImZWFjdXRlO2F1eCIsImlkIjoxNTI5OTI0NTQsImNvdW50IjoxLCJwZXJjZW50IjowLjcwOTIxOTg1ODE1NjAyODR9LHsibmFtZSI6IlNpbW9uIExlaGVyaWNleSIsImlkIjoxNDgxMzAyNjQsImNvdW50IjoxLCJwZXJjZW50IjowLjcwOTIxOTg1ODE1NjAyODR9LHsibmFtZSI6IkFubmUgQ2hldnJvdWxldCIsImlkIjoxNTQzMTg3NjMsImNvdW50IjoxLCJwZXJjZW50IjowLjcwOTIxOTg1ODE1NjAyODR9LHsibmFtZSI6Ik1haXNvbiBEZXMgRW50cmVwcmlzZXMgTGliJmVhY3V0ZTtyYWxlcyBNZWwiLCJpZCI6MTU1Mjc5NDQ1LCJjb3VudCI6MSwicGVyY2VudCI6MC43MDkyMTk4NTgxNTYwMjg0fSx7Im5hbWUiOiJGciZlYWN1dGU7ZCZlYWN1dGU7cmljIEJhcm5vaW4iLCJpZCI6MTU1NDc5OTE0LCJjb3VudCI6MSwicGVyY2VudCI6MC43MDkyMTk4NTgxNTYwMjg0fSx7Im5hbWUiOiJEdWZvdXIgQ2FtaWxsZSAtIERnYWxuL2RodXAvZmU1IiwiaWQiOjE1Mzg3NTc0MSwiY291bnQiOjEsInBlcmNlbnQiOjAuNzA5MjE5ODU4MTU2MDI4NH0seyJuYW1lIjoiSW52b2ljZXMgQWNjb3VudCIsImlkIjoxNTU0ODI1NTgsImNvdW50IjoxLCJwZXJjZW50IjowLjcwOTIxOTg1ODE1NjAyODR9LHsibmFtZSI6IlJvbWFpbiBDdWNjaWEiLCJpZCI6MTU1Mzk3NDY2LCJjb3VudCI6MSwicGVyY2VudCI6MC43MDkyMTk4NTgxNTYwMjg0fSx7Im5hbWUiOiJIdWd1ZXMgVmlsY29zcXVpIiwiaWQiOjE1MzI5NzgzNywiY291bnQiOjEsInBlcmNlbnQiOjAuNzA5MjE5ODU4MTU2MDI4NH0seyJuYW1lIjoiUmVuYXJkIEZhYmllbm5lIiwiaWQiOjE1NTIyNjA0NiwiY291bnQiOjEsInBlcmNlbnQiOjAuNzA5MjE5ODU4MTU2MDI4NH0seyJuYW1lIjoiQ29udGFjdCIsImlkIjoxNTU2ODE4ODUsImNvdW50IjoxLCJwZXJjZW50IjowLjcwOTIxOTg1ODE1NjAyODR9LHsibmFtZSI6InBvbHZpbGxlQGJldGh1bmVicnVheS5mciIsImlkIjoxNTQzNDM5NzgsImNvdW50IjoxLCJwZXJjZW50IjowLjcwOTIxOTg1ODE1NjAyODR9LHsibmFtZSI6Im9saXZpZXIudmVybWVyc2NoQHJpdmFsaXMuZnIiLCJpZCI6MTU1NDAxMzkyLCJjb3VudCI6MSwicGVyY2VudCI6MC43MDkyMTk4NTgxNTYwMjg0fSx7Im5hbWUiOiJKJmVhY3V0ZTtyJm9jaXJjO21lIFN0ZWlnZXIgLSBNZXNzb3J0aWVzY2UiLCJpZCI6MTUyOTgyOTY4LCJjb3VudCI6MSwicGVyY2VudCI6MC43MDkyMTk4NTgxNTYwMjg0fSx7Im5hbWUiOiJDZWRyaWMgTmV2ZXUiLCJpZCI6MTU0NjgzNjk5LCJjb3VudCI6MSwicGVyY2VudCI6MC43MDkyMTk4NTgxNTYwMjg0fSx7Im5hbWUiOiJQb3J0IEJydW5vIiwiaWQiOjE1Mzg0ODA0MSwiY291bnQiOjEsInBlcmNlbnQiOjAuNzA5MjE5ODU4MTU2MDI4NH0seyJuYW1lIjoiTGVjb2ludGUgSnVsaWV0dGUiLCJpZCI6MTQ4NjYyNzYzLCJjb3VudCI6MSwicGVyY2VudCI6MC43MDkyMTk4NTgxNTYwMjg0fSx7Im5hbWUiOiJkb21pbmlxdWVAY29sbGFydC5mciIsImlkIjoxNDg4MTA4OTcsImNvdW50IjoxLCJwZXJjZW50IjowLjcwOTIxOTg1ODE1NjAyODR9LHsibmFtZSI6Ikd1aWxsYXVtZSBDcmFpdCIsImlkIjoxNTU0NDQ3MzEsImNvdW50IjoxLCJwZXJjZW50IjowLjcwOTIxOTg1ODE1NjAyODR9LHsibmFtZSI6IkNoYW5lYWMgR3VpbGxhdW1lIFByZWY2MCIsImlkIjoxNTMzNDI3NjIsImNvdW50IjoxLCJwZXJjZW50IjowLjcwOTIxOTg1ODE1NjAyODR9LHsibmFtZSI6IkxlYmFzdGFyZCBGcmFuY2sgKGFkam9pbnQgQXUgQ2hlZiBEZSBCdXJlYXUpIC0gRGdhbG4vc2FncC9zZHAvYmNzaSIsImlkIjoxNTI5NzA5ODMsImNvdW50IjoxLCJwZXJjZW50IjowLjcwOTIxOTg1ODE1NjAyODR9LHsibmFtZSI6IkF1ciZlYWN1dGU7bGllIiwiaWQiOjE1MDkyOTg3NCwiY291bnQiOjEsInBlcmNlbnQiOjAuNzA5MjE5ODU4MTU2MDI4NH0seyJuYW1lIjoiUGFzY2FsZSBNaXNzeSIsImlkIjoxNTQ3NDQ1ODksImNvdW50IjoxLCJwZXJjZW50IjowLjcwOTIxOTg1ODE1NjAyODR9LHsibmFtZSI6IlJhY2hpZCBCb3VkZ3VpZyIsImlkIjoxNTUzMTU5MDAsImNvdW50IjoxLCJwZXJjZW50IjowLjcwOTIxOTg1ODE1NjAyODR9LHsibmFtZSI6IkZhYmllbm5lIEJvdXZlcmVzc2UiLCJpZCI6MTU0MzMxNDYyLCJjb3VudCI6MSwicGVyY2VudCI6MC43MDkyMTk4NTgxNTYwMjg0fSx7Im5hbWUiOiJCb2lzc29uIFRob21hcyIsImlkIjoxNDc4MTQ3OTUsImNvdW50IjoxLCJwZXJjZW50IjowLjcwOTIxOTg1ODE1NjAyODR9LHsibmFtZSI6IkZsYW5keSBOaWNvbGUtTSAtIERyZWFsIEF1dmVyZ25lL3NlYnIvbmF0IiwiaWQiOjE1NDQ4NTY5OSwiY291bnQiOjEsInBlcmNlbnQiOjAuNzA5MjE5ODU4MTU2MDI4NH0seyJuYW1lIjoiU3QmZWFjdXRlO3BoYW5pZSBCb3NzYXJkIiwiaWQiOjE1NDMyMzA5NiwiY291bnQiOjEsInBlcmNlbnQiOjAuNzA5MjE5ODU4MTU2MDI4NH1dfSwiYnVzaWVzdERheSI6eyJkYXkiOjUsImhvdXIiOjAsImNvdW50Ijo0MH0sImZpbHRlclRhZ3MiOltdLCJidXN5VGltZVN0YXJ0IjoxNCwiYnVzeVRpbWVFbmQiOjE2LCJjdXN0b21GaWVsZHMiOnsiZmllbGRzIjpbXSwiY291bnQiOjB9LCJjdXJyZW50Ijp7InN0YXJ0RGF0ZSI6IjIwMTctMTItMDFUMDA6MDA6MDBaIiwiZW5kRGF0ZSI6IjIwMTgtMDEtMDFUMDA6MDA6MDBaIiwidG90YWxDb252ZXJzYXRpb25zIjoxNDEsImNvbnZlcnNhdGlvbnNDcmVhdGVkIjoxMjYsIm5ld0NvbnZlcnNhdGlvbnMiOjEyNiwiY3VzdG9tZXJzIjoxMTIsIm1lc3NhZ2VzUmVjZWl2ZWQiOjE5NiwiY29udmVyc2F0aW9uc1BlckRheSI6NH0sInRhZ0lkcyI6WyIxIl19
+      encoding: UTF-8
+      string: '{"filterTags":[{"name":"administration","id":3745889}],"current":{"startDate":"2017-12-01T00:00:00Z","endDate":"2018-01-01T00:00:00Z","totalConversations":87,"resolutionTime":118563.57471264368,"repliesToResolve":1.6666666666666667,"responseTime":36175,"firstResponseTime":30167,"resolved":87,"resolvedOnFirstReply":55,"closed":122,"repliesSent":156,"handleTime":305,"percentResolvedOnFirstReply":63.2183908045977,"ratings":[],"newConversations":126,"messagesReceived":196,"createdInHS":16},"responseTime":{"count":93,"previousCount":0,"ranges":[{"id":1,"count":24,"percent":25.806451612903224},{"id":3,"count":14,"percent":15.053763440860216},{"id":2,"count":12,"percent":12.903225806451612},{"id":5,"count":9,"percent":9.67741935483871},{"id":4,"count":7,"percent":7.526881720430108},{"id":7,"count":7,"percent":7.526881720430108},{"id":10,"count":7,"percent":7.526881720430108},{"id":8,"count":6,"percent":6.451612903225806},{"id":9,"count":5,"percent":5.376344086021505},{"id":6,"count":2,"percent":2.1505376344086025}]},"handleTime":{"count":87,"previousCount":0,"ranges":[{"id":1,"count":36,"percent":41.37931034482759},{"id":3,"count":23,"percent":26.436781609195403},{"id":4,"count":10,"percent":11.494252873563218},{"id":5,"count":10,"percent":11.494252873563218},{"id":2,"count":8,"percent":9.195402298850574}]},"firstResponseTime":{"count":93,"previousCount":0,"ranges":[{"id":1,"count":29,"percent":31.182795698924732},{"id":2,"count":15,"percent":16.129032258064516},{"id":3,"count":11,"percent":11.827956989247312},{"id":8,"count":11,"percent":11.827956989247312},{"id":4,"count":7,"percent":7.526881720430108},{"id":5,"count":7,"percent":7.526881720430108},{"id":6,"count":5,"percent":5.376344086021505},{"id":10,"count":5,"percent":5.376344086021505},{"id":7,"count":2,"percent":2.1505376344086025},{"id":9,"count":1,"percent":1.0752688172043012}]},"resolutionTime":{"count":87,"previousCount":0,"ranges":[{"id":1,"count":57,"percent":65.51724137931035},{"id":2,"count":13,"percent":14.942528735632186},{"id":5,"count":9,"percent":10.344827586206897},{"id":4,"count":5,"percent":5.747126436781609},{"id":3,"count":3,"percent":3.4482758620689653}]},"repliesToResolve":{"count":87,"previousCount":0,"ranges":[{"id":1,"count":55,"percent":63.2183908045977,"resolutionTime":14733},{"id":2,"count":22,"percent":25.287356321839084,"resolutionTime":184942},{"id":5,"count":5,"percent":5.747126436781609,"resolutionTime":632232},{"id":3,"count":4,"percent":4.597701149425287,"resolutionTime":564288},{"id":4,"count":1,"percent":1.1494252873563218,"resolutionTime":17641}]}}'
     http_version:
-  recorded_at: Thu, 13 Dec 2018 12:49:05 GMT
+  recorded_at: Wed, 11 Sep 2019 15:02:24 GMT
 recorded_with: VCR 4.0.0

--- a/spec/lib/helpscout/user_conversations_adapter_spec.rb
+++ b/spec/lib/helpscout/user_conversations_adapter_spec.rb
@@ -15,9 +15,7 @@ describe Helpscout::UserConversationsAdapter do
 
     context 'when all required secrets are present' do
       before do
-        Rails.application.secrets.helpscout[:mailbox_id] = '9999'
-        Rails.application.secrets.helpscout[:client_id] = '1234'
-        Rails.application.secrets.helpscout[:client_secret] = '5678'
+        mock_helpscout_secrets
       end
 
       it { expect(described_class.new(from, to).can_fetch_reports?).to be true }
@@ -25,7 +23,10 @@ describe Helpscout::UserConversationsAdapter do
   end
 
   describe '#reports', vcr: { cassette_name: 'helpscout_conversations_reports' } do
-    before { Rails.cache.clear }
+    before do
+      mock_helpscout_secrets
+      Rails.cache.clear
+    end
 
     subject { described_class.new(from, to) }
 
@@ -34,13 +35,19 @@ describe Helpscout::UserConversationsAdapter do
     end
 
     it 'populates each report with data' do
-      expect(subject.reports.first[:conversations_count]).to be > 0
+      expect(subject.reports.first[:replies_sent]).to be > 0
       expect(subject.reports.first[:start_date]).to eq Time.utc(2017, 11)
       expect(subject.reports.first[:end_date]).to eq Time.utc(2017, 12)
 
-      expect(subject.reports.last[:conversations_count]).to be > 0
+      expect(subject.reports.last[:replies_sent]).to be > 0
       expect(subject.reports.last[:start_date]).to eq Time.utc(2017, 12)
       expect(subject.reports.last[:end_date]).to eq Time.utc(2018, 01)
     end
+  end
+
+  def mock_helpscout_secrets
+    Rails.application.secrets.helpscout[:mailbox_id] = '9999'
+    Rails.application.secrets.helpscout[:client_id] = '1234'
+    Rails.application.secrets.helpscout[:client_secret] = '5678'
   end
 end


### PR DESCRIPTION
Cette PR corrige le calcul des stats de contact Usager.

Aujourd'hui HelpScout marque comme "actives" toutes les conversations répondues – mais aussi celles qui on été taggées ou re-taggées. Ça donne des stats absurdes.

Pour éviter ça, **cette PR passe à un calcul des stats par** **nombre de réponses** sur la boîte principale. Comme ça :

- On corrige le problème du nombre de conversations actives ;
- On évite quand même de prendre en compte le spam, les messages pas qualifiés et donc pas répondus, etc ;
- On évite également de prendre en compte les messages arrivant dans d'autres boites (comme `ne-pas-repondre@demarches-simplifiees.fr`.

Seul bémol : on ne peut plus exclure certaines conversations en fonction du tag (comme "Tour de france"). Mais à l'avenir pour ça on pourra toujours créer des boites mails ponctuelles (comme `tour-de-france@demarches-simplifiees.fr`) si on veut éviter de polluer les boîtes principales.

Fix #4298 (cc @chaibax)