### PR TITLE
Refactor individual creation

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -231,7 +231,11 @@ module Users
         return redirect_to url_for dossiers_path
       end
 
-      dossier = Dossier.create!(groupe_instructeur: procedure.defaut_groupe_instructeur, user: current_user, state: Dossier.states.fetch(:brouillon))
+      dossier = Dossier.create!(
+        groupe_instructeur: procedure.defaut_groupe_instructeur,
+        user: current_user,
+        state: Dossier.states.fetch(:brouillon)
+      )
 
       if dossier.procedure.for_individual
         if current_user.france_connect_information.present?

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -238,10 +238,6 @@ module Users
       )
 
       if dossier.procedure.for_individual
-        if current_user.france_connect_information.present?
-          dossier.update_with_france_connect(current_user.france_connect_information)
-        end
-
         redirect_to identite_dossier_path(dossier)
       else
         redirect_to siret_dossier_path(id: dossier.id)

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -220,10 +220,15 @@ module Users
     def new
       erase_user_location!
 
-      if params[:brouillon]
-        procedure = Procedure.brouillon.find(params[:procedure_id])
-      else
-        procedure = Procedure.publiees.find(params[:procedure_id])
+      begin
+        if params[:brouillon]
+          procedure = Procedure.brouillon.find(params[:procedure_id])
+        else
+          procedure = Procedure.publiees.find(params[:procedure_id])
+        end
+      rescue ActiveRecord::RecordNotFound
+        flash.alert = t('errors.messages.procedure_not_found')
+        return redirect_to url_for dossiers_path
       end
 
       dossier = Dossier.create!(groupe_instructeur: procedure.defaut_groupe_instructeur, user: current_user, state: Dossier.states.fetch(:brouillon))
@@ -237,10 +242,6 @@ module Users
       else
         redirect_to siret_dossier_path(id: dossier.id)
       end
-    rescue ActiveRecord::RecordNotFound
-      flash.alert = t('errors.messages.procedure_not_found')
-
-      redirect_to url_for dossiers_path
     end
 
     def dossier_for_help

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -231,11 +231,13 @@ module Users
         return redirect_to url_for dossiers_path
       end
 
