### PR TITLE
add rescue_from to UserDeviseMailer

### DIFF
--- a/app/mailers/devise_user_mailer.rb
+++ b/app/mailers/devise_user_mailer.rb
@@ -4,6 +4,11 @@ class DeviseUserMailer < Devise::Mailer
   include Devise::Controllers::UrlHelpers # Optional. eg. `confirmation_url`
   layout 'mailers/layout'
 
+  # Don’t retry to send a message if the server rejects the recipient address
+  rescue_from Net::SMTPSyntaxError do |_error|
+    message.perform_deliveries = false
+  end
+
   def template_paths
     ['devise_mailer']
   end


### PR DESCRIPTION
https://github.com/betagouv/demarches-simplifiees.fr/issues/4419
On continue à avoir des erreurs «501 Bad recipient address syntax»: https://sentry.io/organizations/demarches-simplifiees/issues/970367845/?project=1429550&query=is%3Aunresolved


Les mails envoyés par Devise le sont via `DeviseUserMailer` (cf `config.mailer` dans config/initializers/devise.rb), qui hérite de `Devise::Mailer` et non d'`ApplicationMailer`.
Hors seul `ApplicationMailer` a, à ce jour, le super pouvoir de rejeter les erreurs d'envoi de mail. Il faut corriger cela et c'est ce que fait cette PR.
Tous les autres mailers héritent d'`ApplicationMailer`, il ne devrait donc plus y avoir ce genre d'erreurs dans sentry.
