### PR TITLE
Affiche une pastille orange quand le groupe instructeur a changé

### DIFF
--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -10,7 +10,7 @@ module DossierHelper
   end
 
   def highlight_if_unseen_class(seen_at, updated_at)
-    if seen_at&.<(updated_at)
+    if updated_at.present? && seen_at&.<(updated_at)
       "highlighted"
     end
   end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -187,7 +187,7 @@ class Dossier < ApplicationRecord
       .joins('LEFT OUTER JOIN "commentaires" ON "commentaires" . "dossier_id" = "dossiers" . "id" and commentaires.updated_at > follows.messagerie_seen_at and "commentaires"."email" != \'contact@tps.apientreprise.fr\' AND "commentaires"."email" != \'contact@demarches-simplifiees.fr\'')
 
     updated_demandes = joined_dossiers
-      .where('champs.updated_at > follows.demande_seen_at')
+      .where('champs.updated_at > follows.demande_seen_at OR groupe_instructeur_updated_at > follows.demande_seen_at')
 
     updated_annotations = joined_dossiers
       .where('champs_privates_dossiers.updated_at > follows.annotations_privees_seen_at')

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -301,7 +301,7 @@ class Dossier < ApplicationRecord
 
   def assign_to_groupe_instructeur(groupe_instructeur, author = nil)
     if groupe_instructeur.procedure == procedure && groupe_instructeur != self.groupe_instructeur
-      if update(groupe_instructeur: groupe_instructeur)
+      if update(groupe_instructeur: groupe_instructeur, groupe_instructeur_updated_at: Time.zone.now)
         unfollow_stale_instructeurs
 
         if author.present?

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -98,7 +98,8 @@ class Instructeur < ApplicationRecord
       .find_by(instructeur: self, dossier: dossier)
 
     if follow.present?
-      demande = follow.dossier.champs.updated_since?(follow.demande_seen_at).any?
+      demande = follow.dossier.champs.updated_since?(follow.demande_seen_at).any? || follow.dossier.groupe_instructeur_updated_at&.>(follow.demande_seen_at)
+      demande = false if demande.nil?
 
       annotations_privees = follow.dossier.champs_private.updated_since?(follow.annotations_privees_seen_at).any?
 

--- a/app/views/shared/dossiers/_champs.html.haml
+++ b/app/views/shared/dossiers/_champs.html.haml
@@ -2,6 +2,9 @@
   %tbody
     - if dossier.procedure.routee?
       %th= dossier.procedure.routing_criteria_name
-      %td= dossier.groupe_instructeur.label
-      %td
+      %td{ class: highlight_if_unseen_class(demande_seen_at, dossier.groupe_instructeur_updated_at) }= dossier.groupe_instructeur.label
+      %td.updated-at
+        %span{ class: highlight_if_unseen_class(demande_seen_at, dossier.groupe_instructeur_updated_at) }
+          modifié le
+          = try_format_datetime(dossier.updated_at)
     = render partial: "shared/dossiers/champ_row", locals: { champs: champs, demande_seen_at: demande_seen_at, profile: profile, repetition: false }

--- a/db/migrate/20200226174444_add_groupe_instructeur_updated_at_to_dossiers.rb
+++ b/db/migrate/20200226174444_add_groupe_instructeur_updated_at_to_dossiers.rb
@@ -1,0 +1,5 @@
+class AddGroupeInstructeurUpdatedAtToDossiers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :dossiers, :groupe_instructeur_updated_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -252,6 +252,7 @@ ActiveRecord::Schema.define(version: 2020_02_27_100001) do
     t.datetime "brouillon_close_to_expiration_notice_sent_at"
     t.index "to_tsvector('french'::regconfig, (search_terms || private_search_terms))", name: "index_dossiers_on_search_terms_private_search_terms", using: :gin
     t.index "to_tsvector('french'::regconfig, search_terms)", name: "index_dossiers_on_search_terms", using: :gin
+    t.datetime "groupe_instructeur_updated_at"
     t.index ["archived"], name: "index_dossiers_on_archived"
     t.index ["groupe_instructeur_id"], name: "index_dossiers_on_groupe_instructeur_id"
     t.index ["hidden_at"], name: "index_dossiers_on_hidden_at"

--- a/spec/features/routing/full_scenario_spec.rb
+++ b/spec/features/routing/full_scenario_spec.rb
@@ -38,6 +38,13 @@ feature 'The routing', js: true do
 
     victor = User.find_by(email: 'victor@inst.com').instructeur
 
+    # add superwoman to littéraire groupe
+    find('input.select2-search__field').send_keys('superwoman@inst.com', :enter)
+    perform_enqueued_jobs { click_on 'Affecter' }
+    expect(page).to have_text("L’instructeur superwoman@inst.com a été affecté")
+
+    superwoman = User.find_by(email: 'superwoman@inst.com').instructeur
+
     # add scientifique groupe
     click_on 'Groupes d’instructeurs'
     fill_in 'Ajouter un groupe', with: 'scientifique'
