### PR TITLE
#4575 Suggestion d'un email valide

### DIFF
--- a/app/assets/stylesheets/new_design/user_signup.scss
+++ b/app/assets/stylesheets/new_design/user_signup.scss
@@ -3,8 +3,22 @@
 
 .suspect-email {
   background-color: $orange-bg;
-  font-weight: bold;
   text-align: center;
-  padding: $default-padding;
+  margin-top: -$default-padding * 2;
+  margin-bottom: $default-padding * 2;
+  padding: ($default-padding - 2) $default-padding $default-padding $default-padding;
+  border-radius: 0 0 5px 5px;
 }
 
+.email-suggestion-address {
+  font-weight: bold;
+}
+
+.email-suggestion-title {
+  margin-bottom: $default-spacer;
+}
+
+.email-suggestion-answer button {
+  margin: 0 $default-spacer / 2;
+  min-width: 66px;
+}

--- a/app/assets/stylesheets/new_design/user_signup.scss
+++ b/app/assets/stylesheets/new_design/user_signup.scss
@@ -1,0 +1,10 @@
+@import "colors";
+@import "constants";
+
+.suspect-email {
+  background-color: $orange-bg;
+  font-weight: bold;
+  text-align: center;
+  padding: $default-padding;
+}
+

--- a/app/javascript/new_design/user-sign_up.js
+++ b/app/javascript/new_design/user-sign_up.js
@@ -2,6 +2,7 @@ import { delegate, show, hide } from '@utils';
 import { suggest } from 'email-butler';
 
 const userNewEmailSelector = '#new_user input#user_email';
+const passwordFieldSelector = '#new_user input#user_password';
 const suggestionsSelector = '.suspect-email';
 const emailSuggestionSelector = '.suspect-email .email-suggestion-address';
 
