### PR TITLE
admin: relabel the `number` champ

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -538,7 +538,7 @@ enum TypeDeChamp {
   multiple_drop_down_list
 
   """
-  Nombre entier
+  Nombre
   """
   number
 

--- a/config/locales/models/type_de_champ/fr.yml
+++ b/config/locales/models/type_de_champ/fr.yml
@@ -9,7 +9,7 @@ fr:
           textarea: 'Zone de texte'
           date: 'Date'
           datetime: 'Date et Heure'
-          number: 'Nombre entier'
+          number: 'Nombre'
           decimal_number: 'Nombre décimal'
           integer_number: 'Nombre entier'
           checkbox: 'Case à cocher'


### PR DESCRIPTION
Cette PR est une première étape pour unfuck les champs "Nombre entier" (#4414).

Spécifiquement, elle fait en sorte que deux types de champ différents n'aient pas le même label.

On pourra voir un plan de migration plus complet plus tard.

## Avant (feature flag activé)

<img width="492" alt="Capture d’écran 2019-10-16 à 17 19 25" src="https://user-images.githubusercontent.com/179923/66935324-1e62b480-f03c-11e9-8b54-b8643c27c17c.png">


## Après (feature flag activé)

<img width="509" alt="Capture d’écran 2019-10-16 à 17 33 44" src="https://user-images.githubusercontent.com/179923/66935358-23bfff00-f03c-11e9-8367-b4b7196c8321.png">
