### PR TITLE
Only load rubocop's custom rule in development

### DIFF
--- a/lib/cops/unscoped.rb
+++ b/lib/cops/unscoped.rb
@@ -1,16 +1,18 @@
-module RuboCop
-  module Cop
-    module DS
-      class Unscoped < Cop
-        MSG = "Avoid using `unscoped`. Instead unscope specific clauses by using `unscope(where: :attribute)`."
+if ENV["RAILS_ENV"] == "development"
+  module RuboCop
+    module Cop
+      module DS
+        class Unscoped < Cop
+          MSG = "Avoid using `unscoped`. Instead unscope specific clauses by using `unscope(where: :attribute)`."
 
-        def_node_matcher :unscoped?, <<-END
-          (send _ :unscoped)
-        END
+          def_node_matcher :unscoped?, <<-END
+            (send _ :unscoped)
+          END
 
-        def on_send(node)
-          return unless unscoped?(node)
-          add_offense(node)
+          def on_send(node)
+            return unless unscoped?(node)
+            add_offense(node)
+          end
         end
       end
     end


### PR DESCRIPTION
problème: le répertoire lib est inclus dans le boot de rails, mais rubocop est uniquement une dépendance de dev, donc on a des problèmes qui mènent au crash du boot lorsque l'environnement est celui de prod.