### PR TITLE
Corrige la notion d'administrateur actif

### DIFF
--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -13,7 +13,7 @@ class Administrateur < ApplicationRecord
 
   before_validation -> { sanitize_email(:email) }
 
-  scope :inactive, -> { where(active: false) }
+  scope :inactive, -> { joins(:user).where(users: { last_sign_in_at: nil }) }
   scope :with_publiees_ou_archivees, -> { joins(:procedures).where(procedures: { aasm_state: [:publiee, :archivee] }) }
 
   # validate :password_complexity, if: Proc.new { |a| Devise.password_length.include?(a.password.try(:size)) }

--- a/lib/tasks/deployment/20191007124230_update_admin_last_sign_in_at.rake
+++ b/lib/tasks/deployment/20191007124230_update_admin_last_sign_in_at.rake
@@ -1,0 +1,17 @@
+namespace :after_party do
+  desc 'Deployment task: update_admin_last_sign_in_at'
+  task update_admin_last_sign_in_at: :environment do
+    sql = <<-SQL
+      UPDATE users
+      SET last_sign_in_at = administrateurs.updated_at
+      FROM administrateurs
+      WHERE administrateur_id = administrateurs.id
+        AND users.last_sign_in_at IS NULL
+        AND administrateurs.active = true
+    SQL
+
+    ActiveRecord::Base.connection.execute(sql)
+
+    AfterParty::TaskRecord.create version: '20191007124230'
+  end
+end

--- a/spec/lib/tasks/deployment/20191007124230_update_admin_last_sign_in_at.rake_spec.rb
+++ b/spec/lib/tasks/deployment/20191007124230_update_admin_last_sign_in_at.rake_spec.rb
@@ -1,0 +1,27 @@
+describe '20191007124230_update_admin_last_sign_in_at.rake' do
+  let(:rake_task) { Rake::Task['after_party:update_admin_last_sign_in_at'] }
+
+  subject { rake_task.invoke }
+  after { rake_task.reenable }
+
+  context 'with 2 administrateurs' do
+    let!(:admin) { create(:administrateur, active: true) }
+    let(:user) { admin.user }
+    let!(:admin2) { create(:administrateur, active: false) }
+    let(:user2) { admin2.user }
+
+    before do
+    end
+
+    it do
+      expect(admin.active).to be true
+      expect(user.last_sign_in_at).to be_nil
+      expect(admin.updated_at).not_to be_nil
+
+      subject
+
+      expect(user.reload.last_sign_in_at).to eq(admin.reload.updated_at)
+      expect(user2.reload.last_sign_in_at).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
A partir de cette pr, on considère un administrateur actif comme s'étant connecté au moins une fois. On obtient cette information à partir de `user.last_sign_in_at`

Il faut également corriger de la mauvaise donnée ou le champ `user.last_sign_in_at` n'était pas rempli car devise utilisait le profil admin et donc mettait à jour `administrateur.last_sign_in_at` .

Fix #4361