### PR TITLE
dossiers: fix autosave not ignoring file inputs

### DIFF
--- a/app/javascript/new_design/autosave.js
+++ b/app/javascript/new_design/autosave.js
@@ -19,7 +19,7 @@ const autosaveController = new AutosaveController();
 // Whenever a 'change' event is triggered on one of the form inputs, try to autosave.
 
 const formSelector = 'form#dossier-edit-form.autosave-enabled';
-const formInputsSelector = `${formSelector} input:not([type=input]), ${formSelector} select, ${formSelector} textarea`;
+const formInputsSelector = `${formSelector} input:not([type=file]), ${formSelector} select, ${formSelector} textarea`;
 
 delegate(
   'change',


### PR DESCRIPTION
The dossier autosave is supposed to ignore file inputs (which are handled differently by ActiveStorage).

Fix a typo in the CSS selector.