### PR TITLE
Amélioration du bouton "Ajouter une ligne" des blocs répétables

### DIFF
--- a/app/assets/images/icons/add.svg
+++ b/app/assets/images/icons/add.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="24" height="24"><path d="M18 10.5h-4.5V6a1 1 0 0 0-1-1h-1a1 1 0 0 0-1 1v4.5H6a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1h4.5V18a1 1 0 0 0 1 1h1a1 1 0 0 0 1-1v-4.5H18a1 1 0 0 0 1-1v-1a1 1 0 0 0-1-1z" fill="#333"/></svg>

--- a/app/assets/stylesheets/new_design/icons.scss
+++ b/app/assets/stylesheets/new_design/icons.scss
@@ -79,10 +79,15 @@
     background-image: image-url("icons/lock.svg");
   }
 
+  &.add {
+    background-image: image-url("icons/add.svg");
+    margin-left: -5px;
+    margin-right: 0px;
+  }
+
   &.justificatif {
     background-image: image-url("icons/justificatif.svg");
   }
-
 
   &.printer {
     background-image: image-url("icons/printer.svg");

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -39,6 +39,16 @@ class RootController < ApplicationController
         champ.value = '["option B", "option C"]'
       end
 
+    all_champs
+      .filter { |champ| champ.type_champ == TypeDeChamp.type_champs.fetch(:repetition) }
+      .each do |champ_repetition|
+        libelles = ['Prénom', 'Nom'];
+        champ_repetition.champs << libelles.map.with_index do |libelle, i|
+          text_tdc = TypeDeChamp.new(type_champ: :text, private: false, libelle: libelle, description: description, mandatory: true)
+          text_tdc.champ.build(id: all_champs.length + i)
+        end
+      end
+
     type_champ_values = {
       TypeDeChamp.type_champs.fetch(:date)      => '2016-07-26',
       TypeDeChamp.type_champs.fetch(:datetime)  => '26/07/2016 07:35',

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -17,15 +17,15 @@ class RootController < ApplicationController
   end
 
   def patron
-    description = 'aller voir le super site : https://demarches-simplifiees.fr'
+    description = 'Aller voir le super site : https://demarches-simplifiees.fr'
 
     all_champs = TypeDeChamp.type_champs
-      .map { |name, _| TypeDeChamp.new(type_champ: name, private: false, libelle: name, description: description, mandatory: true) }
+      .map { |name, _| TypeDeChamp.new(type_champ: name, private: false, libelle: name.humanize, description: description, mandatory: true) }
       .map.with_index { |type_de_champ, i| type_de_champ.champ.build(id: i) }
 
     all_champs
       .filter { |champ| champ.type_champ == TypeDeChamp.type_champs.fetch(:header_section) }
-      .each { |champ| champ.type_de_champ.libelle = 'un super titre de section' }
+      .each { |champ| champ.type_de_champ.libelle = 'Un super titre de section' }
 
     all_champs
       .filter { |champ| [TypeDeChamp.type_champs.fetch(:drop_down_list), TypeDeChamp.type_champs.fetch(:multiple_drop_down_list)].include?(champ.type_champ) }

--- a/app/views/root/patron.html.haml
+++ b/app/views/root/patron.html.haml
@@ -16,6 +16,7 @@
     %span.icon.bubble
     %span.icon.attachment
     %span.icon.lock
+    %span.icon.add
     %span.icon.justificatif
     %span.icon.printer
     %span.icon.account

--- a/app/views/root/patron.html.haml
+++ b/app/views/root/patron.html.haml
@@ -1,6 +1,6 @@
 .patron
   .container
-    %h1 Icones
+    %h1 Icônes
 
     %span.icon.follow
     %span.icon.unfollow
@@ -47,7 +47,9 @@
           = render partial: "shared/dossiers/editable_champs/editable_champ",
             locals: { champ: champ, form: champ_form, seen_at: nil }
 
+        %label Mot de passe
         %input{ type: "password", value: "12345678" }
+
         .send-wrapper
           = f.submit 'Enregistrer un brouillon (formnovalidate)', formnovalidate: true, class: 'button send'
           = f.submit 'Envoyer', class: 'button send primary'

--- a/app/views/shared/dossiers/editable_champs/_repetition.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_repetition.html.haml
@@ -14,6 +14,10 @@
             Supprimer
 
 - if champ.persisted?
-  = link_to "Ajouter une ligne pour « #{champ.libelle} »", champs_repetition_path(form.index), class: 'button add-row', data: { remote: true, method: 'POST', params: { champ_id: champ&.id }.to_query }
+  = link_to champs_repetition_path(form.index), class: 'button add-row', data: { remote: true, method: 'POST', params: { champ_id: champ&.id }.to_query } do
+    %span.icon.add
+    Ajouter une ligne pour « #{champ.libelle} »
 - else
-  %a.button.add-row Ajouter une ligne pour « #{champ.libelle} »
+  %a.button.add-row
+    %span.icon.add
+    Ajouter une ligne pour « #{champ.libelle} »

--- a/app/views/shared/dossiers/editable_champs/_repetition.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_repetition.html.haml
@@ -16,5 +16,4 @@
 - if champ.persisted?
   = link_to "Ajouter une ligne pour « #{champ.libelle} »", champs_repetition_path(form.index), class: 'button add-row', data: { remote: true, method: 'POST', params: { champ_id: champ&.id }.to_query }
 - else
-  %button.button{ type: :button }
-    = "Ajouter une ligne pour « #{champ.libelle} »"
+  %a.button.add-row Ajouter une ligne pour « #{champ.libelle} »

--- a/spec/models/concern/tags_substitution_concern_spec.rb
+++ b/spec/models/concern/tags_substitution_concern_spec.rb
@@ -119,8 +119,8 @@ describe TagsSubstitutionConcern, type: :model do
       let(:types_de_champ) do
         [
           create(:type_de_champ_repetition, libelle: 'Répétition', types_de_champ: [
-            create(:type_de_champ_text, libelle: 'Nom'),
-            create(:type_de_champ_text, libelle: 'Prénom')
+            create(:type_de_champ_text, libelle: 'Nom', order_place: 1),
+            create(:type_de_champ_text, libelle: 'Prénom', order_place: 2)
           ])
         ]
       end


### PR DESCRIPTION
On en a discuté avec la maison départementale du 92 ce matin, du coup un peu de live-coding :

- Correction de l'absence de marge sur le bouton "Ajouter une ligne" quand on est en Prévisualisation
- Ajout d'une icône "+" au bouton "Ajouter une ligne"
- Patron : affichage d'un vrai bloc répétable au complet
- Patron : amélioration des libellés des champs


## Avant

<img width="552" alt="Capture d’écran 2019-10-23 à 13 12 43" src="https://user-images.githubusercontent.com/179923/67387261-d50fe900-f596-11e9-9bab-fa278be7ff8a.png">


## Après

<img width="552" alt="Capture d’écran 2019-10-23 à 13 12 27" src="https://user-images.githubusercontent.com/179923/67387267-d93c0680-f596-11e9-83f0-4d925290dd1a.png">

