### PR TITLE
#4698 - Possibilite de selectionner un resultat quand il n'y a rien de suggéré dans le champ adresse

### DIFF
--- a/app/javascript/new_design/select2.js
+++ b/app/javascript/new_design/select2.js
@@ -122,12 +122,14 @@ const adresseOptions = {
       };
     },
     processResults(data) {
+      let r = data.features.map(({ properties: { label }, geometry }) => ({
+        id: label,
+        text: label,
+        geometry
+      }));
+      r.unshift({ id: data.query, text: data.query });
       return {
-        results: data.features.map(({ properties: { label }, geometry }) => ({
-          id: label,
-          text: label,
-          geometry
-        }))
+        results: r
       };
     }
   }

--- a/app/javascript/new_design/select2.js
+++ b/app/javascript/new_design/select2.js
@@ -127,6 +127,8 @@ const adresseOptions = {
         text: label,
         geometry
       }));
+      // Allow the user to select an arbitrary address missing from the results,
+      // by adding the plain-text query to the list of results.
       r.unshift({ id: data.query, text: data.query });
       return {
         results: r


### PR DESCRIPTION
#4698 

J'inclue l'adresse demandée dans les résultats de l'autocomplete. Ainsi, si aucun résultat ne remonte, il est tout de même possible de sélectionner ce qu'on a tapé. Le problème ne vient pas de la BAN (enfin, si, sans doute aussi car il ne remonte pas de résultats, mais ce n'est pas le sujet)

ex:
![autocomplete-include-request](https://user-images.githubusercontent.com/1223316/73172289-f7b81d80-4102-11ea-9076-f9c67fbca60e.png)

puis j'essaie de remplacer test par une adresse à Papeete:

![resultat-non-dispo](https://user-images.githubusercontent.com/1223316/73172281-f38c0000-4102-11ea-8a9a-9f884da93c20.png)

