### PR TITLE
#4601 - Suppression des groupes instructeurs

### DIFF
--- a/app/controllers/new_administrateur/groupe_instructeurs_controller.rb
+++ b/app/controllers/new_administrateur/groupe_instructeurs_controller.rb
@@ -48,6 +48,18 @@ module NewAdministrateur
       end
     end
 
+    def destroy
+      if procedure.groupe_instructeurs.one?
+        flash[:alert] = "Suppression impossible : il doit y avoir au moins un groupe instructeur sur chaque procédure"
+      elsif groupe_instructeur == procedure.defaut_groupe_instructeur
+        flash[:alert] = "Impossible de supprimer le groupe par défaut"
+      else
+        flash[:notice] = "le groupe « #{groupe_instructeur.label} » a été supprimé."
+        groupe_instructeur.destroy
+      end
+      redirect_to procedure_groupe_instructeurs_path(procedure)
+    end
+
     def add_instructeur
       emails = params['emails'].presence || []
       emails = emails.map(&:strip).map(&:downcase)

--- a/app/controllers/new_administrateur/groupe_instructeurs_controller.rb
+++ b/app/controllers/new_administrateur/groupe_instructeurs_controller.rb
@@ -60,6 +60,27 @@ module NewAdministrateur
       redirect_to procedure_groupe_instructeurs_path(procedure)
     end
 
+    def reaffecter_dossiers
+      @procedure = procedure
+      @groupe_instructeur = groupe_instructeur
+      @groupes_instructeurs = paginated_groupe_instructeurs
+        .without_group(@groupe_instructeur)
+    end
+
+    def reaffecter
+      target_group = GroupeInstructeur.find(params[:target_group])
+      if target_group.blank? || !procedure.groupe_instructeurs.include?(target_group)
+        flash[:notice] = "Impossible de réaffecter les dossiers au groupe demandé."
+      else
+        groupe_instructeur.dossiers.each do |d|
+          d.update(groupe_instructeur: target_group)
+        end
+        flash[:notice] = "Les dossiers du groupe « #{groupe_instructeur.label} » ont été réaffectés au groupe « #{target_group.label} »."
+
+      end
+      redirect_to procedure_groupe_instructeurs_path(procedure)
+    end
+
     def add_instructeur
       emails = params['emails'].presence || []
       emails = emails.map(&:strip).map(&:downcase)

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -10,4 +10,6 @@ class GroupeInstructeur < ApplicationRecord
   validates :label, uniqueness: { scope: :procedure, message: 'existe déjà' }
 
   before_validation -> { label&.strip! }
+
+  scope :without_group, -> (group) { where.not(id: group) }
 end

--- a/app/views/new_administrateur/groupe_instructeurs/index.html.haml
+++ b/app/views/new_administrateur/groupe_instructeurs/index.html.haml
@@ -34,15 +34,12 @@
           %tr
             %td= group.label
             %td.actions= link_to "voir", procedure_groupe_instructeur_path(@procedure, group)
-            - if @groupes_instructeurs.count > 1
-              - if group.dossiers.count == 0
+            - if @groupes_instructeurs.many?
+              - if group.dossiers.empty?
                 %td.actions
-                  - if group == @procedure.defaut_groupe_instructeur
-                    Groupe par défaut − ne peut être supprimé
-                  - else
-                    = link_to procedure_groupe_instructeur_path(@procedure, group), { method: :delete, class: 'button', data: { confirm: "Êtes-vous sûr de vouloir supprimer le groupe « #{group.label} » ?" }} do
-                      %span.icon.delete
-                      supprimer ce groupe
+                  = link_to procedure_groupe_instructeur_path(@procedure, group), { method: :delete, class: 'button', data: { confirm: "Êtes-vous sûr de vouloir supprimer le groupe « #{group.label} » ?" }} do
+                    %span.icon.delete
+                    supprimer ce groupe
               - else
                 %td.actions
                   = link_to reaffecter_dossiers_procedure_groupe_instructeur_path(@procedure, group), class: 'button', title:'Réaffecter les dossiers à un autre groupe afin de pouvoir le supprimer' do

