### PR TITLE
Dont unfollow a Dossier when archiving it

### DIFF
--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -78,7 +78,6 @@ module Instructeurs
 
     def archive
       dossier.update(archived: true)
-      current_instructeur.unfollow(dossier)
       redirect_back(fallback_location: instructeur_procedures_url)
     end
 

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -176,7 +176,7 @@ class Instructeur < ApplicationRecord
 
       h = {
         nb_en_construction: groupe.dossiers.en_construction.count,
-        nb_notification: notifications_for_procedure(procedure, :all).count
+        nb_notification: notifications_for_procedure(procedure, :not_archived).count
       }
 
       if h[:nb_en_construction] > 0 || h[:nb_notification] > 0

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -137,11 +137,6 @@ class Instructeur < ApplicationRecord
     Dossier.joins(:groupe_instructeur).where(id: dossiers_id_with_notifications(dossiers)).group('groupe_instructeurs.procedure_id').count
   end
 
-  def create_trusted_device_token
-    trusted_device_token = trusted_device_tokens.create
-    trusted_device_token.token
-  end
-
   def dossiers_id_with_notifications(dossiers)
     dossiers = dossiers.followed_by(self)
 
@@ -173,11 +168,6 @@ class Instructeur < ApplicationRecord
     Follow.where(instructeur: self, dossier: dossier).update_all(attributes)
   end
 
-  def young_login_token?
-    trusted_device_token = trusted_device_tokens.order(created_at: :desc).first
-    trusted_device_token&.token_young?
-  end
-
   def email_notification_data
     groupe_instructeur_with_email_notifications
       .reduce([]) do |acc, groupe|
@@ -197,6 +187,16 @@ class Instructeur < ApplicationRecord
 
       acc
     end
+  end
+
+  def create_trusted_device_token
+    trusted_device_token = trusted_device_tokens.create
+    trusted_device_token.token
+  end
+
+  def young_login_token?
+    trusted_device_token = trusted_device_tokens.order(created_at: :desc).first
+    trusted_device_token&.token_young?
   end
 
   private

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -109,29 +109,29 @@ class Instructeur < ApplicationRecord
     end
   end
 
-  def notifications_for_procedure(procedure, state = :en_cours)
+  def notifications_for_procedure(procedure, state)
     dossiers = case state
+    when :en_cours
+      procedure.defaut_groupe_instructeur.dossiers.en_cours
     when :termine
       procedure.defaut_groupe_instructeur.dossiers.termine
     when :not_archived
       procedure.defaut_groupe_instructeur.dossiers.not_archived
     when :all
       procedure.defaut_groupe_instructeur.dossiers
-    else
-      procedure.defaut_groupe_instructeur.dossiers.en_cours
     end
 
     dossiers_id_with_notifications(dossiers)
   end
 
-  def notifications_per_procedure(state = :en_cours)
+  def notifications_per_procedure(state)
     dossiers = case state
+    when :en_cours
+      Dossier.en_cours
     when :termine
       Dossier.termine
     when :not_archived
       Dossier.not_archived
-    else
-      Dossier.en_cours
     end
 
     Dossier.joins(:groupe_instructeur).where(id: dossiers_id_with_notifications(dossiers)).group('groupe_instructeurs.procedure_id').count

--- a/app/views/instructeurs/procedures/index.html.haml
+++ b/app/views/instructeurs/procedures/index.html.haml
@@ -27,7 +27,7 @@
                 %li
                   %object
                     = link_to(instructeur_procedure_path(p, statut: 'suivis')) do
-                      - if current_instructeur.notifications_per_procedure[p.id].present?
+                      - if current_instructeur.notifications_per_procedure(:en_cours)[p.id].present?
                         %span.notifications{ 'aria-label': "notifications" }
                       - followed_count = @followed_dossiers_count_per_procedure[p.id] || 0
                       .stats-number

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -24,7 +24,7 @@
             instructeur_procedure_path(@procedure, statut: 'suivis'),
             active: @statut == 'suivis',
             badge: @followed_dossiers.count,
