### PR TITLE
app: improve wording of the strike banner

### DIFF
--- a/app/views/layouts/_strike_banner.html.haml
+++ b/app/views/layouts/_strike_banner.html.haml
@@ -3,6 +3,6 @@
     .site-banner-icon ⚠️
     .site-banner-text
       %strong
-        En raison d’une grève nationale interprofessionnelle, une partie des personnels ne travaille pas.
+        En raison d’une grève nationale interprofessionnelle, une partie du personnel de demarches-simplifiees.fr ne travaille pas.
       %br
       Les délais de réponse aux questions techniques pourront être perturbés pendant les prochains jours.


### PR DESCRIPTION
Make it clearer that the strike affects only the DS staff.

Fait suite à une discussion avec Ndriana sur Slack.