### PR TITLE
mailers: fix procedure_after_confirmation in the confirmation email

### DIFF
--- a/app/mailers/devise_user_mailer.rb
+++ b/app/mailers/devise_user_mailer.rb
@@ -15,7 +15,7 @@ class DeviseUserMailer < Devise::Mailer
 
   def confirmation_instructions(record, token, opts = {})
     opts[:from] = NO_REPLY_EMAIL
-    @procedure = CurrentConfirmation.procedure_after_confirmation || nil
+    @procedure = opts[:procedure_after_confirmation] || nil
     super
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,20 @@ class User < ApplicationRecord
 
   before_validation -> { sanitize_email(:email) }
 
+  # Override of Devise::Models::Confirmable#send_confirmation_instructions
+  def send_confirmation_instructions
+    unless @raw_confirmation_token
+      generate_confirmation_token!
+    end
+
+    opts = pending_reconfirmation? ? { to: unconfirmed_email } : {}
+
+    # Make our procedure_after_confirmation available to the Mailer
+    opts[:procedure_after_confirmation] = CurrentConfirmation.procedure_after_confirmation
+
+    send_devise_notification(:confirmation_instructions, @raw_confirmation_token, opts)
+  end
+
   # Callback provided by Devise
   def after_confirmation
     link_invites!


### PR DESCRIPTION
As mailers are run asynchronously, they don't have access to the CurrentConfirmation defined in an earlier request.

For the procedure_after_confirmation to be serialized to the Mailer, we need to pass it at invokation time.