-            notification: current_instructeur.notifications_for_procedure(@procedure).present?)
+            notification: current_instructeur.notifications_for_procedure(@procedure, :en_cours).present?)
 
           = tab_item(t('pluralize.processed', count: @termines_dossiers.count),
             instructeur_procedure_path(@procedure, statut: 'traites'),

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -82,7 +82,6 @@ describe Instructeurs::DossiersController, type: :controller do
 
     it { expect(dossier.archived).to be true }
     it { expect(response).to redirect_to(instructeur_procedures_url) }
-    it { expect(instructeur.followed_dossiers).not_to include(dossier) }
   end
 
   describe '#unarchive' do

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -248,7 +248,7 @@ describe Instructeur, type: :model do
       instructeur_2.followed_dossiers << dossier
     end
 
-    subject { instructeur.notifications_for_procedure(procedure) }
+    subject { instructeur.notifications_for_procedure(procedure, :en_cours) }
 
     context 'when the instructeur has just followed the dossier' do
       it { is_expected.to match([]) }
@@ -258,8 +258,8 @@ describe Instructeur, type: :model do
       before { dossier.champs.first.update_attribute('value', 'toto') }
 
       it { is_expected.to match([dossier.id]) }
-      it { expect(instructeur_2.notifications_for_procedure(procedure)).to match([dossier.id]) }
-      it { expect(instructeur_on_procedure_2.notifications_for_procedure(procedure)).to match([]) }
+      it { expect(instructeur_2.notifications_for_procedure(procedure, :en_cours)).to match([dossier.id]) }
+      it { expect(instructeur_on_procedure_2.notifications_for_procedure(procedure, :en_cours)).to match([]) }
 
       context 'and there is a modification on private champs' do
         before { dossier.champs_private.first.update_attribute('value', 'toto') }
@@ -273,7 +273,7 @@ describe Instructeur, type: :model do
         before { follow.update_attribute('demande_seen_at', Time.zone.now) }
 
         it { is_expected.to match([]) }
-        it { expect(instructeur_2.notifications_for_procedure(procedure)).to match([dossier.id]) }
+        it { expect(instructeur_2.notifications_for_procedure(procedure, :en_cours)).to match([dossier.id]) }
       end
     end
 
@@ -315,7 +315,7 @@ describe Instructeur, type: :model do
     let(:instructeur) { dossier.follows.first.instructeur }
     let(:procedure) { dossier.procedure }
 
-    subject { instructeur.notifications_per_procedure }
+    subject { instructeur.notifications_per_procedure(:en_cours) }
 
     context 'when there is a modification on public champs' do
       before { dossier.champs.first.update_attribute('value', 'toto') }

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -389,7 +389,7 @@ describe Instructeur, type: :model do
     context 'when a notification exists' do
       before do
         allow(instructeur).to receive(:notifications_for_procedure)
-          .with(procedure_to_assign, :all)
+          .with(procedure_to_assign, :not_archived)
           .and_return([1, 2, 3])
       end
 


### PR DESCRIPTION
It was slightly broken in two ways:
- it doesn’t make other instructeurs unfollow the dossier
- if the dossier is unarchived, instructeurs don’t refollow automatically.

In any case, notifications on archived dossiers are not a real issue:
- They seldom appear in real world situations. For example, Comments are closed when a Dossier is archived. 
- The UI in `/procedures#index` and `/procedures#show` only display notifications badges for `:en_cours` and `:termine` dossiers. 
- The weekly summary email *did* count notifications for all dossiers, including archived. This is patched too, so that the weekly summary reflects what the `/procedures` pages show.

(Also included, some light cleanup.)

refs #4195, but I’m not sure we can close it. The underlying issue is fixed: instructeurs will appear in the ProcedurePresentation even if the Dossier is archived. On the other hand, we have a lot of _unfollowed_ in DB, we may want to write a script to make Instructeurs re-follow their archived Dossiers.

Additionally, there is more room for refactoring and (possibly) perf improvements in the `notifications_*` methods. Let this be another PR.