### PR TITLE
Autosave : id unique de form ; brouillon par défaut

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -147,13 +147,13 @@ module Users
         flash.now.alert = errors
         render :brouillon
       else
-        if save_draft?
-          flash.now.notice = 'Votre brouillon a bien été sauvegardé.'
-          render :brouillon
-        else
+        if passage_en_construction?
           @dossier.en_construction!
           NotificationMailer.send_initiated_notification(@dossier).deliver_later
           redirect_to merci_dossier_path(@dossier)
+        else
+          flash.now.notice = 'Votre brouillon a bien été sauvegardé.'
+          render :brouillon
         end
       end
     end
@@ -368,7 +368,7 @@ module Users
     end
 
     def save_draft?
-      dossier.brouillon? && params[:save_draft]
+      dossier.brouillon? && !params[:submit_draft]
     end
   end
 end

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -43,13 +43,14 @@
         - if dossier.brouillon?
           = f.button 'Enregistrer le brouillon',
             formnovalidate: true,
-            name: :save_draft,
             value: true,
             class: 'button send secondary',
             data: { 'disable-with': "Envoi en cours…" }
 
           - if dossier.can_transition_to_en_construction?
             = f.button 'Déposer le dossier',
+              name: :submit_draft,
+              value: true,
               class: 'button send primary',
               disabled: !current_user.owns?(dossier),
               data: { 'disable-with': "Envoi en cours…" }

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -2,13 +2,13 @@
   = render partial: "shared/dossiers/submit_is_over", locals: { dossier: dossier }
 
   - if apercu
-    - form_options = { url: '', method: :get, html: { class: 'form', multipart: true } }
+    - form_options = { url: '', method: :get }
   - elsif dossier.brouillon?
-    - form_options = { url: brouillon_dossier_url(dossier), method: :patch, html: { class: 'form', multipart: true } }
+    - form_options = { url: brouillon_dossier_url(dossier), method: :patch }
   - else
-    - form_options = { url: modifier_dossier_url(dossier), method: :patch, html: { class: 'form', multipart: true } }
+    - form_options = { url: modifier_dossier_url(dossier), method: :patch }
 
-  = form_for dossier, form_options do |f|
+  = form_for dossier, form_options.merge({ html: { id: 'dossier-edit-form', class: 'form', multipart: true } }) do |f|
 
     .prologue
       %p.mandatory-explanation

--- a/app/views/users/dossiers/brouillon.html.haml
+++ b/app/views/users/dossiers/brouillon.html.haml
@@ -3,8 +3,9 @@
 - content_for :footer do
   = render partial: "users/procedure_footer", locals: { procedure: @dossier.procedure, dossier: @dossier }
 
-.dossier-header.sub-header
-  .container
-    = render partial: "shared/dossiers/header", locals: { dossier: @dossier, apercu: false }
+#dossier-draft
+  .dossier-header.sub-header
+    .container
+      = render partial: "shared/dossiers/header", locals: { dossier: @dossier, apercu: false }
 
-= render partial: "shared/dossiers/edit", locals: { dossier: @dossier, apercu: false }
+  = render partial: "shared/dossiers/edit", locals: { dossier: @dossier, apercu: false }

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -100,38 +100,38 @@ describe Users::DossiersController, type: :controller do
     let(:user) { create(:user) }
     let(:asked_dossier) { create(:dossier) }
     let(:ensure_authorized) { :forbid_invite_submission! }
-    let(:draft) { false }
+    let(:submit) { true }
 
     before do
-      @controller.params = @controller.params.merge(dossier_id: asked_dossier.id, save_draft: draft)
+      @controller.params = @controller.params.merge(dossier_id: asked_dossier.id, submit_draft: submit)
       allow(@controller).to receive(:current_user).and_return(user)
       allow(@controller).to receive(:redirect_to)
     end
 
     context 'when a user save their own draft' do
       let(:asked_dossier) { create(:dossier, user: user) }
-      let(:draft) { true }
+      let(:submit) { false }
 
       it_behaves_like 'does not redirect nor flash'
     end
 
     context 'when a user submit their own dossier' do
       let(:asked_dossier) { create(:dossier, user: user) }
-      let(:draft) { false }
+      let(:submit) { true }
 
       it_behaves_like 'does not redirect nor flash'
     end
 
     context 'when an invite save the draft for a dossier where they where invited' do
       before { create(:invite, dossier: asked_dossier, user: user) }
-      let(:draft) { true }
+      let(:submit) { false }
 
       it_behaves_like 'does not redirect nor flash'
     end
 
     context 'when an invite submit a dossier where they where invited' do
       before { create(:invite, dossier: asked_dossier, user: user) }
-      let(:draft) { false }
+      let(:submit) { true }
 
       it_behaves_like 'redirects and flashes'
     end
@@ -394,7 +394,7 @@ describe Users::DossiersController, type: :controller do
         }
       }
     end
-    let(:payload) { submit_payload }
+    let(:payload) { submit_payload.merge(submit_draft: true) }
 
     subject do
       Timecop.freeze(now) do
@@ -480,7 +480,7 @@ describe Users::DossiersController, type: :controller do
       it { expect(flash.alert).to eq(['Le champ l doit être rempli.']) }
 
       context 'and the user saves a draft' do
-        let(:payload) { submit_payload.merge(save_draft: true) }
+        let(:payload) { submit_payload.except(:submit_draft) }
 
         it { expect(response).to render_template(:brouillon) }
         it { expect(flash.notice).to eq('Votre brouillon a bien été sauvegardé.') }
@@ -510,7 +510,7 @@ describe Users::DossiersController, type: :controller do
       let!(:invite) { create(:invite, dossier: dossier, user: user) }
 
       context 'and the invite saves a draft' do
-        let(:payload) { submit_payload.merge(save_draft: true) }
+        let(:payload) { submit_payload.except(:submit_draft) }
 
         before do
           first_champ.type_de_champ.update(mandatory: true, libelle: 'l')


### PR DESCRIPTION
Premiers morceaux de code préparatoire pour l'autosave des brouillons :

- Attribution d'un ID unique de form facilement identifiable ensuite ;
- L'action par défaut du POST sur un brouillon devient d'enregistrer le brouillon (plutôt que de soumettre le dossier).

L'action par défaut, c'est parce que je voudrais que le POST de l'autosave (qui se fera en JS) soit le moins risqué possible.

Donc par défaut, s'il n'y a pas de paramètres spéciaux, on enregistre le brouillon. Le dossier n'est maintenant déposé que si le bouton "Déposer" a été cliqué (et donc que sa `value` a été envoyée dans le formulaire).