### PR TITLE
[GraphQL] list demarches

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -5,7 +5,7 @@ class API::V2::BaseController < ApplicationController
 
   def context
     {
-      administrateur_id: current_administrateur&.id,
+      administrateur_id: administrateur_id,
       token: authorization_bearer_token
     }
   end
@@ -16,5 +16,15 @@ class API::V2::BaseController < ApplicationController
       received_token = token
     end
     received_token
+  end
+
+  def administrateur_id
+    if administrateur_signed_in?
+      current_administrateur.id
+    else
+      JsonWebToken.decode(authorization_bearer_token)[:sub].to_i
+    end
+  rescue JWT::DecodeError
+    nil
   end
 end

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -309,6 +309,32 @@ type Demarche {
   title: String!
 }
 
+"""
+Une demarche
+"""
+type DemarcheDescriptor {
+  """
+  Description de la démarche.
+  """
+  description: String!
+  id: ID!
+
+  """
+  Le numero de la démarche.
+  """
+  number: Int!
+
+  """
+  L'état de la démarche.
+  """
+  state: DemarcheState!
+
+  """
+  Le titre de la démarche.
+  """
+  title: String!
+}
+
 enum DemarcheState {
   """
   Brouillon
@@ -928,6 +954,16 @@ type Query {
     """
     number: Int!
   ): Demarche!
+
+  """
+  Liste des démarches.
+  """
+  demarches(
+    """
+    État de la démarche.
+    """
+    state: DemarcheState
+  ): [DemarcheDescriptor!]!
 
   """
   Informations sur un dossier d'une démarche.

--- a/app/graphql/types/demarche_descriptor_type.rb
+++ b/app/graphql/types/demarche_descriptor_type.rb
@@ -1,0 +1,15 @@
+module Types
+  class DemarcheDescriptorType < Types::BaseObject
+    description "Une demarche"
+
+    global_id_field :id
+    field :number, Int, "Le numero de la démarche.", null: false, method: :id
+    field :title, String, "Le titre de la démarche.", null: false, method: :libelle
+    field :description, String, "Description de la démarche.", null: false
+    field :state, Types::DemarcheType::DemarcheState, "L'état de la démarche.", null: false
+
+    def state
+      object.aasm.current_state
+    end
+  end
+end

--- a/app/graphql/types/demarche_type.rb
+++ b/app/graphql/types/demarche_type.rb
@@ -1,7 +1,7 @@
 module Types
   class DemarcheType < Types::BaseObject
     class DemarcheState < Types::BaseEnum
-      Procedure.aasm.states.reject { |state| state.name == :hidden }.each do |state|
+      Procedure.aasm.states.each do |state|
         value(state.name.to_s, state.display_name, value: state.name)
       end
     end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -4,6 +4,10 @@ module Types
       argument :number, Int, "Numéro de la démarche.", required: true
     end
 
+    field :demarches, [DemarcheDescriptorType], null: false, description: "Liste des démarches." do
+      argument :state, Types::DemarcheType::DemarcheState, "État de la démarche.", required: false
+    end
+
     field :dossier, DossierType, null: false, description: "Informations sur un dossier d'une démarche." do
       argument :number, Int, "Numéro du dossier.", required: true
     end
@@ -18,6 +22,20 @@ module Types
       Dossier.for_api_v2.find(number)
     rescue => e
       raise GraphQL::ExecutionError.new(e.message, extensions: { code: :not_found })
+    end
+
+    def demarches(state: nil)
+      if context[:administrateur_id]
+        procedures = Administrateur.find(context[:administrateur_id]).procedures.for_api_v2
+
+        if state.present?
+          procedures.where(aasm_state: state)
+        else
+          procedures.publiees
+        end
+      else
+        []
+      end
     end
 
     def self.accessible?(context)

--- a/app/lib/json_web_token.rb
+++ b/app/lib/json_web_token.rb
@@ -1,0 +1,12 @@
+class JsonWebToken
+  SECRET_KEY = Rails.application.secrets.secret_key_base.to_s
+
+  def self.encode(payload)
+    JWT.encode(payload, SECRET_KEY)
+  end
+
+  def self.decode(token)
+    decoded = JWT.decode(token, SECRET_KEY)[0]
+    HashWithIndifferentAccess.new decoded
+  end
+end

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -102,6 +102,31 @@ describe API::V2::GraphqlController do
       request.env['HTTP_AUTHORIZATION'] = authorization_header
     end
 
+    context "demarches" do
+      let(:query) do
+        "{
+          demarches {
+            id
+            number
+            title
+            state
+          }
+        }"
+      end
+
+      it "should be returned" do
+        expect(gql_errors).to eq(nil)
+        expect(gql_data).to eq(demarches: [
+          {
+            id: procedure.to_typed_id,
+            number: procedure.id,
+            title: procedure.libelle,
+            state: 'publiee'
+          }
+        ])
+      end
+    end
+
     context "demarche" do
       it "should be returned" do
         expect(gql_errors).to eq(nil)

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -96,7 +96,7 @@ describe API::V2::GraphqlController do
   end
 
   context "when authenticated" do
-    let(:authorization_header) { ActionController::HttpAuthentication::Token.encode_credentials(token) }
+    let(:authorization_header) { "Bearer token=#{token}" }
 
     before do
       request.env['HTTP_AUTHORIZATION'] = authorization_header

--- a/spec/models/administrateur_spec.rb
+++ b/spec/models/administrateur_spec.rb
@@ -10,7 +10,8 @@ describe Administrateur, type: :model do
 
   describe "#renew_api_token" do
     let!(:administrateur) { create(:administrateur) }
-    let!(:token) { administrateur.renew_api_token }
+    let!(:jwt_token) { administrateur.renew_api_token }
+    let(:token) { JsonWebToken.decode(jwt_token)[:jti] }
 
     it { expect(BCrypt::Password.new(administrateur.encrypted_token)).to eq(token) }
 


### PR DESCRIPTION
L'idée de cette PR est d'exposer l'id de l'administrateur qui a émis le token dans un JWT qui wrap le token encripté. Donc ça ne remet pas en question le fait qu’en base on garde les token encriptés. La PR est complètement “backward compatible” – les vieux tokens continuent de fonctionner. Mais pour avoir accès à la liste de démarches, il va falloir régénérer le token.