### PR TITLE
editor: insert new champs after the last fully visible champ

### DIFF
--- a/app/javascript/components/TypesDeChampEditor/typeDeChampsReducer.js
+++ b/app/javascript/components/TypesDeChampEditor/typeDeChampsReducer.js
@@ -219,7 +219,7 @@ function getUpdateHandler(typeDeChamp, { queue, flash }) {
 }
 
 function findItemToInsertAfter() {
-  const target = getFirstTarget();
+  const target = getLastVisibleTypeDeChamp();
 
   return {
     target,
@@ -227,8 +227,10 @@ function findItemToInsertAfter() {
   };
 }
 
-function getFirstTarget() {
-  const [target] = document.querySelectorAll('[data-in-view]');
+function getLastVisibleTypeDeChamp() {
+  const typeDeChamps = document.querySelectorAll('[data-in-view]');
+  const target = typeDeChamps[typeDeChamps.length - 1];
+
   if (target) {
     const parentTarget = target.closest('[data-repetition]');
     if (parentTarget) {

--- a/app/javascript/components/TypesDeChampEditor/typeDeChampsReducer.js
+++ b/app/javascript/components/TypesDeChampEditor/typeDeChampsReducer.js
@@ -56,7 +56,9 @@ function addTypeDeChamp(state, typeDeChamps, insertAfter, done) {
       state.flash.success();
       done();
       if (insertAfter) {
-        scrollToComponent(insertAfter.target.nextElementSibling);
+        scrollToComponent(insertAfter.target.nextElementSibling, {
+          duration: 300
+        });
       }
     })
     .catch(message => state.flash.error(message));


### PR DESCRIPTION
Before, when the "Add new champ" button was clicked, the new champ
was inserted after the **first** fully visible champ.

That was most of the time unexpected. The correct behavior would be to
insert the new champ after the **last** fully visible champ.

That's what this commit does. Now the "Add new champ" behavior feels
much less confusing.