### PR TITLE
4127 suppression users via manager

### DIFF
--- a/app/controllers/manager/administrateurs_controller.rb
+++ b/app/controllers/manager/administrateurs_controller.rb
@@ -22,11 +22,7 @@ module Manager
     def delete
       administrateur = Administrateur.find(params[:id])
 
-      if !administrateur.can_be_deleted?
-        fail "Impossible de supprimer cet administrateur car il a des dossiers ou des procédures"
-      end
-      administrateur.dossiers.each(&:delete_and_keep_track)
-      administrateur.destroy
+      administrateur.delete_and_transfer_services
 
       logger.info("L'administrateur #{administrateur.id} est supprimé par #{current_administration.id}")
       flash[:notice] = "L'administrateur #{administrateur.id} est supprimé"

--- a/app/controllers/manager/instructeurs_controller.rb
+++ b/app/controllers/manager/instructeurs_controller.rb
@@ -6,5 +6,19 @@ module Manager
       flash[:notice] = "Instructeur réinvité."
       redirect_to manager_instructeur_path(instructeur)
     end
+
+    def delete
+      instructeur = Instructeur.find(params[:id])
+
+      if !instructeur.can_be_deleted?
+        fail "Impossible de supprimer cet instructeur car il est administrateur ou il est le seul instructeur sur une démarche"
+      end
+      instructeur.destroy!
+
+      logger.info("L'instructeur #{instructeur.id} est supprimé par #{current_administration.id}")
+      flash[:notice] = "L'instructeur #{instructeur.id} est supprimé"
+
+      redirect_to manager_instructeurs_path
+    end
   end
 end

--- a/app/controllers/manager/users_controller.rb
+++ b/app/controllers/manager/users_controller.rb
@@ -37,7 +37,7 @@ module Manager
     def delete
       user = User.find(params[:id])
       if !user.can_be_deleted?
-        fail "Impossible de supprimer cet utilisateur car il a des dossiers en instruction"
+        fail "Impossible de supprimer cet utilisateur. Il a des dossiers en instruction ou il est administrateur."
       end
       user.delete_and_keep_track_dossiers(current_administration)
 

--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -72,7 +72,7 @@ class Administrateur < ApplicationRecord
 
   def delete_and_transfer_services
     if !can_be_deleted?
-      fail "Impossible de supprimer cet administrateur car il a des procédures où il est le seul administrateur"
+      fail "Impossible de supprimer cet administrateur car il a des démarches où il est le seul administrateur"
     end
 
     procedures.each do |procedure|

--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -68,14 +68,13 @@ class Administrateur < ApplicationRecord
   end
 
   def can_be_deleted?
-    dossiers.state_instruction_commencee.none? && procedures.all? { |p| p.administrateurs.count > 1 }
+    procedures.all? { |p| p.administrateurs.count > 1 }
   end
 
   def delete_and_transfer_services
     if !can_be_deleted?
-      fail "Impossible de supprimer cet administrateur car il a des dossiers ou des procédures"
+      fail "Impossible de supprimer cet administrateur car il a des procédures où il est le seul administrateur"
     end
-    dossiers.each(&:delete_and_keep_track)
 
     procedures.each do |procedure|
       next_administrateur = procedure.administrateurs.where.not(id: self.id).first

--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -7,7 +7,6 @@ class Administrateur < ApplicationRecord
   has_many :administrateurs_procedures
   has_many :procedures, through: :administrateurs_procedures
   has_many :services
-  has_many :dossiers, -> { state_not_brouillon }, through: :procedures
 
   has_one :user, dependent: :nullify
 

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -17,9 +17,9 @@ class Instructeur < ApplicationRecord
   has_many :previously_followed_dossiers, -> { distinct }, through: :previous_follows, source: :dossier
   has_many :avis
   has_many :dossiers_from_avis, through: :avis, source: :dossier
-  has_many :trusted_device_tokens
+  has_many :trusted_device_tokens, dependent: :destroy
 
-  has_one :user
+  has_one :user, dependent: :nullify
 
   default_scope { eager_load(:user) }
 
@@ -174,6 +174,10 @@ class Instructeur < ApplicationRecord
   def young_login_token?
     trusted_device_token = trusted_device_tokens.order(created_at: :desc).first
     trusted_device_token&.token_young?
+  end
+
+  def can_be_deleted?
+    user.administrateur.nil? && procedures.all? { |p| p.defaut_groupe_instructeur.instructeurs.count > 1 }
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -108,7 +108,7 @@ class User < ApplicationRecord
     dossiers.each do |dossier|
       dossier.delete_and_keep_track(administration)
     end
-    dossiers.unscoped.destroy_all
+    dossiers.with_hidden.destroy_all
     destroy!
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -97,7 +97,7 @@ class User < ApplicationRecord
   end
 
   def can_be_deleted?
