### PR TITLE
Usager : redirige vers la démarche après l'email de confirmation

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -42,9 +42,19 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
     if sign_in_after_confirmation?(resource)
       resource.remember_me = true
       sign_in(resource)
+    end
+
+    if procedure_from_params
+      commencer_path(path: procedure_from_params.path)
+    elsif signed_in?
+      # Will try to use `stored_location_for` to find a path
       after_sign_in_path_for(resource_name)
     else
       super(resource_name, resource)
     end
+  end
+
+  def procedure_from_params
+    params[:procedure_id] && Procedure.find_by(id: params[:procedure_id])
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -21,6 +21,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # POST /resource
   def create
+    # We may need the confirmation mailer to access the current procedure.
+    # But there's no easy way to pass an argument to the mailer through
+    # all Devise code.
+    # So instead we use a per-request global variable.
+    CurrentConfirmation.procedure_after_confirmation = @procedure
+
     # Handle existing user trying to sign up again
     existing_user = User.find_by(email: params[:user][:email])
     if existing_user.present?

--- a/app/mailers/devise_user_mailer.rb
+++ b/app/mailers/devise_user_mailer.rb
@@ -15,6 +15,7 @@ class DeviseUserMailer < Devise::Mailer
 
   def confirmation_instructions(record, token, opts = {})
     opts[:from] = NO_REPLY_EMAIL
+    @procedure = CurrentConfirmation.procedure_after_confirmation || nil
     super
   end
 end

--- a/app/models/current_confirmation.rb
+++ b/app/models/current_confirmation.rb
@@ -1,0 +1,3 @@
+class CurrentConfirmation < ActiveSupport::CurrentAttributes
+  attribute :procedure_after_confirmation
+end

--- a/app/views/devise_mailer/confirmation_instructions.html.haml
+++ b/app/views/devise_mailer/confirmation_instructions.html.haml
@@ -7,7 +7,8 @@
 
   %p
     Pour activer votre compte sur demarches-simplifiees.fr, veuillez cliquer sur le lien suivant :
-    = link_to(confirmation_url(@user, confirmation_token: @token), confirmation_url(@user, confirmation_token: @token))
+    - link = confirmation_url(@user, confirmation_token: @token, procedure_id: @procedure&.id)
+    = link_to(link, link)
 
 - else
   - content_for(:title, "Changement d'adresse email")

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -77,8 +77,10 @@ feature 'Signing up:' do
       sign_up_with user_email, user_password
       expect(page).to have_content "nous avons besoin de vérifier votre adresse #{user_email}"
 
-      click_confirmation_link_for user_email
+      click_confirmation_link_for(user_email, in_another_browser: true)
 
+      # After confirmation, the user is redirected to the procedure they were initially starting
+      # (even when confirming the account in another browser).
       expect(page).to have_current_path(commencer_path(path: procedure.path))
       expect(page).to have_content 'Votre compte a été activé'
       click_on 'Commencer la démarche'
@@ -106,6 +108,14 @@ feature 'Signing up:' do
       # The confirmation email is sent again
       confirmation_email = open_email(user_email)
       expect(confirmation_email.body).to have_text('Pour activer votre compte')
+
+      click_confirmation_link_for(user_email, in_another_browser: true)
+
+      # After confirmation, the user is redirected to the procedure they were initially starting
+      # (even when confirming the account in another browser).
+      expect(page).to have_current_path(commencer_path(path: procedure.path))
+      expect(page).to have_content 'Votre compte a été activé'
+      expect(page).to have_content 'Commencer la démarche'
     end
   end
 

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -67,11 +67,9 @@ feature 'Signing up:' do
   context 'when visiting a procedure' do
     let(:procedure) { create :simple_procedure, :with_service }
 
-    before do
-      visit commencer_path(path: procedure.path)
-    end
-
     scenario 'a new user can sign-up and fill the procedure' do
+      visit commencer_path(path: procedure.path)
+
       click_on 'Créer un compte'
       expect(page).to have_current_path new_user_registration_path
       expect(page).to have_procedure_description(procedure)
@@ -102,7 +100,7 @@ feature 'Signing up:' do
       sign_up_with user_email, user_password
 
       # The same page than for initial sign-ups is displayed, to avoid leaking informations
-      # about the accound existence.
+      # about the account existence.
       expect(page).to have_content "nous avons besoin de vérifier votre adresse #{user_email}"
 
       # The confirmation email is sent again
@@ -130,8 +128,8 @@ feature 'Signing up:' do
       warning_email = open_email(user_email)
       expect(warning_email.body).to have_text('Votre compte existe déjà')
 
