### PR TITLE
lint: improve Rubocop detection

### DIFF
--- a/lib/cops/unscoped.rb
+++ b/lib/cops/unscoped.rb
@@ -1,4 +1,4 @@
-if ENV["RAILS_ENV"] == "development"
+if defined?(RuboCop)
   module RuboCop
     module Cop
       module DS


### PR DESCRIPTION
Instead on relying on `RAILS_ENV`, we try to load the Rubocop cop only if Rubocop is currently loaded.