--- a/app/views/new_administrateur/groupe_instructeurs/index.html.haml
+++ b/app/views/new_administrateur/groupe_instructeurs/index.html.haml
@@ -34,5 +34,14 @@
           %tr
             %td= group.label
             %td.actions= link_to "voir", procedure_groupe_instructeur_path(@procedure, group)
+            - if @groupes_instructeurs.count > 1
+              - if group.dossiers.count == 0
+                %td.actions
+                  - if group == @procedure.defaut_groupe_instructeur
+                    Groupe par défaut − ne peut être supprimé
+                  - else
+                    = link_to procedure_groupe_instructeur_path(@procedure, group), { method: :delete, class: 'button', data: { confirm: "Êtes-vous sûr de vouloir supprimer le groupe « #{group.label} » ?" }} do
+                      %span.icon.delete
+                      supprimer ce groupe
 
     = paginate @groupes_instructeurs

--- a/app/views/new_administrateur/groupe_instructeurs/index.html.haml
+++ b/app/views/new_administrateur/groupe_instructeurs/index.html.haml
@@ -28,7 +28,7 @@
     %table.table.mt-2
       %thead
         %tr
-          %th{ colspan: 2 }= t(".existing_groupe", count: @groupes_instructeurs.count)
+          %th{ colspan: 2 }= t(".existing_groupe", count: @groupes_instructeurs.total_count)
       %tbody
         - @groupes_instructeurs.each do |group|
           %tr

--- a/app/views/new_administrateur/groupe_instructeurs/index.html.haml
+++ b/app/views/new_administrateur/groupe_instructeurs/index.html.haml
@@ -43,5 +43,9 @@
                     = link_to procedure_groupe_instructeur_path(@procedure, group), { method: :delete, class: 'button', data: { confirm: "Êtes-vous sûr de vouloir supprimer le groupe « #{group.label} » ?" }} do
                       %span.icon.delete
                       supprimer ce groupe
-
+              - else
+                %td.actions
+                  = link_to reaffecter_dossiers_procedure_groupe_instructeur_path(@procedure, group), class: 'button', title:'Réaffecter les dossiers à un autre groupe afin de pouvoir le supprimer' do
+                    %span.icon.follow
+                    déplacer les dossiers
     = paginate @groupes_instructeurs

--- a/app/views/new_administrateur/groupe_instructeurs/reaffecter_dossiers.html.haml
+++ b/app/views/new_administrateur/groupe_instructeurs/reaffecter_dossiers.html.haml
@@ -1,0 +1,27 @@
+= render partial: 'new_administrateur/breadcrumbs',
+  locals: { steps: [link_to('Démarches', admin_procedures_path),
+                    link_to(@procedure.libelle, admin_procedure_path(@procedure)),
+                    link_to('Groupes d’instructeurs', procedure_groupe_instructeurs_path(@procedure)),
+                    @groupe_instructeur.label] }
+
+.container.groupe-instructeur
+
+  .card
+    .card-title Réaffectation des dossiers du groupe «&nbsp;#{@groupe_instructeur.label}&nbsp;»
+    %p
+      Le groupe « #{@groupe_instructeur.label} » contient des dossiers. Afin de procéder à sa suppression, vous devez réaffecter ses dossiers à un autre groupe instructeur.
+
+    %table.table.mt-2
+      %thead
+        %tr
+          %th{ colspan: 2 }= t(".existing_groupe", count: @groupes_instructeurs.total_count)
+      %tbody
+        - @groupes_instructeurs.each do |group|
+          %tr
+            %td= group.label
+            %td.actions= button_to 'Réaffecter les dossiers à ce groupe',
+              reaffecter_procedure_groupe_instructeur_path(:target_group => group),
+              { class: 'button',
+                data: { confirm: "Êtes-vous sûr de vouloir réaffecter les dossiers du groupe « #{@groupe_instructeur.label} » vers le groupe  « #{group.label} » ?" } }
+
+    = paginate @groupes_instructeurs

