### PR TITLE
Refactor dossiers factories

### DIFF
--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -288,8 +288,8 @@ describe API::V2::GraphqlController do
       end
 
       context "with entreprise" do
-        let(:procedure) { create(:procedure, :published, administrateurs: [admin]) }
-        let(:dossier) { create(:dossier, :en_construction, :with_entreprise, procedure: procedure) }
+        let(:procedure_for_entreprise) { create(:procedure, :published, administrateurs: [admin]) }
+        let(:dossier) { create(:dossier, :en_construction, :with_entreprise, procedure: procedure_for_entreprise) }
 
         let(:query) do
           "{

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -8,14 +8,14 @@ describe API::V2::GraphqlController do
     dossier = create(:dossier,
       :en_construction,
       :with_all_champs,
-      :for_individual,
+      :with_individual,
       procedure: procedure)
     create(:commentaire, :with_file, dossier: dossier, email: 'test@test.com')
     dossier
   end
-  let(:dossier1) { create(:dossier, :en_construction, :for_individual, procedure: procedure, en_construction_at: 1.day.ago) }
-  let(:dossier2) { create(:dossier, :en_construction, :for_individual, procedure: procedure, en_construction_at: 3.days.ago) }
-  let(:dossier_brouillon) { create(:dossier, :for_individual, procedure: procedure) }
+  let(:dossier1) { create(:dossier, :en_construction, :with_individual, procedure: procedure, en_construction_at: 1.day.ago) }
+  let(:dossier2) { create(:dossier, :en_construction, :with_individual, procedure: procedure, en_construction_at: 3.days.ago) }
+  let(:dossier_brouillon) { create(:dossier, :with_individual, procedure: procedure) }
   let(:dossiers) { [dossier2, dossier1, dossier] }
   let(:instructeur) { create(:instructeur, followed_dossiers: dossiers) }
 
@@ -416,7 +416,7 @@ describe API::V2::GraphqlController do
       end
 
       describe 'dossierPasserEnInstruction' do
