### PR TITLE
Améliore l'accessibilité en encadrant les liens sous focus

### DIFF
--- a/app/assets/stylesheets/new_design/_placeholders.scss
+++ b/app/assets/stylesheets/new_design/_placeholders.scss
@@ -1,3 +1,4 @@
+@import "colors";
 @import "constants";
 
 %horizontal-list {
@@ -16,4 +17,11 @@
 %animation {
   animation-fill-mode: forwards;
   animation-duration: 0.3s;
+}
+
+%outline {
+  &:active,
+  &:focus {
+    outline: 3px solid $blue;
+  }
 }

--- a/app/assets/stylesheets/new_design/buttons.scss
+++ b/app/assets/stylesheets/new_design/buttons.scss
@@ -1,7 +1,10 @@
 @import "colors";
 @import "constants";
+@import "placeholders";
 
 .button {
+  @extend %outline;
+
   display: inline-block;
   padding: 8px 16px;
   border-radius: 30px;
@@ -18,11 +21,6 @@
     cursor: pointer;
     background: $light-grey;
     text-decoration: none;
-  }
-
-  &:active,
-  &:focus {
-    outline: none;
   }
 
   &:disabled {

--- a/app/assets/stylesheets/new_design/custom_reset.scss
+++ b/app/assets/stylesheets/new_design/custom_reset.scss
@@ -1,3 +1,6 @@
+@import "colors";
+@import "placeholders";
+
 html,
 body {
   height: 100%;
@@ -14,5 +17,7 @@ html {
 }
 
 a {
+  @extend %outline;
+
   text-decoration: none;
 }

--- a/app/assets/stylesheets/new_design/forms.scss
+++ b/app/assets/stylesheets/new_design/forms.scss
@@ -1,5 +1,6 @@
 @import "constants";
 @import "colors";
+@import "placeholders";
 
 .form {
   h1 {
@@ -177,6 +178,8 @@
 
   input[type=checkbox],
   input[type=radio] {
+    @extend %outline;
+
     margin-left: 5px;
     margin-right: 4px;
     margin-bottom: 2 * $default-padding;

--- a/app/assets/stylesheets/new_design/landing.scss
+++ b/app/assets/stylesheets/new_design/landing.scss
@@ -365,6 +365,11 @@ $cta-panel-button-border-size: 2px;
     color: #FFFFFF;
     text-decoration: none;
   }
+
+  &:active,
+  &:focus {
+    outline: 3px solid #FFFFFF;
+  }
 }
 
 .cta-panel-button-blue {


### PR DESCRIPTION
Largement inspiré par https://www.gov.uk/ , cette PR encadre en bleu les différents endroits cliquables de l'appli pour faciliter une navigation clavier.

![Screenshot_2019-11-14 demarches-simplifiees fr](https://user-images.githubusercontent.com/907405/68841461-f27f3100-06c4-11ea-88c4-0c5af9bee97b.png)
![Screenshot_2019-11-14 demarches-simplifiees fr(1)](https://user-images.githubusercontent.com/907405/68841464-f4e18b00-06c4-11ea-80d8-6c343ff1c341.png)
![Screenshot_2019-11-14 demarches-simplifiees fr(2)](https://user-images.githubusercontent.com/907405/68841470-f90da880-06c4-11ea-8027-d5868c7ddbc1.png)
![Screenshot_2019-11-14 demarches-simplifiees fr(3)](https://user-images.githubusercontent.com/907405/68841476-fc089900-06c4-11ea-9e46-3d03c9e21006.png)
![Screenshot_2019-11-14 demarches-simplifiees fr(4)](https://user-images.githubusercontent.com/907405/68841483-fe6af300-06c4-11ea-8817-2156d737dcb0.png)
