### PR TITLE
Compatibilité W3C sur pages publiques et usager

### DIFF
--- a/app/views/root/accessibilite.html.haml
+++ b/app/views/root/accessibilite.html.haml
@@ -14,7 +14,7 @@
   %h2.new-h2 Défenseur des droits
   %p.new-p
     Si vous constatez un défaut d'accessibilité vous empêchant d'accéder à un contenu ou une fonctionnalité du site, que vous nous le signalez et que vous ne parvenez pas à obtenir une réponse rapide de notre part, vous êtes en droit de faire parvenir vos doléances ou une demande de saisine au Défenseur des droits. Plusieurs moyens sont à votre disposition :
-    %ul
-      %li un <a href="http://www.defenseurdesdroits.fr/contact" target="_blank" rel="noopener">formulaire de contact</a> ;
-      %li la <a href="http://www.defenseurdesdroits.fr/office/" target="_blank" rel="noopener">liste du ou des délégués de votre région</a> avec leurs informations de contact direct ;
-      %li une adresse postale : Le Défenseur des droits - 7 rue Saint-Florentin - 75409 Paris Cedex 08.
+  %ul
+    %li un <a href="http://www.defenseurdesdroits.fr/contact" target="_blank" rel="noopener">formulaire de contact</a> ;
+    %li la <a href="http://www.defenseurdesdroits.fr/office/" target="_blank" rel="noopener">liste du ou des délégués de votre région</a> avec leurs informations de contact direct ;
+    %li une adresse postale : Le Défenseur des droits - 7 rue Saint-Florentin - 75409 Paris Cedex 08.

--- a/app/views/shared/dossiers/editable_champs/_textarea.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_textarea.html.haml
@@ -1,4 +1,4 @@
 ~ form.text_area :value,
-  row: 6,
+  rows: 6,
   required: champ.mandatory?,
   value: html_to_string(champ.value)

--- a/app/views/support/index.html.haml
+++ b/app/views/support/index.html.haml
@@ -72,10 +72,10 @@
       .contact-champ
         = label_tag :text do
           Pièce jointe
-          .notice.hidden{ data: { 'contact-type-only': Helpscout::FormAdapter::TYPE_AMELIORATION } }
-            Une capture d’écran peut nous aider à identifier plus facilement l’endroit à améliorer.
-          .notice.hidden{ data: { 'contact-type-only': Helpscout::FormAdapter::TYPE_AUTRE } }
-            Une capture d’écran peut nous aider à identifier plus facilement le problème.
+        %p.notice.hidden{ data: { 'contact-type-only': Helpscout::FormAdapter::TYPE_AMELIORATION } }
+          Une capture d’écran peut nous aider à identifier plus facilement l’endroit à améliorer.
+        %p.notice.hidden{ data: { 'contact-type-only': Helpscout::FormAdapter::TYPE_AUTRE } }
+          Une capture d’écran peut nous aider à identifier plus facilement le problème.
         = file_field_tag :piece_jointe
 
       = hidden_field_tag :tags, @tags&.join(',')

--- a/app/views/users/dossiers/merci.html.haml
+++ b/app/views/users/dossiers/merci.html.haml
@@ -5,7 +5,7 @@
 
 .merci
   .container
-    = image_tag('user/envoi-dossier.svg')
+    = image_tag('user/envoi-dossier.svg', alt: '')
     %h1 Merci !
     %p.send
       Votre dossier sur la démarche


### PR DESCRIPTION
Avec ces quelques modifs, on est compatible W3C sur les pages publiques et les pages usager :

# Pages publiques, non logguées

 - [x] la homepage
 - [x] /users/sign_in
 - [x] /users/sign_up
 - [ ] /stats
 - [x] /suivi
 - [x] /accessibilite
 - [x] /contact

# Pages usager, logguées

 - [x] /commencer/xxx
 - [ ] formulaire de dépot d'un dossier
 - [x] /dossiers
 - [x] /dossiers/:id
 - [x] /dossiers/:id/demande
 - [x] /dossiers/:id/messagerie

Il reste des warnings sur /stats (`l'attribut type="javascript" est optionnel dans une balise script inline`) mais sur du code généré par chartkick

J'ai fait les vérifications à la main en testant ces pages sur https://validator.w3.org/, ça pourra être cool de prévoir l'ajout de l'automatisation de cette vérification dans la CI