### PR TITLE
sign_in: remove the hint about password length

### DIFF
--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -9,7 +9,7 @@
     = f.text_field :email, autofocus: true
 
     = f.label :password, "Mot de passe"
-    = f.password_field :password, placeholder: "8 caractères minimum"
+    = f.password_field :password
 
     .auth-options
       %div


### PR DESCRIPTION
On a besoin de l'indication de longueur au moment de la création de compte, mais pas au moment du login.

<img width="561" alt="Capture d’écran 2020-02-05 à 17 02 54" src="https://user-images.githubusercontent.com/179923/73858897-731f7a80-4839-11ea-88e3-b15182087021.png">
