### PR TITLE
Suppression de la possibilité pour instructeur de changer son propre email

### DIFF
--- a/app/controllers/users/profil_controller.rb
+++ b/app/controllers/users/profil_controller.rb
@@ -1,5 +1,9 @@
 module Users
   class ProfilController < UserController
+    before_action :redirect_if_instructeur,
+      only: :update_email,
+      if: -> { instructeur_signed_in? }
+
     def show
     end
 
@@ -31,6 +35,10 @@ module Users
 
     def requested_email
       update_email_params[:email]
+    end
+
+    def redirect_if_instructeur
+      redirect_to profil_path
     end
   end
 end

--- a/app/controllers/users/profil_controller.rb
+++ b/app/controllers/users/profil_controller.rb
@@ -10,14 +10,14 @@ module Users
     end
 
     def update_email
-      if @current_user.update(update_email_params)
+      if current_user.update(update_email_params)
         flash.notice = t('devise.registrations.update_needs_confirmation')
-      elsif @current_user.errors&.details&.dig(:email)&.any? { |e| e[:error] == :taken }
-        UserMailer.account_already_taken(@current_user, requested_email).deliver_later
+      elsif current_user.errors&.details&.dig(:email)&.any? { |e| e[:error] == :taken }
+        UserMailer.account_already_taken(current_user, requested_email).deliver_later
         # avoid leaking information about whether an account with this email exists or not
         flash.notice = t('devise.registrations.update_needs_confirmation')
       else
-        flash.alert = @current_user.errors.full_messages
+        flash.alert = current_user.errors.full_messages
       end
 
       redirect_to profil_path

--- a/app/views/users/profil/show.html.haml
+++ b/app/views/users/profil/show.html.haml
@@ -18,9 +18,10 @@
         %p
           Pour finaliser votre changement d’adresse, vérifiez vos emails et cliquez sur le lien de confirmation.
 
-    = form_for @current_user, url: update_email_path, method: :patch, html: { class: 'form' } do |f|
-      = f.email_field :email, value: nil, placeholder: 'Nouvelle adresse email', required: true
-      = f.submit "Changer mon adresse", class: 'button primary'
+    - if !instructeur_signed_in?
+      = form_for @current_user, url: update_email_path, method: :patch, html: { class: 'form' } do |f|
+        = f.email_field :email, value: nil, placeholder: 'Nouvelle adresse email', required: true
+        = f.submit "Changer mon adresse", class: 'button primary'
 
   - if current_administrateur.present?
     .card

--- a/spec/controllers/users/profil_controller_spec.rb
+++ b/spec/controllers/users/profil_controller_spec.rb
@@ -52,8 +52,6 @@ describe Users::ProfilController, type: :controller do
     end
 
     context 'when the mail is incorrect' do
-      let!(:user2) { create(:user) }
-
       before do
         patch :update_email, params: { user: { email: 'incorrect' } }
         user.reload

--- a/spec/controllers/users/profil_controller_spec.rb
+++ b/spec/controllers/users/profil_controller_spec.rb
@@ -60,5 +60,18 @@ describe Users::ProfilController, type: :controller do
       it { expect(response).to redirect_to(profil_path) }
       it { expect(flash.alert).to eq(['Email invalide']) }
     end
+
+    context 'when the user has an instructeur role' do
+      let(:instructeur_email) { 'instructeur_email@a.com' }
+      let!(:user) { create(:instructeur, email: instructeur_email).user }
+
+      before do
+        patch :update_email, params: { user: { email: 'loulou@lou.com' } }
+        user.reload
+      end
+
+      it { expect(user.unconfirmed_email).to be_nil }
+      it { expect(response).to redirect_to(profil_path) }
+    end
   end
 end


### PR DESCRIPTION
Change son propre email rentre en contradiction avec la feature de vérification d'email professionnel pour les instructeurs.