### PR TITLE
Improve CircleCI caches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,29 @@ yarn_install: &yarn_install
     name: Install JS Dependencies
     command: yarn install --frozen-lockfile --non-interactive || yarn install --frozen-lockfile --non-interactive
 
+webpacker_restore_cache: &webpacker_restore_cache
+  restore_cache:
+    name: Restore Webpacker Cache
+    keys:
+      - webpacker-v1-{{ .Branch }}-{{ .Revision }}
+      - webpacker-v1-{{ .Branch }}
+      - webpacker-v1
+
+webpacker_save_cache: &webpacker_save_cache
+  save_cache:
+    name: Save Webpacker Cache
+    key: webpacker-v1-{{ .Branch }}-{{ .Revision }}
+    paths:
+      - public/packs-test
+      - tmp/cache/webpacker
+
+webpacker_precompile: &webpacker_precompile
+  run:
+    environment:
+      RAILS_ENV: test
+    name: Precompile Webpack assets
+    command: bin/webpack
+
 jobs:
   build:
     <<: *defaults
@@ -64,16 +87,15 @@ jobs:
       - *bundle_install
       - *yarn_restore_cache
       - *yarn_install
+      - *webpacker_restore_cache
+      - *webpacker_precompile
+      - *webpacker_save_cache
       - run:
           environment:
             DATABASE_URL: "postgres://tps_test@localhost:5432/tps_test"
-          name: Create DB
+          name: Create Database
           command: bundle exec rake db:create db:schema:load db:migrate RAILS_ENV=test
-      - run:
-          environment:
-            RAILS_ENV: test
-          name: Precompile Webpack assets
-          command: bin/webpack
+
       - run:
           environment:
             DATABASE_URL: "postgres://tps_test@localhost:5432/tps_test"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,19 +30,19 @@ bundle_install: &bundle_install
 yarn_restore_cache: &yarn_restore_cache
   restore_cache:
     name: Restore Yarn Package Cache
-    key: yarn-install-v2-{{ arch }}-{{ checksum "yarn.lock" }}
+    key: yarn-install-v3-{{ arch }}-{{ checksum "yarn.lock" }}
 
 yarn_save_cache: &yarn_save_cache
   save_cache:
     name: Save Yarn Package Cache
-    key: yarn-install-v2-{{ arch }}-{{ checksum "yarn.lock" }}
+    key: yarn-install-v3-{{ arch }}-{{ checksum "yarn.lock" }}
     paths:
       - ~/.cache/yarn
 
 yarn_install: &yarn_install
   run:
     name: Install JS Dependencies
-    command: yarn install --non-interactive || yarn install --non-interactive
+    command: yarn install --frozen-lockfile --non-interactive || yarn install --frozen-lockfile --non-interactive
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,10 @@ defaults: &defaults
 bundle_restore_cache: &bundle_restore_cache
   restore_cache:
     name: Restore Bundler Package Cache
-    key: bundle-install-v9-{{ arch }}-{{ checksum "Gemfile.lock" }}
+    keys:
+      - bundle-install-v9-{{ arch }}-{{ checksum "Gemfile.lock" }}
+      - bundle-install-v9-{{ arch }}
+      - bundle-install-v9
 
 bundle_save_cache: &bundle_save_cache
   save_cache:
@@ -30,7 +33,10 @@ bundle_install: &bundle_install
 yarn_restore_cache: &yarn_restore_cache
   restore_cache:
     name: Restore Yarn Package Cache
-    key: yarn-install-v3-{{ arch }}-{{ checksum "yarn.lock" }}
+    keys:
+      - yarn-install-v3-{{ arch }}-{{ checksum "yarn.lock" }}
+      - yarn-install-v3-{{ arch }}
+      - yarn-install-v3
 
 yarn_save_cache: &yarn_save_cache
   save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,12 +30,12 @@ bundle_install: &bundle_install
 yarn_restore_cache: &yarn_restore_cache
   restore_cache:
     name: Restore Yarn Package Cache
-    key: yarn-install-v1-{{ arch }}-{{ checksum "yarn.lock" }}
+    key: yarn-install-v2-{{ arch }}-{{ checksum "yarn.lock" }}
 
 yarn_save_cache: &yarn_save_cache
   save_cache:
     name: Save Yarn Package Cache
-    key: yarn-install-v1-{{ arch }}-{{ checksum "yarn.lock" }}
+    key: yarn-install-v2-{{ arch }}-{{ checksum "yarn.lock" }}
     paths:
       - ~/.cache/yarn
 
@@ -53,8 +53,8 @@ jobs:
       - *bundle_install
       - *bundle_save_cache
       - *yarn_restore_cache
-      - *yarn_save_cache
       - *yarn_install
+      - *yarn_save_cache
   test:
     <<: *defaults
     parallelism: 3


### PR DESCRIPTION
- **Corrigé** : le cache de Yarn est correctement mis à jour après le build (au lieu d'**avant** le build 🤦‍♂)
    _Le cache de Yarn sera donc plus souvent correct et parfaitement à jour. Concrètement `yarn install` passe de 30s à 7s)._
- **Amélioration** : les fichiers de Webpacker sont mis en cache sur la CI.
    _On passe de environ 15s à 4s de pré-compilation webpacker._
- **Amélioration** : yarn est invoqué avec une option qui s'assure que le package.lock ne sera pas modifié
- **Amélioration** : si un cache exact n'est pas trouvé mais qu'un cache plus ancien existe, le cache plus ancien est quand même restauré.
    _Ça devrait améliorer les performances lorsqu'un fichier lock est modifié : au lieu de tout rebuilder, on restaure le cache quand même, et le package manager rebuilde ce qui a changé._

Ça, plus les améliorations des timings de tests de @maatinito, on passe la durée d'un run sur Circle CI de environ 4 mn 30 à 3 mn 30.