### PR TITLE
Rgaa 3.0 : corrections pour les pages non connectés 

### DIFF
--- a/app/assets/stylesheets/new_design/help_dropdown.scss
+++ b/app/assets/stylesheets/new_design/help_dropdown.scss
@@ -11,7 +11,7 @@
   }
 }
 
-h4.help-dropdown-title {
+.help-dropdown-title {
   font-size: 16px;
   color: $blue;
 }

--- a/app/assets/stylesheets/new_design/new_footer.scss
+++ b/app/assets/stylesheets/new_design/new_footer.scss
@@ -113,3 +113,19 @@ footer {
     margin-bottom: 0;
   }
 }
+
+.footer-site-links {
+  li {
+    display: inline;
+
+
+    &::before {
+      content: "-";
+      margin: $default-spacer;
+    }
+
+    &:first-child::before {
+      content: none;
+    }
+  }
+}

--- a/app/assets/stylesheets/new_design/title.scss
+++ b/app/assets/stylesheets/new_design/title.scss
@@ -1,0 +1,12 @@
+@import "constants";
+
+.huge-title {
+  text-align: center;
+  margin-bottom: 20px;
+  font-size: 35px;
+  font-weight: bold;
+
+  @media (max-width: $two-columns-breakpoint) {
+    font-size: 25px;
+  }
+}

--- a/app/helpers/string_to_html_helper.rb
+++ b/app/helpers/string_to_html_helper.rb
@@ -1,6 +1,6 @@
 module StringToHtmlHelper
-  def string_to_html(str)
-    html_formatted = simple_format(str)
+  def string_to_html(str, wrapper_tag = 'p')
+    html_formatted = simple_format(str, {}, { wrapper_tag: wrapper_tag })
     with_links = html_formatted.gsub(URI.regexp, '<a target="_blank" rel="noopener" href="\0">\0</a>')
     sanitize(with_links, attributes: ['target', 'rel', 'href'])
   end

--- a/app/views/commencer/show.html.haml
+++ b/app/views/commencer/show.html.haml
@@ -2,7 +2,7 @@
 
 .commencer.form
   - if !user_signed_in?
-    %h1 Commencer la démarche
+    %h2.huge-title Commencer la démarche
     = link_to commencer_sign_up_path(path: @procedure.path), class: ['button large expand primary'] do
       Créer un compte
       %span.optional-on-small-screens
@@ -20,7 +20,7 @@
 
     - elsif drafts.count == 1 && not_drafts.count == 0
       - dossier = drafts.first
-      %h1 Vous avez déjà commencé à remplir un dossier
+      %h2.huge-title Vous avez déjà commencé à remplir un dossier
       %p
         Il y a <strong>#{time_ago_in_words(dossier.created_at)}</strong>,
         vous avez commencé à remplir un dossier sur la démarche « #{dossier.procedure.libelle} ».
@@ -29,7 +29,7 @@
 
     - elsif not_drafts.count == 1
       - dossier = not_drafts.first
-      %h1 Vous avez déjà déposé un dossier
+      %h2.huge-title Vous avez déjà déposé un dossier
       %p
         Il y a <strong>#{time_ago_in_words(dossier.en_construction_at)}</strong>,
         vous avez déposé un dossier sur la démarche « #{dossier.procedure.libelle} ».
@@ -37,6 +37,6 @@
       = link_to 'Commencer un nouveau dossier', url_for_new_dossier(@procedure), class: ['button large expand']
 
     - else
-      %h1 Vous avez déjà des dossiers pour cette démarche
+      %h2.huge-title Vous avez déjà des dossiers pour cette démarche
       = link_to 'Voir mes dossiers en cours', dossiers_path, class: ['button large expand primary']
       = link_to 'Commencer un nouveau dossier', url_for_new_dossier(@procedure), class: ['button large expand']

--- a/app/views/layouts/_new_header.haml
+++ b/app/views/layouts/_new_header.haml
@@ -3,7 +3,7 @@
 - dossier = controller.try(:dossier_for_help)
 - procedure = controller.try(:procedure_for_help)
 
-.new-header{ class: current_page?(root_path) ? nil : "new-header-with-border" }
+%header.new-header{ class: current_page?(root_path) ? nil : "new-header-with-border" }
   .header-inner-content
 
     .flex.align-center

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -33,8 +33,9 @@
           Env Test
 
       = render partial: "layouts/new_header"
