### PR TITLE
Maj du message de refus sur le dossier

### DIFF
--- a/app/views/users/dossiers/show/_status_overview.html.haml
+++ b/app/views/users/dossiers/show/_status_overview.html.haml
@@ -70,7 +70,7 @@
       .refuse
         %p.decision
           %span.icon.refuse
-          Nous sommes désolés, votre dossier a malheureusement été
+          Votre dossier a été
           = succeed '.' do
             %strong refusé
 


### PR DESCRIPTION
Retour usager
Dossiers qui peuvent être très politiques, le "nous sommes désolés" peut alors paraître complétement déplacé...

A discuter si ça pose un problème 