@@ -50,6 +57,11 @@ feature 'The routing', js: true do
     expect(page).to have_text("L’instructeur marie@inst.com a été affecté")
 
     marie = User.find_by(email: 'marie@inst.com').instructeur
+
+    # add superwoman to scientifique groupe
+    find('input.select2-search__field').send_keys('superwoman@inst.com', :enter)
+    perform_enqueued_jobs { click_on 'Affecter' }
+    expect(page).to have_text("L’instructeur superwoman@inst.com a été affecté")
 
     # publish
     publish_procedure(procedure)
@@ -134,6 +146,31 @@ feature 'The routing', js: true do
     expect(page).to have_current_path(instructeur_procedures_path)
     expect(find('.procedure-stats')).not_to have_css('span.notifications')
     log_out
+
+    # the instructeurs who belong to scientifique AND litteraire groups manage scientifique and litterraire dossiers
+    register_instructeur_and_log_in(superwoman.email)
+    visit procedure_path(procedure, params: { statut: 'tous' })
+    expect(page).to have_text(litteraire_user.email)
+    expect(page).to have_text(scientifique_user.email)
+
+    # follow the dossier
+    click_on scientifique_user.email
+    click_on 'Suivre le dossier'
+
+    visit procedure_path(procedure, params: { statut: 'tous' })
+    click_on litteraire_user.email
+    click_on 'Suivre le dossier'
+    log_out
+
+    # scientifique_user updates its group
+    user_update_group(scientifique_user, 'littéraire')
+
+    # the instructeurs who belong to scientifique AND litteraire groups should have a notification
+    visit new_user_session_path
+    sign_in_with superwoman.user.email, password
+
+    expect(page).to have_current_path(instructeur_procedures_path)
+    expect(find('.procedure-stats')).to have_css('span.notifications')
   end
 
   def publish_procedure(procedure)
@@ -160,6 +197,19 @@ feature 'The routing', js: true do
 
     click_on 'Déposer le dossier'
     expect(page).to have_text('Merci')
+
+    log_out
+  end
+
+  def user_update_group(user, new_group)
+    login_as user, scope: :user
+    visit dossiers_path
+    click_on user.dossiers.first.id.to_s
+    click_on "Modifier mon dossier"
+
+    select(new_group, from: 'dossier_groupe_instructeur_id')
+    click_on "Enregistrer les modifications du dossier"
+    expect(page).to have_text(new_group)
 
     log_out
   end

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -223,6 +223,13 @@ describe Instructeur, type: :model do
       it { is_expected.to match({ demande: true, annotations_privees: false, avis: false, messagerie: false }) }
     end
 
+    context 'when there is a modification on groupe instructeur' do
+      let(:groupe_instructeur) { create(:groupe_instructeur, instructeurs: [instructeur], procedure: dossier.procedure) }
+      before { dossier.assign_to_groupe_instructeur(groupe_instructeur) }
+
+      it { is_expected.to match({ demande: true, annotations_privees: false, avis: false, messagerie: false }) }
+    end
+
     context 'when there is a modification on private champs' do
       before { dossier.champs_private.first.update_attribute('value', 'toto') }
 

--- a/spec/views/shared/dossiers/_champs.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_champs.html.haml_spec.rb
@@ -67,6 +67,31 @@ describe 'shared/dossiers/champs.html.haml', type: :view do
       expect(subject).to include(procedure.routing_criteria_name)
       expect(subject).to include(dossier.groupe_instructeur.label)
     end
+
+    context "with seen_at" do
+      let(:dossier) { create(:dossier) }
+      let(:nouveau_groupe_instructeur) { create(:groupe_instructeur, procedure: dossier.procedure) }
+      let(:champ1) { create(:champ, :checkbox, value: "on") }
+      let(:champs) { [champ1] }
+
+      context "with a demande_seen_at after groupe_instructeur_updated_at" do
+        let(:demande_seen_at) { dossier.groupe_instructeur_updated_at + 1.hour }
+
+        it "expect to not highlight new group instructeur label" do
+          dossier.assign_to_groupe_instructeur(nouveau_groupe_instructeur)
+          expect(subject).not_to have_css(".highlighted")
+        end
+      end
+
+      context "with a demande_seen_at before groupe_instructeur_updated_at" do
+        let(:demande_seen_at) { dossier.groupe_instructeur_updated_at - 1.hour }
+
+        it "expect to not highlight new group instructeur label" do
+          dossier.assign_to_groupe_instructeur(nouveau_groupe_instructeur)
+          expect(subject).to have_css(".highlighted")
+        end
+      end
+    end
   end
 
   context "with a dossier champ, but we are not authorized to acces the dossier" do


### PR DESCRIPTION
Fix #4784 
En tant qu'instructeur, lorsque je suis un dossier dont le groupe instructeur a changé (et que j'appartiens aux groupes instructeur ancien et nouveau), je vois une pastille orange :
- sur l'onglet "Suivi" de la page qui liste les demandes
- au niveau du dossier changé sur la page qui liste les demandes
- sur l'onglet "Demande" du dossier changé

Et le label du nouveau groupe instructeur sur la page du dossier est surligné en orange avec la date de la mise à jour.