### PR TITLE
Édition d'une démarche : améliorations de design

### DIFF
--- a/app/assets/stylesheets/new_design/procedure_form.scss
+++ b/app/assets/stylesheets/new_design/procedure_form.scss
@@ -73,7 +73,7 @@
 .procedure-form__options-summary {
   cursor: pointer;
 
-  .header-section {
+  .header-subsection {
     display: inline-block;
   }
 }

--- a/app/views/new_administrateur/procedures/_informations.html.haml
+++ b/app/views/new_administrateur/procedures/_informations.html.haml
@@ -13,7 +13,7 @@
   %span.mandatory *
 = f.text_area :description, rows: '6', placeholder: 'Description de la démarche, destinataires, etc. ', class: 'form-control'
 
-%h2.header-section Logo de la démarche
+%h3.header-subsection Logo de la démarche
 = render 'shared/attachment/edit',
   { form: f,
     attached_file: @procedure.logo,
@@ -21,7 +21,7 @@
     user_can_destroy: true }
 
 - if !@procedure.locked?
-  %h2.header-section Conservation des données
+  %h3.header-subsection Conservation des données
   = f.label :duree_conservation_dossiers_dans_ds do
     Sur demarches-simplifiees.fr
     %span.mandatory *
@@ -39,7 +39,7 @@
     Où les usagers trouveront-ils le lien vers la démarche ?
   = f.text_field :lien_site_web, class: 'form-control', placeholder: 'https://exemple.gouv.fr/ma_demarche'
 
-%h2.header-section
+%h3.header-subsection
   Cadre juridique
   %span.mandatory *
 
@@ -64,7 +64,7 @@
     attached_file: @procedure.deliberation,
     user_can_destroy: true }
 
-%h2.header-section Notice explicative de la démarche
+%h3.header-subsection Notice explicative de la démarche
 
 %p.notice
   Une notice explicative est un document destiné à guider l’usager dans sa démarche. C’est un document que vous avez élaboré et qui peut prendre la forme d’un fichier doc, d’un pdf ou encore de diapositives. Le bouton pour télécharger cette notice apparaît en haut du formulaire pour l’usager.
@@ -77,7 +77,7 @@
     user_can_destroy: true }
 
 - if !@procedure.locked?
-  %h2.header-section À qui s’adresse ma démarche ?
+  %h3.header-subsection À qui s’adresse ma démarche ?
   .radios.vertical
     = f.label :for_individual, value: true do
       = f.radio_button :for_individual, true
@@ -95,7 +95,7 @@
 
 %details.procedure-form__options-details
   %summary.procedure-form__options-summary
-    %h2.header-section Options avancées
+    %h3.header-subsection Options avancées
 
   - if feature_enabled?(:administrateur_web_hook)
     = f.label :web_hook_url do

--- a/app/views/new_administrateur/procedures/_informations.html.haml
+++ b/app/views/new_administrateur/procedures/_informations.html.haml
@@ -118,7 +118,7 @@
   = f.select :declarative_with_state, Procedure.declarative_attributes_for_select, { prompt: 'Non' }, class: 'form-control'
 
   %p.explication
-    Par défaut, une démarche n'est pas déclarative; à son dépot, un dossier est «en construction». Vous pouvez choisir de la rendre déclarative, afin que tous les dossiers déposés soient immédiatement au statut "en instruction" en "accepté".
+    Par défaut, une démarche n’est pas déclarative ; à son dépôt, un dossier est « en construction ». Vous pouvez choisir de la rendre déclarative, afin que tous les dossiers déposés passent immédiatement au statut « en instruction » ou « accepté ».
     %br
     %br
-    Dans le cadre d'une démarche déclarative, au dépot, seul l'email associé à l'état choisi est envoyé. (ex: démarche déclarative «accepté»: envoi uniquement de l'email d'acceptation)
+    Dans le cadre d’une démarche déclarative, au dépôt, seul l’email associé à l’état choisi est envoyé. (ex: démarche déclarative « accepté » : envoi uniquement de l’email d'acceptation)

--- a/app/views/new_administrateur/procedures/_informations.html.haml
+++ b/app/views/new_administrateur/procedures/_informations.html.haml
@@ -115,7 +115,7 @@
 
   = f.label :declarative_with_state do
     Démarche déclarative
-  = f.select :declarative_with_state, Procedure.declarative_attributes_for_select, { include_blank: true }, class: 'form-control'
+  = f.select :declarative_with_state, Procedure.declarative_attributes_for_select, { prompt: 'Non' }, class: 'form-control'
 
   %p.explication
     Par défaut, une démarche n'est pas déclarative; à son dépot, un dossier est «en construction». Vous pouvez choisir de la rendre déclarative, afin que tous les dossiers déposés soient immédiatement au statut "en instruction" en "accepté".


### PR DESCRIPTION
- Les sections qui séparent le formulaire sont plus légères (elles étaient trop fortes depuis le refactoring des titres de section).
- L'option par défaut du menu "Démarche déclarative" est "Non" (plutôt qu'un champ vide).
- La description du champ "Démarche déclarative" est un peu plus d'équerre (même si ça reste pas encore très clair).

## Captures d'écran

<img width="1004" alt="Capture d’écran 2020-02-24 à 11 39 15" src="https://user-images.githubusercontent.com/179923/75146089-9d5aae80-56fa-11ea-9ea5-678e0b9d5be1.png">

<img width="530" alt="Capture d’écran 2020-02-24 à 11 42 15" src="https://user-images.githubusercontent.com/179923/75146204-deeb5980-56fa-11ea-92af-d2434f87fc76.png">

