### PR TITLE
[#4832] Amélioration des performances des écrans de listes de dossiers

### DIFF
--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -75,7 +75,6 @@ class ProcedurePresentation < ApplicationRecord
   end
 
   def sorted_ids(dossiers, instructeur)
-    dossiers.each { |dossier| assert_matching_procedure(dossier) }
     table, column, order = sort.values_at('table', 'column', 'order')
 
     case table
@@ -110,7 +109,6 @@ class ProcedurePresentation < ApplicationRecord
   end
 
   def filtered_ids(dossiers, statut)
-    dossiers.each { |dossier| assert_matching_procedure(dossier) }
     filters[statut].group_by { |filter| filter.values_at('table', 'column') } .map do |(table, column), filters|
       values = filters.pluck('value')
       case table


### PR DESCRIPTION
…par la suppression des preconditions sur `sorted_ids` et `filtered_ids`, cf #4832

Ces preconditions induisent un probleme de n+1. On peut résoudre le problème en supprimant la précondition, ou en incluant les procedures dans les dossiers.
J'ai opté pour la suppression de la précondition, qui avait fait débat lors de son introduction

https://github.com/betagouv/demarches-simplifiees.fr/pull/2770/commits/667deae5ccc5a4bf1d5386440bb4cd5f8086b305#diff-b6be6196cd739f8b31e0b195677e46d6R176

Par ailleurs le gain de perfs semble meilleurs lors de mes tests, ce qui parait cohérent.

Avec 15000 dossiers, en local on passe de 4-6s de rendu à 700ms-1.2s