### PR TITLE
#4703 - fix menu déroulant lié obligatoire

### DIFF
--- a/app/models/champs/linked_drop_down_list_champ.rb
+++ b/app/models/champs/linked_drop_down_list_champ.rb
@@ -45,8 +45,9 @@ class Champs::LinkedDropDownListChamp < Champ
     value.present? ? { primary: primary_value, secondary: secondary_value } : nil
   end
 
-  def mandatory_and_blank?
-    mandatory? && (primary_value.blank? || secondary_value.blank?)
+  def blank?
+    primary_value.blank? ||
+      (has_secondary_options_for_primary? && secondary_value.blank?)
   end
 
   def search_terms
@@ -57,5 +58,9 @@ class Champs::LinkedDropDownListChamp < Champ
 
   def pack_value(primary, secondary)
     self.value = JSON.generate([primary, secondary])
+  end
+
+  def has_secondary_options_for_primary?
+    primary_value.present? && secondary_options[primary_value].any?(&:present?)
   end
 end

--- a/app/models/champs/linked_drop_down_list_champ.rb
+++ b/app/models/champs/linked_drop_down_list_champ.rb
@@ -61,6 +61,6 @@ class Champs::LinkedDropDownListChamp < Champ
   end
 
   def has_secondary_options_for_primary?
-    primary_value.present? && secondary_options[primary_value].any?(&:present?)
+    primary_value.present? && secondary_options[primary_value]&.any?(&:present?)
   end
 end

--- a/spec/models/champs/linked_drop_down_list_champ_spec.rb
+++ b/spec/models/champs/linked_drop_down_list_champ_spec.rb
@@ -91,7 +91,14 @@ describe Champs::LinkedDropDownListChamp do
         end
 
         context 'when there is a secondary value' do
-          before { subject.secondary_value = 'Primary' }
+          before { subject.secondary_value = 'Secondary' }
+
+          it { is_expected.not_to be_mandatory_and_blank }
+        end
+
+        context 'when there is nothing to select for the secondary value' do
+          let(:drop_down_list) { build(:drop_down_list, value: "--A--\nAbbott\nAbelard\n--B--\n--C--\nCynthia") }
+          before { subject.primary_value = 'B' }
 
           it { is_expected.not_to be_mandatory_and_blank }
         end


### PR DESCRIPTION
#4703 : Permet de déposer un dossier lorsqu'un menu déroulant lié obligatoire n'a pas de valeur (car la liste est légitimement vide) dans le second champ.

![menu-deroulant-lie2](https://user-images.githubusercontent.com/1223316/73178999-bb8cb900-4112-11ea-86c2-9179c67bc866.gif)
