### PR TITLE
#4434 - Rend possible le fait de télécharger 2x un export

### DIFF
--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -207,16 +207,19 @@ module Instructeurs
 
     def download_export
       export_format = params[:export_format]
-
+      notice_message = "Nous générons cet export. Lorsque celui-ci sera disponible, vous recevrez une notification par email accompagnée d'un lien de téléchargement."
       if procedure.should_generate_export?(export_format)
         procedure.queue_export(current_instructeur, export_format)
 
         respond_to do |format|
           format.js do
-            flash.notice = "Nous générons cet export. Lorsque celui-ci sera disponible, vous recevrez une notification par email accompagnée d'un lien de téléchargement."
+            flash.notice = notice_message
             @procedure = procedure
           end
         end
+      elsif procedure.export_queued?(export_format)
+        flash.notice = notice_message
+        redirect_to procedure
       else
         redirect_to url_for(procedure.export_file(export_format))
       end

--- a/app/jobs/cleanup_stale_exports_job.rb
+++ b/app/jobs/cleanup_stale_exports_job.rb
@@ -2,9 +2,25 @@ class CleanupStaleExportsJob < ApplicationJob
   queue_as :cron
 
   def perform(*args)
-    ActiveStorage::Attachment.where(
+    attachments = ActiveStorage::Attachment.where(
       "name in ('csv_export_file', 'ods_export_file', 'xlsx_export_file') and created_at < ?",
       Procedure::MAX_DUREE_CONSERVATION_EXPORT.ago
-    ).find_each(&:purge_later)
+    )
+    attachments.each do |attachment|
+      procedure = Procedure.find(attachment.record_id)
+      # export can't be queued if it's already attached
+      #  so we clean the flag up just in case it was not removed during
+      # the asynchronous generation
+      case attachment.name
+      when 'csv_export_file'
+        procedure.update(csv_export_queued: false)
+      when 'ods_export_file'
+        procedure.update(ods_export_queued: false)
+      when 'xlsx_export_file'
+        procedure.update(xlsx_export_queued: false)
+      end
+      # and we remove the stale attachment
+      attachment.purge_later
+    end
   end
 end

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -169,7 +169,6 @@ class Procedure < ApplicationRecord
   end
 
   def queue_export(instructeur, export_format)
-    ExportProcedureJob.perform_now(self, instructeur, export_format)
     case export_format.to_sym
     when :csv
       update(csv_export_queued: true)
@@ -178,6 +177,7 @@ class Procedure < ApplicationRecord
     when :ods
       update(ods_export_queued: true)
     end
+    ExportProcedureJob.perform_later(self, instructeur, export_format)
   end
 
   def prepare_export_download(format)

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -145,6 +145,18 @@ class Procedure < ApplicationRecord
     !ods_export_file.attached? || ods_export_file.created_at < MAX_DUREE_CONSERVATION_EXPORT.ago
   end
 
+  def export_queued?(format)
+    case format.to_sym
+    when :csv
+      return csv_export_queued?
+    when :xlsx
+      return xlsx_export_queued?
+    when :ods
+      return ods_export_queued?
+    end
+    false
+  end
+
   def should_generate_export?(format)
     case format.to_sym
     when :csv


### PR DESCRIPTION
Les flags `xlsx_export_queued` n'étaient pas bien nettoyés, à cause a) d'une séquence d'opération dans le mauvais ordre et b) du fait que l'export n'était pas aussi asynchrone qu'il le laissait croire.

Hors, les fichiers sont pourtant bien supprimés au bout de 3h, donc les gens qui ont un export en cours de génération rentraient dans la branche `pas besoin de générer un export` du controller https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/app/controllers/instructeurs/procedures_controller.rb#L211
ce qui les fait essayer de télécharger un fichier que n'existe plus.