@@ -26,6 +27,7 @@ export function acceptEmailSuggestion() {
 
   userEmailInput.value = suggestedEmailSpan.innerHTML;
   hide(document.querySelector(suggestionsSelector));
+  document.querySelector(passwordFieldSelector).focus();
 }
 
 export function discardEmailSuggestionBox() {

--- a/app/javascript/new_design/user-sign_up.js
+++ b/app/javascript/new_design/user-sign_up.js
@@ -15,6 +15,8 @@ delegate('focusout', userNewEmailSelector, () => {
   if (suggestion && suggestion.full) {
     suggestedEmailSpan.innerHTML = suggestion.full;
     show(document.querySelector(suggestionsSelector));
+  } else {
+    hide(document.querySelector(suggestionsSelector));
   }
 });
 

--- a/app/javascript/new_design/user-sign_up.js
+++ b/app/javascript/new_design/user-sign_up.js
@@ -1,0 +1,20 @@
+import { on, show, hide } from '@utils';
+
+const USER_NEW_EMAIL_SELECTOR = '#new_user > #user_email';
+const suspectSuggestionsBox = document.querySelector('.suspect-email');
+const emailSuggestionSpan = document.querySelector(".suspect-email .question .suggested-email");
+
+on(USER_NEW_EMAIL_SELECTOR, 'blur', _ => {
+  emailSuggestionSpan.innerHTML = 'bidou@plop.com';
+  show(suspectSuggestionsBox)
+});
+
+export function acceptEmailSuggestion() {
+  document.querySelector(USER_NEW_EMAIL_SELECTOR).value = emailSuggestionSpan.innerHTML;
+  hide(suspectSuggestionsBox);
+}
+
+export function discardEmailSuggestionBox() {
+  hide(suspectSuggestionsBox);
+}
+

--- a/app/javascript/new_design/user-sign_up.js
+++ b/app/javascript/new_design/user-sign_up.js
@@ -1,30 +1,31 @@
-import { on, show, hide } from '@utils';
+import { delegate, show, hide } from '@utils';
 import { suggest } from 'email-butler';
 
-const user_new_email_selector = '#new_user > #user_email';
-const suspectSuggestionsBox = document.querySelector('.suspect-email');
-const emailSuggestionSpan = document.querySelector(
-  '.suspect-email .question .suggested-email'
-);
+const userNewEmailSelector = '#new_user input#user_email';
+const suggestionsSelector = '.suspect-email';
+const emailSuggestionSelector = '.suspect-email .suggested-email';
 
-on(user_new_email_selector, 'blur', () => {
+delegate('focusout', userNewEmailSelector, () => {
   // When the user leaves the email input during account creation, we check if this account looks correct.
-  // If not (e.g if its "bidou@gmail.coo" or "john@yahoo.rf") we attempt to suggest a fix for the invalid email.
-  const suggestion = suggest(
-    document.querySelector(user_new_email_selector).value
-  );
-  if (suggestion.full) {
-    emailSuggestionSpan.innerHTML = suggestion.full;
-    show(suspectSuggestionsBox);
+  // If not (e.g if its "bidou@gmail.coo" or "john@yahoo.rf"), we attempt to suggest a fix for the invalid email.
+  const userEmailInput = document.querySelector(userNewEmailSelector);
+  const suggestedEmailSpan = document.querySelector(emailSuggestionSelector);
+
+  const suggestion = suggest(userEmailInput.value);
+  if (suggestion && suggestion.full) {
+    suggestedEmailSpan.innerHTML = suggestion.full;
+    show(document.querySelector(suggestionsSelector));
   }
 });
 
 export function acceptEmailSuggestion() {
-  document.querySelector(user_new_email_selector).value =
-    emailSuggestionSpan.innerHTML;
-  hide(suspectSuggestionsBox);
+  const userEmailInput = document.querySelector(userNewEmailSelector);
+  const suggestedEmailSpan = document.querySelector(emailSuggestionSelector);
+
+  userEmailInput.value = suggestedEmailSpan.innerHTML;
+  hide(document.querySelector(suggestionsSelector));
 }
 
 export function discardEmailSuggestionBox() {
-  hide(suspectSuggestionsBox);
+  hide(document.querySelector(suggestionsSelector));
 }

--- a/app/javascript/new_design/user-sign_up.js
+++ b/app/javascript/new_design/user-sign_up.js
@@ -1,20 +1,30 @@
 import { on, show, hide } from '@utils';
+import { suggest } from 'email-butler';
 
-const USER_NEW_EMAIL_SELECTOR = '#new_user > #user_email';
+const user_new_email_selector = '#new_user > #user_email';
 const suspectSuggestionsBox = document.querySelector('.suspect-email');
-const emailSuggestionSpan = document.querySelector(".suspect-email .question .suggested-email");
+const emailSuggestionSpan = document.querySelector(
+  '.suspect-email .question .suggested-email'
+);
 
-on(USER_NEW_EMAIL_SELECTOR, 'blur', _ => {
-  emailSuggestionSpan.innerHTML = 'bidou@plop.com';
-  show(suspectSuggestionsBox)
+on(user_new_email_selector, 'blur', () => {
+  // When the user leaves the email input during account creation, we check if this account looks correct.
+  // If not (e.g if its "bidou@gmail.coo" or "john@yahoo.rf") we attempt to suggest a fix for the invalid email.
+  const suggestion = suggest(
+    document.querySelector(user_new_email_selector).value
+  );
+  if (suggestion.full) {
+    emailSuggestionSpan.innerHTML = suggestion.full;
+    show(suspectSuggestionsBox);
+  }
 });
 
 export function acceptEmailSuggestion() {
-  document.querySelector(USER_NEW_EMAIL_SELECTOR).value = emailSuggestionSpan.innerHTML;
+  document.querySelector(user_new_email_selector).value =
+    emailSuggestionSpan.innerHTML;
   hide(suspectSuggestionsBox);
 }
 
 export function discardEmailSuggestionBox() {
   hide(suspectSuggestionsBox);
 }
-

--- a/app/javascript/new_design/user-sign_up.js
+++ b/app/javascript/new_design/user-sign_up.js
@@ -3,7 +3,7 @@ import { suggest } from 'email-butler';
 
 const userNewEmailSelector = '#new_user input#user_email';
 const suggestionsSelector = '.suspect-email';
-const emailSuggestionSelector = '.suspect-email .suggested-email';
+const emailSuggestionSelector = '.suspect-email .email-suggestion-address';
 
 delegate('focusout', userNewEmailSelector, () => {
   // When the user leaves the email input during account creation, we check if this account looks correct.

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -40,7 +40,10 @@ import {
 } from '../new_design/state-button';
 import { toggleChart } from '../new_design/toggle-chart';
 import { replaceSemicolonByComma } from '../new_design/avis';
-import { acceptEmailSuggestion, discardEmailSuggestionBox } from '../new_design/user-sign_up';
+import {
+  acceptEmailSuggestion,
+  discardEmailSuggestionBox
+} from '../new_design/user-sign_up';
 
 // This is the global application namespace where we expose helpers used from rails views
 const DS = {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -40,6 +40,7 @@ import {
 } from '../new_design/state-button';
 import { toggleChart } from '../new_design/toggle-chart';
 import { replaceSemicolonByComma } from '../new_design/avis';
+import { acceptEmailSuggestion, discardEmailSuggestionBox } from '../new_design/user-sign_up';
 
 // This is the global application namespace where we expose helpers used from rails views
 const DS = {
@@ -50,7 +51,9 @@ const DS = {
   motivationCancel,
   showImportJustificatif,
   toggleChart,
-  replaceSemicolonByComma
+  replaceSemicolonByComma,
+  acceptEmailSuggestion,
+  discardEmailSuggestionBox
 };
 
 // Start Rails helpers

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -5,11 +5,13 @@
   = form_for resource, url: user_registration_path, html: { class: "form" } do |f|
     %h1 Créez-vous un compte demarches-simplifiees.fr
 
-    .suspect-email
-      .question Vouliez-vous dire blabla@gmail.com ?
+    .suspect-email.hidden
+      .question Vouliez-vous dire <span class="suggested-email">blabla@gmail.com</span>&nbsp;?
       .answer
-        .button Oui
-        .button Non
+        = button_tag type: 'button', class:'button', onclick: "DS.acceptEmailSuggestion()" do
+          Oui
+        = button_tag type: 'button', class:'button', onclick: "DS.discardEmailSuggestionBox()" do
+          Non
 
     = f.label :email, "Email"
     = f.text_field :email, autofocus: true, placeholder: "Votre adresse email"

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -5,6 +5,12 @@
   = form_for resource, url: user_registration_path, html: { class: "form" } do |f|
     %h1 Créez-vous un compte demarches-simplifiees.fr
 
+    .suspect-email
+      .question Vouliez-vous dire blabla@gmail.com ?
+      .answer
+        .button Oui
+        .button Non
+
     = f.label :email, "Email"
     = f.text_field :email, autofocus: true, placeholder: "Votre adresse email"
 

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -8,15 +8,15 @@
     = f.label :email, "Email"
     = f.text_field :email, autofocus: true, placeholder: "Votre adresse email"
 
-    .suspect-email.hidden
+    .suspect-email
       .email-suggestion-title
-        Vouliez-vous dire
+        Voulez-vous dire
         %span.email-suggestion-address blabla@gmail.com
         &nbsp;?
       .email-suggestion-answer
-        = button_tag type: 'button', class: 'button', onclick: "DS.acceptEmailSuggestion()" do
+        = button_tag type: 'button', class: 'button small', onclick: "DS.acceptEmailSuggestion()" do
           Oui
-        = button_tag type: 'button', class: 'button', onclick: "DS.discardEmailSuggestionBox()" do
+        = button_tag type: 'button', class: 'button small', onclick: "DS.discardEmailSuggestionBox()" do
           Non
 
     = f.label :password, "Mot de passe"

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -5,6 +5,9 @@
   = form_for resource, url: user_registration_path, html: { class: "form" } do |f|
     %h1 Créez-vous un compte demarches-simplifiees.fr
 
+    = f.label :email, "Email"
+    = f.text_field :email, autofocus: true, placeholder: "Votre adresse email"
+
     .suspect-email.hidden
       .question Vouliez-vous dire <span class="suggested-email">blabla@gmail.com</span>&nbsp;?
       .answer
@@ -12,9 +15,6 @@
           Oui
         = button_tag type: 'button', class:'button', onclick: "DS.discardEmailSuggestionBox()" do
           Non
-
-    = f.label :email, "Email"
-    = f.text_field :email, autofocus: true, placeholder: "Votre adresse email"
 
     = f.label :password, "Mot de passe"
     = f.password_field :password, value: @user.password, placeholder: "8 caractères minimum"

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -9,11 +9,14 @@
     = f.text_field :email, autofocus: true, placeholder: "Votre adresse email"
 
     .suspect-email.hidden
-      .question Vouliez-vous dire <span class="suggested-email">blabla@gmail.com</span>&nbsp;?
-      .answer
-        = button_tag type: 'button', class:'button', onclick: "DS.acceptEmailSuggestion()" do
+      .email-suggestion-title
+        Vouliez-vous dire
+        %span.email-suggestion-address blabla@gmail.com
+        &nbsp;?
+      .email-suggestion-answer
+        = button_tag type: 'button', class: 'button', onclick: "DS.acceptEmailSuggestion()" do
           Oui
-        = button_tag type: 'button', class:'button', onclick: "DS.discardEmailSuggestionBox()" do
+        = button_tag type: 'button', class: 'button', onclick: "DS.discardEmailSuggestionBox()" do
           Non
 
     = f.label :password, "Mot de passe"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "core-js": "^2.0.0",
     "debounce": "^1.2.0",
     "dom4": "^2.1.5",
+    "email-butler": "^1.0.12",
     "highcharts": "^6.1.2",
     "intersection-observer": "^0.7.0",
     "jquery": "^3.4.1",

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -17,6 +17,32 @@ feature 'Signing up:' do
     expect(page).to have_current_path commencer_path(path: procedure.path)
   end
 
+  context 'a new user can sign-up and be suggested a valid email when he makes a typo' do
+    let(:procedure) { create :simple_procedure, :with_service }
+
+    before do
+      visit commencer_path(path: procedure.path)
+      click_on 'Créer un compte demarches-simplifiees.fr'
+      expect(page).to have_selector('.suspect-email', visible: false)
+      fill_in :user_email, with: 'bidou@yahoo.rf'
+      fill_in :user_password, with: '12345'
+    end
+
+    scenario 'it can accept the suggestion' do
+      expect(page).to have_selector('.suspect-email', visible: true)
+      click_on 'Oui'
+      # expect(page).to have_field("Email", :with => 'bidou@yahoo.fr')
+      expect(page).to have_selector('.suspect-email', visible: false)
+    end
+
+    scenario 'it can discard the suggestion' do
+      expect(page).to have_selector('.suspect-email', visible: true)
+      click_on 'Non'
+      expect(page).to have_field("Email", :with => 'bidou@yahoo.rf')
+      expect(page).to have_selector('.suspect-email', visible: false)
+    end
+  end
+
   scenario 'a new user can’t sign-up with too short password when visiting a procedure' do
     visit commencer_path(path: procedure.path)
     click_on 'Créer un compte demarches-simplifiees.fr'

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -41,6 +41,13 @@ feature 'Signing up:' do
       expect(page).to have_field("Email", :with => 'bidou@yahoo.rf')
       expect(page).to have_selector('.suspect-email', visible: false)
     end
+
+    scenario 'they can fix the typo themselves', js: true do
+      expect(page).to have_selector('.suspect-email', visible: true)
+      fill_in 'Email', with: 'bidou@yahoo.fr'
+      blur
+      expect(page).to have_selector('.suspect-email', visible: false)
+    end
   end
 
   scenario 'a new user can’t sign-up with too short password when visiting a procedure' do

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -17,25 +17,25 @@ feature 'Signing up:' do
     expect(page).to have_current_path commencer_path(path: procedure.path)
   end
 
-  context 'a new user can sign-up and be suggested a valid email when he makes a typo' do
+  context 'when the user makes a typo in their email address' do
     let(:procedure) { create :simple_procedure, :with_service }
 
     before do
       visit commencer_path(path: procedure.path)
       click_on 'Créer un compte demarches-simplifiees.fr'
       expect(page).to have_selector('.suspect-email', visible: false)
-      fill_in :user_email, with: 'bidou@yahoo.rf'
-      fill_in :user_password, with: '12345'
+      fill_in 'Email', with: 'bidou@yahoo.rf'
+      fill_in 'Mot de passe', with: '12345'
     end
 
-    scenario 'it can accept the suggestion' do
+    scenario 'they can accept the suggestion', js: true do
       expect(page).to have_selector('.suspect-email', visible: true)
       click_on 'Oui'
-      # expect(page).to have_field("Email", :with => 'bidou@yahoo.fr')
+      expect(page).to have_field("Email", :with => 'bidou@yahoo.fr')
       expect(page).to have_selector('.suspect-email', visible: false)
     end
 
-    scenario 'it can discard the suggestion' do
+    scenario 'they can discard the suggestion', js: true do
       expect(page).to have_selector('.suspect-email', visible: true)
       click_on 'Non'
       expect(page).to have_field("Email", :with => 'bidou@yahoo.rf')

--- a/yarn.lock
+++ b/yarn.lock
@@ -3110,6 +3110,11 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+email-butler@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/email-butler/-/email-butler-1.0.12.tgz#f504b45658fea6257dbc0f891be2cf822d29caa6"
+  integrity sha512-JcvRCjCpLp3fIHlP+KgdDadSmhETA/D4KUtIi3VnwEw2bJKilMOcd+xLJUHrD631bToxxxYRnxB3xTvAQeIRCQ==
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"


### PR DESCRIPTION
Cf #4575 , commencé avec @krichtof en pair

![suggest-email](https://user-images.githubusercontent.com/1223316/69970045-d3362f80-151d-11ea-8037-854c1230f45b.gif)

Je suis preneur d'un coup de main sur le test auto: dans un des cas (j'accepte les modifs), le test ne passe pas si je décommente `expect(page).to have_field("Email", :with => 'bidou@yahoo.fr')` alors que le scénario est similaire à l'autre qui passe.
Dans le navigateur je valide bien le comportement. C'est sans doute évident, mais j'ai passé un temps déraisonnable là dessus, qqun d'autre, ou moi demain verra sans doute le truc.

```ruby
    scenario 'it can accept the suggestion' do
      expect(page).to have_selector('.suspect-email', visible: true)
      click_on 'Oui'
      # expect(page).to have_field("Email", :with => 'bidou@yahoo.fr')
      expect(page).to have_selector('.suspect-email', visible: false)
    end

    scenario 'it can discard the suggestion' do
      expect(page).to have_selector('.suspect-email', visible: true)
      click_on 'Non'
      expect(page).to have_field("Email", :with => 'bidou@yahoo.rf')
      expect(page).to have_selector('.suspect-email', visible: false)
    end
```