-    dossiers.state_instruction_commencee.empty?
+    administrateur.nil? && instructeur.nil? && dossiers.state_instruction_commencee.empty?
   end
 
   def delete_and_keep_track_dossiers(administration)
@@ -105,12 +105,11 @@ class User < ApplicationRecord
       raise "Cannot delete this user because instruction has started for some dossiers"
     end
 
-    if can_be_deleted?
-      dossiers.each do |dossier|
-        dossier.delete_and_keep_track(administration)
-      end
-      destroy
+    dossiers.each do |dossier|
+      dossier.delete_and_keep_track(administration)
     end
+    dossiers.unscoped.destroy_all
+    destroy!
   end
 
   private

--- a/app/views/manager/administrateurs/show.html.erb
+++ b/app/views/manager/administrateurs/show.html.erb
@@ -36,7 +36,7 @@ as well as a link to its edit page.
     <% if page.resource.invitation_expired? %>
       <%= link_to "renvoyer l'invitation", reinvite_manager_administrateur_path(page.resource), method: :post, class: "button" %>
     <% end %>
-    <%= button_to "supprimer", delete_manager_administrateur_path(page.resource), method: :delete, disabled: !page.resource.can_be_deleted?, class: "button", data: { confirm: "Confirmez-vous la suppression de l'administrateur ?" }, title: page.resource.can_be_deleted? ? "Supprimer" : "Cet administrateur a des procédures dont il est le seul admin et ne peut être supprimé" %>
+    <%= button_to "supprimer", delete_manager_administrateur_path(page.resource), method: :delete, disabled: !page.resource.can_be_deleted?, class: "button", data: { confirm: "Confirmez-vous la suppression de l'administrateur ?" }, title: page.resource.can_be_deleted? ? "Supprimer" : "Cet administrateur a des démarches dont il est le seul admin et ne peut être supprimé" %>
   </div>
 
 </header>

--- a/app/views/manager/administrateurs/show.html.erb
+++ b/app/views/manager/administrateurs/show.html.erb
@@ -36,7 +36,7 @@ as well as a link to its edit page.
     <% if page.resource.invitation_expired? %>
       <%= link_to "renvoyer l'invitation", reinvite_manager_administrateur_path(page.resource), method: :post, class: "button" %>
     <% end %>
-    <%= button_to "supprimer", delete_manager_administrateur_path(page.resource), method: :delete, disabled: !page.resource.can_be_deleted?, class: "button", data: { confirm: "Confirmez-vous la suppression de l'administrateur ?" }, title: page.resource.can_be_deleted? ? "Supprimer" : "Cet administrateur a des dossiers ou des procédures dont il est le seul admin et ne peut être supprimé" %>
+    <%= button_to "supprimer", delete_manager_administrateur_path(page.resource), method: :delete, disabled: !page.resource.can_be_deleted?, class: "button", data: { confirm: "Confirmez-vous la suppression de l'administrateur ?" }, title: page.resource.can_be_deleted? ? "Supprimer" : "Cet administrateur a des procédures dont il est le seul admin et ne peut être supprimé" %>
   </div>
 
 </header>

--- a/app/views/manager/instructeurs/show.html.erb
+++ b/app/views/manager/instructeurs/show.html.erb
@@ -34,7 +34,10 @@ as well as a link to its edit page.
 
   <div>
       <%= link_to 'Réinviter', reinvite_manager_instructeur_path(instructeur), method: :post, class: 'button' %>
+  </div>
   <div>
+    <%= button_to "Supprimer", delete_manager_instructeur_path(page.resource), method: :delete, disabled: !page.resource.can_be_deleted?, class: "button", data: { confirm: "Confirmez-vous la suppression de l'instructeur ?" }, title: page.resource.can_be_deleted? ? "Supprimer" : "Cet instructeur est administrateur ou a des démarches dont il est le seul instructeur et ne peut être supprimé" %>
+  </div>
 </header>
 
 <section class="main-content__body">

--- a/app/views/manager/users/show.html.erb
+++ b/app/views/manager/users/show.html.erb
@@ -28,7 +28,7 @@ as well as a link to its edit page.
     <%= button_to "modifier", edit_manager_user_path(page.resource), method: :get, class: "button" %>
   </div>
   <div>
-    <%= button_to "supprimer", delete_manager_user_path(page.resource), method: :delete, disabled: !page.resource.can_be_deleted?, class: "button", data: { confirm: "Confirmez-vous la suppression de l'utilisateur ?" }, title: page.resource.can_be_deleted? ? "Supprimer" : "Cet utilisateur a des dossiers dont l'instruction a commencé et ne peut être supprimé" %>
+    <%= button_to "supprimer", delete_manager_user_path(page.resource), method: :delete, disabled: !page.resource.can_be_deleted?, class: "button", data: { confirm: "Confirmez-vous la suppression de l'utilisateur ?" }, title: page.resource.can_be_deleted? ? "Supprimer" : "Cet utilisateur ne peut être supprimé. Il a des dossiers dont l'instruction a commencé ou il est administrateur ou instructeur" %>
   </div>
   <div>
     <% if !user.confirmed? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
 
     resources :instructeurs, only: [:index, :show] do
       post 'reinvite', on: :member
