### PR TITLE
Fix procedure_locked_spec

### DIFF
--- a/spec/features/admin/procedure_locked_spec.rb
+++ b/spec/features/admin/procedure_locked_spec.rb
@@ -2,17 +2,27 @@ require 'spec_helper'
 
 feature 'procedure locked' do
   let(:administrateur) { create(:administrateur) }
-  let (:published_at) { nil }
-  let(:procedure) { create(:procedure, administrateur: administrateur, published_at: published_at) }
 
   before do
-    login_as administrateur, scope: :administrateur
+    login_as administrateur.user, scope: :user
     visit admin_procedure_path(procedure)
   end
 
   context 'when procedure is not published' do
+    let(:procedure) { create(:procedure, administrateur: administrateur) }
+
     scenario 'info label is not present' do
-      expect(page).not_to have_content('Cette démarche a été publiée, certains éléments ne peuvent plus être modifiés')
+      expect(page).to have_content('Test et publication')
+      expect(page).not_to have_content('Cette démarche est publiée, certains éléments ne peuvent plus être modifiés.')
+    end
+  end
+
+  context 'when procedure is published' do
+    let(:procedure) { create(:procedure, :published, administrateur: administrateur) }
+
+    scenario 'info label is present' do
+      expect(page).to have_content('Publication')
+      expect(page).to have_content('Cette démarche est publiée, certains éléments ne peuvent plus être modifiés.')
     end
   end
 end


### PR DESCRIPTION
`login_as administrateur, scope: :administrateur` doesn’t seem to actually do anything, but testing for the _absence_ of content can’t break.

- Make the test fail if login fails,
- Fix the login,
- Write the opposite test,
- Update the searched content to the actual text used in the partial

(I had to do the same kind of fixes when rebasing #4048)