### PR TITLE
form: display index of section in header (again)

### DIFF
--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -25,6 +25,14 @@ class Champ < ApplicationRecord
     !private?
   end
 
+  def siblings
+    if public?
+      dossier&.champs
+    else
+      dossier&.champs_private
+    end
+  end
+
   def mandatory_and_blank?
     mandatory? && blank?
   end

--- a/app/models/champs/header_section_champ.rb
+++ b/app/models/champs/header_section_champ.rb
@@ -2,4 +2,10 @@ class Champs::HeaderSectionChamp < Champ
   def search_terms
     # The user cannot enter any information here so it doesn’t make much sense to search
   end
+
+  def section_index
+    siblings
+      .filter { |c| c.type_champ == TypeDeChamp.type_champs.fetch(:header_section) }
+      .index(self) + 1
+  end
 end

--- a/app/views/shared/dossiers/editable_champs/_header_section.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_header_section.html.haml
@@ -1,2 +1,5 @@
 %h2.header-section
-  = "#{champ.section_index}. #{champ.libelle}"
+  - libelle_starts_with_number = (champ.libelle =~ /^\d/)
+  - if !libelle_starts_with_number
+    = "#{champ.section_index}."
+  = champ.libelle

--- a/app/views/shared/dossiers/editable_champs/_header_section.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_header_section.html.haml
@@ -1,2 +1,2 @@
 %h2.header-section
-  = champ.libelle
+  = "#{champ.section_index}. #{champ.libelle}"

--- a/spec/models/champ_spec.rb
+++ b/spec/models/champ_spec.rb
@@ -22,6 +22,20 @@ describe Champ do
     end
   end
 
+  describe '#siblings' do
+    let(:procedure) { create(:procedure, :with_type_de_champ, :with_type_de_champ_private, types_de_champ_count: 1, types_de_champ_private_count: 1) }
+    let(:dossier) { create(:dossier, procedure: procedure) }
+    let(:public_champ) { dossier.champs.first }
+    let(:private_champ) { dossier.champs_private.first }
+    let(:standalone_champ) { create(:champ, dossier: nil) }
+
+    it 'returns the sibling champs of a champ' do
+      expect(public_champ.siblings).to eq(dossier.champs)
+      expect(private_champ.siblings).to eq(dossier.champs_private)
+      expect(standalone_champ.siblings).to be_nil
+    end
+  end
+
   describe '#format_datetime' do
     let(:type_de_champ) { build(:type_de_champ_datetime) }
     let(:champ) { type_de_champ.champ.build(value: value) }

--- a/spec/models/champs/header_section_champ_spec.rb
+++ b/spec/models/champs/header_section_champ_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Champs::HeaderSectionChamp do
+  describe '#section_index' do
+    let(:types_de_champ) do
+      [
+        create(:type_de_champ_header_section, order_place: 1),
+        create(:type_de_champ_civilite,       order_place: 2),
+        create(:type_de_champ_text,           order_place: 3),
+        create(:type_de_champ_header_section, order_place: 4),
+        create(:type_de_champ_email,          order_place: 5)
+      ]
+    end
+    let(:procedure) { create(:procedure, types_de_champ: types_de_champ) }
+    let(:dossier) { create(:dossier, procedure: procedure) }
+    let(:first_header)  { dossier.champs[0] }
+    let(:second_header) { dossier.champs[3] }
+
+    it 'returns the index of the section (starting from 1)' do
+      expect(first_header.section_index).to eq 1
+      expect(second_header.section_index).to eq 2
+    end
+  end
+end


### PR DESCRIPTION
La version précédente plantait quand on affichait des annotations privées.

Cette fois-ci, la PR introduit une méthode `Champ#siblings`, qui renvoie la collection des champs ou des annotations privées à laquelle le champ appartient.

