### PR TITLE
[Instructeur] Improve attestation preview

### DIFF
--- a/app/views/instructeurs/dossiers/_state_button_motivation.html.haml
+++ b/app/views/instructeurs/dossiers/_state_button_motivation.html.haml
@@ -8,7 +8,9 @@
       = text_area :dossier, :motivation, class: 'motivation-text-area', placeholder: placeholder, required: false
       - if dossier.procedure.attestation_template&.activated?
         %p.help
-          L'acceptation du dossier envoie automatiquement une attestation à l'usager.
+          L'acceptation du dossier envoie automatiquement
+          = link_to 'une attestation', apercu_attestation_instructeur_dossier_path(dossier.procedure, dossier), target: '_blank', rel: 'noopener', title: "Voir l'attestation qui sera envoyée à l'usager"
+          à l'usager.
 
       - unspecified_attestation_champs = dossier.unspecified_attestation_champs
       - if unspecified_attestation_champs.present?
@@ -34,7 +36,5 @@
     .hidden{ id: "justificatif_motivation_import_#{popup_class}" }
       = file_field :dossier, :justificatif_motivation, direct_upload: true
     .text-right
-      - if title == 'Accepter' && dossier.procedure.attestation_template&.activated?
-        = link_to "Voir l'attestation", apercu_attestation_instructeur_dossier_path(dossier.procedure, dossier), target: '_blank', rel: 'noopener', class: 'button', title: "Voir l'attestation qui sera envoyée au demandeur"
       %span.button{ onclick: 'DS.motivationCancel();' } Annuler
       = button_tag 'Valider la décision', name: :process_action, value: process_action, class: 'button primary', title: title, data: { confirm: confirm }

--- a/app/views/instructeurs/dossiers/_state_button_motivation.html.haml
+++ b/app/views/instructeurs/dossiers/_state_button_motivation.html.haml
@@ -6,8 +6,9 @@
   = form_tag(terminer_instructeur_dossier_path(dossier.procedure, dossier), remote: true, method: :post, class: 'form') do
     - if title == 'Accepter'
       = text_area :dossier, :motivation, class: 'motivation-text-area', placeholder: placeholder, required: false
-      %p.help
-        L'acceptation du dossier envoie automatiquement une attestation à l'usager.
+      - if dossier.procedure.attestation_template&.activated?
+        %p.help
+          L'acceptation du dossier envoie automatiquement une attestation à l'usager.
 
       - unspecified_attestation_champs = dossier.unspecified_attestation_champs
       - if unspecified_attestation_champs.present?

--- a/spec/views/instructeur/dossiers/_state_button_motivation.html.haml_spec.rb
+++ b/spec/views/instructeur/dossiers/_state_button_motivation.html.haml_spec.rb
@@ -16,11 +16,10 @@ describe 'instructeurs/dossiers/state_button_motivation.html.haml', type: :view 
 
   context 'with an attestation preview' do
     let(:dossier) { create :dossier, :accepte, :with_attestation }
-    it { expect(rendered).to have_text("Voir l'attestation") }
+    it { expect(rendered).to have_link(href: apercu_attestation_instructeur_dossier_path(dossier.procedure, dossier)) }
   end
 
   context 'without an attestation preview' do
-    it { expect(rendered).not_to have_text("envoie automatiquement une attestation") }
-    it { expect(rendered).not_to have_text("Voir l'attestation") }
+    it { expect(rendered).not_to have_link(href: apercu_attestation_instructeur_dossier_path(dossier.procedure, dossier)) }
   end
 end

--- a/spec/views/instructeur/dossiers/_state_button_motivation.html.haml_spec.rb
+++ b/spec/views/instructeur/dossiers/_state_button_motivation.html.haml_spec.rb
@@ -20,6 +20,7 @@ describe 'instructeurs/dossiers/state_button_motivation.html.haml', type: :view 
   end
 
   context 'without an attestation preview' do
+    it { expect(rendered).not_to have_text("envoie automatiquement une attestation") }
     it { expect(rendered).not_to have_text("Voir l'attestation") }
   end
 end


### PR DESCRIPTION
- Amélioration : le bouton "Voir l'attestation" est remplacé par un lien vers l'attestation, directement dans le texte qui la mentionne. Ça limite l'effet "Tas de boutons" en bas du dialogue.
- Correction de bug : le texte "Une attestation sera envoyée automatiquement" était affiché même quand l'attestation était désactivée.

## Avant

<img width="482" alt="Capture d’écran 2019-10-14 à 15 40 31" src="https://user-images.githubusercontent.com/179923/66755785-fdae2980-ee98-11e9-8fae-186e39c70697.png">

## Après

<img width="483" alt="Capture d’écran 2019-10-14 à 15 36 35" src="https://user-images.githubusercontent.com/179923/66755743-e96a2c80-ee98-11e9-9860-baffe55f8896.png">
