### PR TITLE
[fix #4311] Unable to reinvite admin

### DIFF
--- a/app/controllers/manager/administrateurs_controller.rb
+++ b/app/controllers/manager/administrateurs_controller.rb
@@ -14,7 +14,7 @@ module Manager
     end
 
     def reinvite
-      Administrateur.find_inactive_by_id(params[:id]).invite!(current_administration.id)
+      Administrateur.find_inactive_by_id(params[:id]).user.invite_administrateur!(current_administration.id)
       flash.notice = "Invitation renvoyée"
       redirect_to manager_administrateur_path(params[:id])
     end


### PR DESCRIPTION
Je ne suis pas sur que vous utilisiez vraiment cette feature de reinvitation. 
En tout cas voilà une modif qui m'a semblé en accord avec le refactoring des instructeurs/admin vis a vis de Devise.

