### PR TITLE
Ajout de PgHero pour un suivi plus fin de PostgreSQL

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -681,6 +681,7 @@ Rails/CreateTableWithTimestamps:
     - db/migrate/2016*.rb
     - db/migrate/2017*.rb
     - db/migrate/2018*.rb
+    - db/migrate/2019*.rb
 
 Rails/Date:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem 'omniauth-rails_csrf_protection', '~> 0.1'
 gem 'openid_connect'
 gem 'openstack'
 gem 'pg'
+gem 'pghero'
 gem 'prawn' # PDF Generation
 gem 'prawn_rails'
 gem 'premailer-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -416,6 +416,8 @@ GEM
       ast (~> 2.4.0)
     pdf-core (0.7.0)
     pg (1.1.3)
+    pghero (2.3.0)
+      activerecord (>= 5)
     powerpack (0.1.2)
     prawn (2.2.2)
       pdf-core (~> 0.7.0)
@@ -757,6 +759,7 @@ DEPENDENCIES
   openid_connect
   openstack
   pg
+  pghero
   prawn
   prawn_rails
   premailer-rails

--- a/app/views/manager/application/_navigation.html.erb
+++ b/app/views/manager/application/_navigation.html.erb
@@ -24,5 +24,6 @@ as defined by the routes in the `admin/` namespace
   <hr />
 
   <%= link_to "Delayed Jobs", manager_delayed_job_path, class: "navigation__link" %>
+  <%= link_to "PostgreSQL", manager_pg_hero_path, class: "navigation__link" %>
   <%= link_to "Features", manager_flipper_path, class: "navigation__link" %>
 </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,7 @@ Rails.application.routes.draw do
     authenticate :administration do
       mount Flipper::UI.app(-> { Flipper.instance }) => "/features", as: :flipper
       match "/delayed_job" => DelayedJobWeb, :anchor => false, :via => [:get, :post]
+      mount PgHero::Engine, at: "pghero"
     end
 
     root to: "administrateurs#index"

--- a/db/migrate/20190916152127_create_pghero_space_stats.rb
+++ b/db/migrate/20190916152127_create_pghero_space_stats.rb
@@ -1,0 +1,13 @@
+class CreatePgheroSpaceStats < ActiveRecord::Migration[5.2]
+  def change
+    create_table :pghero_space_stats do |t|
+      t.text :database
+      t.text :schema
+      t.text :relation
+      t.integer :size, limit: 8
+      t.timestamp :captured_at
+    end
+
+    add_index :pghero_space_stats, [:database, :captured_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_28_073736) do
+ActiveRecord::Schema.define(version: 2019_09_16_152127) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -486,6 +486,26 @@ ActiveRecord::Schema.define(version: 2019_08_28_073736) do
     t.index ["procedure_id"], name: "index_module_api_cartos_on_procedure_id", unique: true
   end
 
+  create_table "pghero_query_stats", force: :cascade do |t|
+    t.text "database"
+    t.text "user"
+    t.text "query"
+    t.bigint "query_hash"
+    t.float "total_time"
+    t.bigint "calls"
+    t.datetime "captured_at"
+    t.index ["database", "captured_at"], name: "index_pghero_query_stats_on_database_and_captured_at"
+  end
+
+  create_table "pghero_space_stats", force: :cascade do |t|
+    t.text "database"
+    t.text "schema"
+    t.text "relation"
+    t.bigint "size"
+    t.datetime "captured_at"
+    t.index ["database", "captured_at"], name: "index_pghero_space_stats_on_database_and_captured_at"
+  end
+
   create_table "procedure_presentations", id: :serial, force: :cascade do |t|
     t.integer "assign_to_id"
     t.jsonb "sort", default: {"order"=>"desc", "table"=>"notifications", "column"=>"notifications"}, null: false
@@ -530,6 +550,7 @@ ActiveRecord::Schema.define(version: 2019_08_28_073736) do
     t.boolean "durees_conservation_required", default: true
     t.string "path"
     t.string "declarative_with_state"
+    t.text "monavis"
     t.text "monavis_embed"
     t.index ["declarative_with_state"], name: "index_procedures_on_declarative_with_state"
     t.index ["hidden_at"], name: "index_procedures_on_hidden_at"
@@ -621,10 +642,10 @@ ActiveRecord::Schema.define(version: 2019_08_28_073736) do
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.text "unconfirmed_email"
     t.integer "failed_attempts", default: 0, null: false
     t.string "unlock_token"
     t.datetime "locked_at"
+    t.text "unconfirmed_email"
     t.bigint "instructeur_id"
     t.bigint "administrateur_id"
     t.index ["administrateur_id"], name: "index_users_on_administrateur_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -486,17 +486,6 @@ ActiveRecord::Schema.define(version: 2019_09_16_152127) do
     t.index ["procedure_id"], name: "index_module_api_cartos_on_procedure_id", unique: true
   end
 
-  create_table "pghero_query_stats", force: :cascade do |t|
-    t.text "database"
-    t.text "user"
-    t.text "query"
-    t.bigint "query_hash"
-    t.float "total_time"
-    t.bigint "calls"
-    t.datetime "captured_at"
-    t.index ["database", "captured_at"], name: "index_pghero_query_stats_on_database_and_captured_at"
-  end
-
   create_table "pghero_space_stats", force: :cascade do |t|
     t.text "database"
     t.text "schema"

--- a/lib/tasks/2019_09_16_daily_db_space_usage_update.rake
+++ b/lib/tasks/2019_09_16_daily_db_space_usage_update.rake
@@ -1,0 +1,8 @@
+require Rails.root.join("lib", "tasks", "task_helper")
+
+namespace :'2019_09_16_daily_db_space_usage_update' do
+  task enable: :environment do
+    # every day, 1am
+    PgHero.capture_space_stats.set(cron: "0 1 * * *").perform_later
+  end
+end


### PR DESCRIPTION
Premier jet pour l'inclusion de [PgHero](https://github.com/ankane/pghero/) dans le manager

Quand on aura activé [pg_stat_statements](https://bartwullems.blogspot.com/2017/12/postgresql-identify-your-slowest-queries.html) − nécessite une maj de la conf postgres et un restart, on est pas chaud tout de suite −, on pourra inclure le [suivi des requêtes qui prennent du temps](https://github.com/ankane/pghero/blob/master/guides/Rails.md#historical-query-stats)