--- a/app/views/new_administrateur/groupe_instructeurs/reaffecter_dossiers.html.haml
+++ b/app/views/new_administrateur/groupe_instructeurs/reaffecter_dossiers.html.haml
@@ -7,7 +7,7 @@
 .container.groupe-instructeur
 
   .card
-    .card-title Réaffectation des dossiers du groupe «&nbsp;#{@groupe_instructeur.label}&nbsp;»
+    .card-title Réaffectation des dossiers du groupe « {@groupe_instructeur.label} »
     %p
       Le groupe « #{@groupe_instructeur.label} » contient des dossiers. Afin de procéder à sa suppression, vous devez réaffecter ses dossiers à un autre groupe instructeur.
 

--- a/config/locales/views/new_administrateur/groupe_instructeurs/fr.yml
+++ b/config/locales/views/new_administrateur/groupe_instructeurs/fr.yml
@@ -16,3 +16,7 @@ fr:
         assignment:
           one: "L’instructeur %{value} a été affecté au groupe « %{groupe} »."
           other: "Les instructeurs %{value} ont été affectés au groupe « %{groupe} »."
+      reaffecter_dossiers:
+        existing_groupe:
+          one: "%{count} groupe existe"
+          other: "%{count} groupes existent"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -356,7 +356,7 @@ Rails.application.routes.draw do
         get 'annotations'
       end
 
-      resources :groupe_instructeurs, only: [:index, :show, :create, :update] do
+      resources :groupe_instructeurs, only: [:index, :show, :create, :update, :destroy] do
         member do
           post 'add_instructeur'
           delete 'remove_instructeur'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -360,6 +360,8 @@ Rails.application.routes.draw do
         member do
           post 'add_instructeur'
           delete 'remove_instructeur'
+          get 'reaffecter_dossiers'
+          post 'reaffecter'
         end
 
         collection do

--- a/spec/controllers/new_administrateur/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/new_administrateur/groupe_instructeurs_controller_spec.rb
@@ -59,6 +59,43 @@ describe NewAdministrateur::GroupeInstructeursController, type: :controller do
     end
   end
 
+  describe '#destroy' do
+    def delete_group(group)
+      delete :destroy,
+        params: {
+          procedure_id: procedure.id,
+          id: group.id
+        }
+    end
+
+    context 'with only one group' do
+      before { delete_group gi_1_1 }
+
+      it { expect(flash.alert).to be_present }
+      it { expect(response).to redirect_to(procedure_groupe_instructeurs_path(procedure)) }
+      it { expect(procedure.groupe_instructeurs.count).to eq(1) }
+    end
+
+    context 'with many groups' do
+      let!(:gi_1_2) { procedure.groupe_instructeurs.create(label: 'groupe instructeur 2') }
+      context 'of the default group' do
+        before { delete_group procedure.defaut_groupe_instructeur }
+
+        it { expect(flash.alert).to be_present }
+        it { expect(procedure.groupe_instructeurs.count).to eq(2) }
+        it { expect(response).to redirect_to(procedure_groupe_instructeurs_path(procedure)) }
+      end
+
+      context 'of a group that can be deleted' do
+        before { delete_group gi_1_2 }
+
+        it { expect(flash.notice).to be_present }
+        it { expect(procedure.groupe_instructeurs.count).to eq(1) }
+        it { expect(response).to redirect_to(procedure_groupe_instructeurs_path(procedure)) }
+      end
+    end
+  end
+
   describe '#update' do
     let(:new_name) { 'nouveau nom du groupe' }
 

