### PR TITLE
Ajout de tests d'acceptance pour les Experts

### DIFF
--- a/spec/factories/avis.rb
+++ b/spec/factories/avis.rb
@@ -1,27 +1,16 @@
 FactoryBot.define do
+  sequence(:expert_email) { |n| "expert#{n}@expert.com" }
+
   factory :avis do
+    email { generate(:expert_email) }
     introduction { 'Bonjour, merci de me donner votre avis sur ce dossier' }
+    confidentiel { false }
 
-    before(:create) do |avis, _evaluator|
-      if !avis.instructeur
-        avis.instructeur = create :instructeur
-      end
-    end
-
-    before(:create) do |avis, _evaluator|
-      if !avis.dossier
-        avis.dossier = create :dossier
-      end
-    end
-
-    before(:create) do |avis, _evaluator|
-      if !avis.claimant
-        avis.claimant = create :instructeur
-      end
-    end
+    association :dossier
+    association :claimant, factory: :instructeur
 
     trait :with_answer do
-      answer { "Mon avis se décompose en deux points :\n- La demande semble pertinente\n- Le demandeur remplit les conditions." }
+      answer { "Mon avis se décompose en deux points :\n- La demande semble pertinente\n- Le demandeur remplit les conditions." }
     end
   end
 end

--- a/spec/features/instructeurs/expert_spec.rb
+++ b/spec/features/instructeurs/expert_spec.rb
@@ -1,0 +1,127 @@
+require 'spec_helper'
+
+feature 'Inviting an expert:' do
+  include ActiveJob::TestHelper
+  include ActionView::Helpers
+
+  let(:instructeur) { create(:instructeur, password: 'démarches-simplifiées-pwd') }
+  let(:expert) { create(:instructeur, password: expert_password) }
+  let(:expert_password) { 'mot de passe d’expert' }
+  let(:procedure) { create(:procedure, :published, instructeurs: [instructeur]) }
+  let(:dossier) { create(:dossier, state: Dossier.states.fetch(:en_construction), procedure: procedure) }
+
+  context 'as an Instructeur' do
+    scenario 'I can invite an expert' do
+      login_as instructeur.user, scope: :user
+      visit instructeur_dossier_path(procedure, dossier)
+
+      click_on 'Avis externes'
+      expect(page).to have_current_path(avis_instructeur_dossier_path(procedure, dossier))
+
+      fill_in 'avis_emails', with: 'expert1@exemple.fr, expert2@exemple.fr'
+      fill_in 'avis_introduction', with: 'Bonjour, merci de me donner votre avis sur ce dossier.'
+      page.select 'confidentiel', from: 'avis_confidentiel'
+
+      perform_enqueued_jobs do
+        click_on 'Demander un avis'
+      end
+
+      expect(page).to have_content('Une demande d\'avis a été envoyée')
+      expect(page).to have_content('Avis des invités')
+      within('.list-avis') do
+        expect(page).to have_content('expert1@exemple.fr')
+        expect(page).to have_content('expert2@exemple.fr')
+        expect(page).to have_content('Bonjour, merci de me donner votre avis sur ce dossier.')
+      end
+
+      invitation_email = open_email('expert2@exemple.fr')
+      avis = Avis.find_by(email: 'expert2@exemple.fr')
+      sign_up_link = sign_up_instructeur_avis_path(avis.id, avis.email)
+      expect(invitation_email.body).to include(sign_up_link)
+    end
+
+    context 'when experts submitted their answer' do
+      let!(:answered_avis) { create(:avis, :with_answer, dossier: dossier, claimant: instructeur, email: expert.email) }
+
+      scenario 'I can read the expert answer' do
+        login_as instructeur.user, scope: :user
+        visit instructeur_dossier_path(procedure, dossier)
+
+        click_on 'Avis externes'
+
+        expect(page).to have_content(expert.email)
+        answered_avis.answer.split("\n").each do |answer_line|
+          expect(page).to have_content(answer_line)
+        end
+      end
+    end
+  end
+
+  context 'as an invited Expert' do
+    let(:avis_email) { expert.email }
+    let(:avis) { create(:avis, dossier: dossier, claimant: instructeur, email: avis_email, confidentiel: true) }
+
+    context 'when I don’t already have an account' do
+      let(:avis_email) { 'not-signed-up-expert@exemple.fr' }
+
+      scenario 'I can sign up' do
+        visit sign_up_instructeur_avis_path(avis.id, avis_email)
+
+        expect(page).to have_field('Email', with: avis_email, disabled: true)
+        fill_in 'Mot de passe', with: 'This is a very complicated password !'
+        click_on 'Créer un compte'
+
+        expect(page).to have_current_path(instructeur_avis_index_path)
+        expect(page).to have_text('avis à donner 1')
+      end
+    end
+
+    context 'when I already have an existing account' do
+      let(:avis_email) { expert.email }
+
+      scenario 'I can sign in' do
+        visit sign_up_instructeur_avis_path(avis.id, avis_email)
+
+        expect(page).to have_current_path(new_user_session_path)
+        sign_in_with(expert.email, expert_password)
+
+        expect(page).to have_current_path(instructeur_avis_index_path)
+        expect(page).to have_text('avis à donner 1')
+      end
+    end
+
+    scenario 'I can give an answer' do
+      avis # create avis
+      login_as expert.user, scope: :user
+
+      visit instructeur_avis_index_path
+      expect(page).to have_text('avis à donner 1')
+      expect(page).to have_text('avis donnés 0')
+
+      click_on avis.dossier.user.email
+
+      within('.tabs') { click_on 'Avis' }
+      expect(page).to have_text("Demandeur : #{instructeur.email}")
+      expect(page).to have_text('Cet avis est confidentiel')
+
+      fill_in 'avis_answer', with: 'Ma réponse d’expert : c’est un oui.'
+      find('.piece-justificative input[type=file]').attach_file(Rails.root + 'spec/fixtures/files/RIB.pdf')
+      click_on 'Envoyer votre avis'
+
+      expect(page).to have_content('Votre réponse est enregistrée')
+      expect(page).to have_content('Ma réponse d’expert : c’est un oui.')
+      expect(page).to have_content('RIB.pdf')
+
+      within('.new-header') { click_on 'Avis' }
+      expect(page).to have_text('avis à donner 0')
+      expect(page).to have_text('avis donné 1')
+    end
+
+    # TODO
+    # scenario 'I can read other experts advices' do
+    # end
+
+    # scenario 'I can invite other experts' do
+    # end
+  end
+end

