### PR TITLE
spec: fix a flaky experts feature spec

### DIFF
--- a/spec/features/instructeurs/expert_spec.rb
+++ b/spec/features/instructeurs/expert_spec.rb
@@ -41,8 +41,9 @@ feature 'Inviting an expert:' do
 
       expect(Avis.count).to eq(4)
       expect(all_emails.size).to eq(2)
+
       invitation_email = open_email('expert2@exemple.fr')
-      avis = Avis.find_by(email: 'expert2@exemple.fr')
+      avis = Avis.find_by(email: 'expert2@exemple.fr', dossier: dossier)
       sign_up_link = sign_up_instructeur_avis_path(avis.id, avis.email)
       expect(invitation_email.body).to include(sign_up_link)
     end


### PR DESCRIPTION
When "invite linked dossiers" is checked, the invitation will generate
one avis per dossier (including the linked ones).

So when we retrieve the email send to the expert, and try to match it
with the avis record, we need to specify which avis (the one for the main
dossier, or for the linked dossier).

Otherwise the test is flaky, and sometimes doesn't match the right avis
with the sent email.

Fix https://circleci.com/gh/betagouv/demarches-simplifiees.fr/19020#tests/containers/2

