### PR TITLE
#4705 - investigation des problèmes de mail

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -3,11 +3,6 @@ class ApplicationMailer < ActionMailer::Base
   default from: "demarches-simplifiees.fr <#{CONTACT_EMAIL}>"
   layout 'mailer'
 
-  # Don’t retry to send a message if the server rejects the recipient address
-  rescue_from Net::SMTPSyntaxError do |_error|
-    message.perform_deliveries = false
-  end
-
   # Attach the procedure logo to the email (if any).
   # Returns the attachment url.
   def attach_logo(procedure)

--- a/app/mailers/devise_user_mailer.rb
+++ b/app/mailers/devise_user_mailer.rb
@@ -4,11 +4,6 @@ class DeviseUserMailer < Devise::Mailer
   include Devise::Controllers::UrlHelpers # Optional. eg. `confirmation_url`
   layout 'mailers/layout'
 
-  # Don’t retry to send a message if the server rejects the recipient address
-  rescue_from Net::SMTPSyntaxError do |_error|
-    message.perform_deliveries = false
-  end
-
   def template_paths
     ['devise_mailer']
   end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -3,16 +3,6 @@ RSpec.describe ApplicationMailer, type: :mailer do
     let(:dossier) { create(:dossier, procedure: build(:simple_procedure)) }
     subject { DossierMailer.notify_new_draft(dossier) }
 
-    describe 'invalid emails are not sent' do
-      before do
-        allow_any_instance_of(DossierMailer)
-          .to receive(:notify_new_draft)
-          .and_raise(Net::SMTPSyntaxError)
-      end
-
-      it { expect(subject.message).to be_an_instance_of(ActionMailer::Base::NullMail) }
-    end
-
     describe 'valid emails are sent' do
       it { expect(subject.message).not_to be_an_instance_of(ActionMailer::Base::NullMail) }
     end


### PR DESCRIPTION
On a des mails qui ne sont pas délivrés et plusieurs retours à ce sujet au support
 1) il n'y a trace ni dans mailjet ni sendinblue
 2) on a pas de log d'erreur, donc pas moyen de creuser le problème
 3) on a volontairement ignoré les erreurs de mail il y a quelques temps (https://github.com/betagouv/demarches-simplifiees.fr/pull/4465)

Je soupconne cette dernière modif de jeter un peu trop de mails et d'être la cause de l'absence de logs. En tout cas, je propose de la désactiver pour explicitement avoir des erreurs qui remplissent la queue. Ca devrait permettre:
 - d'identifier si c'est bien la source du problème
 - si c'est le cas, d'identifier les personnes et quantifier le volume de problèmes de mail qu'on a
