### PR TITLE
instructeurs: fix email casing in invitation

### DIFF
--- a/app/controllers/admin/instructeurs_controller.rb
+++ b/app/controllers/admin/instructeurs_controller.rb
@@ -15,7 +15,7 @@ class Admin::InstructeursController < AdminController
     procedure_id = params[:procedure_id]
 
     if @instructeur.nil?
-      invite_instructeur(params[:instructeur][:email])
+      invite_instructeur(email)
     else
       assign_instructeur!
     end


### PR DESCRIPTION
Autre retombée de la migration des emails instructeurs :

When inviting an instructeur, the code first looked up an existing instructeur using the normalized (downcased) email address–but then tried to promote it using the non-normalized version, which failed.

This fixes the issue by always using the normalized email.