### PR TITLE
manager: allow hidden procedures to be searched

### DIFF
--- a/app/controllers/manager/procedures_controller.rb
+++ b/app/controllers/manager/procedures_controller.rb
@@ -1,5 +1,21 @@
 module Manager
   class ProceduresController < Manager::ApplicationController
+    #
+    # Administrate overrides
+    #
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    def scoped_resource
+      if unfiltered_list?
+        # Don't display deleted dossiers in the unfiltered list…
+        Procedure
+      else
+        # … but allow them to be searched and displayed.
+        Procedure.unscope(:where)
+      end
+    end
+
     def whitelist
       procedure.whitelist!
       flash[:notice] = "Démarche whitelistée."
@@ -54,6 +70,10 @@ module Manager
 
     def type_de_champ_params
       params.require(:type_de_champ).permit(:piece_justificative_template)
+    end
+
+    def unfiltered_list?
+      action_name == "index" && !params[:search]
     end
   end
 end

--- a/app/views/manager/procedures/show.html.erb
+++ b/app/views/manager/procedures/show.html.erb
@@ -43,7 +43,9 @@ as well as a link to its edit page.
       <%= link_to 'repasser en test', draft_manager_procedure_path(procedure), method: :post, class: 'button' %>
     <% end %>
 
-    <%= link_to 'supprimer la démarche', hide_manager_procedure_path(procedure), method: :post, class: 'button', data: { confirm: "Confirmez-vous la suppression de la démarche ?" } %>
+    <% if !procedure.hidden? %>
+      <%= link_to 'supprimer la démarche', hide_manager_procedure_path(procedure), method: :post, class: 'button', data: { confirm: "Confirmez-vous la suppression de la démarche ?" } %>
+    <% end %>
   <div>
 
 </header>


### PR DESCRIPTION
The `Manager::DossiersController` already allow hidden dossiers to be searched and displayed. Give the same behavior to Procedures.