--- a/spec/controllers/new_administrateur/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/new_administrateur/groupe_instructeurs_controller_spec.rb
@@ -96,6 +96,70 @@ describe NewAdministrateur::GroupeInstructeursController, type: :controller do
     end
   end
 
+  describe '#reaffecter_dossiers' do
+    let!(:gi_1_2) { procedure.groupe_instructeurs.create(label: 'groupe instructeur 2') }
+    let!(:gi_1_3) { procedure.groupe_instructeurs.create(label: 'groupe instructeur 3') }
+
+    before do
+      get :reaffecter_dossiers,
+        params: {
+          procedure_id: procedure.id,
+          id: gi_1_2.id
+        }
+    end
+    def reaffecter_url(group)
+      reaffecter_procedure_groupe_instructeur_path(:id => gi_1_2,
+                                                    :target_group => group)
+    end
+
+    it { expect(response).to have_http_status(:ok) }
+    it { expect(response.body).to include(reaffecter_url(procedure.defaut_groupe_instructeur)) }
+    it { expect(response.body).not_to include(reaffecter_url(gi_1_2)) }
+    it { expect(response.body).to include(reaffecter_url(gi_1_3)) }
+  end
+
+  describe '#reaffecter' do
+    let!(:gi_1_2) { procedure.groupe_instructeurs.create(label: 'groupe instructeur 2') }
+    let!(:dossier12) { create(:dossier, procedure: procedure, state: Dossier.states.fetch(:en_construction), groupe_instructeur: gi_1_1) }
+
+    describe 'when the new group is a group of the procedure' do
+      before do
+        post :reaffecter,
+          params: {
+            procedure_id: procedure.id,
+            id: gi_1_1.id,
+            target_group: gi_1_2.id
+          }
+        dossier12.reload
+      end
+
+      it { expect(response).to redirect_to(procedure_groupe_instructeurs_path(procedure)) }
+      it { expect(gi_1_1.dossiers.count).to be(0) }
+      it { expect(gi_1_2.dossiers.count).to be(1) }
+      it { expect(gi_1_2.dossiers.last.id).to be(dossier12.id) }
+      it { expect(dossier12.groupe_instructeur.id).to be(gi_1_2.id) }
+    end
+
+    describe 'when the new group is not a possible group' do
+      before do
+        post :reaffecter,
+          params:
+            {
+              procedure_id: procedure.id,
+              id: gi_1_1.id,
+              target_group: gi_2_2.id
+            }
+        dossier12.reload
+      end
+
+      it { expect(response).to redirect_to(procedure_groupe_instructeurs_path(procedure)) }
+      it { expect(gi_1_1.dossiers.count).to be(1) }
+      it { expect(gi_2_2.dossiers.count).to be(0) }
+      it { expect(gi_1_1.dossiers.last.id).to be(dossier12.id) }
+      it { expect(dossier12.groupe_instructeur.id).to be(gi_1_1.id) }
+    end
+  end
+
   describe '#update' do
     let(:new_name) { 'nouveau nom du groupe' }
 


### PR DESCRIPTION
https://github.com/betagouv/demarches-simplifiees.fr/issues/4601

2 fonctionnalités pour le prix d'une:
 - supprimer un groupe sans dossiers
 - déplacer les dossiers d'une groupe qui en a plusieurs vers un groupe qui n'en a pas.

(au départ, j'ai essayé de faire «déplacer et supprimer» d'un coup, mais je me dis que niveau UX c'est moins clair)

# Suppression d'un groupe

![supprimer-groupe](https://user-images.githubusercontent.com/1223316/72054933-360fa900-32ca-11ea-95a7-c2e0dce93c9d.gif)

# Déplacement des dossiers
Un écran intermédiaire permet de choisir sur quel groupe réaffecter les dossiers

![deplacer-dossiers2](https://user-images.githubusercontent.com/1223316/72054925-31e38b80-32ca-11ea-86f4-b5d8cb016ea1.gif)