### PR TITLE
Add depubliee state to procedures

### DIFF
--- a/app/controllers/admin/procedures_controller.rb
+++ b/app/controllers/admin/procedures_controller.rb
@@ -52,7 +52,7 @@ class Admin::ProceduresController < AdminController
   def destroy
     procedure = current_administrateur.procedures.find(params[:id])
 
-    if procedure.publiee_ou_close?
+    if procedure.locked?
       return render json: {}, status: 401
     end
 

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -10,7 +10,7 @@ module Instructeurs
         .procedures
         .with_attached_logo
         .includes(:defaut_groupe_instructeur)
-        .order(closed_at: :desc, archived_at: :desc, published_at: :desc, created_at: :desc)
+        .order(closed_at: :desc, archived_at: :desc, unpublished_at: :desc, published_at: :desc, created_at: :desc)
 
       dossiers = current_instructeur.dossiers.joins(:groupe_instructeur)
       @dossiers_count_per_procedure = dossiers.all_state.group('groupe_instructeurs.procedure_id').reorder(nil).count

--- a/app/dashboards/procedure_dashboard.rb
+++ b/app/dashboards/procedure_dashboard.rb
@@ -25,6 +25,7 @@ class ProcedureDashboard < Administrate::BaseDashboard
     for_individual: Field::Boolean,
     auto_archive_on: Field::DateTime,
     published_at: Field::DateTime,
+    unpublished_at: Field::DateTime,
     hidden_at: Field::DateTime,
     closed_at: Field::DateTime,
     whitelisted_at: Field::DateTime,
@@ -48,7 +49,8 @@ class ProcedureDashboard < Administrate::BaseDashboard
     :libelle,
     :service,
     :dossiers,