--- a/spec/features/instructeurs/instruction_spec.rb
+++ b/spec/features/instructeurs/instruction_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-feature 'The instructeur part' do
+feature 'Instructing a dossier:' do
   include ActiveJob::TestHelper
 
   let(:password) { 'démarches-simplifiées-pwd' }

--- a/spec/features/instructeurs/instruction_spec.rb
+++ b/spec/features/instructeurs/instruction_spec.rb
@@ -93,59 +93,6 @@ feature 'Instructing a dossier:' do
     expect(page).to have_text('Aucun dossier')
   end
 
-  scenario 'A instructeur can use avis' do
-    log_in(instructeur.email, password)
-
-    click_on procedure.libelle
-    click_on dossier.user.email
-
-    click_on 'Avis externes'
-    expect(page).to have_current_path(avis_instructeur_dossier_path(procedure, dossier))
-
-    expert_email = 'expert@tps.com'
-
-    perform_enqueued_jobs do
-      ask_confidential_avis(expert_email, 'a good introduction')
-    end
-
-    log_out
-
-    avis = dossier.avis.first
-    test_mail(expert_email, sign_up_instructeur_avis_path(avis, expert_email))
-
-    avis_sign_up(avis, expert_email)
-
-    expect(page).to have_current_path(instructeur_avis_index_path)
-    expect(page).to have_text('avis à donner 1')
-    expect(page).to have_text('avis donnés 0')
-
-    click_on dossier.user.email
-    expect(page).to have_current_path(instructeur_avis_path(dossier.avis.first))
-
-    within(:css, '.tabs') do
-      click_on 'Avis'
-    end
-    expect(page).to have_current_path(instruction_instructeur_avis_path(dossier.avis.first))
-
-    within(:css, '.give-avis') do
-      expect(page).to have_text("Demandeur : #{instructeur.email}")
-      expect(page).to have_text('a good introduction')
-      expect(page).to have_text('Cet avis est confidentiel')
-      fill_in 'avis_answer', with: 'a great answer'
-      click_on 'Envoyer votre avis'
-    end
-
-    log_out
-
-    log_in(instructeur.email, password, check_email: false)
-
-    click_on procedure.libelle
-    click_on dossier.user.email
-    click_on 'Avis externes'
-
-    expect(page).to have_text('a great answer')
-  end
-
   scenario 'A instructeur can see the personnes impliquées' do
     instructeur2 = FactoryBot.create(:instructeur, password: password)
 

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -63,6 +63,13 @@ module FeatureHelpers
     expect(page).to have_content(procedure.service.email)
   end
 
+  def click_reset_password_link_for(email)
+    reset_password_email = open_email(email)
+    token_params = reset_password_email.body.match(/reset_password_token=[^"]+/)
+
+    visit "/users/password/edit?#{token_params}"
+  end
+
   def blur
     page.find('body').click
   end
@@ -77,13 +84,6 @@ module FeatureHelpers
       sleep(0.1) until (value = yield)
       value
     end
-  end
-
-  def click_reset_password_link_for(email)
-    reset_password_email = open_email(email)
-    token_params = reset_password_email.body.match(/reset_password_token=[^"]+/)
-
-    visit "/users/password/edit?#{token_params}"
   end
 end
 

--- a/spec/views/instructeur/avis/instruction.html.haml_spec.rb
+++ b/spec/views/instructeur/avis/instruction.html.haml_spec.rb
@@ -1,9 +1,11 @@
 describe 'instructeurs/avis/instruction.html.haml', type: :view do
-  let(:avis) { create(:avis, confidentiel: confidentiel) }
+  let(:expert) { create(:instructeur) }
+  let(:avis) { create(:avis, confidentiel: confidentiel, email: expert.email) }
 
   before do
     assign(:avis, avis)
-    @dossier = create(:dossier, :accepte)
+    assign(:new_avis, Avis.new)
+    assign(:dossier, avis.dossier)
     allow(view).to receive(:current_instructeur).and_return(avis.instructeur)
   end
 


### PR DESCRIPTION
Jusque ici on n'avait aucun test d'acceptance pour les Experts (recevoir un avis, y répondre, etc).

Cette PR en rajoute quelques uns :

- ETQ Instructeur, demander un avis
- ETQ Expert : 
	- Créer un compte suite à une demande d'avis
	- Se connecter suite à une demande d'avis
	- Répondre à un avis

Il reste encore des parties non-couvertes (demander soi-même un avis à qq d'autres, modifier son avis, etc), mais c'est déjà un début. 