### PR TITLE
Bug circleci not dispatching tests according previous time to r…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
             echo $COMMAND
             eval $COMMAND
       - store_test_results:
-          path: ~/test_results/rspec.xml
+          path: ~/test_results
   lint:
     <<: *defaults
     steps:


### PR DESCRIPTION
A priori : store_test_results demande un répertoire, du coup les anciennes mesures n'étaient pas sauvegardées pour optimiser la phase de test suivante. 
D'où des warnings qui indiquaient que CircleCI n'avait pas de temps de calculs pour certains tests.
Cf https://circleci.com/docs/2.0/collect-test-data/

Bémol: ca c'est la théorie. Je vous laisse regarder si cela améliore la rapidité des tests de DS :-) 