### PR TITLE
Suppression des erreurs d'email pour cause de syntaxe erronée

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -3,6 +3,11 @@ class ApplicationMailer < ActionMailer::Base
   default from: "demarches-simplifiees.fr <#{CONTACT_EMAIL}>"
   layout 'mailer'
 
+  # Don’t retry to send a message if the server rejects the recipient address
+  rescue_from Net::SMTPSyntaxError do |_error|
+    message.perform_deliveries = false
+  end
+
   # Attach the procedure logo to the email (if any).
   # Returns the attachment url.
   def attach_logo(procedure)

--- a/app/mailers/devise_user_mailer.rb
+++ b/app/mailers/devise_user_mailer.rb
@@ -4,6 +4,11 @@ class DeviseUserMailer < Devise::Mailer
   include Devise::Controllers::UrlHelpers # Optional. eg. `confirmation_url`
   layout 'mailers/layout'
 
+  # Don’t retry to send a message if the server rejects the recipient address
+  rescue_from Net::SMTPSyntaxError do |_error|
+    message.perform_deliveries = false
+  end
+
   def template_paths
     ['devise_mailer']
   end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -3,6 +3,16 @@ RSpec.describe ApplicationMailer, type: :mailer do
     let(:dossier) { create(:dossier, procedure: build(:simple_procedure)) }
     subject { DossierMailer.notify_new_draft(dossier) }
 
+    describe 'invalid emails are not sent' do
+      before do
+        allow_any_instance_of(DossierMailer)
+          .to receive(:notify_new_draft)
+          .and_raise(Net::SMTPSyntaxError)
+      end
+
+      it { expect(subject.message).to be_an_instance_of(ActionMailer::Base::NullMail) }
+    end
+
     describe 'valid emails are sent' do
       it { expect(subject.message).not_to be_an_instance_of(ActionMailer::Base::NullMail) }
     end


### PR DESCRIPTION
This reverts commit 415cc2c2f1d4a7d037bf59da65239a10f1e82581.