### PR TITLE
Autosave : amélioration de la fiabilité

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -155,7 +155,7 @@ module Users
 
       respond_to do |format|
         format.html { render :brouillon }
-        format.json { head :ok }
+        format.json { render json: {}, status: :ok }
       end
     end
 

--- a/app/javascript/new_design/autosave-controller.js
+++ b/app/javascript/new_design/autosave-controller.js
@@ -37,6 +37,7 @@ export default class AutosaveController {
       const fetchOptions = {
         method: form.method,
         body: formData,
+        credentials: 'same-origin',
         headers: { Accept: 'application/json' }
       };
 

--- a/app/javascript/new_design/autosave-controller.js
+++ b/app/javascript/new_design/autosave-controller.js
@@ -62,7 +62,7 @@ export default class AutosaveController {
     // exclude them from the draft (by disabling them).
     // (Also Safari has issue with FormData containing empty file inputs)
     const fileInputs = form.querySelectorAll(
-      'input[type="file"]:not([disabled])'
+      'input[type="file"]:not([disabled]), .editable-champ-piece_justificative input:not([disabled])'
     );
     fileInputs.forEach(fileInput => (fileInput.disabled = true));
 

--- a/app/javascript/new_design/autosave.js
+++ b/app/javascript/new_design/autosave.js
@@ -19,7 +19,7 @@ const autosaveController = new AutosaveController();
 // Whenever a 'change' event is triggered on one of the form inputs, try to autosave.
 
 const formSelector = 'form#dossier-edit-form.autosave-enabled';
-const formInputsSelector = `${formSelector} input, ${formSelector} select, ${formSelector} textarea`;
+const formInputsSelector = `${formSelector} input:not([type=input]), ${formSelector} select, ${formSelector} textarea`;
 
 delegate(
   'change',

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -3,6 +3,7 @@ import Turbolinks from 'turbolinks';
 import Rails from '@rails/ujs';
 import * as ActiveStorage from '@rails/activestorage';
 import '@rails/actiontext';
+import 'whatwg-fetch'; // window.fetch polyfill
 import Chartkick from 'chartkick';
 import Highcharts from 'highcharts';
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "react_ujs": "^2.6.0",
     "select2": "^4.0.11",
     "trix": "^1.2.1",
-    "turbolinks": "^5.2.0"
+    "turbolinks": "^5.2.0",
+    "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8931,6 +8931,11 @@ websocket-extensions@>=0.1.1:
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
   integrity sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==
 
+whatwg-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
+
 which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"


### PR DESCRIPTION
- Polyfill pour les [navigateurs qui ne gèrent pas `window.fetch`](https://caniuse.com/#feat=fetch) ;
- Blindage de la compatibilité avec les anciennes versions de fetch.

Plus d'infos dans les messages de commit eux-même.