### PR TITLE
#3245 -Export PDF d'un dossier pour usager et instructeur

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem 'openstack'
 gem 'pg'
 gem 'phonelib'
 gem 'prawn' # PDF Generation
+gem 'prawn-svg'
 gem 'prawn_rails'
 gem 'premailer-rails'
 gem 'puma' # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -425,6 +425,9 @@ GEM
     prawn (2.2.2)
       pdf-core (~> 0.7.0)
       ttfunk (~> 1.5)
+    prawn-svg (0.29.1)
+      css_parser (~> 1.6)
+      prawn (>= 0.11.1, < 3)
     prawn_rails (0.0.11)
       prawn (>= 0.11.1)
       railties (>= 3.0.0)
@@ -770,6 +773,7 @@ DEPENDENCIES
   pg
   phonelib
   prawn
+  prawn-svg
   prawn_rails
   premailer-rails
   pry-byebug

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -27,6 +27,14 @@ module Instructeurs
 
     def show
       @demande_seen_at = current_instructeur.follows.find_by(dossier: dossier)&.demande_seen_at
+
+      respond_to do |format|
+        format.pdf do
+          @include_infos_administration = true
+          render(file: 'dossiers/show', formats: [:pdf])
+        end
+        format.all
+      end
     end
 
     def messagerie

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -36,6 +36,13 @@ module Users
       end
 
       @dossier = dossier
+      respond_to do |format|
+        format.pdf do
+          @include_infos_administration = false
+          render(file: 'dossiers/show', formats: [:pdf])
+        end
+        format.all
+      end
     end
 
     def demande

--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -23,9 +23,7 @@ def add_title(pdf, title)
 end
 
 def format_date(date)
-  is_current_year = (date.year == Time.zone.today.year)
-  template = is_current_year ? :message_date : :message_date_with_year
-  I18n.l(date, format: template)
+  I18n.l(date, format: :message_date_with_year)
 end
 
 def add_identite_individual(pdf, dossier)
@@ -84,6 +82,8 @@ def render_single_champ(pdf, champ)
       pdf.text champ.libelle
     end
     pdf.text "\n"
+  when 'Champs::ExplicationChamp'
+    format_in_2_lines(pdf, champ.libelle, champ.description)
   when 'Champs::CarteChamp'
     format_in_2_lines(pdf, champ.libelle, champ.geo_json.to_s)
   when 'Champs::SiretChamp'
@@ -180,7 +180,7 @@ prawn_document(page_size: "A4") do |pdf|
   end
 
   add_title(pdf, 'Messagerie')
-  @dossier.commentaires.with_attached_piece_jointe.each do |commentaire|
+  @dossier.commentaires.each do |commentaire|
     add_message(pdf, commentaire)
   end
 end

