### PR TITLE
Modification d'un email d'un utilisateur dans le manager

### DIFF
--- a/app/controllers/manager/users_controller.rb
+++ b/app/controllers/manager/users_controller.rb
@@ -1,5 +1,18 @@
 module Manager
   class UsersController < Manager::ApplicationController
+    def update
+      user = User.find(params[:id])
+      new_email = params[:user][:email]
+      user.skip_reconfirmation!
+      user.update(email: new_email)
+      if (user.valid?)
+        flash[:notice] = "L'email a été modifié en « #{new_email} » sans notification ni validation par email."
+      else
+        flash[:error] = "« #{new_email} » n'est pas une adresse valide."
+      end
+      redirect_to edit_manager_user_path(user)
+    end
+
     def resend_confirmation_instructions
       user = User.find(params[:id])
       user.resend_confirmation_instructions

--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -41,7 +41,9 @@ class UserDashboard < Administrate::BaseDashboard
   # FORM_ATTRIBUTES
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
-  FORM_ATTRIBUTES = [].freeze
+  FORM_ATTRIBUTES = [
+    :email
+  ].freeze
 
   # Overwrite this method to customize how users are displayed
   # across all pages of the admin dashboard.

--- a/app/views/manager/users/show.html.erb
+++ b/app/views/manager/users/show.html.erb
@@ -25,8 +25,10 @@ as well as a link to its edit page.
   </h1>
 
   <div>
+    <%= button_to "modifier", edit_manager_user_path(page.resource), method: :get, class: "button" %>
+  </div>
+  <div>
     <%= button_to "supprimer", delete_manager_user_path(page.resource), method: :delete, disabled: !page.resource.can_be_deleted?, class: "button", data: { confirm: "Confirmez-vous la suppression de l'utilisateur ?" }, title: page.resource.can_be_deleted? ? "Supprimer" : "Cet utilisateur a des dossiers dont l'instruction a commencé et ne peut être supprimé" %>
-
   </div>
   <div>
     <% if !user.confirmed? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Rails.application.routes.draw do
       delete 'delete', on: :member
     end
 
-    resources :users, only: [:index, :show] do
+    resources :users, only: [:index, :show, :edit, :update] do
       delete 'delete', on: :member
       post 'resend_confirmation_instructions', on: :member
       put 'enable_feature', on: :member

--- a/spec/controllers/manager/users_controller_spec.rb
+++ b/spec/controllers/manager/users_controller_spec.rb
@@ -1,6 +1,36 @@
 describe Manager::UsersController, type: :controller do
   let(:administration) { create(:administration) }
 
+  describe '#update' do
+    let!(:user) { create(:user, email: 'ancien.email@domaine.fr') }
+
+    before {
+      sign_in administration
+    }
+    subject { patch :update, params: { id: user.id, user: { email: nouvel_email } } }
+
+    describe 'with a valid email' do
+      let(:nouvel_email) { 'nouvel.email@domaine.fr' }
+
+      it 'updates the user email' do
+        subject
+
+        expect(User.find_by(id: user.id).email).to eq(nouvel_email)
+      end
+    end
+
+    describe 'with an invalid email' do
+      let(:nouvel_email) { 'plop' }
+
+      it 'does not update the user email' do
+        subject
+
+        expect(User.find_by(id: user.id).email).not_to eq(nouvel_email)
+        expect(flash[:error]).to match("« #{nouvel_email} » n'est pas une adresse valide.")
+      end
+    end
+  end
+
   describe '#delete' do
     let!(:user) { create(:user) }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1223316/72432904-77a3c680-3798-11ea-860b-92a75f9d6b35.png)

L'email est modifié sans reconfirmation utilisateur ; certains utilisateurs n'ont en effet pas accès à l'ancienne boite mail, soit car elle est désactivée, soit car l'adresse tapée initialement est erronée