### PR TITLE
#4666 - filtrage par groupe dans le récap hebdo si nécessaire

### DIFF
--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -76,7 +76,7 @@ class Instructeur < ApplicationRecord
 
     active_procedure_overviews = procedures
       .publiees
-      .map { |procedure| procedure.procedure_overview(start_date) }
+      .map { |procedure| procedure.procedure_overview(start_date, groupe_instructeurs) }
       .filter(&:had_some_activities?)
 
     if active_procedure_overviews.count == 0

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -464,8 +464,8 @@ class Procedure < ApplicationRecord
     export(dossiers).to_ods
   end
 
-  def procedure_overview(start_date)
-    ProcedureOverview.new(self, start_date)
+  def procedure_overview(start_date, groups)
+    ProcedureOverview.new(self, start_date, groups)
   end
 
   def initiated_mail_template

--- a/app/models/procedure_overview.rb
+++ b/app/models/procedure_overview.rb
@@ -10,8 +10,7 @@ class ProcedureOverview
     @start_date = start_date
     @procedure = procedure
 
-    dossiers = procedure.dossiers
-    dossiers = dossiers.where(groupe_instructeur: groups) if procedure.routee?
+    dossiers = procedure.dossiers.where(groupe_instructeur: groups)
 
     @dossiers_en_instruction_count = dossiers.state_en_instruction.count
     @old_dossiers_en_instruction = dossiers

--- a/app/models/procedure_overview.rb
+++ b/app/models/procedure_overview.rb
@@ -6,24 +6,24 @@ class ProcedureOverview
     :dossiers_en_construction_count,
     :old_dossiers_en_construction
 
-  def initialize(procedure, start_date)
+  def initialize(procedure, start_date, groups)
     @start_date = start_date
     @procedure = procedure
 
-    @dossiers_en_instruction_count = procedure.dossiers.state_en_instruction.count
-    @old_dossiers_en_instruction = procedure
-      .dossiers
+    dossiers = procedure.dossiers
+    dossiers = dossiers.where(groupe_instructeur: groups) if procedure.routee?
+
+    @dossiers_en_instruction_count = dossiers.state_en_instruction.count
+    @old_dossiers_en_instruction = dossiers
       .state_en_instruction
       .where('en_instruction_at < ?', 1.week.ago)
 
-    @dossiers_en_construction_count = procedure.dossiers.state_en_construction.count
-    @old_dossiers_en_construction = procedure
-      .dossiers
+    @dossiers_en_construction_count = dossiers.state_en_construction.count
+    @old_dossiers_en_construction = dossiers
       .state_en_construction
       .where('en_construction_at < ?', 1.week.ago)
 
-    @created_dossiers_count = procedure
-      .dossiers
+    @created_dossiers_count = dossiers
       .where(created_at: start_date..Time.zone.now)
       .state_not_brouillon
       .count

--- a/spec/models/procedure_overview_spec.rb
+++ b/spec/models/procedure_overview_spec.rb
@@ -8,7 +8,7 @@ describe ProcedureOverview, type: :model do
   before { Timecop.freeze(friday) }
   after { Timecop.return }
 
-  let(:procedure_overview) { ProcedureOverview.new(procedure, monday) }
+  let(:procedure_overview) { ProcedureOverview.new(procedure, monday, []) }
 
   describe 'dossiers_en_instruction_count' do
     let!(:en_instruction_dossier) do
@@ -54,6 +54,27 @@ describe ProcedureOverview, type: :model do
     end
 
     it { expect(procedure_overview.created_dossiers_count).to eq(1) }
+  end
+
+  describe 'with a procedure routee' do
+    let!(:gi_2) { procedure.groupe_instructeurs.create(label: 'groupe instructeur 2') }
+    let!(:gi_3) { procedure.groupe_instructeurs.create(label: 'groupe instructeur 3') }
+
+    def create_dossier_in_group(g)
+      create(:dossier, procedure: procedure, created_at: monday, state: Dossier.states.fetch(:en_instruction), groupe_instructeur: g)
+    end
+
+    let!(:created_dossier_during_the_week_on_group_2) { create_dossier_in_group(gi_2) }
+    let!(:created_dossier_during_the_week_on_group_3_a) { create_dossier_in_group(gi_3) }
+    let!(:created_dossier_during_the_week_on_group_3_b) { create_dossier_in_group(gi_3) }
+
+    let(:procedure_overview_gi_2) { ProcedureOverview.new(procedure, monday, [gi_2]) }
+    let(:procedure_overview_gi_3) { ProcedureOverview.new(procedure, monday, [gi_3]) }
+    let(:procedure_overview_default) { ProcedureOverview.new(procedure, monday, [procedure.defaut_groupe_instructeur]) }
+
+    it { expect(procedure_overview_gi_2.created_dossiers_count).to eq(1) }
+    it { expect(procedure_overview_gi_3.created_dossiers_count).to eq(2) }
+    it { expect(procedure_overview_default.created_dossiers_count).to eq(0) }
   end
 
   describe 'had_some_activities?' do

--- a/spec/models/procedure_overview_spec.rb
+++ b/spec/models/procedure_overview_spec.rb
@@ -8,7 +8,7 @@ describe ProcedureOverview, type: :model do
   before { Timecop.freeze(friday) }
   after { Timecop.return }
 
-  let(:procedure_overview) { ProcedureOverview.new(procedure, monday, []) }
+  let(:procedure_overview) { ProcedureOverview.new(procedure, monday, [procedure.defaut_groupe_instructeur]) }
 
   describe 'dossiers_en_instruction_count' do
     let!(:en_instruction_dossier) do


### PR DESCRIPTION
#4666
Pour les procédures routees, le récap hebdo envoit l'intégralité des dossiers de la procédure.
Les instructeurs n'ont parfois pas accès à tous les groupes, et donc pas accès à tous les dossiers.
Cette PR ajoute ce niveau de filtre.
