### PR TITLE
javascript: make utils resilient to missing elements

### DIFF
--- a/app/javascript/shared/utils.js
+++ b/app/javascript/shared/utils.js
@@ -5,16 +5,16 @@ import debounce from 'debounce';
 export { debounce };
 export const { fire, ajax } = Rails;
 
-export function show({ classList }) {
-  classList.remove('hidden');
+export function show(el) {
+  el && el.classList.remove('hidden');
 }
 
-export function hide({ classList }) {
-  classList.add('hidden');
+export function hide(el) {
+  el && el.classList.add('hidden');
 }
 
-export function toggle({ classList }) {
-  classList.toggle('hidden');
+export function toggle(el) {
+  el && el.classList.toggle('hidden');
 }
 
 export function delegate(eventNames, selector, callback) {


### PR DESCRIPTION
_Fait partie de l'enregistrement automatique des brouillons._

Dans le code d'UI de l'autosave, j'ai souvent besoin de désactiver un élément. Mais comme ce sont des opérations asynchrones, il se peut que l'élément ne soit plus présent sur la page.

Dans ce cas, je gagne à pouvoir juste faire un `disable(document.querySelector(…))`, et que si l'élément n'existe pas ça soit un no-op – plutôt que de mettre un `if element` à chaque fois.

C'est aussi la même chose que jQuery, où `$('.element-qui-n-existe-pas').hide()` est un no-op.

@tchak tu en penses quoi ? Tu crois que ça se tient d'avaler ce cas dans les helpers ?