### PR TITLE
specs: add an actual test case to the Exercice spec

### DIFF
--- a/spec/models/exercice_spec.rb
+++ b/spec/models/exercice_spec.rb
@@ -1,4 +1,7 @@
 require 'spec_helper'
 
 describe Exercice do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:ca) }
+  end
 end


### PR DESCRIPTION
This fixes the "No timing found for 'spec/models/exercice_spec.rb'" warning message during CircleCI specs.

(I suspect this may cause the whole repartition of tests by timings to be discarded.)