### PR TITLE
Fix UnknownFormat durant les exports de procédures

### DIFF
--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -210,12 +210,13 @@ module Instructeurs
       notice_message = "Nous générons cet export. Lorsque celui-ci sera disponible, vous recevrez une notification par email accompagnée d'un lien de téléchargement."
       if procedure.should_generate_export?(export_format)
         procedure.queue_export(current_instructeur, export_format)
+        flash.notice = notice_message
 
         respond_to do |format|
           format.js do
-            flash.notice = notice_message
             @procedure = procedure
           end
+          format.all { redirect_to procedure }
         end
       elsif procedure.export_queued?(export_format)
         flash.notice = notice_message


### PR DESCRIPTION
https://sentry.io/organizations/demarches-simplifiees/issues/1295388828/?project=1429550&referrer=webhooks_plugin

Normalement, cette route est appelée via JS, mais il se trouve qu'on peut la déclencher «à la main» en allant sur `procedures/:id/download_export?export_format=csv` (par exemple avec ctrl-clic).
Dans ce cas, on ne rentre pas dans le cas géré par `format.js`, et bien que l'export soit généré, cela déclenche une exception.
Cette PR corrige ce comportement.