### PR TITLE
Fix - Suppression des caractères invalides pour feuilles excel

### DIFF
--- a/app/models/champs/repetition_champ.rb
+++ b/app/models/champs/repetition_champ.rb
@@ -36,7 +36,8 @@ class Champs::RepetitionChamp < Champ
   # We have to truncate the label here as spreadsheets have a (30 char) limit on length.
   def libelle_for_export
     str = "(#{type_de_champ.stable_id}) #{libelle}"
-    ActiveStorage::Filename.new(str).sanitized.truncate(30)
+    # /\*?[] are invalid Excel worksheet characters
+    ActiveStorage::Filename.new(str.delete('[]*?')).sanitized.truncate(30)
   end
 
   class Row < Hashie::Dash

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -334,7 +334,7 @@ describe ProcedureExportService do
 
       context 'with invalid characters' do
         before do
-          champ_repetition.type_de_champ.update(libelle: 'A / B \ C')
+          champ_repetition.type_de_champ.update(libelle: 'A / B \ C *[]?')
         end
 
         it 'should have valid sheet name' do


### PR DESCRIPTION
Lors de la génération des noms de feuilles excel, la présence de certains caractères (on a le cas actuellement avec `?` dans un nom de bloc répétable) peut casser l'export.

Je supprime ces caractères dans les noms de feuilles.