### PR TITLE
Fix de vocabulaire pour les dossiers non modifiables

### DIFF
--- a/app/views/invites/_dropdown.html.haml
+++ b/app/views/invites/_dropdown.html.haml
@@ -5,7 +5,10 @@
       Voir les personnes invitées
       %span.badge= dossier.invites.count
     - else
-      Inviter une personne à modifier ce dossier
+      - if dossier.read_only?
+        Inviter une personne à consulter ce dossier
+      - else
+        Inviter une personne à modifier ce dossier
 
   .dropdown-content.fade-in-down
     = render partial: "invites/form", locals: { dossier: dossier }

--- a/app/views/users/dossiers/merci.html.haml
+++ b/app/views/users/dossiers/merci.html.haml
@@ -16,8 +16,9 @@
       %b dossier en ligne.
     %p
       Vous pouvez
-      %b le modifier
-      et
+      - if !@dossier.read_only?
+        %b le modifier
+        et
       %b échanger avec un instructeur.
 
     .flex.column.align-center


### PR DESCRIPTION
 - `merci`: ne pas dire qu'on peut modifier le dossier si ce n'est pas le cas (ça arrive pour les procédures déclaratives acceptées automatiquement)
 - `invitation d'invité`: vocabulaire qui prend moins de risque ;)