### PR TITLE
Ajout d'une bannière pour prévenir des perturbations à partir d…

### DIFF
--- a/app/views/layouts/_main_container.html.haml
+++ b/app/views/layouts/_main_container.html.haml
@@ -1,5 +1,6 @@
 #main-container{ class: "col-xs-#{main_container_size}" }
   .row
+    = render partial: 'layouts/strike_banner'
     = render partial: 'layouts/outdated_browser_banner'
     = render partial: 'layouts/pre_maintenance'
   .row

--- a/app/views/layouts/_strike_banner.html.haml
+++ b/app/views/layouts/_strike_banner.html.haml
@@ -1,0 +1,8 @@
+#strike-banner.site-banner
+  .container
+    .site-banner-icon ⚠️
+    .site-banner-text
+      %strong
+        En raison d’une grève nationale interprofessionnelle, une partie des personnels ne travaille pas.
+      %br
+      Les délais de réponse aux questions techniques pourront être perturbés pendant les prochains jours.

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -26,8 +26,10 @@
 
   %body{ id: content_for(:page_id), class: browser.platform.ios? ? 'ios' : nil }
     .page-wrapper
+      = render partial: 'layouts/strike_banner'
       = render partial: "layouts/outdated_browser_banner"
       = render partial: 'layouts/pre_maintenance'
+
       - if staging?
         #beta
           Env Test

--- a/config/initializers/browser.rb
+++ b/config/initializers/browser.rb
@@ -2,6 +2,7 @@
 Browser.modern_rules.clear
 Browser.modern_rules << -> b { b.chrome? && b.version.to_i >= 50 && !b.platform.ios? }
 Browser.modern_rules << -> b { b.edge? && b.version.to_i >= 14 && !b.compatibility_view? }
+Browser.modern_rules << -> b { b.ie? && b.version.to_i >= 11 && !b.compatibility_view? }
 Browser.modern_rules << -> b { b.firefox? && b.version.to_i >= 50 && !b.platform.ios? }
 Browser.modern_rules << -> b { b.opera? && b.version.to_i >= 40 }
 Browser.modern_rules << -> b { b.safari? && b.version.to_i >= 8 }

--- a/spec/features/outdated_browser_spec.rb
+++ b/spec/features/outdated_browser_spec.rb
@@ -3,29 +3,29 @@ require 'spec_helper'
 feature 'Outdated browsers support:' do
   context 'when the user browser is outdated' do
     before(:each) do
-      ie_11_user_agent = 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko'
-      Capybara.page.driver.header('user-agent', ie_11_user_agent)
+      ie_10_user_agent = 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)'
+      Capybara.page.driver.header('user-agent', ie_10_user_agent)
     end
 
     scenario 'a banner is displayed' do
       visit new_user_session_path
-      expect(page).to have_content('Internet Explorer 11 est trop ancien')
+      expect(page).to have_content('Internet Explorer 10 est trop ancien')
     end
 
     scenario 'the banner can be dismissed' do
       visit new_user_session_path
-      expect(page).to have_content('Internet Explorer 11 est trop ancien')
+      expect(page).to have_content('Internet Explorer 10 est trop ancien')
 
       # The banner is hidden immediately
       within '#outdated-browser-banner' do
         click_on 'Ignorer'
       end
-      expect(page).not_to have_content('Internet Explorer 11 est trop ancien')
+      expect(page).not_to have_content('Internet Explorer 10 est trop ancien')
       expect(page).to have_current_path(new_user_session_path)
 
       # The banner is hidden after a refresh
       page.refresh
-      expect(page).not_to have_content('Internet Explorer 11 est trop ancien')
+      expect(page).not_to have_content('Internet Explorer 10 est trop ancien')
     end
   end
 end


### PR DESCRIPTION
- Ajout d'une bannière, grosso-modo modelée sur celle de la SNCF.

Cette PR désactive aussi le bandeau de dépréciation d'IE 11. Je me dis que ça fait peut-être beaucoup de bannières et beaucoup d'infos à processer d'un coup pour les gens. Et on pourra remettre la bannière IE 11 à la fin de la grève.

## Demarches-simplifiees

![Screenshot_2019-12-04 demarches-simplifiees fr(2)](https://user-images.githubusercontent.com/179923/70154078-2e982700-16b0-11ea-8462-cb1c3aea84d3.png)


## La SNCF

<img width="1036" alt="Capture d’écran 2019-12-04 à 14 29 09" src="https://user-images.githubusercontent.com/179923/70154054-29d37300-16b0-11ea-913c-3d264224c872.png">
