### PR TITLE
[fix #4058] instructeur peut passer accepte → instruction

### DIFF
--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -112,12 +112,8 @@ module Instructeurs
       if dossier.en_instruction?
         flash.notice = 'Le dossier est déjà en instruction.'
       else
-        if dossier.accepte?
-          flash.notice = 'Il n’est pas possible de repasser un dossier accepté en instruction.'
-        else
-          flash.notice = "Le dossier #{dossier.id} a été repassé en instruction."
-          dossier.repasser_en_instruction!(current_instructeur)
-        end
+        flash.notice = "Le dossier #{dossier.id} a été repassé en instruction."
+        dossier.repasser_en_instruction!(current_instructeur)
       end
 
       render partial: 'state_button_refresh', locals: { dossier: dossier }

--- a/app/views/instructeurs/dossiers/_state_button.html.haml
+++ b/app/views/instructeurs/dossiers/_state_button.html.haml
@@ -1,4 +1,4 @@
-- if dossier.en_construction? || dossier.en_instruction?
+- if dossier.en_construction? || dossier.en_instruction? || dossier.accepte?
   %span.dropdown
     %button.button.primary.dropdown-button
       = dossier_display_state dossier
@@ -17,6 +17,13 @@
                 %h4 Passer en instruction
                 L'usager ne pourra plus modifier le formulaire
 
+        - if dossier.accepte?
+          %li
+            = link_to repasser_en_instruction_instructeur_dossier_path(dossier.procedure, dossier), method: :post, data: { remote: true, confirm: "Confirmez-vous le passage en instruction de ce dossier ?" } do
+              %span.icon.in-progress
+              .dropdown-description
+                %h4 Passer en instruction
+                L'usager ne pourra plus modifier le formulaire
         - if dossier.en_instruction?
           %li
             = link_to repasser_en_construction_instructeur_dossier_path(dossier.procedure, dossier), method: :post, data: { remote:true, confirm: "Confirmez-vous le passage en construction de ce dossier ?" } do

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -169,17 +169,9 @@ describe Instructeurs::DossiersController, type: :controller do
     context 'when the dossier is accepte' do
       let(:dossier) { create(:dossier, :accepte, procedure: procedure) }
 
-      it 'it is not possible to go back to en_instruction as instructeur' do
-        expect(dossier.reload.state).to eq(Dossier.states.fetch(:accepte))
+      it 'it is possible to go back to en_instruction as instructeur' do
+        expect(dossier.reload.state).to eq(Dossier.states.fetch(:en_instruction))
         expect(response).to have_http_status(:ok)
-      end
-
-      context 'as superadmin' do
-        let (:current_user) { administration }
-        it 'it is not possible to go back to en_instruction' do
-          expect(dossier.reload.state).to eq(Dossier.states.fetch(:accepte))
-          expect(response).to have_http_status(:ok)
-        end
       end
     end
   end


### PR DESCRIPTION
Comme dit dans le titre. C'est demandé par les utilisateurs, et ça va réduire les remontées d'erreurs AASM.