### PR TITLE
Add thousand separator on tabs instructors general view

### DIFF
--- a/app/views/instructeurs/procedures/_list.html.haml
+++ b/app/views/instructeurs/procedures/_list.html.haml
@@ -15,7 +15,7 @@
                   = link_to(instructeur_procedure_path(p, statut: 'a-suivre')) do
                     - a_suivre_count = dossiers_a_suivre_count_per_procedure[p.id] || 0
                     .stats-number
-                      = a_suivre_count
+                      = number_with_html_delimiter(a_suivre_count)
                     .stats-legend
                       à suivre
               %li
@@ -25,7 +25,7 @@
                       %span.notifications{ 'aria-label': "notifications" }
                     - followed_count = followed_dossiers_count_per_procedure[p.id] || 0
                     .stats-number
-                      = followed_count
+                      = number_with_html_delimiter(followed_count)
                     .stats-legend
                       = t('pluralize.followed', count: followed_count)
               %li
@@ -35,7 +35,7 @@
                       %span.notifications{ 'aria-label': "notifications" }
                     - termines_count = dossiers_termines_count_per_procedure[p.id] || 0
                     .stats-number
-                      = termines_count
+                      = number_with_html_delimiter(termines_count)
                     .stats-legend
                       = t('pluralize.processed', count: termines_count)
               %li
@@ -43,7 +43,7 @@
                   = link_to(instructeur_procedure_path(p, statut: 'tous')) do
                     - dossier_count = dossiers_count_per_procedure[p.id] || 0
                     .stats-number
-                      = dossier_count
+                      = number_with_html_delimiter(dossier_count)
                     .stats-legend
                       = t('pluralize.case', count: dossier_count)
               %li
@@ -51,7 +51,7 @@
                   = link_to(instructeur_procedure_path(p, statut: 'archives')) do
                     - archived_count = dossiers_archived_count_per_procedure[p.id] || 0
                     .stats-number
-                      = archived_count
+                      = number_with_html_delimiter(archived_count)
                     .stats-legend
                       = t('pluralize.archived', count: archived_count)
 

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -24,29 +24,29 @@
           = tab_item('à suivre',
             instructeur_procedure_path(@procedure, statut: 'a-suivre'),
             active: @statut == 'a-suivre',
-            badge: @a_suivre_dossiers.count)
+            badge: number_with_html_delimiter(@a_suivre_dossiers.count))
 
           = tab_item(t('pluralize.followed', count: @followed_dossiers.count),
             instructeur_procedure_path(@procedure, statut: 'suivis'),
             active: @statut == 'suivis',
-            badge: @followed_dossiers.count,
+            badge: number_with_html_delimiter(@followed_dossiers.count),
             notification: current_instructeur.notifications_for_procedure(@procedure, :en_cours).exists?)
 
           = tab_item(t('pluralize.processed', count: @termines_dossiers.count),
             instructeur_procedure_path(@procedure, statut: 'traites'),
             active: @statut == 'traites',
-            badge: @termines_dossiers.count,
+            badge: number_with_html_delimiter(@termines_dossiers.count),
             notification: current_instructeur.notifications_for_procedure(@procedure, :termine).exists?)
 
           = tab_item('tous les dossiers',
             instructeur_procedure_path(@procedure, statut: 'tous'),
             active: @statut == 'tous',
-            badge: @all_state_dossiers.count)
+            badge: number_with_html_delimiter(@all_state_dossiers.count))
 
           = tab_item(t('pluralize.archived', count: @archived_dossiers.count),
             instructeur_procedure_path(@procedure, statut: 'archives'),
             active: @statut == 'archives',
-            badge: @archived_dossiers.count)
+            badge: number_with_html_delimiter(@archived_dossiers.count))
 
       .procedure-actions
         = render partial: "download_dossiers",


### PR DESCRIPTION
#QuickWin suite au mail de Mr Barnoin qui le demandait sur les tabs (vue général de l'instructeur ainsi que la vue par démarche) . HS 27264