### PR TITLE
#4419 - Ne pas relancer les envois d'email lorsqu'ils échouent car le destinataire est inexistant

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -3,6 +3,7 @@ class ApplicationMailer < ActionMailer::Base
   default from: "demarches-simplifiees.fr <#{CONTACT_EMAIL}>"
   layout 'mailer'
 
+  # Don’t retry to send a message if the server rejects the recipient address
   rescue_from Net::SMTPSyntaxError do |_error|
     message.perform_deliveries = false
   end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -3,6 +3,10 @@ class ApplicationMailer < ActionMailer::Base
   default from: "demarches-simplifiees.fr <#{CONTACT_EMAIL}>"
   layout 'mailer'
 
+  rescue_from Net::SMTPSyntaxError do |_error|
+    message.perform_deliveries = false
+  end
+
   # Attach the procedure logo to the email (if any).
   # Returns the attachment url.
   def attach_logo(procedure)

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe ApplicationMailer, type: :mailer do
+  describe 'dealing with invalid emails' do
+    let(:dossier) { create(:dossier, procedure: build(:simple_procedure)) }
+    subject { DossierMailer.notify_new_draft(dossier) }
+
+    describe 'invalid emails are not sent' do
+      before do
+        allow_any_instance_of(DossierMailer)
+          .to receive(:notify_new_draft)
+          .and_raise(Net::SMTPSyntaxError)
+      end
+
+      it { expect(subject.message).to be_an_instance_of(ActionMailer::Base::NullMail) }
+    end
+
+    describe 'valid emails are sent' do
+      it { expect(subject.message).not_to be_an_instance_of(ActionMailer::Base::NullMail) }
+    end
+  end
+end


### PR DESCRIPTION
Suite à #4419, Active mailer réessaie d'envoyer plusieurs fois des emails en échec lorsque l'email est invalide. Cela déclenche une Net::SMTPSyntaxError, qui correspond au code d'erreur SMTP 501.

SMTP 501, ça veut dire que l'email utilisateur est **sans doute** invalide mais pas forcément:

```
Command is correct and recognised, but the parameters were invalid. You may receive this error when sending to invalid email addresses or to an invalid domain name. Also, it may be caused by drops in communication and problems with antivirus settings.
```

Ça peut être temporaire, du à une erreur de configuration coté réception.

Du coup, mon [approche initiale](https://medium.com/@jplethier/quick-tips-action-mailer-rescue-from-method-8a10defa7f34) qui consiste à blacklister des emails parait une mauvaise idée (c'est un peu trop définitif, même en ajoutant un TTL et en purgeant cette blacklist de temps en temps) ; blacklister des emails, ce n'est pas notre job, notre provider fait déja ça dans certains cas. Par ailleurs, ça ne nous coûte pas cher d'envoyer des mails erronés une fois, ce qu'on ne veut pas, c'est le faire 10x. On veut juste que la file de message ne soit pas engorgée.

On a [pas moyen](https://stackoverflow.com/questions/32363587/deliver-later-with-no-retry) de configurer moins de retry uniquement pour active mailer. C'est peut-être ce qu'on voudrait pourtant: là, on envoie tout simplement pas d'email, et nous n'aurons pas d'erreur.

Tout ça pour dire que le mieux que j'ai trouvé tient en 3 lignes ;)