### PR TITLE
Corrige la pr d'activation des admins

### DIFF
--- a/db/migrate/20191024092136_drop_active_column_from_administrateurs.rb
+++ b/db/migrate/20191024092136_drop_active_column_from_administrateurs.rb
@@ -1,5 +1,0 @@
-class DropActiveColumnFromAdministrateurs < ActiveRecord::Migration[5.2]
-  def change
-    remove_column :administrateurs, :active
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_24_092136) do
+ActiveRecord::Schema.define(version: 2019_10_23_183120) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 2019_10_24_092136) do
     t.string "email", default: "", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean "active", default: false
     t.string "encrypted_token"
     t.index ["email"], name: "index_administrateurs_on_email", unique: true
   end


### PR DESCRIPTION
Pour supprimer la colonne dans une autre mep.

Revert "DB: drop active column from adminsitrateurs table"

This reverts commit 2cb80415606c6a6470d9f95959d72a4db1facfb7.