+      delete 'delete', on: :member
     end
 
     resources :dossiers, only: [:show]

--- a/spec/controllers/manager/instructeurs_controller_spec.rb
+++ b/spec/controllers/manager/instructeurs_controller_spec.rb
@@ -1,0 +1,17 @@
+describe Manager::InstructeursController, type: :controller do
+  let(:administration) { create(:administration) }
+
+  describe '#delete' do
+    let!(:instructeur) { create(:instructeur) }
+
+    before { sign_in administration }
+
+    subject { delete :delete, params: { id: instructeur.id } }
+
+    it 'deletes the instructeur' do
+      subject
+
+      expect(Instructeur.find_by(id: instructeur.id)).to be_nil
+    end
+  end
+end

--- a/spec/models/administrateur_spec.rb
+++ b/spec/models/administrateur_spec.rb
@@ -24,19 +24,19 @@ describe Administrateur, type: :model do
   describe "#can_be_deleted?" do
     subject { administrateur.can_be_deleted? }
 
-    context 'when the administrateur has a dossier in instruction' do
-      let!(:dossier) { create(:dossier, :en_instruction) }
-      let(:administrateur) { dossier.procedure.administrateurs.first }
-
-      it { is_expected.to be false }
-    end
-
     context "when the administrateur's procedures have other administrateurs" do
       let!(:administrateur) { create(:administrateur) }
       let!(:autre_administrateur) { create(:administrateur) }
       let!(:procedure) { create(:procedure, administrateurs: [administrateur, autre_administrateur]) }
 
       it { is_expected.to be true }
+    end
+
+    context "when the administrateur has a procedure where he/she is the only admin" do
+      let!(:administrateur) { create(:administrateur) }
+      let!(:procedure) { create(:procedure, administrateurs: [administrateur]) }
+
+      it { is_expected.to be false }
     end
 
     context "when the administrateur has no procedure" do

--- a/spec/models/administrateur_spec.rb
+++ b/spec/models/administrateur_spec.rb
@@ -46,6 +46,21 @@ describe Administrateur, type: :model do
     end
   end
 
+  describe '#delete_and_transfer_services' do
+    let!(:administrateur) { create(:administrateur) }
+    let!(:autre_administrateur) { create(:administrateur) }
+    let!(:procedure) { create(:procedure, :with_service, administrateurs: [administrateur, autre_administrateur]) }
+    let(:service) { procedure.service }
+
+    it "delete and transfer services to other admin" do
+      service.update(administrateur: administrateur)
+      administrateur.delete_and_transfer_services
+
+      expect(Administrateur.find_by(id: administrateur.id)).to be_nil
+      expect(service.reload.administrateur).to eq(autre_administrateur)
+    end
+  end
+
   # describe '#password_complexity' do
   #   let(:email) { 'mail@beta.gouv.fr' }
   #   let(:passwords) { ['pass', '12pass23', 'démarches ', 'démarches-simple', 'démarches-simplifiées-pwd'] }

--- a/spec/models/administrateur_spec.rb
+++ b/spec/models/administrateur_spec.rb
@@ -32,7 +32,7 @@ describe Administrateur, type: :model do
       it { is_expected.to be true }
     end
 
-    context "when the administrateur has a procedure where he/she is the only admin" do
+    context "when the administrateur has a procedure where they is the only admin" do
       let!(:administrateur) { create(:administrateur) }
       let!(:procedure) { create(:procedure, administrateurs: [administrateur]) }
 

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -424,9 +424,40 @@ describe Instructeur, type: :model do
     it { expect(instructeur_a.procedures.all.to_ary).to eq([procedure_a]) }
   end
 
+  describe "#can_be_deleted?" do
+    subject { instructeur.can_be_deleted? }
+
+    context 'when the instructeur is an administrateur' do
+      let!(:administrateur) { create(:administrateur) }
+      let(:instructeur) { administrateur.instructeur }
+
+      it { is_expected.to be false }
+    end
+
+    context "when the instructeur's procedures have other instructeurs" do
+      let(:instructeur_not_admin) { create(:instructeur) }
+      let(:autre_instructeur) { create(:instructeur) }
+
+      it "can be deleted" do
+        assign(procedure, instructeur_assigne: instructeur_not_admin)
+        assign(procedure, instructeur_assigne: autre_instructeur)
+        expect(autre_instructeur.can_be_deleted?).to be_truthy
+      end
+    end
+
+    context "when the instructeur's procedures is the only one" do
+      let(:instructeur_not_admin) { create :instructeur }
+      let(:autre_procedure) { create :procedure }
+      it "can be deleted" do
+        assign(autre_procedure, instructeur_assigne: instructeur_not_admin)
+        expect(instructeur_not_admin.can_be_deleted?).to be_falsy
+      end
+    end
+  end
+
   private
 
