### PR TITLE
Integration API carto IGN

### DIFF
--- a/app/controllers/champs/carte_controller.rb
+++ b/app/controllers/champs/carte_controller.rb
@@ -39,14 +39,6 @@ class Champs::CarteController < ApplicationController
         end
       end
 
-      if @champ.quartiers_prioritaires?
-        quartiers_prioritaires = ApiCartoService.generate_qp(coordinates)
-        geo_areas += quartiers_prioritaires.map do |qp|
-          qp[:source] = GeoArea.sources.fetch(:quartier_prioritaire)
-          qp
-        end
-      end
-
       selection_utilisateur = ApiCartoService.generate_selection_utilisateur(coordinates)
       selection_utilisateur[:source] = GeoArea.sources.fetch(:selection_utilisateur)
       geo_areas << selection_utilisateur

--- a/app/javascript/components/TypesDeChampEditor/components/TypeDeChamp.js
+++ b/app/javascript/components/TypesDeChampEditor/components/TypeDeChamp.js
@@ -137,10 +137,6 @@ const TypeDeChamp = sortableElement(
           />
           <TypeDeChampCarteOptions isVisible={isCarte}>
             <TypeDeChampCarteOption
-              label="Quartiers prioritaires"
-              handler={updateHandlers.quartiers_prioritaires}
-            />
-            <TypeDeChampCarteOption
               label="Cadastres"
               handler={updateHandlers.cadastres}
             />

--- a/app/lib/api_carto/api.rb
+++ b/app/lib/api_carto/api.rb
@@ -5,20 +5,19 @@ class ApiCarto::API
   end
 
   def self.search_cadastre(geojson)
-    url = [API_CARTO_URL, "cadastre", "geometrie"].join("/")
+    url = [API_CARTO_URL, "cadastre", "parcelle"].join("/")
     call(url, geojson)
   end
 
   private
 
   def self.call(url, geojson)
-    response = Typhoeus.post(url, body: geojson.to_s, headers: { 'content-type' => 'application/json' })
+    response = Typhoeus.get(url, params: { geom: geojson.to_s }, headers: { 'content-type' => 'application/json' })
 
     if response.success?
       response.body
     else
-      message = response.code == 0 ? response.return_message : response.code.to_s
-      Rails.logger.error "[ApiCarto] Error on #{url}: #{message}"
+      Rails.logger.error "[ApiCarto] Error on #{url}. Code #{response.code}, #{response.body}"
       raise RestClient::ResourceNotFound
     end
   end

--- a/app/services/geojson_service.rb
+++ b/app/services/geojson_service.rb
@@ -12,15 +12,8 @@ class GeojsonService
 
   def self.to_json_polygon_for_cadastre(coordinates)
     polygon = {
-      geom: {
-        type: "Feature",
-        geometry: {
-          type: "Polygon",
-          coordinates: [
-            coordinates
-          ]
-        }
-      }
+      type: "Polygon",
+      coordinates: [coordinates]
     }
 
     polygon.to_json

--- a/app/views/shared/champs/carte/_geo_areas.html.haml
+++ b/app/views/shared/champs/carte/_geo_areas.html.haml
@@ -24,7 +24,10 @@
     - else
       %ul
         - champ.cadastres.each do |pc|
-          %li Parcelle n° #{pc.numero} - Feuille #{pc.code_arr} #{pc.section} #{pc.feuille} - #{pc.surface_parcelle.round} m<sup>2</sup>
+          - if pc.surface_parcelle.blank?
+            %li Parcelle n° #{pc.numero} - Feuille #{pc.code_arr} #{pc.section} #{pc.feuille}
+          - else
+            %li Parcelle n° #{pc.numero} - Feuille #{pc.code_arr} #{pc.section} #{pc.feuille} - #{pc.surface_parcelle.round} m<sup>2</sup>
 
 - if champ.parcelles_agricoles?
   .areas-title Parcelles agricoles (RPG)

--- a/config/initializers/urls.rb
+++ b/config/initializers/urls.rb
@@ -1,6 +1,6 @@
 # API URLs
 API_ADRESSE_URL = ENV.fetch("API_ADRESSE_URL", "https://api-adresse.data.gouv.fr")
-API_CARTO_URL = ENV.fetch("API_CARTO_URL", "https://sandbox.geo.api.gouv.fr/apicarto")
+API_CARTO_URL = ENV.fetch("API_CARTO_URL", 'https://apicarto.ign.fr/api')
 API_ENTREPRISE_URL = ENV.fetch("API_ENTREPRISE_URL", "https://entreprise.api.gouv.fr/v2")
 API_GEO_URL = ENV.fetch("API_GEO_URL", "https://geo.api.gouv.fr")
 API_GEO_SANDBOX_URL = ENV.fetch("API_GEO_SANDBOX_URL", "https://sandbox.geo.api.gouv.fr")


### PR DESCRIPTION
J'arrive à faire tourner un service alternatif à celui dont on dispose mais je n'ai pas du tout confiance.

 - je ne fournis ni token, ni referer. Cela fonctionne maintenant (en particulier sur https://apicarto.ign.fr/api/doc/cadastre#/Parcelle/get_cadastre_parcelle), mais je suis quasi sûr que ça ne fonctionnait pas sans paramètre apiToken quand j'ai commencé, jeudi dernier et ce matin. Rien n'est précisé concernant le rate-limiting, il est donc possible que nous ayons des problèmes.
 - remplacement du endpoint /geometry par un autre qui contient les infos sur les parcelles également, le premier n'est plus dispo dans le fork de l'IGN.
 - le référentiel «quartiers prioritaires» n'est pas dispo dans l'API IGN, jai du le supprimer (j'ai fait le minimun; il y a/aurait du cleanup supplémentaire à faire si on persévère dans cette direction)