### PR TITLE
Maj message quand messagerie désactivée

### DIFF
--- a/app/assets/stylesheets/new_design/card.scss
+++ b/app/assets/stylesheets/new_design/card.scss
@@ -40,6 +40,10 @@
     .card-title {
       margin-bottom: $default-spacer;
     }
+
+    b {
+      font-weight: bold;
+    }
   }
 
   p:not(:last-of-type) {

--- a/app/views/shared/dossiers/_messagerie.html.haml
+++ b/app/views/shared/dossiers/_messagerie.html.haml
@@ -7,4 +7,4 @@
   - if dossier.messagerie_available?
     = render partial: "shared/dossiers/messages/form", locals: { commentaire: new_commentaire, form_url: form_url }
   - else
-    = render partial: "shared/dossiers/messages/messagerie_disabled", locals: { service: dossier.procedure.service }
+    = render partial: "shared/dossiers/messages/messagerie_disabled", locals: { service: dossier.procedure.service, dossier: dossier }

--- a/app/views/shared/dossiers/messages/_messagerie_disabled.html.haml
+++ b/app/views/shared/dossiers/messages/_messagerie_disabled.html.haml
@@ -12,4 +12,11 @@
       - horaires = "Horaires : #{formatted_horaires(service.horaires)}"
       = simple_format(horaires)
     %p
-      = link_to service.email, "mailto:#{service.email}"
+      = mail_to service.email,
+        service.email,
+        subject: "[demarches-simplifiees.fr] Question sur le dossier Nº #{dossier.id} de la démarche Nº #{dossier.procedure.id}",
+        rel: "noopener noreferrer",
+        target: '_blank'
+
+    %p
+      Penser bien à préciser que votre demande concerne le <b>dossier Nº #{dossier.id}</b>.


### PR DESCRIPTION
Retour de Daniel WIF qui explique qu'il reçoit plein de mails en support et que cela leur prend souvent du temps pour remonter jusqu'au dossier concerné. 

Proposition 1 : cette PR 

Proposition 2 : 

faire un message qui précise directement  le numéro de dossier à mettre dans le mail, du type : 
"Penser bien à préciser que votre demande concerne le numéro de dossier : "numéro de dossier""

Eventuellement mettre la phrase en gras pourrait être bien !