--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -1,0 +1,145 @@
+require 'prawn/measurement_extensions'
+
+def format_in_2_lines(pdf, label, text)
+  pdf.font 'liberation serif', style: :bold, size: 12 do
+    pdf.text label
+  end
+  pdf.text text
+  pdf.text "\n"
+end
+
+def format_in_2_columns(pdf, label, text)
+  pdf.text_box label, width: 200, height: 100, overflow: :expand, at: [0, pdf.cursor]
+      pdf.text_box ":", width: 10, height: 100, overflow: :expand, at: [100, pdf.cursor]
+  pdf.text_box text, width: 420, height: 100, overflow: :expand, at: [110, pdf.cursor]
+  pdf.text "\n"
+end
+
+def add_title(pdf, title)
+  title_style = {style: :bold, size: 24}
+  pdf.font 'liberation serif', title_style do
+    pdf.text title
+  end
+end
+
+def format_date(date)
+  is_current_year = (date.year == Time.zone.today.year)
+  template = is_current_year ? :message_date : :message_date_with_year
+  I18n.l(date, format: template)
+end
+
+def render_single_champ(pdf, champ)
+  case champ.type
+  when 'Champs::RepetitionChamp'
+    raise 'There should not be a RepetitionChamp here !'
+  when 'Champs::PieceJustificativeChamp'
+    return
+  when 'Champs::HeaderSectionChamp'
+    pdf.font 'liberation serif', style: :bold, size: 18 do
+      pdf.text champ.libelle
+    end
+    pdf.text "\n"
+  when 'Champs::CarteChamp'
+    format_in_2_lines(pdf, champ.libelle, champ.geo_json.to_s)
+  when 'Champs::SiretChamp'
+    format_in_2_lines(pdf, champ.libelle, champ.to_s)
+    if champ.etablissement.present?
+      etablissement = champ.etablissement
+      format_in_2_lines(pdf, champ.libelle, raison_sociale_or_name(etablissement))
+    end
+  else
+    value = champ.to_s.empty? ? 'Non communiqué' : champ.to_s
+    format_in_2_lines(pdf, champ.libelle, value)
+  end
+end
+
+def add_champs(pdf, champs)
+  champs.each do |champ|
+    if champ.type == 'Champs::RepetitionChamp'
+      champ.rows.each do |row|
+        row.each do |inner_champ|
+          render_single_champ(pdf, inner_champ)
+        end
+      end
+    else
+      render_single_champ(pdf, champ)
+    end
+  end
+end
+
+def add_message(pdf, message)
+  sender = message.redacted_email
+  if message.sent_by_system?
+    sender = 'Email automatique'
+  elsif message.sent_by?(@dossier.user)
+    sender = @dossier.user.email
+  end
+
+  pdf.text "#{sender}, #{format_date(message.created_at)}", style: :bold
+  pdf.text ActionView::Base.full_sanitizer.sanitize(message.body)
+  pdf.text "\n"
+end
+
+def add_avis(pdf, avis)
+  pdf.text "Avis de #{avis.email_to_display}", style: :bold
+  if avis.confidentiel?
+    pdf.text "(confidentiel)", style: :bold
+  end
+  text = avis.answer || 'En attente de réponse'
+  pdf.text text, style: :bold
+end
+
+prawn_document(page_size: "A4") do |pdf|
+  pdf.font_families.update( 'liberation serif' => {
+    normal: Rails.root.join('lib/prawn/fonts/liberation_serif/LiberationSerif-Regular.ttf' ),
+    bold: Rails.root.join('lib/prawn/fonts/liberation_serif/LiberationSerif-Bold.ttf' ),
+  })
+  pdf.font 'liberation serif'
+
+  pdf.svg IO.read("app/assets/images/header/logo-ds-wide.svg"), width: 300, position: :center
+  pdf.move_down(40)
+
+  pdf.text "Dossier Nº #{@dossier.id} déposé sur la démarche #{@dossier.procedure.libelle}"
+  pdf.text "\n"
+
+  entete = "Ce dossier est <b>#{dossier_display_state(@dossier, lower: true)}</b>"
+  if @dossier.motivation.present?
+    entete += " avec la motivation suivante : #{@dossier.motivation}"
+  end
+
+  pdf.text entete, inline_format: true
+  pdf.text "\n"
+
+  add_title(pdf, "Identité du demandeur")
+
+  if @dossier.individual.present?
+    format_in_2_columns(pdf, "Civilité", @dossier.individual.gender)
+    format_in_2_columns(pdf, "Nom", @dossier.individual.nom)
+    format_in_2_columns(pdf, "Prénom", @dossier.individual.prenom)
+
+    if @dossier.individual.birthdate.present?
+      format_in_2_columns(pdf, "Date de naissance", try_format_date(@dossier.individual.birthdate))
+    end
+  end
+  pdf.text "\n"
+
+  add_title(pdf, 'Formulaire')
+  add_champs(pdf, @dossier.champs)
+
+  if @include_infos_administration && @dossier.champs_private&.size > 0
+    add_title(pdf, "Annotations privées")
+    add_champs(pdf, @dossier.champs_private)
+  end
+
+  if @include_infos_administration && @dossier.avis.present?
+    add_title(pdf, "Avis")
+    @dossier.avis.each do |avis|
+      add_avis(pdf, avis)
+    end
+  end
+
+  add_title(pdf, 'Messagerie')
+  @dossier.commentaires.with_attached_piece_jointe.each do |commentaire|
+    add_message(pdf, commentaire)
+  end
+end

--- a/app/views/instructeurs/dossiers/_header_actions.html.haml
+++ b/app/views/instructeurs/dossiers/_header_actions.html.haml
@@ -3,9 +3,11 @@
     %span.icon.printer
   %ul.print-menu.dropdown-content
     %li
