### PR TITLE
[WIP] france_connect: avoid a race condition when creating the user

### DIFF
--- a/app/controllers/france_connect/particulier_controller.rb
+++ b/app/controllers/france_connect/particulier_controller.rb
@@ -13,7 +13,7 @@ class FranceConnect::ParticulierController < ApplicationController
         fetched_fci.tap(&:save)
 
     if fci.user.nil?
-      user = User.find_or_create_by!(email: fci.email_france_connect.downcase) do |new_user|
+      user = User.create_or_find_by!(email: fci.email_france_connect.downcase) do |new_user|
         new_user.password = Devise.friendly_token[0, 20]
         new_user.confirmed_at = Time.zone.now
       end


### PR DESCRIPTION
We spotted an `ActiveRecord::RecordNotUnique` exception on the email
field at this location. Technically, `find_or_create_by` creates the
record only if it doesn't exist, so this should not be possible. And
it doesn't look like a casing issue either.

https://sentry.io/organizations/demarches-simplifiees/issues/1512049702/activity/?environment=production&project=2468119

What this could be is a known race condition between the `find` and the
`create` statement. Maybe the France Connect callback being sent twice,
and reaching two different servers or threads.

(See https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-find_or_create_by)

To fix this, we can instead try to create the record–and find it if the
creation fails because of the uniqueness constraint.

This is what `create_or_find_by` does.

(See https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-create_or_find_by)