### PR TITLE
Disable turbolinks for links to Stats pages

### DIFF
--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -11,7 +11,7 @@
         %h1= procedure_libelle @procedure
         = link_to 'gestion des notifications', email_notifications_instructeur_procedure_path(@procedure), class: 'header-link'
         |
-        = link_to 'statistiques', stats_instructeur_procedure_path(@procedure), class: 'header-link'
+        = link_to 'statistiques', stats_instructeur_procedure_path(@procedure), class: 'header-link', data: { turbolinks: false } # Turbolinks disabled for Chartkick. See Issue #350
 
 
         %ul.tabs

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -5,7 +5,7 @@
     \-
     = link_to 'Nouveautés', 'https://github.com/betagouv/demarches-simplifiees.fr/releases', target: '_blank'
     \-
-    = link_to 'Statistiques', stats_path
+    = link_to 'Statistiques', stats_path, data: { turbolinks: false } # Turbolinks disabled for Chartkick. See Issue #350
     \-
     = link_to 'CGU / Mentions légales', CGU_URL
     \-

--- a/app/views/root/_footer.html.haml
+++ b/app/views/root/_footer.html.haml
@@ -23,7 +23,7 @@
           %li.footer-link
             = link_to "Nouveautés", "https://github.com/betagouv/demarches-simplifiees.fr/releases", :class => "footer-link"
           %li.footer-link
-            = link_to "Statistiques", stats_path, :class => "footer-link"
+            = link_to "Statistiques", stats_path, :class => "footer-link", data: { turbolinks: false } # Turbolinks disabled for Chartkick. See Issue #350
           %li.footer-link
             = link_to "CGU", CGU_URL, :class => "footer-link", :target => "_blank", rel: "noopener noreferrer"
           %li.footer-link


### PR DESCRIPTION
This is a workaround for #350

It should make the `/stats` and `/procedure/<id>/stats` pages behave correctly on initial navigation.