-      = render partial: "layouts/flash_messages"
-      = content_for?(:content) ? yield(:content) : yield
+      %main
+        = render partial: "layouts/flash_messages"
+        = content_for?(:content) ? yield(:content) : yield
 
       - if content_for?(:footer)
         = content_for(:footer)

--- a/app/views/layouts/commencer/_no_procedure.html.haml
+++ b/app/views/layouts/commencer/_no_procedure.html.haml
@@ -1,5 +1,5 @@
 .no-procedure
-  = image_tag "landing/hero/dematerialiser.svg", class: "paperless-logo"
+  = image_tag "landing/hero/dematerialiser.svg", class: "paperless-logo", alt: "moins de papier"
   .baseline.center
     %h3 Un outil simple
     %p

--- a/app/views/root/_footer.html.haml
+++ b/app/views/root/_footer.html.haml
@@ -6,22 +6,22 @@
         %ul.footer-logos
           %li.footer-text
             Un service fourni par la
-            = link_to "DINSIC", "http://www.modernisation.gouv.fr/"
+            = link_to "DINUM", "http://www.modernisation.gouv.fr/", title: "Direction Interministérielle au Numérique"
             %br
             et incubé par
-            = link_to "beta.gouv.fr", "https://beta.gouv.fr"
+            = link_to "beta.gouv.fr", "https://beta.gouv.fr", title: "le site de Beta.gouv.fr"
           %li
-            = link_to "http://www.modernisation.gouv.fr/" do
+            = link_to "http://www.modernisation.gouv.fr/", title: "DINUM" do
               %span.footer-logo.footer-logo-dinsic{ role: 'img', 'aria-label': 'DINSIC' }
-            = link_to "https://beta.gouv.fr" do
+            = link_to "https://beta.gouv.fr", title: "le site de Beta.gouv.fr" do
               %span.footer-logo.footer-logo-beta-gouv-fr{ role: 'img', 'aria-label': 'beta.gouv.fr' }
 
       %li.footer-column
         %ul.footer-links
           %li.footer-link
-            = link_to "Newsletter", "https://my.sendinblue.com/users/subscribe/js_id/3s2q1/id/1", :class => "footer-link", :target => "_blank", rel: "noopener"
+            = link_to "Newsletter", "https://my.sendinblue.com/users/subscribe/js_id/3s2q1/id/1", :title => "Notre newsletter", :class => "footer-link", :target => "_blank", rel: "noopener"
           %li.footer-link
-            = link_to "Nouveautés", "https://github.com/betagouv/demarches-simplifiees.fr/releases", :class => "footer-link"
+            = link_to "Nouveautés", "https://github.com/betagouv/demarches-simplifiees.fr/releases", :class => "footer-link", :title => "Nos nouveautés"
           %li.footer-link
             = link_to "Statistiques", stats_path, :class => "footer-link", data: { turbolinks: false } # Turbolinks disabled for Chartkick. See Issue #350
           %li.footer-link

--- a/app/views/root/landing.html.haml
+++ b/app/views/root/landing.html.haml
@@ -14,13 +14,13 @@
             %em.hero-tagline-em en ligne
 
         .hero-illustration
-          %img{ :src => image_url("landing/hero/dematerialiser.svg"), alt: "" }
+          %img{ :src => image_url("landing/hero/dematerialiser.svg"), alt: "dématérialisez" }
 
   .landing-panel.usagers-panel
     .container
       .role-panel-wrapper
         .role-panel-30.role-usagers-image
-          %img.role-image{ :src => image_url("landing/roles/usagers.svg"), alt: "" }
+          %img.role-image{ :src => image_url("landing/roles/usagers.svg"), alt: "usager" }
 
         .role-panel-70
           %h1.role-panel-title Vous souhaitez effectuer une demande auprès d'une administration ?

--- a/app/views/shared/_procedure_description.html.haml
+++ b/app/views/shared/_procedure_description.html.haml
@@ -1,5 +1,5 @@
 .procedure-logos
-  = image_tag procedure.logo_url
+  = image_tag procedure.logo_url, alt: "logo #{procedure.libelle}"
   - if procedure.euro_flag
     = image_tag("flag_of_europe.svg", id: 'euro_flag', class: (!procedure.euro_flag ? "hidden" : ""))
 %h2.procedure-title

