### PR TITLE
Migrate Sendinblue API to v3

### DIFF
--- a/app/lib/sendinblue/api.rb
+++ b/app/lib/sendinblue/api.rb
@@ -15,8 +15,8 @@ class Sendinblue::Api
     client_key.present?
   end
 
-  def identify(email, attributes = {})
-    req = api_request('identify', email: email, attributes: attributes)
+  def update_contact(email, attributes = {})
+    req = post_api_request('contacts', email: email, attributes: attributes, updateEnabled: true)
     req.on_complete do |response|
       if !response.success?
         push_failure("Error while updating identity for administrateur '#{email}' in Sendinblue: #{response.response_code} '#{response.body}'")
@@ -34,7 +34,7 @@ class Sendinblue::Api
   private
 
   def hydra
-    @hydra ||= Typhoeus::Hydra.new
+    @hydra ||= Typhoeus::Hydra.new(max_concurrency: 50)
   end
 
   def push_failure(failure)
@@ -49,8 +49,8 @@ class Sendinblue::Api
     end
   end
 
-  def api_request(path, body)
-    url = "#{SENDINBLUE_API_URL}/#{path}"
+  def post_api_request(path, body)
+    url = "#{SENDINBLUE_API_V3_URL}/#{path}"
 
     Typhoeus::Request.new(
       url,
@@ -62,12 +62,12 @@ class Sendinblue::Api
 
   def headers
     {
-      'ma-key': client_key,
+      'api-key': client_key,
       'Content-Type': 'application/json; charset=UTF-8'
     }
   end
 
   def client_key
-    Rails.application.secrets.sendinblue[:client_key]
+    Rails.application.secrets.sendinblue[:api_v3_key]
   end
 end

--- a/app/services/administrateur_usage_statistics_service.rb
+++ b/app/services/administrateur_usage_statistics_service.rb
@@ -10,7 +10,7 @@ class AdministrateurUsageStatisticsService
   def update_administrateurs
     Administrateur.includes(:user).find_each do |administrateur|
       stats = administrateur_stats(administrateur)
-      api.identify(administrateur.email, stats)
+      api.update_contact(administrateur.email, stats)
     end
     api.run
   end

--- a/config/initializers/urls.rb
+++ b/config/initializers/urls.rb
@@ -7,6 +7,7 @@ API_GEO_SANDBOX_URL = ENV.fetch("API_GEO_SANDBOX_URL", "https://sandbox.geo.api.
 HELPSCOUT_API_URL = ENV.fetch("HELPSCOUT_API_URL", "https://api.helpscout.net/v2")
 PIPEDRIVE_API_URL = ENV.fetch("PIPEDRIVE_API_URL", "https://api.pipedrive.com/v1")
 SENDINBLUE_API_URL = ENV.fetch("SENDINBLUE_API_URL", "https://in-automate.sendinblue.com/api/v2")
+SENDINBLUE_API_V3_URL = ENV.fetch("SENDINBLUE_API_V3_URL", "https://api.sendinblue.com/v3")
 UNIVERSIGN_API_URL = ENV.fetch("UNIVERSIGN_API_URL", "https://ws.universign.eu/tsa/post/")
 
 # Internal URLs

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -55,6 +55,7 @@ defaults: &defaults
   sendinblue:
     enabled: <%= ENV['SENDINBLUE_ENABLED'] == 'enabled' %>
     client_key: <%= ENV['SENDINBLUE_CLIENT_KEY'] %>
+    api_v3_key: <%= ENV['SENDINBLUE_API_V3_KEY'] %>
   matomo:
     enabled: <%= ENV['MATOMO_ENABLED'] == 'enabled' %>
     client_key: <%= ENV['MATOMO_ID'] %>


### PR DESCRIPTION
Sendinblue API v2 is not deprecated and not maintained. This is a migration to API v3. Deployment of the key is required prior to this deployment.

We start to perform a lot of contact update requests, so we may be rate-limited (https://developers.sendinblue.com/docs/api#section-rate-limiting), which may be the cause of todays' bug. Limiting hydra simultaneous requests is a low-cost attempt to bypass that.

If migration to v3 does not fix the issue, hopefully we'll have better error messages (we have nothing at the moment)