### PR TITLE
sign_up: fix suggestions error when navigating away

### DIFF
--- a/app/javascript/new_design/user-sign_up.js
+++ b/app/javascript/new_design/user-sign_up.js
@@ -13,7 +13,7 @@ delegate('focusout', userNewEmailSelector, () => {
   const suggestedEmailSpan = document.querySelector(emailSuggestionSelector);
 
   const suggestion = suggest(userEmailInput.value);
-  if (suggestion && suggestion.full) {
+  if (suggestion && suggestion.full && suggestedEmailSpan) {
     suggestedEmailSpan.innerHTML = suggestion.full;
     show(document.querySelector(suggestionsSelector));
   } else {

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -8,7 +8,7 @@
     = f.label :email, "Email"
     = f.text_field :email, autofocus: true, placeholder: "Votre adresse email"
 
-    .suspect-email
+    .suspect-email.hidden
       .email-suggestion-title
         Voulez-vous dire
         %span.email-suggestion-address blabla@gmail.com


### PR DESCRIPTION
When navigating away from the page, the field receives the 'focusout' event – but stops to be present in the DOM.

Thus we need to check that the DOM element is actually present.

Fix https://sentry.io/organizations/demarches-simplifiees/issues/1369476739/?project=1429547