-      = link_to "Tout le dossier", instructeur_dossier_path(dossier.procedure, dossier, format: :pdf), target: "_blank", rel: "noopener", class: "menu-item menu-link"
+      = link_to "Tout le dossier", print_instructeur_dossier_path(dossier.procedure, dossier), target: "_blank", rel: "noopener", class: "menu-item menu-link"
     %li
       = link_to "Uniquement cet onglet", "#", onclick: "window.print()", class: "menu-item menu-link"
+    %li
+      = link_to "Export PDF", instructeur_dossier_path(dossier.procedure, dossier, format: :pdf), target: "_blank", rel: "noopener", class: "menu-item menu-link"
 
 - if !PiecesJustificativesService.liste_pieces_justificatives(dossier).empty?
   %span.dropdown.print-menu-opener

--- a/app/views/instructeurs/dossiers/_header_actions.html.haml
+++ b/app/views/instructeurs/dossiers/_header_actions.html.haml
@@ -3,7 +3,7 @@
     %span.icon.printer
   %ul.print-menu.dropdown-content
     %li
-      = link_to "Tout le dossier", print_instructeur_dossier_path(dossier.procedure, dossier), target: "_blank", rel: "noopener", class: "menu-item menu-link"
+      = link_to "Tout le dossier", instructeur_dossier_path(dossier.procedure, dossier, format: :pdf), target: "_blank", rel: "noopener", class: "menu-item menu-link"
     %li
       = link_to "Uniquement cet onglet", "#", onclick: "window.print()", class: "menu-item menu-link"
 

--- a/app/views/users/dossiers/show/_header.html.haml
+++ b/app/views/users/dossiers/show/_header.html.haml
@@ -15,6 +15,12 @@
         = render partial: 'invites/dropdown', locals: { dossier: dossier }
         - if dossier.can_be_updated_by_user? && !current_page?(modifier_dossier_path(dossier))
           = link_to "Modifier mon dossier", modifier_dossier_path(dossier), class: 'button accepted edit-form', 'title'=> "Vous pouvez modifier votre dossier tant qu'il n'est passé en instruction"
+        %span.dropdown.print-menu-opener
+          %button.button.dropdown-button.icon-only{ title: 'imprimer' }
+            %span.icon.printer
+          %ul.print-menu.dropdown-content
+            %li
+              = link_to "Tout le dossier", dossier_path(dossier, format: :pdf), target: "_blank", rel: "noopener", class: "menu-item menu-link"
 
     %ul.tabs
       = dynamic_tab_item('Résumé', dossier_path(dossier))

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -473,6 +473,34 @@ describe Instructeurs::DossiersController, type: :controller do
     end
   end
 
+  describe "#show" do
+    context "when the dossier is exported as PDF" do
+      let(:instructeur) { create(:instructeur) }
+      let(:dossier) {
+  create(:dossier,
+    :accepte,
+    :with_all_champs,
+    :with_all_annotations,
+    :with_motivation,
+    :with_commentaires, procedure: procedure)
+}
+      let!(:avis) { create(:avis, dossier: dossier, instructeur: instructeur) }
+      subject do
+        get :show, params: {
+          procedure_id: procedure.id,
+          dossier_id: dossier.id,
+          format: :pdf
+        }
+      end
+
+      before do
+        subject
+      end
+      it { expect(assigns(:include_infos_administration)).to eq(true) }
+      it { expect(response).to render_template 'dossiers/show' }
+    end
+  end
+
   describe "#update_annotations" do
     let(:champ_multiple_drop_down_list) do
       create(:type_de_champ_multiple_drop_down_list, :private, libelle: 'libelle').champ.create

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -731,17 +731,37 @@ describe Users::DossiersController, type: :controller do
       sign_in(user)
     end
 
-    subject! { get(:show, params: { id: dossier.id }) }
+    context 'with default output' do
+      subject! { get(:show, params: { id: dossier.id }) }
 
