### PR TITLE
Rend l'indicateur d'autosave tout le temps visible sous IE 11

### DIFF
--- a/app/assets/stylesheets/new_design/dossier_edit.scss
+++ b/app/assets/stylesheets/new_design/dossier_edit.scss
@@ -1,6 +1,8 @@
 @import "colors";
 @import "constants";
 
+$dossier-actions-bar-border-width: 1px;
+
 .dossier-header {
   .container {
     padding-bottom: $default-padding;
@@ -46,29 +48,40 @@
     border-radius: 4px;
   }
 
-  .send-dossier-actions-bar {
-    // scss-lint:disable VendorPrefix
+  .dossier-edit-sticky-footer {
+    // scss-lint:disable VendorPrefix DuplicateProperty
+    position: fixed;           // Fallback for IE 11, and other browser that don't support sticky
     position: -webkit-sticky;  // This is needed on Safari (tested on 12.1)
-    // scss-lint:enable VendorPrefix
     position: sticky;
+    // scss-lint:enable VendorPrefix DuplicateProperty
+
+    // IE 11 uses `position:fixed` – and thus needs an explicit width, content-box for better layout, etc.
+    width: 100%;
+    max-width: $page-width + 2 * $default-padding;
+    box-sizing: content-box;
+
     bottom: 0;
 
-    display: flex;
-    flex-direction: row;
-    align-items: center;
     margin-top: $default-padding;
     margin-left: -$default-padding;
     margin-right: -$default-padding;
     margin-bottom: 0;
-    padding-top: 0;
-    padding-bottom: $default-spacer;
-    padding-right: $default-padding;
-    padding-left: $default-padding;
+
+    padding-right: $default-padding - $dossier-actions-bar-border-width;
+    padding-left: $default-padding - $dossier-actions-bar-border-width;
+
     background: #FFFFFF;
-    border: 1px solid #CCCCCC;
+
+    border: $dossier-actions-bar-border-width solid #CCCCCC;
     border-top-left-radius: 5px;
     border-top-right-radius: 5px;
     border-bottom: none;
+  }
+
+  .send-dossier-actions-bar {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
 
     .button:not(:small) {
       min-height: 38px;
@@ -81,13 +94,13 @@
     }
 
     // Normal layout
-    @media (min-width: 500px) {
+    @media (min-width: 620px) {
       padding-top: $default-spacer * 2;
       padding-bottom: $default-spacer * 2;
     }
 
     // Compact layout
-    @media (max-width: 500px) {
+    @media (max-width: 620px) {
       padding-top: $default-spacer;
       padding-bottom: $default-spacer;
     }

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -53,31 +53,32 @@
         locals: { champ: champ, form: champ_form }
 
     - if !apercu
-      .send-dossier-actions-bar
-        - if dossier.brouillon?
-          - if autosave_available?(dossier)
-            = render partial: 'users/dossiers/autosave'
+      .dossier-edit-sticky-footer
+        .send-dossier-actions-bar
+          - if dossier.brouillon?
+            - if autosave_available?(dossier)
+              = render partial: 'users/dossiers/autosave'
+            - else
+              = f.button 'Enregistrer le brouillon',
+                formnovalidate: true,
+                class: 'button send secondary',
+                data: { 'disable-with': "Envoi en cours…" }
+
+            - if dossier.can_transition_to_en_construction?
+              = f.button 'Déposer le dossier',
+                name: :submit_draft,
+                value: true,
+                class: 'button send primary',
+                disabled: !current_user.owns?(dossier),
+                data: { 'disable-with': "Envoi en cours…" }
+
           - else
-            = f.button 'Enregistrer le brouillon',
-              formnovalidate: true,
-              class: 'button send secondary',
-              data: { 'disable-with': "Envoi en cours…" }
-
-          - if dossier.can_transition_to_en_construction?
-            = f.button 'Déposer le dossier',
-              name: :submit_draft,
-              value: true,
+            = f.button 'Enregistrer les modifications du dossier',
               class: 'button send primary',
-              disabled: !current_user.owns?(dossier),
               data: { 'disable-with': "Envoi en cours…" }
 
-        - else
-          = f.button 'Enregistrer les modifications du dossier',
-            class: 'button send primary',
-            data: { 'disable-with': "Envoi en cours…" }
+        - if dossier.brouillon? && !current_user.owns?(dossier)
+          .send-notice.invite-cannot-submit
+            En tant qu’invité, vous pouvez remplir ce formulaire – mais le titulaire du dossier doit le déposer lui-même.
 
-      - if dossier.brouillon? && !current_user.owns?(dossier)
-        .send-notice.invite-cannot-submit
-          En tant qu’invité, vous pouvez remplir ce formulaire – mais le titulaire du dossier doit le déposer lui-même.
-
-      = render partial: "shared/dossiers/submit_is_over", locals: { dossier: dossier }
+        = render partial: "shared/dossiers/submit_is_over", locals: { dossier: dossier }


### PR DESCRIPTION
Aujourd'hui l'indicateur "Le brouillon a été sauvegardé automatiquement" est dans la barre d'actions du brouillon. Cette barre est toujours visible à l'écran (`position: sticky`) – sauf sur les navigateurs où `position: sticky` n'est pas géré.

Je me dis que ça serait bien que même les utilisateurs d'IE 11 sachent que leur brouillon est sauvegardé. Et donc d'essayer de rendre la barre sticky sous IE11.

C'est pas mal de taf pénible de gérer à la fois les navigateurs qui gère le sticky et les autres. J'utilise du `position: fixed`, mais le comportement du layout entre `fixed` et `sticky` est assez différent.

Au final ça donne ça :

## Écran large

<img width="700" alt="Capture d’écran 2019-11-25 à 15 43 49" src="https://user-images.githubusercontent.com/179923/69549911-6a3d3d80-0f9a-11ea-96c8-6024823de0f6.png">


## Écran étroit

<img width="600" alt="Capture d’écran 2019-11-25 à 15 35 03" src="https://user-images.githubusercontent.com/179923/69549701-10d50e80-0f9a-11ea-8e5a-a131a1bfa1b7.png">

La question est de savoir si on veut vraiment faire ça.

## Arguments Pour :

- Les utilisateurs d'IE 11 auront un indicateur de sauvegarde clair, cool pour eux.
- Ils voient eux aussi la barre tout le temps, ce qui est toujours sympa.

## Arguments Contre :

- Ça rajoute des hacks CSS dans le code.
- Le bouton "Déposer un dossier" devient tronqué sur les IE 11 + écran étroit.
- Après tout on déprécie IE 11, et c'est surtout les administrations qui s'en servent.

## Question ouverte

Qu'est-ce qu'on fait ?

- 1️⃣ Mort à IE 11 et aux hacks CSS
- 2️⃣ Oué, ça a l'air bien qu'on fasse le taf