### PR TITLE
supprime les colonnes ignorées

### DIFF
--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -1,5 +1,4 @@
 class Administrateur < ApplicationRecord
-  self.ignored_columns = ['features', 'encrypted_password', 'reset_password_token', 'reset_password_sent_at', 'remember_created_at', 'sign_in_count', 'current_sign_in_at', 'last_sign_in_at', 'current_sign_in_ip', 'last_sign_in_ip', 'failed_attempts', 'unlock_token', 'locked_at']
   include ActiveRecord::SecureToken
 
   has_and_belongs_to_many :instructeurs

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -1,6 +1,4 @@
 class Instructeur < ApplicationRecord
-  self.ignored_columns = ['features', 'encrypted_password', 'reset_password_token', 'reset_password_sent_at', 'remember_created_at', 'sign_in_count', 'current_sign_in_at', 'last_sign_in_at', 'current_sign_in_ip', 'last_sign_in_ip', 'failed_attempts', 'unlock_token', 'locked_at']
-
   has_and_belongs_to_many :administrateurs
 
   has_many :assign_to, dependent: :destroy


### PR DESCRIPTION
fix #4789 
Supprime les `ignored_columns` des classes `Administrateur` et `Instructeur` car elles sont inutiles