### PR TITLE
Laisser les administrateurs déclarer eux-mêmes les démarches comme déclaratives

### DIFF
--- a/app/controllers/new_administrateur/procedures_controller.rb
+++ b/app/controllers/new_administrateur/procedures_controller.rb
@@ -68,7 +68,7 @@ module NewAdministrateur
     end
 
     def procedure_params
-      editable_params = [:libelle, :description, :organisation, :direction, :lien_site_web, :cadre_juridique, :deliberation, :notice, :web_hook_url, :euro_flag, :logo, :auto_archive_on, :monavis_embed]
+      editable_params = [:libelle, :description, :organisation, :direction, :lien_site_web, :cadre_juridique, :deliberation, :notice, :web_hook_url, :declarative_with_state, :euro_flag, :logo, :auto_archive_on, :monavis_embed]
       permited_params = if @procedure&.locked?
         params.require(:procedure).permit(*editable_params)
       else

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -185,6 +185,11 @@ type Demarche {
   datePublication: ISO8601DateTime!
 
   """
+  L'état de dossier pour une démarche déclarative
+  """
+  declarative: DossierDeclarativeState
+
+  """
   Description de la démarche.
   """
   description: String!
@@ -426,6 +431,18 @@ type DossierConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+}
+
+enum DossierDeclarativeState {
+  """
+  Accepté
+  """
+  accepte
+
+  """
+  En instruction
+  """
+  en_instruction
 }
 
 """

--- a/app/graphql/types/demarche_type.rb
+++ b/app/graphql/types/demarche_type.rb
@@ -6,6 +6,14 @@ module Types
       end
     end
 
+    class DossierDeclarativeState < Types::BaseEnum
+      Procedure.declarative_with_states.each do |symbol_name, string_name|
+        value(string_name,
+          I18n.t("declarative_with_state/#{string_name}", scope: [:activerecord, :attributes, :procedure]),
+          value: symbol_name)
+      end
+    end
+
     description "Une demarche"
 
     global_id_field :id
@@ -13,6 +21,7 @@ module Types
     field :title, String, "Le titre de la démarche.", null: false, method: :libelle
     field :description, String, "Description de la démarche.", null: false
     field :state, DemarcheState, "L'état de la démarche.", null: false
+    field :declarative, DossierDeclarativeState, "L'état de dossier pour une démarche déclarative", null: true, method: :declarative_with_state
 
     field :date_creation, GraphQL::Types::ISO8601DateTime, "Date de la création.", null: false, method: :created_at
     field :date_publication, GraphQL::Types::ISO8601DateTime, "Date de la publication.", null: false, method: :published_at

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -305,6 +305,12 @@ class Procedure < ApplicationRecord
     declarative_with_state == Procedure.declarative_with_states.fetch(:accepte)
   end
 
+  def self.declarative_attributes_for_select
+    declarative_with_states.map do |state, _|
+      [I18n.t("activerecord.attributes.#{model_name.i18n_key}.declarative_with_state/#{state}"), state]
+    end
+  end
+
   # Warning: dossier after_save build_default_champs must be removed
   # to save a dossier created from this method
   def new_dossier

--- a/app/views/new_administrateur/procedures/_informations.html.haml
+++ b/app/views/new_administrateur/procedures/_informations.html.haml
@@ -113,3 +113,13 @@
   %p.explication
     La clôture automatique suspend la publication de la démarche et entraîne le passage de tous les dossiers "en construction"
     (c'est à dire ceux qui ont été déposés), au statut "en instruction", ce qui ne permet plus aux usagers de les modifier.
+
+  = f.label :declarative_with_state do
+    Démarche déclarative
+  = f.select :declarative_with_state, Procedure.declarative_attributes_for_select, { include_blank: true }, class: 'form-control'
+
+  %p.explication
+    Par défaut, une démarche n'est pas déclarative; à son dépot, un dossier est «en construction». Vous pouvez choisir de la rendre déclarative, afin que tous les dossiers déposés soient immédiatement au statut "en instruction" en "accepté".
+    %br
+    %br
+    Dans le cadre d'une démarche déclarative, au dépot, seul l'email associé à l'état choisi est envoyé. (ex: démarche déclarative «accepté»: envoi uniquement de l'email d'acceptation)

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -14,3 +14,5 @@ fr:
         aasm_state/publiee: Publiée
         aasm_state/close: Close
         aasm_state/hidden: Suprimée
+        declarative_with_state/en_instruction: En instruction
+        declarative_with_state/accepte: Accepté


### PR DESCRIPTION

<img width="596" alt="Screenshot 2019-12-04 at 12 19 37" src="https://user-images.githubusercontent.com/12428/70138346-5f686400-1690-11ea-9565-e67969889901.png">

Je n'en peux plus de le faire au support...