### PR TITLE
champ: fix `siblings` for repetition champs

### DIFF
--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -26,7 +26,9 @@ class Champ < ApplicationRecord
   end
 
   def siblings
-    if public?
+    if parent
+      parent&.champs
+    elsif public?
       dossier&.champs
     else
       dossier&.champs_private

--- a/spec/models/champ_spec.rb
+++ b/spec/models/champ_spec.rb
@@ -23,15 +23,17 @@ describe Champ do
   end
 
   describe '#siblings' do
-    let(:procedure) { create(:procedure, :with_type_de_champ, :with_type_de_champ_private, types_de_champ_count: 1, types_de_champ_private_count: 1) }
+    let(:procedure) { create(:procedure, :with_type_de_champ, :with_type_de_champ_private, :with_repetition, types_de_champ_count: 1, types_de_champ_private_count: 1) }
     let(:dossier) { create(:dossier, procedure: procedure) }
     let(:public_champ) { dossier.champs.first }
     let(:private_champ) { dossier.champs_private.first }
+    let(:champ_in_repetition) { dossier.champs.find(&:repetition?).champs.first }
     let(:standalone_champ) { create(:champ, dossier: nil) }
 
     it 'returns the sibling champs of a champ' do
       expect(public_champ.siblings).to eq(dossier.champs)
       expect(private_champ.siblings).to eq(dossier.champs_private)
+      expect(champ_in_repetition.siblings).to eq(champ_in_repetition.parent.champs)
       expect(standalone_champ.siblings).to be_nil
     end
   end

--- a/spec/models/champs/header_section_champ_spec.rb
+++ b/spec/models/champs/header_section_champ_spec.rb
@@ -11,14 +11,35 @@ describe Champs::HeaderSectionChamp do
         create(:type_de_champ_email,          order_place: 5)
       ]
     end
-    let(:procedure) { create(:procedure, types_de_champ: types_de_champ) }
-    let(:dossier) { create(:dossier, procedure: procedure) }
-    let(:first_header)  { dossier.champs[0] }
-    let(:second_header) { dossier.champs[3] }
 
-    it 'returns the index of the section (starting from 1)' do
-      expect(first_header.section_index).to eq 1
-      expect(second_header.section_index).to eq 2
+    context 'for root-level champs' do
+      let(:procedure) { create(:procedure, types_de_champ: types_de_champ) }
+      let(:dossier) { create(:dossier, procedure: procedure) }
+      let(:first_header)  { dossier.champs[0] }
+      let(:second_header) { dossier.champs[3] }
+
+      it 'returns the index of the section (starting from 1)' do
+        expect(first_header.section_index).to eq 1
+        expect(second_header.section_index).to eq 2
+      end
+    end
+
+    context 'for repetition champs' do
+      let(:procedure) { create(:procedure, :with_repetition) }
+      let(:dossier) { create(:dossier, procedure: procedure) }
+
+      let(:repetition_tdc)  { procedure.types_de_champ.find(&:repetition?) }
+      let(:first_header)  { dossier.champs.first.champs[0] }
+      let(:second_header) { dossier.champs.first.champs[3] }
+
+      before do
+        repetition_tdc.types_de_champ = types_de_champ
+      end
+
+      it 'returns the index of the section in the repetition (starting from 1)' do
+        expect(first_header.section_index).to eq 1
+        expect(second_header.section_index).to eq 2
+      end
     end
   end
 end


### PR DESCRIPTION
Fix a crash when requesting the `section_index` of a section header in a repetition champ.

Fix https://sentry.io/organizations/demarches-simplifiees/issues/1510432590/?referrer=webhooks_plugin