### PR TITLE
webhook: fix a crash when the Helpscout customer is unknown

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -4,28 +4,27 @@ class WebhookController < ActionController::Base
   def helpscout
     email = params[:customer][:email].downcase
     user = User.find_by(email: email)
-    instructeur = user.instructeur
-    administrateur = user.administrateur
-    html = []
 
-    if user
-      url = manager_user_url(user)
-      html << link_to_manager(user, url)
-    end
-
-    if instructeur
-      url = manager_instructeur_url(instructeur)
-      html << link_to_manager(instructeur, url)
-    end
-
-    if administrateur
-      url = manager_administrateur_url(administrateur)
-      html << link_to_manager(administrateur, url)
-    end
-
-    if html.empty?
+    if user.nil?
       head :not_found
+
     else
+      instructeur = user.instructeur
+      administrateur = user.administrateur
+
+      url = manager_user_url(user)
+      html = [link_to_manager(user, url)]
+
+      if instructeur
+        url = manager_instructeur_url(instructeur)
+        html << link_to_manager(instructeur, url)
+      end
+
+      if administrateur
+        url = manager_administrateur_url(administrateur)
+        html << link_to_manager(administrateur, url)
+      end
+
       render json: { html: html.join('<br>') }
     end
   end

--- a/spec/controllers/webhook_controller_spec.rb
+++ b/spec/controllers/webhook_controller_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe WebhookController, type: :controller do
+  describe '#helpscout' do
+    before { allow(controller).to receive(:verify_signature!).and_return(true) }
+
+    subject(:response) { get :helpscout, params: { customer: { email: customer_email } } }
+
+    let(:payload) { JSON.parse(subject.body) }
+
+    context 'when there is no matching user' do
+      let(:customer_email) { 'not-a-user@exemple.fr' }
+
+      it 'returns an empty response' do
+        expect(subject.status).to eq(404)
+        expect(subject.body).to be_empty
+      end
+    end
+
+    context 'when there is a matching user' do
+      let(:user) { create(:user) }
+      let(:customer_email) { user.email }
+
+      it 'returns a 200 response' do
+        expect(subject.status).to eq(200)
+        expect(subject.body).to be_present
+      end
+
+      it 'returns a link to the User profile in the Manager' do
+        expect(payload).to have_key('html')
+        expect(payload['html']).to have_selector("a[href='#{manager_user_url(user)}']")
+      end
+
+      context 'when there are an associated Instructeur and Administrateur' do
+        let!(:instructeur) { create(:instructeur,    user: user) }
+        let!(:admin)       { create(:administrateur, user: user) }
+
+        it 'returns a link to the Instructeur profile in the Manager' do
+          expect(payload).to have_key('html')
+          expect(payload['html']).to have_selector("a[href='#{manager_instructeur_url(instructeur)}']")
+        end
+
+        it 'returns a link to the Administrateur profile in the Manager' do
+          expect(payload).to have_key('html')
+          expect(payload['html']).to have_selector("a[href='#{manager_administrateur_url(admin)}']")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Crash récent introduit par la PR des emails Instructeurs.

J'ai rajouté des tests au passage.

@LeSim ça t'irait ?