-  def assign(procedure_to_assign)
-    create :assign_to, instructeur: instructeur, procedure: procedure_to_assign, groupe_instructeur: procedure_to_assign.defaut_groupe_instructeur
+  def assign(procedure_to_assign, instructeur_assigne: instructeur)
+    create :assign_to, instructeur: instructeur_assigne, procedure: procedure_to_assign, groupe_instructeur: procedure_to_assign.defaut_groupe_instructeur
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -273,6 +273,9 @@ describe User, type: :model do
         let!(:dossier_cache) do
           create(:dossier, :en_construction, user: user)
         end
+        let!(:dossier_from_another_user) do
+          create(:dossier, :en_construction, user: create(:user))
+        end
 
         it "keep track of dossiers and delete user" do
           dossier_cache.delete_and_keep_track(administration)
@@ -281,6 +284,13 @@ describe User, type: :model do
           expect(DeletedDossier.find_by(dossier_id: dossier_en_construction)).to be_present
           expect(DeletedDossier.find_by(dossier_id: dossier_brouillon)).to be_present
           expect(User.find_by(id: user.id)).to be_nil
+        end
+
+        it "doesn't destroy dossiers of another user" do
+          dossier_cache.delete_and_keep_track(administration)
+          user.delete_and_keep_track_dossiers(administration)
+
+          expect(Dossier.find_by(id: dossier_from_another_user.id)).not_to be_nil
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -290,7 +290,7 @@ describe User, type: :model do
           dossier_cache.delete_and_keep_track(administration)
           user.delete_and_keep_track_dossiers(administration)
 
-          expect(Dossier.find_by(id: dossier_from_another_user.id)).not_to be_nil
+          expect(Dossier.find_by(id: dossier_from_another_user.id)).to be_present
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -224,6 +224,24 @@ describe User, type: :model do
     context 'when the user has no dossier in instruction' do
       it { is_expected.to be true }
     end
+
+    context 'when the user is an administrateur' do
+      it 'cannot be deleted' do
+        administrateur = create(:administrateur)
+        user = administrateur.user
+
+        expect(user.can_be_deleted?).to be_falsy
+      end
+    end
+
+    context 'when the user is an instructeur' do
+      it 'cannot be deleted' do
+        instructeur = create(:instructeur)
+        user = instructeur.user
+
+        expect(user.can_be_deleted?).to be_falsy
+      end
+    end
   end
 
   describe '#delete_and_keep_track_dossiers' do
@@ -241,12 +259,29 @@ describe User, type: :model do
       let!(:dossier_en_construction) { create(:dossier, :en_construction, user: user) }
       let!(:dossier_brouillon) { create(:dossier, user: user) }
 
-      it "keep track of dossiers and delete user" do
-        user.delete_and_keep_track_dossiers(administration)
+      context 'without a hidden dossier' do
+        it "keep track of dossiers and delete user" do
+          user.delete_and_keep_track_dossiers(administration)
 
-        expect(DeletedDossier.find_by(dossier_id: dossier_en_construction)).to be_present
-        expect(DeletedDossier.find_by(dossier_id: dossier_brouillon)).to be_present
-        expect(User.find_by(id: user.id)).to be_nil
+          expect(DeletedDossier.find_by(dossier_id: dossier_en_construction)).to be_present
+          expect(DeletedDossier.find_by(dossier_id: dossier_brouillon)).to be_present
+          expect(User.find_by(id: user.id)).to be_nil
+        end
+      end
+
+      context 'with a hidden dossier' do
+        let!(:dossier_cache) do
+          create(:dossier, :en_construction, user: user)
+        end
+
+        it "keep track of dossiers and delete user" do
+          dossier_cache.delete_and_keep_track(administration)
+          user.delete_and_keep_track_dossiers(administration)
+
+          expect(DeletedDossier.find_by(dossier_id: dossier_en_construction)).to be_present
+          expect(DeletedDossier.find_by(dossier_id: dossier_brouillon)).to be_present
+          expect(User.find_by(id: user.id)).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
- permet la suppression des utilisateurs, administrateurs, instructeurs par les superadmin via le manager
- corrige la suppression des dossiers (uniquement les dossiers de l'utilisateur, pas TOUS les dossiers de tous les utilisateurs)

Le comportement est documenté dans [le wiki](https://github.com/betagouv/demarches-simplifiees.fr/wiki/Suppression-d%27un-utilisateur)