### PR TITLE
fix: les demandes de PDF pour les brouillons génèrent des DoubleRender

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -33,6 +33,7 @@ module Users
     def show
       if dossier.brouillon?
         redirect_to brouillon_dossier_path(dossier)
+        return
       end
 
       @dossier = dossier

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -757,11 +757,17 @@ describe Users::DossiersController, type: :controller do
     procedure: procedure,
     user: user)
 }
-
       subject! { get(:show, params: { id: dossier.id, format: :pdf }) }
 
-      it { expect(assigns(:include_infos_administration)).to eq(false) }
-      it { expect(response).to render_template 'dossiers/show' }
+      context 'when the dossier is a brouillon' do
+        let(:dossier) { create(:dossier, user: user) }
+        it { is_expected.to redirect_to(brouillon_dossier_path(dossier)) }
+      end
+
+      context 'when the dossier has been submitted' do
+        it { expect(assigns(:include_infos_administration)).to eq(false) }
+        it { expect(response).to render_template 'dossiers/show' }
+      end
     end
   end
 


### PR DESCRIPTION
En l'état, pour les dossiers en brouillon, on fait une redirection + un render, ce qui déclenche des DoubleRender qui remontent occasionnellement dans sentry.

Il faut choisir et j'ai opté pour la redirection.