### PR TITLE
Revert "app: hide IE11 deprecation banner during the strike"

### DIFF
--- a/config/initializers/browser.rb
+++ b/config/initializers/browser.rb
@@ -2,7 +2,6 @@
 Browser.modern_rules.clear
 Browser.modern_rules << -> b { b.chrome? && b.version.to_i >= 50 && !b.platform.ios? }
 Browser.modern_rules << -> b { b.edge? && b.version.to_i >= 14 && !b.compatibility_view? }
-Browser.modern_rules << -> b { b.ie? && b.version.to_i >= 11 && !b.compatibility_view? }
 Browser.modern_rules << -> b { b.firefox? && b.version.to_i >= 50 && !b.platform.ios? }
 Browser.modern_rules << -> b { b.opera? && b.version.to_i >= 40 }
 Browser.modern_rules << -> b { b.safari? && b.version.to_i >= 8 }

--- a/spec/features/outdated_browser_spec.rb
+++ b/spec/features/outdated_browser_spec.rb
@@ -3,29 +3,29 @@ require 'spec_helper'
 feature 'Outdated browsers support:' do
   context 'when the user browser is outdated' do
     before(:each) do
-      ie_10_user_agent = 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)'
-      Capybara.page.driver.header('user-agent', ie_10_user_agent)
+      ie_11_user_agent = 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko'
+      Capybara.page.driver.header('user-agent', ie_11_user_agent)
     end
 
     scenario 'a banner is displayed' do
       visit new_user_session_path
-      expect(page).to have_content('Internet Explorer 10 est trop ancien')
+      expect(page).to have_content('Internet Explorer 11 est trop ancien')
     end
 
     scenario 'the banner can be dismissed' do
       visit new_user_session_path
-      expect(page).to have_content('Internet Explorer 10 est trop ancien')
+      expect(page).to have_content('Internet Explorer 11 est trop ancien')
 
       # The banner is hidden immediately
       within '#outdated-browser-banner' do
         click_on 'Ignorer'
       end
-      expect(page).not_to have_content('Internet Explorer 10 est trop ancien')
+      expect(page).not_to have_content('Internet Explorer 11 est trop ancien')
       expect(page).to have_current_path(new_user_session_path)
 
       # The banner is hidden after a refresh
       page.refresh
-      expect(page).not_to have_content('Internet Explorer 10 est trop ancien')
+      expect(page).not_to have_content('Internet Explorer 11 est trop ancien')
     end
   end
 end


### PR DESCRIPTION
Vu que la bannière de grève n'est plus affichée en permanence, je pense qu'on peut remettre le bandeau "IE 11 est déprécié".

Ça fera toujours un double-bandeau les jours de grève – mais je pense que c'est bien que cette bannière soit là, à un moment.

Ça vous va ?