-        let(:dossier) { create(:dossier, :en_construction, :for_individual, procedure: procedure) }
+        let(:dossier) { create(:dossier, :en_construction, :with_individual, procedure: procedure) }
         let(:query) do
           "mutation {
             dossierPasserEnInstruction(input: {
@@ -451,7 +451,7 @@ describe API::V2::GraphqlController do
         end
 
         context 'validation error' do
-          let(:dossier) { create(:dossier, :en_instruction, :for_individual, procedure: procedure) }
+          let(:dossier) { create(:dossier, :en_instruction, :with_individual, procedure: procedure) }
 
           it "should fail" do
             expect(gql_errors).to eq(nil)
@@ -464,7 +464,7 @@ describe API::V2::GraphqlController do
       end
 
       describe 'dossierClasserSansSuite' do
-        let(:dossier) { create(:dossier, :en_instruction, :for_individual, procedure: procedure) }
+        let(:dossier) { create(:dossier, :en_instruction, :with_individual, procedure: procedure) }
         let(:query) do
           "mutation {
             dossierClasserSansSuite(input: {
@@ -501,7 +501,7 @@ describe API::V2::GraphqlController do
         end
 
         context 'validation error' do
-          let(:dossier) { create(:dossier, :accepte, :for_individual, procedure: procedure) }
+          let(:dossier) { create(:dossier, :accepte, :with_individual, procedure: procedure) }
 
           it "should fail" do
             expect(gql_errors).to eq(nil)
@@ -514,7 +514,7 @@ describe API::V2::GraphqlController do
       end
 
       describe 'dossierRefuser' do
-        let(:dossier) { create(:dossier, :en_instruction, :for_individual, procedure: procedure) }
+        let(:dossier) { create(:dossier, :en_instruction, :with_individual, procedure: procedure) }
         let(:query) do
           "mutation {
             dossierRefuser(input: {
@@ -551,7 +551,7 @@ describe API::V2::GraphqlController do
         end
 
         context 'validation error' do
-          let(:dossier) { create(:dossier, :sans_suite, :for_individual, procedure: procedure) }
+          let(:dossier) { create(:dossier, :sans_suite, :with_individual, procedure: procedure) }
 
           it "should fail" do
             expect(gql_errors).to eq(nil)
@@ -564,7 +564,7 @@ describe API::V2::GraphqlController do
       end
 
       describe 'dossierAccepter' do
-        let(:dossier) { create(:dossier, :en_instruction, :for_individual, procedure: procedure) }
+        let(:dossier) { create(:dossier, :en_instruction, :with_individual, procedure: procedure) }
         let(:query) do
           "mutation {
             dossierAccepter(input: {
@@ -634,7 +634,7 @@ describe API::V2::GraphqlController do
         end
 
         context 'validation error' do
-          let(:dossier) { create(:dossier, :refuse, :for_individual, procedure: procedure) }
+          let(:dossier) { create(:dossier, :refuse, :with_individual, procedure: procedure) }
 
           it "should fail" do
             expect(gql_errors).to eq(nil)

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -256,10 +256,10 @@ describe Instructeurs::ProceduresController, type: :controller do
           get :show, params: { procedure_id: procedure.id }
         end
 
-        it { expect(assigns(:a_suivre_dossiers)).to match([new_unfollow_dossier]) }
+        it { expect(assigns(:a_suivre_dossiers)).to match_array([new_unfollow_dossier]) }
         it { expect(assigns(:followed_dossiers)).to be_empty }
         it { expect(assigns(:termines_dossiers)).to be_empty }
-        it { expect(assigns(:all_state_dossiers)).to match([new_unfollow_dossier]) }
+        it { expect(assigns(:all_state_dossiers)).to match_array([new_unfollow_dossier]) }
         it { expect(assigns(:archived_dossiers)).to be_empty }
 
         context 'and dossiers without follower on each of the others groups' do
@@ -270,8 +270,8 @@ describe Instructeurs::ProceduresController, type: :controller do
             get :show, params: { procedure_id: procedure.id }
           end
 
-          it { expect(assigns(:a_suivre_dossiers)).to match([new_unfollow_dossier, new_unfollow_dossier_on_gi_2]) }
-          it { expect(assigns(:all_state_dossiers)).to match([new_unfollow_dossier, new_unfollow_dossier_on_gi_2]) }
+          it { expect(assigns(:a_suivre_dossiers)).to match_array([new_unfollow_dossier, new_unfollow_dossier_on_gi_2]) }
+          it { expect(assigns(:all_state_dossiers)).to match_array([new_unfollow_dossier, new_unfollow_dossier_on_gi_2]) }
         end
       end
 
@@ -284,9 +284,9 @@ describe Instructeurs::ProceduresController, type: :controller do
         end
 
         it { expect(assigns(:a_suivre_dossiers)).to be_empty }
-        it { expect(assigns(:followed_dossiers)).to match([new_followed_dossier]) }
+        it { expect(assigns(:followed_dossiers)).to match_array([new_followed_dossier]) }
         it { expect(assigns(:termines_dossiers)).to be_empty }
-        it { expect(assigns(:all_state_dossiers)).to match([new_followed_dossier]) }
+        it { expect(assigns(:all_state_dossiers)).to match_array([new_followed_dossier]) }
         it { expect(assigns(:archived_dossiers)).to be_empty }
 
         context 'and dossier with a follower on each of the others groups' do
@@ -313,8 +313,8 @@ describe Instructeurs::ProceduresController, type: :controller do
 
         it { expect(assigns(:a_suivre_dossiers)).to be_empty }
         it { expect(assigns(:followed_dossiers)).to be_empty }
-        it { expect(assigns(:termines_dossiers)).to match([termine_dossier]) }
-        it { expect(assigns(:all_state_dossiers)).to match([termine_dossier]) }
+        it { expect(assigns(:termines_dossiers)).to match_array([termine_dossier]) }
+        it { expect(assigns(:all_state_dossiers)).to match_array([termine_dossier]) }
         it { expect(assigns(:archived_dossiers)).to be_empty }
 
         context 'and terminer dossiers on each of the others groups' do
@@ -325,8 +325,8 @@ describe Instructeurs::ProceduresController, type: :controller do
             get :show, params: { procedure_id: procedure.id }
           end
 
-          it { expect(assigns(:termines_dossiers)).to match([termine_dossier, termine_dossier_on_gi_2]) }
-          it { expect(assigns(:all_state_dossiers)).to match([termine_dossier, termine_dossier_on_gi_2]) }
+          it { expect(assigns(:termines_dossiers)).to match_array([termine_dossier, termine_dossier_on_gi_2]) }
+          it { expect(assigns(:all_state_dossiers)).to match_array([termine_dossier, termine_dossier_on_gi_2]) }
         end
       end
 
@@ -341,7 +341,7 @@ describe Instructeurs::ProceduresController, type: :controller do
         it { expect(assigns(:followed_dossiers)).to be_empty }
         it { expect(assigns(:termines_dossiers)).to be_empty }
         it { expect(assigns(:all_state_dossiers)).to be_empty }
-        it { expect(assigns(:archived_dossiers)).to match([archived_dossier]) }
+        it { expect(assigns(:archived_dossiers)).to match_array([archived_dossier]) }
 
         context 'and terminer dossiers on each of the others groups' do
           let!(:archived_dossier_on_gi_2) { create(:dossier, groupe_instructeur: gi_2, state: Dossier.states.fetch(:en_instruction), archived: true) }
@@ -351,7 +351,7 @@ describe Instructeurs::ProceduresController, type: :controller do
             get :show, params: { procedure_id: procedure.id }
           end
 
-          it { expect(assigns(:archived_dossiers)).to match([archived_dossier, archived_dossier_on_gi_2]) }
+          it { expect(assigns(:archived_dossiers)).to match_array([archived_dossier, archived_dossier_on_gi_2]) }
         end
       end
 
@@ -369,7 +369,7 @@ describe Instructeurs::ProceduresController, type: :controller do
         context 'when statut is empty' do
           let(:statut) { nil }
 
-          it { expect(assigns(:dossiers)).to match([a_suivre__dossier]) }
+          it { expect(assigns(:dossiers)).to match_array([a_suivre__dossier]) }
           it { expect(assigns(:statut)).to eq('a-suivre') }
         end
 
@@ -377,21 +377,21 @@ describe Instructeurs::ProceduresController, type: :controller do
           let(:statut) { 'a-suivre' }
 
           it { expect(assigns(:statut)).to eq('a-suivre') }
-          it { expect(assigns(:dossiers)).to match([a_suivre__dossier]) }
+          it { expect(assigns(:dossiers)).to match_array([a_suivre__dossier]) }
         end
 
         context 'when statut is suivis' do
           let(:statut) { 'suivis' }
 
           it { expect(assigns(:statut)).to eq('suivis') }
-          it { expect(assigns(:dossiers)).to match([new_followed_dossier]) }
+          it { expect(assigns(:dossiers)).to match_array([new_followed_dossier]) }
         end
 
         context 'when statut is traites' do
           let(:statut) { 'traites' }
 
           it { expect(assigns(:statut)).to eq('traites') }
-          it { expect(assigns(:dossiers)).to match([termine_dossier]) }
+          it { expect(assigns(:dossiers)).to match_array([termine_dossier]) }
         end
 
         context 'when statut is tous' do
@@ -405,7 +405,7 @@ describe Instructeurs::ProceduresController, type: :controller do
           let(:statut) { 'archives' }
 
           it { expect(assigns(:statut)).to eq('archives') }
-          it { expect(assigns(:dossiers)).to match([archived_dossier]) }
+          it { expect(assigns(:dossiers)).to match_array([archived_dossier]) }
         end
       end
     end

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -170,7 +170,7 @@ describe Users::DossiersController, type: :controller do
     end
 
     context 'when the identite cannot be updated by the user' do
-      let(:dossier) { create(:dossier, :for_individual, :en_instruction, user: user, procedure: procedure) }
+      let(:dossier) { create(:dossier, :with_individual, :en_instruction, user: user, procedure: procedure) }
       let(:individual_params) { { gender: 'M', nom: 'Mouse', prenom: 'Mickey' } }
 
       it 'redirects to the dossiers list' do

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -25,6 +25,9 @@ FactoryBot.define do
 
     trait :with_entreprise do
       after(:build) do |dossier, _evaluator|
+        if dossier.procedure.for_individual?
+          raise 'Inconsistent factory: attempting to create a dossier :with_entreprise on a procedure that is `for_individual?`'
+        end
         etablissement = create(:etablissement)
         dossier.etablissement = etablissement
       end

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -37,9 +37,13 @@ FactoryBot.define do
     end
 
     trait :for_individual do
-      after(:build) do |dossier, _evaluator|
+      after(:build) do |dossier, evaluator|
+        # If the procedure was implicitely created by the factory,
+        # mark it automatically as for_individual.
+        if evaluator.procedure.nil?
+          dossier.procedure.update(for_individual: true)
+        end
         dossier.individual = create(:individual)
-        dossier.save
       end
     end
 

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -36,7 +36,7 @@ FactoryBot.define do
       end
     end
 
-    trait :for_individual do
+    trait :with_individual do
       after(:build) do |dossier, evaluator|
         # If the procedure was implicitely created by the factory,
         # mark it automatically as for_individual.

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -43,6 +43,9 @@ FactoryBot.define do
         if evaluator.procedure.nil?
           dossier.procedure.update(for_individual: true)
         end
+        if !dossier.procedure.for_individual?
+          raise 'Inconsistent factory: attempting to create a dossier :with_individual on a procedure that is not `for_individual?`'
+        end
         dossier.individual = create(:individual)
       end
     end

--- a/spec/features/users/dossier_details_spec.rb
+++ b/spec/features/users/dossier_details_spec.rb
@@ -3,7 +3,7 @@ require 'features/users/dossier_shared_examples.rb'
 describe 'Dossier details:' do
   let(:user) { create(:user) }
   let(:procedure) { create(:simple_procedure) }
-  let(:dossier) { create(:dossier, :en_construction, :for_individual, :with_commentaires, user: user, procedure: procedure) }
+  let(:dossier) { create(:dossier, :en_construction, :with_individual, :with_commentaires, user: user, procedure: procedure) }
 
   before do
     visit_dossier dossier
@@ -17,7 +17,7 @@ describe 'Dossier details:' do
   end
 
   describe "the user can see the mean time they are expected to wait" do
-    let(:other_dossier) { create(:dossier, :accepte, :for_individual, procedure: procedure, en_construction_at: 10.days.ago, en_instruction_at: 9.days.ago, processed_at: Time.zone.now) }
+    let(:other_dossier) { create(:dossier, :accepte, :with_individual, procedure: procedure, en_construction_at: 10.days.ago, en_instruction_at: 9.days.ago, processed_at: Time.zone.now) }
 
     context "when the dossier is in construction" do
       it "displays the estimated wait duration" do
@@ -28,7 +28,7 @@ describe 'Dossier details:' do
     end
 
     context "when the dossier is in instruction" do
-      let(:dossier) { create(:dossier, :en_instruction, :for_individual, :with_commentaires, user: user, procedure: procedure) }
+      let(:dossier) { create(:dossier, :en_instruction, :with_individual, :with_commentaires, user: user, procedure: procedure) }
 
       it "displays the estimated wait duration" do
         other_dossier

--- a/spec/features/users/invite_spec.rb
+++ b/spec/features/users/invite_spec.rb
@@ -8,7 +8,7 @@ feature 'Invitations' do
   let(:invite) { create(:invite, user: invited_user, dossier: dossier) }
 
   context 'when the dossier is a brouillon' do
-    let!(:dossier) { create(:dossier, :for_individual, state: Dossier.states.fetch(:brouillon), user: owner, procedure: procedure) }
+    let!(:dossier) { create(:dossier, :with_individual, state: Dossier.states.fetch(:brouillon), user: owner, procedure: procedure) }
 
     scenario 'on the form, the owner of a dossier can invite another user to collaborate on the dossier', js: true do
       log_in(owner)
@@ -69,7 +69,7 @@ feature 'Invitations' do
   end
 
   context 'when the dossier is en_construction' do
-    let!(:dossier) { create(:dossier, :for_individual, :en_construction, user: owner, procedure: procedure) }
+    let!(:dossier) { create(:dossier, :with_individual, :en_construction, user: owner, procedure: procedure) }
 
     scenario 'on dossier details, the owner of a dossier can invite another user to collaborate on the dossier', js: true do
       log_in(owner)

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe NotificationMailer, type: :mailer do
   let(:user) { create(:user) }
   let(:procedure) { create(:simple_procedure) }
-  let(:dossier) { create(:dossier, :en_construction, :for_individual, :with_service, user: user, procedure: procedure) }
+  let(:dossier) { create(:dossier, :en_construction, :with_individual, :with_service, user: user, procedure: procedure) }
 
   describe '.send_dossier_received' do
     let(:email_template) { create(:received_mail, subject: 'Email subject', body: 'Your dossier was processed. Thanks.') }

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -573,7 +573,7 @@ describe Dossier do
   end
 
   describe '#owner_name' do
-    let!(:procedure) { create(:procedure) }
+    let(:procedure) { create(:procedure) }
     subject { dossier.owner_name }
 
     context 'when there is no entreprise or individual' do
@@ -589,6 +589,7 @@ describe Dossier do
     end
 
     context 'when there is an individual' do
+      let(:procedure) { create(:procedure, :for_individual) }
       let(:dossier) { create(:dossier, :with_individual, procedure: procedure) }
 
       it { is_expected.to eq("#{dossier.individual.nom} #{dossier.individual.prenom}") }

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -589,7 +589,7 @@ describe Dossier do
     end
 
     context 'when there is an individual' do
-      let(:dossier) { create(:dossier, :for_individual, procedure: procedure) }
+      let(:dossier) { create(:dossier, :with_individual, procedure: procedure) }
 
       it { is_expected.to eq("#{dossier.individual.nom} #{dossier.individual.prenom}") }
     end

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -33,7 +33,7 @@ describe ProcedureExportService do
     end
 
     context 'with dossier' do
-      let!(:dossier) { create(:dossier, :en_instruction, :with_all_champs, :for_individual, procedure: procedure) }
+      let!(:dossier) { create(:dossier, :en_instruction, :with_all_champs, :with_individual, procedure: procedure) }
 
       let(:nominal_headers) do
         [
@@ -286,7 +286,7 @@ describe ProcedureExportService do
     end
 
     context 'with avis' do
-      let!(:dossier) { create(:dossier, :en_instruction, :with_all_champs, :for_individual, procedure: procedure) }
+      let!(:dossier) { create(:dossier, :en_instruction, :with_all_champs, :with_individual, procedure: procedure) }
       let!(:avis) { create(:avis, :with_answer, dossier: dossier) }
 
       it 'should have headers' do
@@ -307,8 +307,8 @@ describe ProcedureExportService do
     context 'with repetitions' do
       let!(:dossiers) do
         [
-          create(:dossier, :en_instruction, :with_all_champs, :for_individual, procedure: procedure),
-          create(:dossier, :en_instruction, :with_all_champs, :for_individual, procedure: procedure)
+          create(:dossier, :en_instruction, :with_all_champs, :with_individual, procedure: procedure),
+          create(:dossier, :en_instruction, :with_all_champs, :with_individual, procedure: procedure)
         ]
       end
       let(:champ_repetition) { dossiers.first.champs.find { |champ| champ.type_champ == 'repetition' } }
@@ -341,7 +341,7 @@ describe ProcedureExportService do
       end
 
       context 'with non unique labels' do
-        let(:dossier) { create(:dossier, :en_instruction, :with_all_champs, :for_individual, procedure: procedure) }
+        let(:dossier) { create(:dossier, :en_instruction, :with_all_champs, :with_individual, procedure: procedure) }
         let(:champ_repetition) { dossier.champs.find { |champ| champ.type_champ == 'repetition' } }
         let(:type_de_champ_repetition) { create(:type_de_champ_repetition, procedure: procedure, libelle: champ_repetition.libelle) }
         let!(:another_champ_repetition) { create(:champ_repetition, type_de_champ: type_de_champ_repetition, dossier: dossier) }

--- a/spec/views/commencer/show.html.haml_spec.rb
+++ b/spec/views/commencer/show.html.haml_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'commencer/show.html.haml', type: :view do
 
     context 'and they have a submitted dossier' do
       let!(:brouillon) { create(:dossier, user: user, procedure: procedure) }
-      let!(:dossier) { create(:dossier, :en_construction, :for_individual, user: user, procedure: procedure) }
+      let!(:dossier) { create(:dossier, :en_construction, :with_individual, user: user, procedure: procedure) }
 
       it_behaves_like 'it renders a link to create a new dossier', 'Commencer un nouveau dossier'
 
@@ -66,7 +66,7 @@ RSpec.describe 'commencer/show.html.haml', type: :view do
 
     context 'and they have several submitted dossiers' do
       let!(:brouillon) { create(:dossier, user: user, procedure: procedure) }
-      let!(:dossiers) { create_list(:dossier, 2, :en_construction, :for_individual, user: user, procedure: procedure) }
+      let!(:dossiers) { create_list(:dossier, 2, :en_construction, :with_individual, user: user, procedure: procedure) }
 
       it_behaves_like 'it renders a link to create a new dossier', 'Commencer un nouveau dossier'
 

--- a/spec/views/commencer/show.html.haml_spec.rb
+++ b/spec/views/commencer/show.html.haml_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'commencer/show.html.haml', type: :view do
   include Rails.application.routes.url_helpers
 
-  let(:procedure) { create(:procedure, :with_service, :published) }
+  let(:procedure) { create(:procedure, :published, :for_individual, :with_service) }
 
   before do
     assign(:procedure, procedure)

--- a/spec/views/users/dossiers/brouillon.html.haml_spec.rb
+++ b/spec/views/users/dossiers/brouillon.html.haml_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'users/dossiers/brouillon.html.haml', type: :view do
-  let(:procedure) { create(:procedure, :with_type_de_champ, :with_notice, :with_service, for_individual: true) }
-  let(:dossier) { create(:dossier, :with_entreprise, state: Dossier.states.fetch(:brouillon), procedure: procedure) }
+  let(:procedure) { create(:procedure, :with_type_de_champ, :with_notice, :with_service) }
+  let(:dossier) { create(:dossier, state: Dossier.states.fetch(:brouillon), procedure: procedure) }
   let(:footer) { view.content_for(:footer) }
 
   before do

--- a/spec/views/users/dossiers/identite.html.haml_spec.rb
+++ b/spec/views/users/dossiers/identite.html.haml_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'users/dossiers/identite.html.haml', type: :view do
-  let(:procedure) { create(:simple_procedure, for_individual: true) }
-  let(:dossier) { create(:dossier, :with_entreprise, :with_service, state: Dossier.states.fetch(:brouillon), procedure: procedure) }
+  let(:procedure) { create(:simple_procedure, :for_individual) }
+  let(:dossier) { create(:dossier, :with_service, state: Dossier.states.fetch(:brouillon), procedure: procedure) }
 
   before do
     sign_in dossier.user


### PR DESCRIPTION
In factories:

- Rename dossier `for_individual` to `with_individual`.
_This clarifies the distinction with `create :procedure, :for_individual`._
- At runtime, ensure that dossiers `with_individual` are attached to a procedure for individuals.
- At runtime, ensure that dossiers `with_entreprise` are attached to a procedure for entreprises