### PR TITLE
config: fix France Connect callback URL when testing locally

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -15,7 +15,7 @@ defaults: &defaults
   basic_auth:
     username: <%= ENV['BASIC_AUTH_USERNAME'] %>
     password: <%= ENV['BASIC_AUTH_PASSWORD'] %>
-  france_connect_particulier:
+  france_connect_particulier: &france_connect_particulier
     identifier: <%= ENV['FC_PARTICULIER_ID'] %>
     secret: <%= ENV['FC_PARTICULIER_SECRET'] %>
     redirect_uri: https://<%= ENV['APP_HOST'] %>/france_connect/particulier/callback
@@ -76,6 +76,10 @@ defaults: &defaults
 
 development:
   <<: *defaults
+  france_connect_particulier:
+    <<: *france_connect_particulier
+    redirect_uri: http://<%= ENV['APP_HOST'] %>/france_connect/particulier/callback
+
 
 test:
   <<: *defaults


### PR DESCRIPTION
When testing France Connect on a local development environment, the
callback URL should be something like `http://localhost:3000/…/…`

But currently, the callback URL uses `https`, even in development. This
causes the callback URL to be rejected by France Connect.

This commit overrides the callback URL when in development, to use
an `http` URL instead. In doesn't affect the production settings.