-    :published_at
+    :published_at,
+    :unpublished_at
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -210,6 +210,11 @@ type Demarche {
   dateCreation: ISO8601DateTime!
 
   """
+  Date de la dépublication.
+  """
+  dateDepublication: ISO8601DateTime
+
+  """
   Date de la dernière modification.
   """
   dateDerniereModification: ISO8601DateTime!
@@ -308,6 +313,11 @@ enum DemarcheState {
   Close
   """
   close
+
+  """
+  Depubliee
+  """
+  depubliee
 
   """
   Publiée

--- a/app/graphql/types/demarche_type.rb
+++ b/app/graphql/types/demarche_type.rb
@@ -26,6 +26,7 @@ module Types
     field :date_creation, GraphQL::Types::ISO8601DateTime, "Date de la création.", null: false, method: :created_at
     field :date_publication, GraphQL::Types::ISO8601DateTime, "Date de la publication.", null: false, method: :published_at
     field :date_derniere_modification, GraphQL::Types::ISO8601DateTime, "Date de la dernière modification.", null: false, method: :updated_at
+    field :date_depublication, GraphQL::Types::ISO8601DateTime, "Date de la dépublication.", null: true, method: :unpublished_at
     field :date_fermeture, GraphQL::Types::ISO8601DateTime, "Date de la fermeture.", null: true, method: :closed_at
 
     field :groupe_instructeurs, [Types::GroupeInstructeurType], null: false

--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -14,7 +14,7 @@ class Administrateur < ApplicationRecord
   before_validation -> { sanitize_email(:email) }
 
   scope :inactive, -> { joins(:user).where(users: { last_sign_in_at: nil }) }
-  scope :with_publiees_ou_closes, -> { joins(:procedures).where(procedures: { aasm_state: [:publiee, :archivee, :close] }) }
+  scope :with_publiees_ou_closes, -> { joins(:procedures).where(procedures: { aasm_state: [:publiee, :archivee, :close, :depubliee] }) }
 
   # validate :password_complexity, if: Proc.new { |a| Devise.password_length.include?(a.password.try(:size)) }
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -267,7 +267,7 @@ class Dossier < ApplicationRecord
   end
 
   def can_transition_to_en_construction?
-    !procedure.close? && brouillon?
+    brouillon? && procedure.dossier_can_transition_to_en_construction?
   end
 
   def can_be_updated_by_user?

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -46,8 +46,8 @@ class Procedure < ApplicationRecord
   default_scope { where(hidden_at: nil) }
   scope :brouillons,            -> { where(aasm_state: :brouillon) }
   scope :publiees,              -> { where(aasm_state: :publiee) }
-  scope :closes,                -> { where(aasm_state: [:archivee, :close]) }
-  scope :publiees_ou_closes,    -> { where(aasm_state: [:publiee, :close, :archivee]) }
+  scope :closes,                -> { where(aasm_state: [:archivee, :close, :depubliee]) }
+  scope :publiees_ou_closes,    -> { where(aasm_state: [:publiee, :close, :archivee, :depubliee]) }
   scope :by_libelle,            -> { order(libelle: :asc) }
   scope :created_during,        -> (range) { where(created_at: range) }
   scope :cloned_from_library,   -> { where(cloned_from_library: true) }
@@ -77,7 +77,7 @@ class Procedure < ApplicationRecord
   validates :lien_site_web, presence: true, if: :publiee?
   validate :validate_for_publication, on: :publication
   validate :check_juridique
-  validates :path, presence: true, format: { with: /\A[a-z0-9_\-]{3,50}\z/ }, uniqueness: { scope: [:path, :closed_at, :archived_at, :hidden_at], case_sensitive: false }
+  validates :path, presence: true, format: { with: /\A[a-z0-9_\-]{3,50}\z/ }, uniqueness: { scope: [:path, :closed_at, :hidden_at, :unpublished_at], case_sensitive: false }
   # FIXME: remove duree_conservation_required flag once all procedures are converted to the new style
   validates :duree_conservation_dossiers_dans_ds, allow_nil: false, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: MAX_DUREE_CONSERVATION }, if: :durees_conservation_required
   validates :duree_conservation_dossiers_hors_ds, allow_nil: false, numericality: { only_integer: true, greater_than_or_equal_to: 0 }, if: :durees_conservation_required
@@ -97,10 +97,12 @@ class Procedure < ApplicationRecord
     state :publiee
     state :close
     state :hidden
+    state :depubliee
 
     event :publish, before: :before_publish, after: :after_publish do
       transitions from: :brouillon, to: :publiee
       transitions from: :close, to: :publiee
+      transitions from: :depubliee, to: :publiee
     end
 
     event :close, after: :after_close do
@@ -112,6 +114,10 @@ class Procedure < ApplicationRecord
       transitions from: :publiee, to: :hidden
       transitions from: :close, to: :hidden
     end
+
+    event :unpublish, after: :after_unpublish do
+      transitions from: :publiee, to: :depubliee
+    end
   end
 
   def publish_or_reopen!(administrateur)
@@ -122,7 +128,7 @@ class Procedure < ApplicationRecord
 
       other_procedure = other_procedure_with_path(path)
       if other_procedure.present? && administrateur.owns?(other_procedure)
-        other_procedure.close!
+        other_procedure.unpublish!
       end
 
       publish!
@@ -282,15 +288,15 @@ class Procedure < ApplicationRecord
   end
 
   def locked?
-    publiee_ou_close?
+    publiee? || close? || depubliee?
   end
 
   def accepts_new_dossiers?
-    !close?
+    publiee? || brouillon?
   end
 
-  def publiee_ou_close?
-    publiee? || close?
+  def dossier_can_transition_to_en_construction?
+    accepts_new_dossiers? || depubliee?
   end
 
   def expose_legacy_carto_api?
@@ -379,6 +385,7 @@ class Procedure < ApplicationRecord
     procedure.aasm_state = :brouillon
     procedure.archived_at = nil
     procedure.closed_at = nil
+    procedure.unpublished_at = nil
     procedure.published_at = nil
     procedure.lien_notice = nil
 
@@ -615,7 +622,7 @@ class Procedure < ApplicationRecord
   end
 
   def before_publish
-    update!(archived_at: nil, closed_at: nil)
+    update!(archived_at: nil, closed_at: nil, unpublished_at: nil)
   end
 
   def after_publish
@@ -633,6 +640,10 @@ class Procedure < ApplicationRecord
     update!(hidden_at: now)
     dossiers.update_all(hidden_at: now)
     purge_export_files
+  end
+
+  def after_unpublish
+    update!(unpublished_at: Time.zone.now)
   end
 
   def update_juridique_required

--- a/app/views/admin/procedures/_list.html.haml
+++ b/app/views/admin/procedures/_list.html.haml
@@ -19,13 +19,13 @@
         %td.col-xs-6= link_to(procedure.libelle, admin_procedure_href)
         - if procedure.publiee?
           %td.procedure-lien= link_to(procedure_lien(procedure), procedure_lien(procedure))
-        - if procedure.publiee_ou_close?
+        - if procedure.locked?
           %td= link_to(procedure.published_at.present? ? try_format_datetime(procedure.published_at) : "", admin_procedure_href)
         - else
           %td= link_to(try_format_datetime(procedure.created_at), admin_procedure_href)
         %td
           = link_to('Cloner', admin_procedure_clone_path(procedure.id), data: { method: :put }, class: 'btn-sm btn-primary clone-btn')
-          - if !procedure.publiee_ou_close?
+          - if !procedure.locked?
             = link_to('X', url_for(controller: 'admin/procedures', action: :destroy, id: procedure.id), data: { method: :delete, confirm: "Confirmez-vous la suppression de la démarche ? \n\n Attention : toute suppression est définitive et s’appliquera aux éventuels autres administrateurs de cette démarche !" }, class: 'btn-sm btn-danger')
 
   = smart_listing.paginate

--- a/app/views/instructeurs/procedures/_list.html.haml
+++ b/app/views/instructeurs/procedures/_list.html.haml
@@ -1,0 +1,63 @@
+%ul.procedure-list
+  - procedures.each do |p|
+    %li.procedure-item.flex.align-start
+      = link_to(instructeur_procedure_path(p)) do
+        .flex
+
+          .procedure-logo{ style: "background-image: url(#{p.logo_url})" }
+
+          .procedure-details
+            %p.procedure-title
+              = procedure_libelle p
+            %ul.procedure-stats.flex
+              %li
+                %object
+                  = link_to(instructeur_procedure_path(p, statut: 'a-suivre')) do
+                    - a_suivre_count = dossiers_a_suivre_count_per_procedure[p.id] || 0
+                    .stats-number
+                      = a_suivre_count
+                    .stats-legend
+                      à suivre
+              %li
+                %object
+                  = link_to(instructeur_procedure_path(p, statut: 'suivis')) do
+                    - if current_instructeur.procedures_with_notifications(:en_cours).include?(p)
+                      %span.notifications{ 'aria-label': "notifications" }
+                    - followed_count = followed_dossiers_count_per_procedure[p.id] || 0
+                    .stats-number
+                      = followed_count
+                    .stats-legend
+                      = t('pluralize.followed', count: followed_count)
+              %li
+                %object
+                  = link_to(instructeur_procedure_path(p, statut: 'traites')) do
+                    - if current_instructeur.procedures_with_notifications(:termine).include?(p)
+                      %span.notifications{ 'aria-label': "notifications" }
+                    - termines_count = dossiers_termines_count_per_procedure[p.id] || 0
+                    .stats-number
+                      = termines_count
+                    .stats-legend
+                      = t('pluralize.processed', count: termines_count)
+              %li
+                %object
+                  = link_to(instructeur_procedure_path(p, statut: 'tous')) do
+                    - dossier_count = dossiers_count_per_procedure[p.id] || 0
+                    .stats-number
+                      = dossier_count
+                    .stats-legend
+                      = t('pluralize.case', count: dossier_count)
+              %li
+                %object
+                  = link_to(instructeur_procedure_path(p, statut: 'archives')) do
+                    - archived_count = dossiers_archived_count_per_procedure[p.id] || 0
+                    .stats-number
+                      = archived_count
+                    .stats-legend
+                      = t('pluralize.archived', count: archived_count)
+
+          - if p.close?
+            .procedure-status
+              %span.label Close
+          - elsif p.depubliee?
+            .procedure-status
+              %span.label Dépubliée

--- a/app/views/instructeurs/procedures/index.html.haml
+++ b/app/views/instructeurs/procedures/index.html.haml
@@ -3,64 +3,9 @@
 .container
   %h1.page-title Démarches
 
-  %ul.procedure-list
-    - @procedures.each do |p|
-      %li.procedure-item.flex.align-start
-        = link_to(instructeur_procedure_path(p)) do
-          .flex
-
-            .procedure-logo{ style: "background-image: url(#{p.logo_url})" }
-
-            .procedure-details
-              %p.procedure-title
-                = procedure_libelle p
-
-              %ul.procedure-stats.flex
-                %li
-                  %object
-                    = link_to(instructeur_procedure_path(p, statut: 'a-suivre')) do
-                      - a_suivre_count = @dossiers_a_suivre_count_per_procedure[p.id] || 0
-                      .stats-number
-                        = a_suivre_count
-                      .stats-legend
-                        à suivre
-                %li
-                  %object
-                    = link_to(instructeur_procedure_path(p, statut: 'suivis')) do
-                      - if current_instructeur.procedures_with_notifications(:en_cours).include?(p)
-                        %span.notifications{ 'aria-label': "notifications" }
-                      - followed_count = @followed_dossiers_count_per_procedure[p.id] || 0
-                      .stats-number
-                        = followed_count
-                      .stats-legend
-                        = t('pluralize.followed', count: followed_count)
-                %li
-                  %object
-                    = link_to(instructeur_procedure_path(p, statut: 'traites')) do
-                      - if current_instructeur.procedures_with_notifications(:termine).include?(p)
-                        %span.notifications{ 'aria-label': "notifications" }
-                      - termines_count = @dossiers_termines_count_per_procedure[p.id] || 0
-                      .stats-number
-                        = termines_count
-                      .stats-legend
-                        = t('pluralize.processed', count: termines_count)
-                %li
-                  %object
-                    = link_to(instructeur_procedure_path(p, statut: 'tous')) do
-                      - dossier_count = @dossiers_count_per_procedure[p.id] || 0
-                      .stats-number
-                        = dossier_count
-                      .stats-legend
-                        = t('pluralize.case', count: dossier_count)
-                %li
-                  %object
-                    = link_to(instructeur_procedure_path(p, statut: 'archives')) do
-                      - archived_count = @dossiers_archived_count_per_procedure[p.id] || 0
-                      .stats-number
-                        = archived_count
-                      .stats-legend
-                        = t('pluralize.archived', count: archived_count)
-
-            - if p.close?
-              .procedure-status
-                %span.label Close
+  = render partial: 'instructeurs/procedures/list', locals: { procedures: @procedures,
+    dossiers_count_per_procedure: @dossiers_count_per_procedure,
+    dossiers_a_suivre_count_per_procedure: @dossiers_a_suivre_count_per_procedure,
+    dossiers_archived_count_per_procedure: @dossiers_archived_count_per_procedure,
+    dossiers_termines_count_per_procedure: @dossiers_termines_count_per_procedure,
+    followed_dossiers_count_per_procedure: @followed_dossiers_count_per_procedure }

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -164,7 +164,7 @@ fr:
           attributes:
             path:
               taken: est déjà utilisé par une démarche. Vous ne pouvez pas l’utiliser car il appartient à un autre administrateur.
-              taken_can_be_claimed: est identique à celui d’une autre de vos démarches publiées. Si vous publiez cette démarche, l’ancienne sera archivée et ne sera plus accessible au public.
+              taken_can_be_claimed: est identique à celui d’une autre de vos démarches publiées. Si vous publiez cette démarche, l’ancienne sera dépubliée et ne sera plus accessible au public. Les utilisateurs qui ont commencé un brouillon vont pouvoir le déposer.
               invalid: n'est pas valide. Il doit comporter au moins 3 caractères, au plus 50 caractères et seuls les caractères a-z, 0-9, '_' et '-' sont autorisés.
 
   errors:

--- a/db/migrate/20191127113700_add_unpublished_at_to_procedures.rb
+++ b/db/migrate/20191127113700_add_unpublished_at_to_procedures.rb
@@ -1,0 +1,5 @@
+class AddUnpublishedAtToProcedures < ActiveRecord::Migration[5.2]
+  def change
+    add_column :procedures, :unpublished_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -490,6 +490,7 @@ ActiveRecord::Schema.define(version: 2019_11_28_081324) do
     t.boolean "xlsx_export_queued"
     t.boolean "ods_export_queued"
     t.datetime "closed_at"
+    t.datetime "unpublished_at"
     t.index ["declarative_with_state"], name: "index_procedures_on_declarative_with_state"
     t.index ["hidden_at"], name: "index_procedures_on_hidden_at"
     t.index ["parent_procedure_id"], name: "index_procedures_on_parent_procedure_id"

--- a/spec/controllers/admin/procedures_controller_spec.rb
+++ b/spec/controllers/admin/procedures_controller_spec.rb
@@ -184,8 +184,8 @@ describe Admin::ProceduresController, type: :controller do
           expect(flash[:notice]).to have_content 'Démarche publiée'
         end
 
-        it 'archive previous procedure' do
-          expect(procedure2.close?).to be_truthy
+        it 'depubliee previous procedure' do
+          expect(procedure2.depubliee?).to be_truthy
         end
       end
 

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -168,6 +168,14 @@ FactoryBot.define do
       end
     end
 
+    trait :unpublished do
+      after(:build) do |procedure, _evaluator|
+        procedure.path = generate(:published_path)
+        procedure.publish!
+        procedure.unpublish!
+      end
+    end
+
     trait :hidden do
       after(:build) do |procedure, _evaluator|
         procedure.path = generate(:published_path)

--- a/spec/features/admin/procedure_cloning_spec.rb
+++ b/spec/features/admin/procedure_cloning_spec.rb
@@ -29,7 +29,7 @@ feature 'As an administrateur I wanna clone a procedure', js: true do
 
       within '#publish-modal' do
         expect(find_field('procedure_path').value).to eq 'libelle-de-la-procedure'
-        expect(page).to have_text('ancienne sera archivée')
+        expect(page).to have_text('ancienne sera dépubliée')
         fill_in 'lien_site_web', with: 'http://some.website'
         click_on 'publish'
       end


### PR DESCRIPTION
L'idée de cette PR est d'introduire un nouvel état de démarche : `dépubliée`. Cet état clôt le dépôt de brouillons, mais laisse les usagers déposer les brouillons en cours. Lors du remplacement de la démarche par une nouvelle version on assigne à cette dernière la procédure canonique. Ce lien nous permet d'afficher les "millésimes" des démarches aux instructeurs et ainsi facilite leur travail.

<img width="1382" alt="Screenshot 2019-11-14 at 17 00 47" src="https://user-images.githubusercontent.com/12428/68873730-596e0b80-0700-11ea-9084-b999e560d855.png">
