### PR TITLE
#4700: Les exports sont immédiatement marqués comme sûrs par l'antivirus

### DIFF
--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -25,7 +25,9 @@ class Export < ApplicationRecord
     file.attach(
       io: io,
       filename: filename,
-      content_type: content_type
+      content_type: content_type,
+      # We generate the exports ourselves, so they are safe
+      metadata: { virus_scan_result: ActiveStorage::VirusScanner::SAFE }
     )
   end
 


### PR DESCRIPTION
(Début d'?) Amélioration des exports (cf #4700)
Dans le cadre des erreurs sur les PJ/proxy, je n'ai pas mis les éléments supplémentaires dont on parlait: pas de retry limité, ni de boutons pour les utilisateurs: Je voudrais voir si, pendant quelques temps, on a pas une réduction des erreurs : en faisant le tour des jobs en erreurs, j'ai l'impression qu'une majorité vient de la synchro avec le passage de l'antivirus

(pour le moment, je ne saurais pas forcément quoi conclure, mais on sait que les pb d'upload sont liées à des requêtes émises par fog-core)

Je me dis que pendant quelques jours, on peut commencer avec juste ça et voir si on a encore des uploads en erreur