### PR TITLE
4784: dossiers reroutés dans la colonne "A suivre" des instructeurs du nouveau groupe

### DIFF
--- a/app/mailers/dossier_mailer.rb
+++ b/app/mailers/dossier_mailer.rb
@@ -90,4 +90,12 @@ class DossierMailer < ApplicationMailer
 
     mail(to: user.email, subject: @subject)
   end
+
+  def notify_groupe_instructeur_changed(instructeur, dossier)
+    @subject = "Un dossier a changé de groupe instructeur"
+    @dossier_id = dossier.id
+    @demarche = dossier.procedure.libelle
+
+    mail(from: NO_REPLY_EMAIL, to: instructeur.email, subject: @subject)
+  end
 end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -649,7 +649,10 @@ class Dossier < ApplicationRecord
   def unfollow_stale_instructeurs
     if saved_change_to_groupe_instructeur_id? && saved_change_to_groupe_instructeur_id[0].present?
       followers_instructeurs.each do |instructeur|
-        instructeur.unfollow(self) unless instructeur.groupe_instructeurs.include?(groupe_instructeur)
+        if instructeur.groupe_instructeurs.exclude?(groupe_instructeur)
+          instructeur.unfollow(self)
+          DossierMailer.notify_groupe_instructeur_changed(instructeur, self).deliver_later
+        end
       end
     end
   end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -654,6 +654,7 @@ class Dossier < ApplicationRecord
           DossierMailer.notify_groupe_instructeur_changed(instructeur, self).deliver_later
         end
       end
+      log_dossier_operation(user, :changer_groupe_instructeur, self)
     end
   end
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -213,6 +213,7 @@ class Dossier < ApplicationRecord
   before_save :build_default_champs, if: Proc.new { groupe_instructeur_id_was.nil? }
   before_save :update_search_terms
 
+  after_save :unfollow_stale_instructeurs
   after_save :send_dossier_received
   after_save :send_web_hook
   after_create :send_draft_notification_email
@@ -642,6 +643,14 @@ class Dossier < ApplicationRecord
         procedure,
         self
       )
+    end
+  end
+
+  def unfollow_stale_instructeurs
+    if saved_change_to_groupe_instructeur_id? && saved_change_to_groupe_instructeur_id[0].present?
+      followers_instructeurs.each do |instructeur|
+        instructeur.unfollow(self) unless instructeur.groupe_instructeurs.include?(groupe_instructeur)
+      end
     end
   end
 