-      # When clicking the main button, the user has a link to directly sign-in
-      # for the procedure they were initially starting
+      # When clicking the main button, the user is redirected directly to
+      # the sign-in page for the procedure they were initially starting.
       click_procedure_sign_in_link_for user_email
 
       expect(page).to have_current_path new_user_session_path

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -5,16 +5,15 @@ feature 'Signing up:' do
   let(:user_password) { 'démarches-simplifiées-pwd' }
   let(:procedure) { create :simple_procedure, :with_service }
 
-  scenario 'a new user can sign-up' do
-    visit commencer_path(path: procedure.path)
-    click_on 'Créer un compte demarches-simplifiees.fr'
+  scenario 'a new user can sign-up from scratch' do
+    visit new_user_registration_path
 
     sign_up_with user_email, user_password
     expect(page).to have_content "nous avons besoin de vérifier votre adresse #{user_email}"
 
     click_confirmation_link_for user_email
     expect(page).to have_content 'Votre compte a été activé'
-    expect(page).to have_current_path commencer_path(path: procedure.path)
+    expect(page).to have_current_path dossiers_path
   end
 
   context 'when the user makes a typo in their email address' do

--- a/spec/mailers/previews/devise_user_mailer_preview.rb
+++ b/spec/mailers/previews/devise_user_mailer_preview.rb
@@ -3,6 +3,11 @@ class DeviseUserMailerPreview < ActionMailer::Preview
     DeviseUserMailer.confirmation_instructions(user, "faketoken", {})
   end
 
+  def confirmation_instructions___with_procedure
+    CurrentConfirmation.procedure_after_confirmation = procedure
+    DeviseUserMailer.confirmation_instructions(user, "faketoken", {})
+  end
+
   def reset_password_instructions
     DeviseUserMailer.reset_password_instructions(user, "faketoken", {})
   end
@@ -11,5 +16,9 @@ class DeviseUserMailerPreview < ActionMailer::Preview
 
   def user
     User.new(id: 10, email: "usager@example.com")
+  end
+
+  def procedure
+    Procedure.new(id: 20, libelle: 'Dotation d’Équipement des Territoires Ruraux - Exercice 2019', path: 'dotation-etr')
   end
 end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -48,11 +48,16 @@ module FeatureHelpers
     end
   end
 
-  def click_confirmation_link_for(email)
+  def click_confirmation_link_for(email, in_another_browser: false)
     confirmation_email = open_email(email)
-    token_params = confirmation_email.body.match(/confirmation_token=[^"]+/)
+    confirmation_link = confirmation_email.body.match(/href="[^"]*(\/users\/confirmation[^"]*)"/)[1]
 
-    visit "/users/confirmation?#{token_params}"
+    if in_another_browser
+      # Simulate the user opening the link in another browser, thus loosing the session cookie
+      Capybara.reset_session!
+    end
+
+    visit confirmation_link
   end
 
   def click_procedure_sign_in_link_for(email)


### PR DESCRIPTION
## Problème

Aujourd'hui, si un Usager va sur une démarche, et cherche à s'inscrire, on lui envoie un email de confirmation. Et quand cette personne clique sur le lien de confirmation contenu dans l'email, on la redirige directement vers la page de la démarche où elle était avant.

Mais techniquement, ce mécanisme fonctionne en stockant la démarche en cours dans la session. Ce qui veut dire que **si l'Usager change de navigateur**, le cookie est perdu, et **la démarche n'est pas restaurée**.

C'est le cas par exemple si l'Usager s'inscrit sur son téléphone, mais vérifie son email de confirmation sur son ordinateur (ou l'inverse). Dans ce cas l'Usager arrive juste sur une page "Mes dossiers" vide, et n'a plus le lien vers sa démarche. (#4738)

## Solution

Cette PR rajoute l'ID de démarche au lien de confirmation. Comme ça, quel que soit le navigateur sur lequel l'email est ouvert, la démarche en cours peut être restaurée.

Dans le cas d'une inscription "sèche" (directement depuis la page de sign-up, sans démarche en cours), l'ID de démarche n'est pas ajouté au lien.

Concrètement, le code essaie d'abord de regarder l'ID de démarche dans le lien de confirmation. S'il n'existe pas, il retombe sur le comportement précédent (regarder si un emplacement est stocké dans la session).

<img width="627" alt="Capture d’écran 2020-02-13 à 16 17 03" src="https://user-images.githubusercontent.com/179923/74449893-88218c80-4e7d-11ea-9475-ac7b125fca86.png">

Fix #4738