--- a/app/views/shared/_procedure_description.html.haml
+++ b/app/views/shared/_procedure_description.html.haml
@@ -2,7 +2,7 @@
   = image_tag procedure.logo_url, alt: "logo #{procedure.libelle}"
   - if procedure.euro_flag
     = image_tag("flag_of_europe.svg", id: 'euro_flag', class: (!procedure.euro_flag ? "hidden" : ""))
-%h2.procedure-title
+%h1.procedure-title
   = procedure.libelle
 .procedure-description
   .procedure-description-body.read-more-enabled.read-more-collapsed

--- a/app/views/shared/help/dropdown_items/_email_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_email_item.html.haml
@@ -2,5 +2,5 @@
   = mail_to CONTACT_EMAIL do
     %span.icon.mail
     .dropdown-description
-      %h4.help-dropdown-title Contact technique
+      %span.help-dropdown-title Contact technique
       %p Envoyez nous un message à #{CONTACT_EMAIL}.

--- a/app/views/shared/help/dropdown_items/_faq_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_faq_item.html.haml
@@ -2,5 +2,5 @@
   = link_to FAQ_URL, target: "_blank", rel: "noopener" do
     %span.icon.help
     .dropdown-description
-      %h4.help-dropdown-title Un problème avec le site ?
+      %span.help-dropdown-title Un problème avec le site ?
       %p Trouvez votre réponse dans l’aide en ligne.

--- a/app/views/shared/help/dropdown_items/_messagerie_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_messagerie_item.html.haml
@@ -2,5 +2,5 @@
   = link_to messagerie_dossier_path(dossier) do
     %span.icon.mail
     .dropdown-description
-      %h4.help-dropdown-title= title
+      %span.help-dropdown-title= title
       %p Envoyez directement un message à l’instructeur.

--- a/app/views/shared/help/dropdown_items/_service_item.html.haml
+++ b/app/views/shared/help/dropdown_items/_service_item.html.haml
@@ -1,7 +1,7 @@
 %li.help-dropdown-service
   %span.icon.person
   .dropdown-description
-    %h4.help-dropdown-title= title
+    %span.help-dropdown-title= title
     .help-dropdown-service-action
       %p Contactez directement l’administration :
       %p.help-dropdown-service-item

--- a/app/views/users/_general_footer_row.html.haml
+++ b/app/views/users/_general_footer_row.html.haml
@@ -1,11 +1,7 @@
-= link_to "Accessibilité", accessibilite_path, :class => "footer-link"
-–
-= link_to "CGU", CGU_URL, :class => "footer-link", :target => "_blank", rel: "noopener noreferrer"
-–
-= link_to "Mentions légales", MENTIONS_LEGALES_URL, :class => "footer-link", :target => "_blank", rel: "noopener noreferrer"
-–
-= link_to 'Documentation', DOC_URL
-–
-= contact_link "Contact technique", class: "footer-link", dossier_id: dossier&.id
-–
-= link_to 'Aide', FAQ_URL
+%ul.footer-row.footer-bottom-line.footer-site-links
+  %li>= link_to "Accessibilité", accessibilite_path
+  %li>= link_to "CGU", CGU_URL, target: "_blank", rel: "noopener noreferrer"
+  %li>= link_to "Mentions légales", MENTIONS_LEGALES_URL, target: "_blank", rel: "noopener noreferrer"
+  %li>= link_to 'Documentation', DOC_URL
+  %li>= contact_link "Contact technique", dossier_id: dossier&.id
+  %li>= link_to 'Aide', FAQ_URL

--- a/app/views/users/_procedure_footer.html.haml
+++ b/app/views/users/_procedure_footer.html.haml
@@ -38,5 +38,5 @@
             - politiques.each do |politique|
               %p= politique
 
-    .footer-row.footer-bottom-line
-      = render partial: 'users/general_footer_row', locals: { dossier: dossier }
+    = render partial: 'users/general_footer_row', locals: { dossier: dossier }
+

--- a/app/views/users/_procedure_footer.html.haml
+++ b/app/views/users/_procedure_footer.html.haml
@@ -4,7 +4,7 @@
     - if service.present?
       %ul.footer-row.footer-columns
         %li.footer-column
-          %h3.footer-header Cette démarche est gérée par :
+          %p.footer-header Cette démarche est gérée par :
           %p
             = service.nom
             %br
