### PR TITLE
Permet de visualiser le contenu d'un type de champ répétable dans le manager

### DIFF
--- a/app/views/fields/types_de_champ_collection_field/_show.html.haml
+++ b/app/views/fields/types_de_champ_collection_field/_show.html.haml
@@ -10,5 +10,10 @@
       - field.data.order(:order_place).each do |type_de_champ|
         = render partial: 'fields/types_de_champ_collection_field/type_champ_line',
           locals: { type_de_champ: type_de_champ }
+
+        - if type_de_champ.type_champ == 'repetition'
+          - type_de_champ.types_de_champ.each do |sub_champ|
+            = render partial: 'fields/types_de_champ_collection_field/type_champ_line',
+              locals: { type_de_champ: sub_champ }
 - else
   Aucun

--- a/app/views/fields/types_de_champ_collection_field/_show.html.haml
+++ b/app/views/fields/types_de_champ_collection_field/_show.html.haml
@@ -7,28 +7,8 @@
         %td.cell-label Rempli
         %td.cell-label Modifier le modèle
     %tbody
-      - field.data.order(:order_place).each do |f|
-        %tr
-          %td.cell-data
-            = f.libelle
-            - if f.mandatory?
-              %span.mandatory{ style: 'color: #A10005;' } *
-          %td.cell-data
-            = I18n.t("activerecord.attributes.type_de_champ.type_champs.#{f.type_champ}")
-
-          %td.cell-data
-            - if f.blank?
-              vide
-            - else
-              rempli
-
-          %td.cell-data
-            - if f.type_champ == 'piece_justificative'
-              = form_for f,
-                url: change_piece_justificative_template_manager_procedure_path,
-                method: :post  do |form|
-                = form.hidden_field :id
-                = form.file_field :piece_justificative_template
-                = form.submit 'modifier'
+      - field.data.order(:order_place).each do |type_de_champ|
+        = render partial: 'fields/types_de_champ_collection_field/type_champ_line',
+          locals: { type_de_champ: type_de_champ }
 - else
   Aucun

--- a/app/views/fields/types_de_champ_collection_field/_show.html.haml
+++ b/app/views/fields/types_de_champ_collection_field/_show.html.haml
@@ -4,7 +4,6 @@
       %tr
         %td.cell-label Libelle
         %td.cell-label Type de champ
-        %td.cell-label Rempli
         %td.cell-label Modifier le modèle
     %tbody
       - field.data.order(:order_place).each do |type_de_champ|

--- a/app/views/fields/types_de_champ_collection_field/_type_champ_line.html.haml
+++ b/app/views/fields/types_de_champ_collection_field/_type_champ_line.html.haml
@@ -1,0 +1,22 @@
+%tr
+  %td.cell-data
+    = type_de_champ.libelle
+    - if type_de_champ.mandatory?
+      %span.mandatory{ style: 'color: #A10005;' } *
+  %td.cell-data
+    = I18n.t("activerecord.attributes.type_de_champ.type_champs.#{type_de_champ.type_champ}")
+
+  %td.cell-data
+    - if type_de_champ.blank?
+      vide
+    - else
+      rempli
+
+  %td.cell-data
+    - if type_de_champ.type_champ == 'piece_justificative'
+      = form_for type_de_champ,
+        url: change_piece_justificative_template_manager_procedure_path,
+        method: :post  do |form|
+        = form.hidden_field :id
+        = form.file_field :piece_justificative_template
+        = form.submit 'modifier'

--- a/app/views/fields/types_de_champ_collection_field/_type_champ_line.html.haml
+++ b/app/views/fields/types_de_champ_collection_field/_type_champ_line.html.haml
@@ -7,12 +7,6 @@
     = I18n.t("activerecord.attributes.type_de_champ.type_champs.#{type_de_champ.type_champ}")
 
   %td.cell-data
-    - if type_de_champ.blank?
-      vide
-    - else
-      rempli
-
-  %td.cell-data
     - if type_de_champ.type_champ == 'piece_justificative'
       = form_for type_de_champ,
         url: change_piece_justificative_template_manager_procedure_path,

--- a/spec/controllers/manager/procedures_controller_spec.rb
+++ b/spec/controllers/manager/procedures_controller_spec.rb
@@ -11,4 +11,18 @@ describe Manager::ProceduresController, type: :controller do
 
     it { expect(procedure.whitelisted_at).not_to be_nil }
   end
+
+  describe '#show' do
+    render_views
+
+    let(:administration) { create(:administration) }
+    let!(:procedure) { create(:procedure, :with_repetition) }
+
+    before do
+      sign_in(administration)
+      get :show, params: { id: procedure.id }
+    end
+
+    it { expect(response.body).to include('sub type de champ') }
+  end
 end

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -153,6 +153,15 @@ FactoryBot.define do
       end
     end
 
+    trait :with_repetition do
+      after(:build) do |procedure, _evaluator|
+        type_de_champ = create(:type_de_champ_repetition)
+        procedure.types_de_champ << type_de_champ
+
+        type_de_champ.types_de_champ << create(:type_de_champ, libelle: 'sub type de champ')
+      end
+    end
+
     trait :published do
       after(:build) do |procedure, _evaluator|
         procedure.path = generate(:published_path)


### PR DESCRIPTION
J'avais besoin de changer un modèle de pièce jointe dans un type de champ contenu dans un bloc répétable. Or il n'était pas afficher dans le manager, d'ou cette pr.

Fix #4685