-      dossier = Dossier.create!(
+      dossier = Dossier.new(
         groupe_instructeur: procedure.defaut_groupe_instructeur,
         user: current_user,
         state: Dossier.states.fetch(:brouillon)
       )
+      dossier.build_default_individual
+      dossier.save!
 
       if dossier.procedure.for_individual
         redirect_to identite_dossier_path(dossier)

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -207,9 +207,6 @@ class Dossier < ApplicationRecord
   delegate :france_connect_information, to: :user
 
   before_validation :update_state_dates, if: -> { state_changed? }
-  before_validation :build_default_individual,
-    if: -> { new_record? && procedure.for_individual? && individual.blank? }
-
   before_save :build_default_champs, if: Proc.new { groupe_instructeur_id_was.nil? }
   before_save :update_search_terms
 
@@ -241,10 +238,12 @@ class Dossier < ApplicationRecord
   end
 
   def build_default_individual
-    self.individual = if france_connect_information.present?
-      Individual.from_france_connect(france_connect_information)
-    else
-      Individual.new
+    if procedure.for_individual? && individual.blank?
+      self.individual = if france_connect_information.present?
+        Individual.from_france_connect(france_connect_information)
+      else
+        Individual.new
+      end
     end
   end
 

--- a/app/models/individual.rb
+++ b/app/models/individual.rb
@@ -9,8 +9,8 @@ class Individual < ApplicationRecord
   GENDER_MALE = 'M.'
   GENDER_FEMALE = 'Mme'
 
-  def self.create_from_france_connect(fc_information)
-    create!(
+  def self.from_france_connect(fc_information)
+    new(
       nom: fc_information.family_name,
       prenom: fc_information.given_name,
       gender: fc_information.gender == 'female' ? GENDER_FEMALE : GENDER_MALE

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -169,71 +169,71 @@ describe API::V2::GraphqlController do
     end
 
     context "dossier" do
-      let(:query) do
-        "{
-          dossier(number: #{dossier.id}) {
-            id
-            number
-            state
-            dateDerniereModification
-            datePassageEnConstruction
-            datePassageEnInstruction
-            dateTraitement
-            motivation
-            motivationAttachment {
-              url
-            }
-            usager {
+      context "with individual" do
+        let(:query) do
+          "{
+            dossier(number: #{dossier.id}) {
               id
-              email
-            }
-            demandeur {
-              id
-              ... on PersonnePhysique {
-                nom
-                prenom
-                civilite
-                dateDeNaissance
-              }
-            }
-            instructeurs {
-              id
-              email
-            }
-            messages {
-              email
-              body
-              attachment {
-                filename
-                checksum
-                byteSize
-                contentType
+              number
+              state
+              dateDerniereModification
+              datePassageEnConstruction
+              datePassageEnInstruction
+              dateTraitement
+              motivation
+              motivationAttachment {
                 url
               }
-            }
-            avis {
-              expert {
+              usager {
+                id
                 email
               }
-              question
-              reponse
-              dateQuestion
-              dateReponse
-              attachment {
-                url
-                filename
+              demandeur {
+                id
+                ... on PersonnePhysique {
+                  nom
+                  prenom
+                  civilite
+                  dateDeNaissance
+                }
+              }
+              instructeurs {
+                id
+                email
+              }
+              messages {
+                email
+                body
+                attachment {
+                  filename
+                  checksum
+                  byteSize
+                  contentType
+                  url
+                }
+              }
+              avis {
+                expert {
+                  email
+                }
+                question
+                reponse
+                dateQuestion
+                dateReponse
+                attachment {
+                  url
+                  filename
+                }
+              }
+              champs {
+                id
+                label
+                stringValue
               }
             }
-            champs {
-              id
-              label
-              stringValue
-            }
-          }
-        }"
-      end
+          }"
+        end
 
-      context "with individual" do
         it "should be returned" do
           expect(gql_errors).to eq(nil)
           expect(gql_data).to eq(dossier: {

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -15,7 +15,7 @@ describe API::V2::GraphqlController do
   end
   let(:dossier1) { create(:dossier, :en_construction, :for_individual, procedure: procedure, en_construction_at: 1.day.ago) }
   let(:dossier2) { create(:dossier, :en_construction, :for_individual, procedure: procedure, en_construction_at: 3.days.ago) }
-  let!(:dossier_brouillon) { create(:dossier, :for_individual, procedure: procedure) }
+  let(:dossier_brouillon) { create(:dossier, :for_individual, procedure: procedure) }
   let(:dossiers) { [dossier2, dossier1, dossier] }
   let(:instructeur) { create(:instructeur, followed_dossiers: dossiers) }
 

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -15,9 +15,12 @@ FactoryBot.define do
         procedure = create(:procedure, :published, :with_type_de_champ, :with_type_de_champ_private)
       end
 
+      # Assign the procedure to the dossier through the groupe_instructeur
       if dossier.groupe_instructeur.nil?
         dossier.groupe_instructeur = procedure.defaut_groupe_instructeur
       end
+
+      dossier.build_default_individual
     end
 
     trait :with_entreprise do


### PR DESCRIPTION
Currently there is an issue where we end up with Dossiers without Individuals in production (#4596).

I don't know where this error comes from, and I didn't manage to reproduce it yet. But a root cause is that we don't validate the presence of an `individual` record at the Rails level. (This is because dossiers that are not `for_individual` shouldn't have one.)

This PR adds a validator on Dossier, which ensures that a dossier on a `for_individual?` procedure always has an `individual` associated record.

## Implementation

For this, the individual needs to be built before the record is validated (i.e. even before the `before_create` callback is run).

This is why the Dossier creation is refactored. Instead of:

1. Creating and saving the dossier record;
2. Updating the individual if there are France Connect infos available.

we instead create the dossier and the individual in a single pass:

1. Create the dossier;
2. Build the default individual (including France Connect infos if available)
3. Save the dossier.

Which means that now, if a dossier is created without an `individual`, or if the `invividual` record is later removed, the validation will fail immediately at creation time.