--- a/app/models/dossier_operation_log.rb
+++ b/app/models/dossier_operation_log.rb
@@ -1,5 +1,6 @@
 class DossierOperationLog < ApplicationRecord
   enum operation: {
+    changer_groupe_instructeur: 'changer_groupe_instructeur',
     passer_en_instruction: 'passer_en_instruction',
     repasser_en_construction: 'repasser_en_construction',
     repasser_en_instruction: 'repasser_en_instruction',

--- a/app/views/dossier_mailer/notify_groupe_instructeur_changed.html.haml
+++ b/app/views/dossier_mailer/notify_groupe_instructeur_changed.html.haml
@@ -1,0 +1,9 @@
+- content_for(:title, "#{@subject}")
+
+%p
+  = "Vous suiviez jusqu'à maintenant le dossier n°#{@dossier_id} de la démarche #{@demarche}."
+  L'usager a modifié le groupe de routage. Son dossier appartient maintenant à un groupe instructeur dont vous ne faites pas partie.
+%p
+  Suite à cette modification, vous ne suivez plus ce dossier.
+
+= render partial: "layouts/mailers/signature"

--- a/spec/mailers/dossier_mailer_spec.rb
+++ b/spec/mailers/dossier_mailer_spec.rb
@@ -154,4 +154,16 @@ RSpec.describe DossierMailer, type: :mailer do
     it { expect(subject.body).to include("PDF") }
     it { expect(subject.body).to include("Vous avez <b>un mois</b> pour traiter le dossier.") }
   end
+
+  describe '.notify_groupe_instructeur_changed_to_instructeur' do
+    let(:dossier) { create(:dossier) }
+    let(:instructeur) { create(:instructeur) }
+
+    subject { described_class.notify_groupe_instructeur_changed(instructeur, dossier) }
+
+    it { expect(subject.subject).to eq("Un dossier a changé de groupe instructeur") }
+    it { expect(subject.body).to include("n°#{dossier.id}") }
+    it { expect(subject.body).to include(dossier.procedure.libelle) }
+    it { expect(subject.body).to include("Suite à cette modification, vous ne suivez plus ce dossier.") }
+  end
 end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -404,6 +404,7 @@ describe Dossier do
     let(:new_groupe_instructeur) { create(:groupe_instructeur) }
     let(:instructeur2) { create(:instructeur, groupe_instructeurs: [procedure.defaut_groupe_instructeur, new_groupe_instructeur]) }
     let(:dossier) { create(:dossier, procedure: procedure, state: Dossier.states.fetch(:en_construction)) }
+    let(:last_operation) { DossierOperationLog.last }
 
     before do
       allow(DossierMailer).to receive(:notify_groupe_instructeur_changed).and_return(double(deliver_later: nil))
@@ -416,8 +417,13 @@ describe Dossier do
 
       expect(dossier.reload.followers_instructeurs).not_to include(instructeur)
       expect(dossier.reload.followers_instructeurs).to include(instructeur2)
+
       expect(DossierMailer).to have_received(:notify_groupe_instructeur_changed).with(instructeur, dossier)
       expect(DossierMailer).not_to have_received(:notify_groupe_instructeur_changed).with(instructeur2, dossier)
+
+      expect(last_operation.operation).to eq("changer_groupe_instructeur")
+      expect(last_operation.dossier).to eq(dossier)
+      expect(last_operation.automatic_operation?).to be_falsey
     end
   end
 

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -398,6 +398,23 @@ describe Dossier do
     it { is_expected.to match([dossier3, dossier4, dossier2]) }
   end
 
+  describe "#unfollow_stale_instructeurs" do
+    let(:procedure) { create(:procedure) }
+    let(:instructeur) { create(:instructeur) }
+    let(:new_groupe_instructeur) { create(:groupe_instructeur) }
+    let(:instructeur2) { create(:instructeur, groupe_instructeurs: [procedure.defaut_groupe_instructeur, new_groupe_instructeur]) }
+    let(:dossier) { create(:dossier, procedure: procedure, state: Dossier.states.fetch(:en_construction)) }
+
+    it "unfollows stale instructeurs when groupe instructeur change" do
+      instructeur.follow(dossier)
+      instructeur2.follow(dossier)
+      dossier.reload.update(groupe_instructeur: new_groupe_instructeur)
+
+      expect(dossier.reload.followers_instructeurs).not_to include(instructeur)
+      expect(dossier.reload.followers_instructeurs).to include(instructeur2)
+    end
+  end
+
   describe "#send_dossier_received" do
     let(:procedure) { create(:procedure) }
     let(:dossier) { create(:dossier, procedure: procedure, state: Dossier.states.fetch(:en_construction)) }

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -405,6 +405,10 @@ describe Dossier do
     let(:instructeur2) { create(:instructeur, groupe_instructeurs: [procedure.defaut_groupe_instructeur, new_groupe_instructeur]) }
     let(:dossier) { create(:dossier, procedure: procedure, state: Dossier.states.fetch(:en_construction)) }
 
+    before do
+      allow(DossierMailer).to receive(:notify_groupe_instructeur_changed).and_return(double(deliver_later: nil))
+    end
+
     it "unfollows stale instructeurs when groupe instructeur change" do
       instructeur.follow(dossier)
       instructeur2.follow(dossier)
@@ -412,6 +416,8 @@ describe Dossier do
 
       expect(dossier.reload.followers_instructeurs).not_to include(instructeur)
       expect(dossier.reload.followers_instructeurs).to include(instructeur2)
+      expect(DossierMailer).to have_received(:notify_groupe_instructeur_changed).with(instructeur, dossier)
+      expect(DossierMailer).not_to have_received(:notify_groupe_instructeur_changed).with(instructeur2, dossier)
     end
   end
 


### PR DESCRIPTION
#4784 

Lorsqu'un usager modifie son groupe de routage,
- tous les instructeurs qui suivent le dossier et qui ne font pas partie du nouveau groupe d'instructeur sont déassignés (ils ne suivent plus le dossier)
- ils sont notifiés par mail
- le changement de groupe d'instructeur est loggé (`DossierOperationLog`)

Ainsi, si aucun ancien follower_instructeur n'appartient au nouveau groupe d'instructeur, le dossier sera listé dans la colonne "A suivre" des instructeurs du nouveau groupe.

