### PR TITLE
auto-archive badly occurs in UTC time 

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -163,8 +163,8 @@ class StatsController < ApplicationController
   def contact_percentage
     number_of_months = 13
 
-    from = Date.today.prev_month(number_of_months)
-    to = Date.today.prev_month
+    from = Time.zone.today.prev_month(number_of_months)
+    to = Time.zone.today.prev_month
 
     adapter = Helpscout::UserConversationsAdapter.new(from, to)
     if !adapter.can_fetch_reports?

--- a/app/helpers/commentaire_helper.rb
+++ b/app/helpers/commentaire_helper.rb
@@ -18,7 +18,7 @@ module CommentaireHelper
   end
 
   def commentaire_date(commentaire)
-    is_current_year = (commentaire.created_at.year == Date.current.year)
+    is_current_year = (commentaire.created_at.year == Time.zone.today.year)
     template = is_current_year ? :message_date : :message_date_with_year
     I18n.l(commentaire.created_at, format: template)
   end

--- a/app/jobs/auto_archive_procedure_job.rb
+++ b/app/jobs/auto_archive_procedure_job.rb
@@ -2,7 +2,7 @@ class AutoArchiveProcedureJob < ApplicationJob
   queue_as :cron
 
   def perform(*args)
-    Procedure.publiees.where("auto_archive_on <= ?", Date.today).each do |procedure|
+    Procedure.publiees.where("auto_archive_on <= ?", Time.zone.today).each do |procedure|
       procedure
         .dossiers
         .state_en_construction

--- a/app/lib/helpscout/user_conversations_adapter.rb
+++ b/app/lib/helpscout/user_conversations_adapter.rb
@@ -35,7 +35,7 @@ class Helpscout::UserConversationsAdapter
   end
 
   def fetch_productivity_report(year, month)
-    if year == Date.today.year && month == Date.today.month
+    if year == Time.zone.today.year && month == Time.zone.today.month
       raise ArgumentError, 'The report for the current month will change in the future, and cannot be cached.'
     end
 

--- a/app/models/champs/date_champ.rb
+++ b/app/models/champs/date_champ.rb
@@ -6,11 +6,11 @@ class Champs::DateChamp < Champ
   end
 
   def to_s
-    value.present? ? I18n.l(Date.parse(value)) : ""
+    value.present? ? I18n.l(Time.zone.parse(value), format: '%d %B %Y') : ""
   end
 
   def for_tag
-    value.present? ? I18n.l(Date.parse(value)) : ""
+    value.present? ? I18n.l(Time.zone.parse(value), format: '%d %B %Y') : ""
   end
 
   private
@@ -18,7 +18,7 @@ class Champs::DateChamp < Champ
   def format_before_save
     self.value =
       begin
-        Date.parse(value).iso8601
+        Time.zone.parse(value).to_date.iso8601
       rescue
         nil
       end

--- a/spec/controllers/france_connect/particulier_controller_spec.rb
+++ b/spec/controllers/france_connect/particulier_controller_spec.rb
@@ -107,7 +107,7 @@ describe FranceConnect::ParticulierController, type: :controller do
 
           before { subject }
 
-          it { expect(stored_fci).to have_attributes(user_info.merge(birthdate: Date.parse(birthdate))) }
+          it { expect(stored_fci).to have_attributes(user_info.merge(birthdate: Time.zone.parse(birthdate).to_datetime)) }
         end
 
         it { is_expected.to redirect_to(root_path) }

--- a/spec/jobs/auto_archive_procedure_job_spec.rb
+++ b/spec/jobs/auto_archive_procedure_job_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe AutoArchiveProcedureJob, type: :job do
   let!(:procedure) { create(:procedure, :published, :with_instructeur, auto_archive_on: nil) }
   let!(:procedure_hier) { create(:procedure, :published, :with_instructeur, auto_archive_on: 1.day.ago) }
-  let!(:procedure_aujourdhui) { create(:procedure, :published, :with_instructeur, auto_archive_on: Date.today) }
+  let!(:procedure_aujourdhui) { create(:procedure, :published, :with_instructeur, auto_archive_on: Time.zone.today) }
   let!(:procedure_demain) { create(:procedure, :published, :with_instructeur, auto_archive_on: 1.day.from_now) }
 
   subject { AutoArchiveProcedureJob.new.perform }

--- a/spec/services/bill_signature_service_spec.rb
+++ b/spec/services/bill_signature_service_spec.rb
@@ -4,7 +4,7 @@ describe BillSignatureService do
   describe ".grouped_unsigned_operation_until" do
     subject { BillSignatureService.grouped_unsigned_operation_until(date).length }
 
-    let(:date) { Date.today }
+    let(:date) { Time.zone.today }
 
     context "when operations of several days need to be signed" do
       before do

--- a/spec/services/france_connect_service_spec.rb
+++ b/spec/services/france_connect_service_spec.rb
@@ -33,7 +33,7 @@ describe FranceConnectService do
       expect(subject).to have_attributes({
         given_name: given_name,
         family_name: family_name,
-        birthdate: Date.parse(birthdate),
+        birthdate: Time.zone.parse(birthdate).to_date,
         birthplace: birthplace,
         gender: gender,
         email_france_connect: email,


### PR DESCRIPTION
A priori le code du job de cloture des démarches utilise les fonctions Date.today au lieu de Time.zone.today. Du coup sur Tahiti la cloture se faisait 10 heures trop tot à 14h ;-)
Mais peut-être que votre serveur est en temps Paris et que cela ne pose pas de pb, ici il est en temps UTC. Donc pas de souci à refuser la PR :-)