@@ -13,7 +13,7 @@
             = string_to_html(service.adresse, wrapper_tag = 'span')
 
         %li.footer-column
-          %h3.footer-header Poser une question sur votre dossier :
+          %p.footer-header Poser une question sur votre dossier :
           %p
             - if dossier.present? && dossier.messagerie_available?
               Directement
@@ -34,7 +34,7 @@
         - politiques = politiques_conservation_de_donnees(procedure)
         - if politiques.present?
           %li.footer-column
-            %h3.footer-header Conservation des données :
+            %p.footer-header Conservation des données :
             - politiques.each do |politique|
               %p= politique
 

--- a/app/views/users/_procedure_footer.html.haml
+++ b/app/views/users/_procedure_footer.html.haml
@@ -10,7 +10,7 @@
             %br
             = service.organisme
             %br
-            = string_to_html(service.adresse)
+            = string_to_html(service.adresse, wrapper_tag = 'span')
 
         %li.footer-column
           %h3.footer-header Poser une question sur votre dossier :
@@ -28,7 +28,7 @@
 
           %p
             - horaires = "Horaires : #{formatted_horaires(service.horaires)}"
-            = simple_format(horaires)
+            = simple_format(horaires, {}, wrapper_tag: 'span')
 
 
         - politiques = politiques_conservation_de_donnees(procedure)

--- a/app/views/users/_procedure_footer.html.haml
+++ b/app/views/users/_procedure_footer.html.haml
@@ -2,19 +2,19 @@
   .container
     - service = procedure.service
     - if service.present?
-      %ul.footer-row.footer-columns
-        %li.footer-column
+      .footer-row.footer-columns
+        %ul.footer-column
           %p.footer-header Cette démarche est gérée par :
-          %p
+          %li
             = service.nom
             %br
             = service.organisme
             %br
             = string_to_html(service.adresse, wrapper_tag = 'span')
 
-        %li.footer-column
+        %ul.footer-column
           %p.footer-header Poser une question sur votre dossier :
-          %p
+          %li
             - if dossier.present? && dossier.messagerie_available?
               Directement
               = link_to "par la messagerie", messagerie_dossier_path(dossier)
@@ -22,21 +22,21 @@
               Par email :
               = link_to service.email, "mailto:#{service.email}"
 
-          %p
+          %li
             Par téléphone :
             %a{ href: "tel:#{service.telephone}" }= service.telephone
 
-          %p
+          %li
             - horaires = "Horaires : #{formatted_horaires(service.horaires)}"
             = simple_format(horaires, {}, wrapper_tag: 'span')
 
 
         - politiques = politiques_conservation_de_donnees(procedure)
         - if politiques.present?
-          %li.footer-column
+          %ul.footer-column
             %p.footer-header Conservation des données :
             - politiques.each do |politique|
-              %p= politique
+              %li= politique
 
     = render partial: 'users/general_footer_row', locals: { dossier: dossier }
 

--- a/app/views/users/dossiers/_index_footer.html.haml
+++ b/app/views/users/dossiers/_index_footer.html.haml
@@ -1,4 +1,3 @@
 %footer.procedure-footer
   .container
-    .footer-row.footer-bottom-line
-      = render partial: "users/general_footer_row", locals: { dossier: nil }
+    = render partial: "users/general_footer_row", locals: { dossier: nil }

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -3,7 +3,7 @@
 .auth-form.sign-in-form
 
   = form_for User.new, url: user_session_path, html: { class: "form" } do |f|
-    %h1 Connectez-vous
+    %h2.huge-title Connectez-vous
 
     = f.label :email, "Email"
     = f.text_field :email, autofocus: true


### PR DESCRIPTION
J'ai corrigé ici les grosses erreurs qui ressortaient immédiatement depuis https://app.asqatasun.org/. 

Le référentiel utilisé est le RGAA 3 (le 4 va bientôt sortir). Il n'y a plus d'erreur pour les niveaux A et AA pour les principales pages publiques (non connecté): 

- notre home 
- les pages de connexion / inscription / mot de passe perdu
- les pages commencés des démarches

<img width="1072" alt="Capture d'écran 2019-11-04 17 13 55" src="https://user-images.githubusercontent.com/3593868/68137125-bca0b680-ff26-11e9-931a-69de0b6785db.png">

