### PR TITLE
Correction de la recherche dans la liste des instructeurs

### DIFF
--- a/app/controllers/admin/assigns_controller.rb
+++ b/app/controllers/admin/assigns_controller.rb
@@ -17,8 +17,9 @@ class Admin::AssignsController < AdminController
 
     not_assign_scope = current_administrateur.instructeurs.where.not(id: assign_scope.ids)
 
-    if params[:filter]
-      not_assign_scope = not_assign_scope.where('users.email LIKE ?', "%#{params[:filter]}%")
+    if params[:filter].present?
+      filter = params[:filter].downcase.strip
+      not_assign_scope = not_assign_scope.where('users.email LIKE ?', "%#{filter}%")
     end
 
     @instructeurs_not_assign = smart_listing_create :instructeurs_not_assign,

--- a/app/controllers/admin/assigns_controller.rb
+++ b/app/controllers/admin/assigns_controller.rb
@@ -18,7 +18,7 @@ class Admin::AssignsController < AdminController
     not_assign_scope = current_administrateur.instructeurs.where.not(id: assign_scope.ids)
 
     if params[:filter]
-      not_assign_scope = not_assign_scope.where("email LIKE ?", "%#{params[:filter]}%")
+      not_assign_scope = not_assign_scope.where('users.email LIKE ?', "%#{params[:filter]}%")
     end
 
     @instructeurs_not_assign = smart_listing_create :instructeurs_not_assign,

--- a/spec/controllers/admin/assigns_controller_spec.rb
+++ b/spec/controllers/admin/assigns_controller_spec.rb
@@ -2,19 +2,45 @@ require 'spec_helper'
 
 describe Admin::AssignsController, type: :controller do
   let(:admin) { create(:administrateur) }
-  let(:procedure) { create :procedure, administrateur: admin }
-  let(:instructeur) { create :instructeur, administrateurs: [admin] }
 
   before do
     sign_in(admin.user)
   end
 
   describe 'GET #show' do
-    subject { get :show, params: { procedure_id: procedure.id } }
-    it { expect(subject.status).to eq(200) }
+    let(:procedure) { create :procedure, administrateur: admin, instructeurs: [instructeur_assigned_1, instructeur_assigned_2] }
+    let!(:instructeur_assigned_1) { create :instructeur, email: 'instructeur_1@ministere_a.gouv.fr', administrateurs: [admin] }
+    let!(:instructeur_assigned_2) { create :instructeur, email: 'instructeur_2@ministere_b.gouv.fr', administrateurs: [admin] }
+    let!(:instructeur_not_assigned_1) { create :instructeur, email: 'instructeur_3@ministere_a.gouv.fr', administrateurs: [admin] }
+    let!(:instructeur_not_assigned_2) { create :instructeur, email: 'instructeur_4@ministere_b.gouv.fr', administrateurs: [admin] }
+    let(:filter) { nil }
+
+    subject! { get :show, params: { procedure_id: procedure.id, filter: filter } }
+
+    it { expect(response.status).to eq(200) }
+
+    it 'sets the assigned and not assigned instructeurs' do
+      expect(assigns(:instructeurs_assign)).to match_array([instructeur_assigned_1, instructeur_assigned_2])
+      expect(assigns(:instructeurs_not_assign)).to match_array([instructeur_not_assigned_1, instructeur_not_assigned_2])
+    end
+
+    context 'with a search filter' do
+      let(:filter) { '@ministere_a.gouv.fr' }
+
+      it 'filters the unassigned instructeurs' do
+        expect(assigns(:instructeurs_not_assign)).to match_array([instructeur_not_assigned_1])
+      end
+
+      it 'does not filter the assigned instructeurs' do
+        expect(assigns(:instructeurs_assign)).to match_array([instructeur_assigned_1, instructeur_assigned_2])
+      end
+    end
   end
 
   describe 'PUT #update' do
+    let(:procedure) { create :procedure, administrateur: admin }
+    let(:instructeur) { create :instructeur, administrateurs: [admin] }
+
     subject { put :update, params: { instructeur_id: instructeur.id, procedure_id: procedure.id, to: 'assign' } }
 
     it { expect(subject).to redirect_to admin_procedure_assigns_path(procedure_id: procedure.id) }

--- a/spec/controllers/admin/assigns_controller_spec.rb
+++ b/spec/controllers/admin/assigns_controller_spec.rb
@@ -34,6 +34,14 @@ describe Admin::AssignsController, type: :controller do
       it 'does not filter the assigned instructeurs' do
         expect(assigns(:instructeurs_assign)).to match_array([instructeur_assigned_1, instructeur_assigned_2])
       end
+
+      context 'when the filter has spaces or a mixed case' do
+        let(:filter) { ' @ministere_A.gouv.fr  ' }
+
+        it 'trims spaces and ignores the case' do
+          expect(assigns(:instructeurs_not_assign)).to match_array([instructeur_not_assigned_1])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
La recherche dans la liste des instructeurs était cassée (depuis la PR de refactor des emails Instructeurs).

Cette PR :

- Corrige la recherche
- Permet de chercher indépendamment de la casse ou des espaces dans l'email

Fix https://sentry.io/organizations/demarches-simplifiees/issues/1314180391/activity/?environment=production&project=1429550