### PR TITLE
Déplacement de la méthode active? sur le model User

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -250,7 +250,7 @@ class ApplicationController < ActionController::Base
         payload: {
           DS_SIGN_IN_COUNT: current_user&.sign_in_count,
           DS_CREATED_AT: current_administrateur&.created_at,
-          DS_ACTIVE: current_administrateur&.active?,
+          DS_ACTIVE: current_user&.active?,
           DS_ID: current_administrateur&.id,
           DS_GESTIONNAIRE_ID: current_instructeur&.id,
           DS_ROLES: current_user_roles

--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -46,7 +46,7 @@ class Administrateur < ApplicationRecord
   end
 
   def registration_state
-    if active?
+    if user.active?
       'Actif'
     elsif user.reset_password_period_valid?
       'En attente'
@@ -56,7 +56,7 @@ class Administrateur < ApplicationRecord
   end
 
   def invitation_expired?
-    !active? && !user.reset_password_period_valid?
+    !user.active? && !user.reset_password_period_valid?
   end
 
   def self.reset_password(reset_password_token, password)

--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -59,16 +59,6 @@ class Administrateur < ApplicationRecord
     !user.active? && !user.reset_password_period_valid?
   end
 
-  def self.reset_password(reset_password_token, password)
-    administrateur = self.reset_password_by_token({
-      password: password,
-      password_confirmation: password,
-      reset_password_token: reset_password_token
-    })
-
-    administrateur
-  end
-
   def owns?(procedure)
     procedure.administrateurs.include?(self)
   end

--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -80,8 +80,4 @@ class Administrateur < ApplicationRecord
   def can_be_deleted?
     dossiers.state_instruction_commencee.none? && procedures.none?
   end
-
-  def active?
-    user.last_sign_in_at.present?
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,7 +49,7 @@ class User < ApplicationRecord
   def invite_administrateur!(administration_id)
     reset_password_token = nil
 
-    if !administrateur.active?
+    if !active?
       reset_password_token = set_reset_password_token
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,6 +92,10 @@ class User < ApplicationRecord
     "User:#{id}"
   end
 
+  def active?
+    last_sign_in_at.present?
+  end
+
   private
 
   def link_invites!

--- a/app/services/administrateur_usage_statistics_service.rb
+++ b/app/services/administrateur_usage_statistics_service.rb
@@ -29,7 +29,7 @@ class AdministrateurUsageStatisticsService
     result = {
       ds_sign_in_count: administrateur.user.sign_in_count,
       ds_created_at: administrateur.created_at,
-      ds_active: administrateur.active?,
+      ds_active: administrateur.user.active?,
       ds_id: administrateur.id,
       nb_services: nb_services_by_administrateur_id[administrateur.id],
       nb_instructeurs: nb_instructeurs_by_administrateur_id[administrateur.id],

--- a/spec/features/admin/admin_creation_spec.rb
+++ b/spec/features/admin/admin_creation_spec.rb
@@ -12,7 +12,7 @@ feature 'As an administrateur', js: true do
   end
 
   scenario 'I can register' do
-    expect(new_admin.reload.active?).to be(false)
+    expect(new_admin.reload.user.active?).to be(false)
 
     confirmation_email = open_email(admin_email)
     token_params = confirmation_email.body.match(/token=[^"]+/)
@@ -24,6 +24,6 @@ feature 'As an administrateur', js: true do
 
     expect(page).to have_content 'Mot de passe enregistré'
 
-    expect(new_admin.reload.active?).to be(true)
+    expect(new_admin.reload.user.active?).to be(true)
   end
 end

--- a/spec/models/administrateur_spec.rb
+++ b/spec/models/administrateur_spec.rb
@@ -50,22 +50,4 @@ describe Administrateur, type: :model do
   #     it { expect(subject).to eq([]) }
   #   end
   # end
-
-  describe '#active?' do
-    let!(:administrateur) { create(:administrateur) }
-
-    subject { administrateur.active? }
-
-    context 'when the user has never signed in' do
-      before { administrateur.user.update(last_sign_in_at: nil) }
-
-      it { is_expected.to be false }
-    end
-
-    context 'when the user has already signed in' do
-      before { administrateur.user.update(last_sign_in_at: Time.zone.now) }
-
-      it { is_expected.to be true }
-    end
-  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -191,4 +191,22 @@ describe User, type: :model do
       it { expect(AdministrationMailer).to have_received(:invite_admin).with(user, nil, administration.id) }
     end
   end
+
+  describe '#active?' do
+    let!(:user) { create(:user) }
+
+    subject { user.active? }
+
+    context 'when the user has never signed in' do
+      before { user.update(last_sign_in_at: nil) }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when the user has already signed in' do
+      before { user.update(last_sign_in_at: Time.zone.now) }
+
+      it { is_expected.to be true }
+    end
+  end
 end


### PR DESCRIPTION
En effet, cette méthode utilise `last_sign_in_at` qui est un attribut de `user` qui porte également tous les informations de connexion. C'est donc à `user` de porter cette notion également.