### PR TITLE
individual: raise when the individual object cannot be created

### DIFF
--- a/app/models/individual.rb
+++ b/app/models/individual.rb
@@ -10,7 +10,7 @@ class Individual < ApplicationRecord
   GENDER_FEMALE = 'Mme'
 
   def self.create_from_france_connect(fc_information)
-    create(
+    create!(
       nom: fc_information.family_name,
       prenom: fc_information.given_name,
       gender: fc_information.gender == 'female' ? GENDER_FEMALE : GENDER_MALE


### PR DESCRIPTION
Currently, a number of dossiers in production are for procedures for individuals, but don't have a `individual` object.

This is probably because creating the Individual from France Connect infos fails – but fails quietly, and nullify the relationship.

As a first step, we now raise an exception when the creation from FC infos fails. We will then identify the issue, and see if we can fix it – or if we should be resilient to this kind of issues.

Fix https://sentry.io/organizations/demarches-simplifiees/issues/1155816209/activity/?project=1429550