### PR TITLE
Ajout de template d'issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/am-lioration.md
+++ b/.github/ISSUE_TEMPLATE/am-lioration.md
@@ -1,0 +1,17 @@
+---
+name: Amélioration
+about: Suggérer une amélioration ou une nouvelle fonctionnalité
+title: ''
+labels: idea
+assignees: ''
+
+---
+
+**Votre amélioration est liée à un problème spécifique ?**
+Si oui, décrivez brièvement quel est le problème que vous rencontrez. Par exemple : Sur demarches-simplifiees.fr, je suis agacé quand je dois […]
+
+**Décrivez la solution proposée**
+Une description rapide de la manière dont vous voudriez résoudre le problème.
+
+**Plus de contexte**
+Ajoutez éventuellement des éléments de contexte concernant votre proposition d'amélioration, ou des captures d'écran.

--- a/.github/ISSUE_TEMPLATE/rapport-de-bug.md
+++ b/.github/ISSUE_TEMPLATE/rapport-de-bug.md
@@ -1,0 +1,27 @@
+---
+name: Rapport de bug
+about: Remonter une erreur ou un plantage
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Décrivez le bug**
+Une description claire et concise du problème, en une phrase ou deux.
+
+**Reproduction**
+Comment reproduire le problème :
+1. Aller sur la page '...'
+2. Cliquez sur '...'
+3. Une erreur '.....' apparaît
+
+**Comportement attendu**
+Comment le site aurait-il dû se comporter ?
+
+**Capture d'écran**
+Si besoin, ajoutez une capture d'écran de votre problème. Cela nous aide à identifier plus rapidement le souci.
+
+**Appareil et navigateur utilisé**
+ - Appareil : [par exemple PC, Mac, iPhone, Android]
+ - Navigateur : [par exemple Firefox, Chrome, Safari]


### PR DESCRIPTION
Les templates d'issues sont affichés lorsque on clique sur le bouton "New issue" dans GitHub.

Deux objectifs :

- **Améliorer nos rapports de bugs interne** : nous encourager à décrire le problème des utilisateurs (plutôt que juste la solution proposée).
- **Améliorer les issues des contributeurs externes** : encourager les contributeurs à créer des issues claires (plutôt que des tableaux Excels imbitables).