### PR TITLE
Fix routage feature spec

### DIFF
--- a/app/views/layouts/_account_dropdown.haml
+++ b/app/views/layouts/_account_dropdown.haml
@@ -1,6 +1,6 @@
 .dropdown.header-menu-opener
-  %button.button.dropdown-button.header-menu-button
-    = image_tag "icons/account-circle.svg", title: "Mon compte"
+  %button.button.dropdown-button.header-menu-button{ title: "Mon compte" }
+    = image_tag "icons/account-circle.svg", alt: ''
   %ul.header-menu.dropdown-content
     %li
       .menu-item{ title: current_email }

--- a/spec/features/routing/full_scenario_spec.rb
+++ b/spec/features/routing/full_scenario_spec.rb
@@ -111,19 +111,20 @@ feature 'The routing', js: true do
     sign_in_with victor.user.email, password
 
     ## on the procedures list
-    expect(page).to have_css("span.notifications")
+    expect(page).to have_current_path(instructeur_procedures_path)
+    expect(find('.procedure-stats')).to have_css('span.notifications')
 
     ## on the dossiers list
     click_on procedure.libelle
     expect(page).to have_current_path(instructeur_procedure_path(procedure))
-    expect(page).to have_css("span.notifications")
+    expect(find('.tabs')).to have_css('span.notifications')
 
     ## on the dossier itself
     click_on 'suivi'
     click_on litteraire_user.email
     expect(page).to have_current_path(instructeur_dossier_path(procedure, litteraire_user.dossiers.first))
-    expect(page).to have_css("span.notifications")
-
+    expect(page).to have_text('Annotations privées') # ensure Turbolinks DID load the DOM content
+    expect(find('.tabs')).to have_css('span.notifications')
     log_out
 
     # the scientifiques instructeurs should not have a notification


### PR DESCRIPTION
Cette PR tente de corriger deux erreurs aléatoires des specs du routage :

- Remplir un champ select2 ne fonctionne pas toujours,
- Le logout échoue parfois vers la fin de la spec.

## select2

J'ai ré-écrit une partie de la spec, pour être plus rigoureux sur "On attend à chaque fois que la nouvelle page soit chargée avant de faire l'action suivante". 

Concrètement, ça veut dire faire un `expect(page).to have_text(…)` avec un texte dont on est sûr qu'il ne peut être que sur la page qu'on attend (par exemple un message de succès ou d'erreur).

Ça permet d'être sûr qu'on ne va pas plus vite que la musique, et ça a l'air de corriger les erreurs.

## Logout

Le logout qui échoue, c'est le menu "Mon compte" qui est bien cliqué, mais qui n'apparaît pas. Après investigation, c'est bien un problème de Turblinks.

En temps normal, le test :
- attend que la page soit sur la bonne URL
- assert la présence d'un texte (mais qui était déjà sur la page précédente)
- clique le menu "Mon compte"
- clique "Se déconnecter"

Mais parfois, rien ne se passe : le menu n'est même pas ouvert. Pourquoi ?

En fait, ce qui se passe, c'est :
- Turbolinks change l'URL de la page, avant que le nouveau contenu soit disponible dans le DOM 😱
- Capybara passe donc à l'étape suivante
- L'assert du texte matche la page précédente qui est en cours de remplacement
- le clic sur le menu ouvre le menu de la page précédente
- le nouveau DOM arrive et est inséré par Turbolinks
- le menu qui a été ouvert était celui de la page précédente
- Fail.

Donc on peut bien `expect(page).to have_current_path` tout ce qu'on veut, avec Turbolinks ce n'est pas suffisant pour s'assurer que la page affichée est bien la nouvelle.

Pour finir :

- J'ai corrigé le bug en expectant un texte qui ne peut être que sur la nouvelle page,
- On devrait corriger Turbolinks,
- Ou mieux, s'en débarrasser entièrement.

Fix #4555 