### PR TITLE
#4785 - Ajout d'une balise 'groupe instructeur'

### DIFF
--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -12,6 +12,12 @@ module TagsSubstitutionConcern
       available_for_states: Dossier::TERMINE
     },
     {
+      libelle: 'groupe instructeur',
+      description: 'Le groupe instructeur en charge du dossier',
+      lambda: -> (d) { d&.groupe_instructeur&.label },
+      available_for_states: Dossier::SOUMIS
+    },
+    {
       libelle: 'date de dépôt',
       description: 'Date du passage en construction du dossier par l’usager',
       lambda: -> (d) { format_date(d.en_construction_at) },

--- a/spec/models/concern/tags_substitution_concern_spec.rb
+++ b/spec/models/concern/tags_substitution_concern_spec.rb
@@ -70,6 +70,23 @@ describe TagsSubstitutionConcern, type: :model do
       end
     end
 
+    context 'when the template use the groupe instructeur tags' do
+      let(:template) { '--groupe instructeur--' }
+      context 'and the dossier has a groupe instructeur' do
+        label = 'Ville de Bordeaux'
+        before do
+          gi = procedure.groupe_instructeurs.create(label: label)
+          gi.dossiers << dossier
+        end
+
+        it { is_expected.to eq(gi.label) }
+      end
+
+      context 'and the dossier has no groupe instructeur' do
+        it { is_expected.to eq('défaut') }
+      end
+    end
+
     context 'when the procedure has a type de champ named libelleA et libelleB' do
       let(:types_de_champ) do
         [


### PR DESCRIPTION
Demandé par #4785.

Mais à la réflexion j'ai l'impression qu'on souhaite ne proposer et remplacer le tag que si la procédure est routée.