### PR TITLE
Corrige une erreur lors de l'affectation d'instructeur avec une adresse vide

### DIFF
--- a/app/controllers/new_administrateur/groupe_instructeurs_controller.rb
+++ b/app/controllers/new_administrateur/groupe_instructeurs_controller.rb
@@ -49,7 +49,8 @@ module NewAdministrateur
     end
 
     def add_instructeur
-      emails = params['emails'].map(&:strip).map(&:downcase)
+      emails = params['emails'].presence || []
+      emails = emails.map(&:strip).map(&:downcase)
 
       correct_emails, bad_emails = emails
         .partition { |email| URI::MailTo::EMAIL_REGEXP.match?(email) }

--- a/spec/controllers/new_administrateur/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/new_administrateur/groupe_instructeurs_controller_spec.rb
@@ -117,6 +117,12 @@ describe NewAdministrateur::GroupeInstructeursController, type: :controller do
       it { expect(flash.alert).to be_present }
       it { expect(response).to redirect_to(procedure_groupe_instructeur_path(procedure, procedure.defaut_groupe_instructeur)) }
     end
+
+    context 'of an empty string' do
+      let(:new_instructeur_emails) { '' }
+
+      it { expect(response).to redirect_to(procedure_groupe_instructeur_path(procedure, procedure.defaut_groupe_instructeur)) }
+    end
   end
 
   describe '#remove_instructeur' do


### PR DESCRIPTION
As select2 does not handle required attribute, we can only add server side logic