### PR TITLE
Bug with time zone: Date breaks database comparisons

### DIFF
--- a/app/services/bill_signature_service.rb
+++ b/app/services/bill_signature_service.rb
@@ -1,9 +1,9 @@
 class BillSignatureService
   def self.grouped_unsigned_operation_until(date)
+    date = date.in_time_zone
     unsigned_operations = DossierOperationLog
       .where(bill_signature: nil)
       .where('executed_at < ?', date)
-
     unsigned_operations.group_by { |e| e.executed_at.to_date }
   end
 

--- a/spec/jobs/auto_archive_procedure_job_spec.rb
+++ b/spec/jobs/auto_archive_procedure_job_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe AutoArchiveProcedureJob, type: :job do
   let!(:procedure) { create(:procedure, :published, :with_instructeur, auto_archive_on: nil) }
-  let!(:procedure_hier) { create(:procedure, :published, :with_instructeur, auto_archive_on: 1.day.ago) }
+  let!(:procedure_hier) { create(:procedure, :published, :with_instructeur, auto_archive_on: 1.day.ago.to_date) }
   let!(:procedure_aujourdhui) { create(:procedure, :published, :with_instructeur, auto_archive_on: Time.zone.today) }
-  let!(:procedure_demain) { create(:procedure, :published, :with_instructeur, auto_archive_on: 1.day.from_now) }
+  let!(:procedure_demain) { create(:procedure, :published, :with_instructeur, auto_archive_on: 1.day.from_now.to_date) }
 
   subject { AutoArchiveProcedureJob.new.perform }
 

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1049,12 +1049,13 @@ describe Dossier do
   end
 
   describe '#send_brouillon_expiration_notices' do
-    let!(:procedure) { create(:procedure, duree_conservation_dossiers_dans_ds: 6) }
-    let!(:date_close_to_expiration) { Date.today - procedure.duree_conservation_dossiers_dans_ds.months + 1.month }
-    let!(:date_expired) { Date.today - procedure.duree_conservation_dossiers_dans_ds.months - 6.days }
-    let!(:date_not_expired) { Date.today - procedure.duree_conservation_dossiers_dans_ds.months + 2.months }
+    before { Timecop.freeze(Time.zone.parse('12/12/2012 15:00:00')) }
 
-    before { Timecop.freeze(Time.zone.parse('12/12/2012').beginning_of_day) }
+    let!(:procedure) { create(:procedure, duree_conservation_dossiers_dans_ds: 6) }
+    let!(:date_close_to_expiration) { Time.zone.now - procedure.duree_conservation_dossiers_dans_ds.months + 1.month }
+    let!(:date_expired) { Time.zone.now - procedure.duree_conservation_dossiers_dans_ds.months - 6.days }
+    let!(:date_not_expired) { Time.zone.now - procedure.duree_conservation_dossiers_dans_ds.months + 2.months }
+
     after { Timecop.return }
 
     context "Envoi de message pour les dossiers expirant dans - d'un mois" do

--- a/spec/services/bill_signature_service_spec.rb
+++ b/spec/services/bill_signature_service_spec.rb
@@ -4,7 +4,7 @@ describe BillSignatureService do
   describe ".grouped_unsigned_operation_until" do
     subject { BillSignatureService.grouped_unsigned_operation_until(date).length }
 
-    let(:date) { Time.zone.today }
+    let(:date) { Time.zone.now.beginning_of_day }
 
     context "when operations of several days need to be signed" do
       before do


### PR DESCRIPTION
Juste une correction habituelle sur les time_zone 
- Time.zone.today ne retourne pas une date avec TimeZone mais juste une date en accord avec la TimeZone ==> Pour la comparer avec des timestamps en base, il faut la convertir en timestamp avec par ex un beginning_of_day ou in_time_zone.
- inversement pour tester réellement un champ 'date' en base, on inscrit une date et non un timestamp d'où la conversion avec to_date (ca peut être considéré comme trop pointilleux j'en conviens)

Pour la petite histoire, A Paris, les tests de type time_zone peuvent planter entre minuit et 1h du matin. L'avantage à Tahiti c'est que les tests foireux en termes de time_zone plantent à partir de 14h :-)