-    context 'when the dossier is a brouillon' do
-      let(:dossier) { create(:dossier, user: user) }
-      it { is_expected.to redirect_to(brouillon_dossier_path(dossier)) }
+      context 'when the dossier is a brouillon' do
+        let(:dossier) { create(:dossier, user: user) }
+        it { is_expected.to redirect_to(brouillon_dossier_path(dossier)) }
+      end
+
+      context 'when the dossier has been submitted' do
+        let(:dossier) { create(:dossier, :en_construction, user: user) }
+        it { expect(assigns(:dossier)).to eq(dossier) }
+        it { is_expected.to render_template(:show) }
+      end
     end
 
-    context 'when the dossier has been submitted' do
-      let(:dossier) { create(:dossier, :en_construction, user: user) }
-      it { expect(assigns(:dossier)).to eq(dossier) }
-      it { is_expected.to render_template(:show) }
+    context "with PDF output" do
+      let(:procedure) { create(:procedure) }
+      let(:dossier) {
+  create(:dossier,
+    :accepte,
+    :with_all_champs,
+    :with_motivation,
+    :with_commentaires,
+    procedure: procedure,
+    user: user)
+}
+
+      subject! { get(:show, params: { id: dossier.id, format: :pdf }) }
+
+      it { expect(assigns(:include_infos_administration)).to eq(false) }
+      it { expect(response).to render_template 'dossiers/show' }
     end
   end
 


### PR DESCRIPTION
https://github.com/betagouv/demarches-simplifiees.fr/issues/3245

 - il y a 2 sorties:
   - une pour les demandeurs (infos demandeurs, formulaire, messages et décision)
   - une pour les instructeurs (en plus, on ajoute les annotations privées et les avis)
 - le rendu se fait à la volée, comme une vue, sur `/dossiers/1088079.pdf` et `/procedures/23393/dossiers/1088079.pdf`. L'export est donc généré à l'instant demandé, sans stockage.
 - ajout d'un bouton coté usager pour obtenir le pdf.

![bouton-imprimer-usager](https://user-images.githubusercontent.com/1223316/70890716-febd1d80-1fe5-11ea-8d1b-0e0215522021.png)
 - suite à discussion avec simon, on est parti sur une lib dédiée (prawn) pour générer un pdf, plutôt que convertir des vues html en pdf (cela requiert un composant type wkhtmltopdf, donc une augmentation de surface d'attaque, un outil à installer et maintenir, etc)

## Esthétique

Exemple de rendu:
(J'ai juste un peu triché sur l'identité, il y a à la fois un individu et une entreprise).
[1088079.pdf](https://github.com/betagouv/demarches-simplifiees.fr/files/3966760/1088079.pdf)

Clairement c'est… minimaliste, car c'est pas simple de faire joli. Dès qu'on veut 2 colonnes par ex, on risque d'avoir le texte des 2 colonnes qui se superposent si on ne maitrise pas la taille du texte de la première.

![overlap](https://user-images.githubusercontent.com/1223316/70890769-1dbbaf80-1fe6-11ea-9729-ad7a16be757e.png)
…d'où le fait que le rendu du champ Siret en «liste à points» est différent du rendu 2 colonnes pour un individu. Si quelqu'un a mieux, je prends.

Je n'ai pas osé faire de sauts de pages (ça va finir imprimé et consommer du papier pour des espaces vides), mais on ne maitrise pas la coupure des sections, donc on peut avoir un titre avant un changement de page. Dans l'exemple ci-dessous, la barre noire sous `Avis` est un changement de page.

![avis-messagerie](https://user-images.githubusercontent.com/1223316/70890868-5f4c5a80-1fe6-11ea-817b-3e1978c1a0d8.png)

## Intégration avec l'existant

On a déja un export pdf via un rendu HTML à imprimer soi-même (`instructeurs/dossiers_controller#print`) chez les instructeurs. On a plusieurs options pour la cohabitation avec ce nouvel export:
  - on peut mettre la nouvelle sortie pdf derriere un feature flag et remplacer l'ancien export si activé
  - on peut avoir 2 boutons d'export pdf en parallèle (niveau UI faut trouver comment rendre ça clair)
  - on peut rediriger print vers la sortie pdf (ceux qui utilisent déja l'export risque d'être surpris, en bien comme en mal)

Pour le moment j'ai laissé l'url existante, et j'ai modifié le bouton imprimer pour qu'il redirige vers le nouveau pdf