### PR TITLE
dossiers controller: render JSON if needed

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -143,18 +143,19 @@ module Users
 
       errors = update_dossier_and_compute_errors
 
-      if errors.present?
+      if passage_en_construction? && errors.blank?
+        @dossier.en_construction!
+        NotificationMailer.send_initiated_notification(@dossier).deliver_later
+        return redirect_to(merci_dossier_path(@dossier))
+      elsif errors.present?
         flash.now.alert = errors
-        render :brouillon
       else
-        if passage_en_construction?
-          @dossier.en_construction!
-          NotificationMailer.send_initiated_notification(@dossier).deliver_later
-          redirect_to merci_dossier_path(@dossier)
-        else
-          flash.now.notice = 'Votre brouillon a bien été sauvegardé.'
-          render :brouillon
-        end
+        flash.now.notice = 'Votre brouillon a bien été sauvegardé.'
+      end
+
+      respond_to do |format|
+        format.html { render :brouillon }
+        format.json { head :ok }
       end
     end
 


### PR DESCRIPTION
_Part of the draft autosave._

When receiving a request that expects JSON, return a simple '200'.

This avoids the unecessary work of rendering all the HTML page when autosaving a draft from a Javascript request.