### PR TITLE
Usager : dans l'email « Le compte existe déjà », ajoute un lien vers la démarche

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -25,7 +25,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     existing_user = User.find_by(email: params[:user][:email])
     if existing_user.present?
       if existing_user.confirmed?
-        UserMailer.new_account_warning(existing_user).deliver_later
+        UserMailer.new_account_warning(existing_user, @procedure).deliver_later
       else
         existing_user.resend_confirmation_instructions
       end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,12 +1,15 @@
 # Preview all emails at http://localhost:3000/rails/mailers/user_mailer
 class UserMailer < ApplicationMailer
+  helper MailerHelper
+
   layout 'mailers/layout'
 
-  def new_account_warning(user)
+  def new_account_warning(user, procedure = nil)
     @user = user
     @subject = "Demande de création de compte"
+    @procedure = procedure
 
-    mail(to: user.email, subject: @subject)
+    mail(to: user.email, subject: @subject, procedure: @procedure)
   end
 
   def account_already_taken(user, requested_email)

--- a/app/views/user_mailer/new_account_warning.html.haml
+++ b/app/views/user_mailer/new_account_warning.html.haml
@@ -7,9 +7,25 @@
   Une demande de création de compte a été réalisée sur le site demarches-simplifiees.fr pour l'email #{@user.email}.
 
 %p
-  Votre compte existe déjà. Si vous souhaitez changer votre mot de passe, veuillez suivre les instructions à l'adresse suivante
-  #{link_to(new_password_url(@user), new_password_url(@user))}.
+  %strong Votre compte existe déjà.
 
+- if @procedure
+  %p
+    Si vous souhaitez remplir la démarche
+    = surround '« ', ' »,' do
+      %i= @procedure.libelle
+    cliquez sur le bouton ci-dessous.
+
+  = round_button("Commencer la démarche « #{@procedure.libelle.truncate(60)} »", commencer_sign_in_url(path: @procedure.path), :primary)
+  = vertical_margin(16)
+  = round_button('J’ai oublié mon mot de passe', new_password_url(@user), :secondary)
+
+- else
+  %p
+    Vous n'avez rien à faire. Si vous avez oublié votre mot de passe, cliquez sur le bouton ci-dessous.
+  = round_button('J’ai oublié mon mot de passe', new_password_url(@user), :secondary)
+
+= vertical_margin(6)
 %p
   Si vous n'êtes pas à l'origine de cette demande, vous pouvez ignorer ce mail.
 

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -91,27 +91,24 @@ feature 'Signing up:' do
     end
   end
 
-  context 'when a user is not confirmed yet' do
+  context 'when the user is not confirmed yet' do
     before do
-      visit commencer_path(path: procedure.path)
-      click_on 'Créer un compte demarches-simplifiees.fr'
-
-      sign_up_with user_email, user_password
+      create(:user, :unconfirmed, email: user_email, password: user_password)
     end
 
-    # Ideally, when signing-in with an unconfirmed account,
-    # the user would be redirected to the "resend email confirmation" page.
-    #
-    # However the check for unconfirmed accounts is made by Warden every time a page is loaded –
-    # and much earlier than SessionsController#create.
-    #
-    # For now only test the default behavior (an error message is displayed).
-    scenario 'they get an error message' do
-      visit root_path
-      click_on 'Connexion'
+    scenario 'the email confirmation page is displayed' do
+      visit commencer_path(path: procedure.path)
+      click_on 'Créer un compte'
 
-      sign_in_with user_email, user_password
-      expect(page).to have_content 'Vous devez confirmer votre adresse email pour continuer'
+      sign_up_with user_email, user_password
+
+      # The same page than for initial sign-ups is displayed, to avoid leaking informations
+      # about the accound existence.
+      expect(page).to have_content "nous avons besoin de vérifier votre adresse #{user_email}"
+
+      # The confirmation email is sent again
+      confirmation_email = open_email(user_email)
+      expect(confirmation_email.body).to have_text('Pour activer votre compte')
     end
   end
 

--- a/spec/mailers/previews/user_mailer_preview.rb
+++ b/spec/mailers/previews/user_mailer_preview.rb
@@ -3,6 +3,11 @@ class UserMailerPreview < ActionMailer::Preview
     UserMailer.new_account_warning(user)
   end
 
+  def new_account_warning___with_procedure
+    procedure = Procedure.new(libelle: 'Dotation d’Équipement des Territoires Ruraux - Exercice 2019', path: 'dotation-etr')
+    UserMailer.new_account_warning(user, procedure)
+  end
+
   def account_already_taken
     UserMailer.account_already_taken(user, 'dircab@territoires.gouv.fr')
   end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -8,6 +8,15 @@ RSpec.describe UserMailer, type: :mailer do
 
     it { expect(subject.to).to eq([user.email]) }
     it { expect(subject.body).to include(user.email) }
+    it { expect(subject.body).to have_link('J’ai oublié mon mot de passe') }
+
+    context 'when a procedure is provided' do
+      let(:procedure) { build(:procedure) }
+
+      subject { described_class.new_account_warning(user, procedure) }
+
+      it { expect(subject.body).to have_link("Commencer la démarche « #{procedure.libelle} »", href: commencer_sign_in_url(path: procedure.path)) }
+    end
   end
 
   describe '.account_already_taken' do

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -55,6 +55,13 @@ module FeatureHelpers
     visit "/users/confirmation?#{token_params}"
   end
 
+  def click_procedure_sign_in_link_for(email)
+    confirmation_email = open_email(email)
+    procedure_sign_in_link = confirmation_email.body.match(/href="([^"]*\/commencer\/[^"]*)"/)[1]
+
+    visit procedure_sign_in_link
+  end
+
   def click_reset_password_link_for(email)
     reset_password_email = open_email(email)
     token_params = reset_password_email.body.match(/reset_password_token=[^"]+/)


### PR DESCRIPTION
Aujourd'hui, si un Usager va sur une démarche, on lui présente par défaut le formulaire de Création de compte.

S'il/elle le remplit avec un compte qui existe déjà, on envoie un email qui dit "Oups, ton compte existe déjà". Et… c'est tout. C'est difficile de continuer sur cette "erreur", et de reprendre la démarche là où on l'avait laissée. Je pense que c'est le souci rencontré dans #4738.

_(Idéalement on devrait connecter directement l'Usager, mais on a essayé, et c'est difficile techniquement)._

Cette PR ajoute un bouton "Commencer la démarche" à cet email. Comme ça, si l'usager s'est trompé, iel a un lien facile vers le formulaire de sign-in de la démarche.

## Avant

<img width="744" alt="Capture d’écran 2020-02-03 à 17 23 32" src="https://user-images.githubusercontent.com/179923/73671031-8819d380-46aa-11ea-863f-11018c451fd5.png">

## Après

<img width="742" alt="Capture d’écran 2020-02-03 à 17 23 18" src="https://user-images.githubusercontent.com/179923/73671045-8e0fb480-46aa-11ea-8722-c6f0e78e12b1.png">


## Question

Avant que j'aille plus loin, vous pensez que c'est une bonne idée ?