### PR TITLE
#3653 - Dossier pdf vide d'une procédure

### DIFF
--- a/app/controllers/users/commencer_controller.rb
+++ b/app/controllers/users/commencer_controller.rb
@@ -20,16 +20,14 @@ module Users
       @procedure = retrieve_procedure
       return procedure_not_found if @procedure.blank? || @procedure.brouillon?
 
-      @dossier = @procedure.new_dossier
-      render(file: 'dossiers/dossier_vide', formats: [:pdf])
+      generate_empty_pdf(@procedure)
     end
 
     def dossier_vide_pdf_test
       @procedure = retrieve_procedure
       return procedure_not_found if @procedure.blank? || @procedure.publiee?
 
-      @dossier = @procedure.new_dossier
-      render(file: 'dossiers/dossier_vide', formats: [:pdf])
+      generate_empty_pdf(@procedure)
     end
 
     def sign_in
@@ -80,6 +78,12 @@ module Users
 
     def store_user_location!(procedure)
       store_location_for(:user, helpers.procedure_lien(procedure))
+    end
+
+    def generate_empty_pdf(procedure)
+      @dossier = procedure.new_dossier
+      s = render_to_string(file: 'dossiers/dossier_vide', formats: [:pdf])
+      send_data(s, :filename => "#{procedure.libelle}.pdf")
     end
   end
 end

--- a/app/controllers/users/commencer_controller.rb
+++ b/app/controllers/users/commencer_controller.rb
@@ -16,6 +16,22 @@ module Users
       render 'commencer/show'
     end
 
+    def dossier_vide_pdf
+      @procedure = retrieve_procedure
+      return procedure_not_found if @procedure.blank? || @procedure.brouillon?
+
+      @dossier = @procedure.new_dossier
+      render(file: 'dossiers/dossier_vide', formats: [:pdf])
+    end
+
+    def dossier_vide_pdf_test
+      @procedure = retrieve_procedure
+      return procedure_not_found if @procedure.blank? || @procedure.publiee?
+
+      @dossier = @procedure.new_dossier
+      render(file: 'dossiers/dossier_vide', formats: [:pdf])
+    end
+
     def sign_in
       @procedure = retrieve_procedure
       return procedure_not_found if @procedure.blank?

--- a/app/helpers/flipper_helper.rb
+++ b/app/helpers/flipper_helper.rb
@@ -2,4 +2,8 @@ module FlipperHelper
   def feature_enabled?(feature_name)
     Flipper.enabled?(feature_name, current_user)
   end
+
+  def feature_enabled_for?(feature_name, item)
+    Flipper.enabled?(feature_name, item)
+  end
 end

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -496,6 +496,10 @@ class Procedure < ApplicationRecord
     dossiers.discard_all
   end
 
+  def flipper_id
+    "Procedure;#{id}"
+  end
+
   private
 
   def move_type_de_champ_attributes(types_de_champ, type_de_champ, new_index)

--- a/app/views/commencer/show.html.haml
+++ b/app/views/commencer/show.html.haml
@@ -41,13 +41,14 @@
       = link_to 'Voir mes dossiers en cours', dossiers_path, class: ['button large expand primary']
       = link_to 'Commencer un nouveau dossier', url_for_new_dossier(@procedure), class: ['button large expand']
 
-  - pdf_link = commencer_dossier_vide_path(path: @procedure.path, format: :pdf)
-  - if @procedure.brouillon?
-    - pdf_link = commencer_dossier_vide_test_path(path: @procedure.path, format: :pdf)
-  %hr
-  %h2.huge-title Effectuer une demande papier
-  %p
-    Vous souhaitez effectuer une demande par papier ? Vous pouvez télécharger un dossier vide au format PDF,
-    et l'envoyer à l’administration concernée.
-  %br
-  = link_to 'Télécharger un dossier vide au format PDF', pdf_link, class: ['button large expand']
+  - if feature_enabled_for?(:dossier_pdf_vide, @procedure)
+    - pdf_link = commencer_dossier_vide_path(path: @procedure.path, format: :pdf)
+    - if @procedure.brouillon?
+      - pdf_link = commencer_dossier_vide_test_path(path: @procedure.path, format: :pdf)
+    %hr
+    %h2.huge-title Effectuer une demande papier
+    %p
+      Vous souhaitez effectuer une demande par papier ? Vous pouvez télécharger un dossier vide au format PDF,
+      et l'envoyer à l’administration concernée.
+    %br
+    = link_to 'Télécharger un dossier vide au format PDF', pdf_link, class: ['button large expand']

--- a/app/views/commencer/show.html.haml
+++ b/app/views/commencer/show.html.haml
@@ -46,9 +46,9 @@
     - if @procedure.brouillon?
       - pdf_link = commencer_dossier_vide_test_path(path: @procedure.path, format: :pdf)
     %hr
-    %h2.huge-title Effectuer une demande papier
     %p
       Vous souhaitez effectuer une demande par papier ? Vous pouvez télécharger un dossier vide au format PDF,
-      et l'envoyer à l’administration concernée.
+      et l'envoyer à l’administration concernée :
+      #{@procedure&.service&.nom} - #{@procedure&.service&.adresse}
     %br
     = link_to 'Télécharger un dossier vide au format PDF', pdf_link, class: ['button large expand']

--- a/app/views/commencer/show.html.haml
+++ b/app/views/commencer/show.html.haml
@@ -40,3 +40,14 @@
       %h2.huge-title Vous avez déjà des dossiers pour cette démarche
       = link_to 'Voir mes dossiers en cours', dossiers_path, class: ['button large expand primary']
       = link_to 'Commencer un nouveau dossier', url_for_new_dossier(@procedure), class: ['button large expand']
+
+  - pdf_link = commencer_dossier_vide_path(path: @procedure.path, format: :pdf)
+  - if @procedure.brouillon?
+    - pdf_link = commencer_dossier_vide_test_path(path: @procedure.path, format: :pdf)
+  %hr
+  %h2.huge-title Effectuer une demande papier
+  %p
+    Vous souhaitez effectuer une demande par papier ? Vous pouvez télécharger un dossier vide au format PDF,
+    et l'envoyer à l’administration concernée.
+  %br
+  = link_to 'Télécharger un dossier vide au format PDF', pdf_link, class: ['button large expand']

--- a/app/views/commencer/show.html.haml
+++ b/app/views/commencer/show.html.haml
@@ -42,9 +42,9 @@
       = link_to 'Commencer un nouveau dossier', url_for_new_dossier(@procedure), class: ['button large expand']
 
   - if feature_enabled_for?(:dossier_pdf_vide, @procedure)
-    - pdf_link = commencer_dossier_vide_path(path: @procedure.path, format: :pdf)
+    - pdf_link = commencer_dossier_vide_path(path: @procedure.path)
     - if @procedure.brouillon?
-      - pdf_link = commencer_dossier_vide_test_path(path: @procedure.path, format: :pdf)
+      - pdf_link = commencer_dossier_vide_test_path(path: @procedure.path)
     %hr
     %p
       Vous souhaitez effectuer une demande par papier ? Vous pouvez télécharger un dossier vide au format PDF,

--- a/app/views/dossiers/dossier_vide.pdf.prawn
+++ b/app/views/dossiers/dossier_vide.pdf.prawn
@@ -1,0 +1,189 @@
+require 'prawn/measurement_extensions'
+
+def render_in_2_columns(pdf, label, text)
+  pdf.text_box label, width: 200, height: 100, overflow: :expand, at: [0, pdf.cursor]
+  pdf.text_box ":", width: 10, height: 100, overflow: :expand, at: [100, pdf.cursor]
+  pdf.text_box text, width: 420, height: 100, overflow: :expand, at: [110, pdf.cursor]
+  pdf.text "\n"
+end
+
+def format_in_2_lines(pdf, label, nb_lines = 1)
+  add_single_line(pdf, label, 12, :bold)
+
+  height = 10 * (nb_lines+1)
+  pdf.bounding_box([0, pdf.cursor],:width => 460,:height => height) do
+    pdf.stroke_bounds
+  end
+  pdf.text "\n"
+end
+
+def format_in_2_columns(pdf, label)
+  pdf.text_box label, width: 200, height: 100, overflow: :expand, at: [0, pdf.cursor]
+  pdf.bounding_box([110, pdf.cursor+5],:width => 350,:height => 20) do
+    pdf.stroke_bounds
+  end
+
+  pdf.text "\n"
+end
+
+def format_with_checkbox(pdf, label, offset = 0)
+  pdf.font 'liberation serif', size: 12 do
+    pdf.stroke_rectangle [0 + offset, pdf.cursor], 10, 10
+    pdf.text_box label, at: [15 + offset, pdf.cursor]
+  end
+  pdf.text "\n"
+end
+
+def add_page_numbering(pdf)
+  # This method should be called at the end of the drawing since pages drawn after
+  # do not have page numbering
+  string = '<page> / <total>'
+  options = {
+      at: [0, -15],
+      align: :right
+  }
+  pdf.number_pages string, options
+end
+
+def format_date(date)
+  I18n.l(date, format: :message_date_with_year)
+end
+
+def add_identite_individual(pdf, dossier)
+  format_in_2_columns(pdf, "Civilité")
+  format_in_2_columns(pdf, "Nom")
+  format_in_2_columns(pdf, "Prénom")
+  format_in_2_columns(pdf, "Date de naissance")
+end
+
+def add_identite_etablissement(pdf, libelle)
+  add_single_line(pdf, libelle, 12, :bold)
+
+  format_in_2_columns(pdf, "SIRET")
+  format_in_2_columns(pdf, "Dénomination")
+  format_in_2_columns(pdf, "Forme juridique")
+end
+
+def add_single_line(pdf, libelle, size, style)
+  pdf.font 'liberation serif', style: style, size: size do
+    pdf.text libelle
+  end
+end
+
+def add_title(pdf, title)
+  add_single_line(pdf, title, 24, :bold)
+  pdf.text "\n"
+end
+
+def add_libelle(pdf, champ)
+  add_single_line(pdf, champ.libelle, 12, :bold)
+end
+
+def add_explanation(pdf, explanation)
+  add_single_line(pdf, explanation, 9, :italic)
+end
+
+def render_single_champ(pdf, champ)
+  case champ.type
+  when 'Champs::RepetitionChamp'
+    raise 'There should not be a RepetitionChamp here !'
+  when 'Champs::PieceJustificativeChamp'
+    add_single_line(pdf, 'Pièce justificative à joindre', 12, :bold)
+    pdf.text champ.libelle
+    pdf.text champ.description
+    pdf.text "\n"
+  when 'Champs::YesNoChamp', 'Champs::CheckboxChamp'
+    add_libelle(pdf, champ)
+    add_explanation(pdf, 'Cochez la mention applicable')
+    format_with_checkbox(pdf, 'Oui')
+    format_with_checkbox(pdf, 'Non')
+    pdf.text "\n"
+  when 'Champs::CiviliteChamp'
+    add_libelle(pdf, champ)
+    format_with_checkbox(pdf, Individual::GENDER_FEMALE)
+    format_with_checkbox(pdf, Individual::GENDER_MALE)
+    pdf.text "\n"
+  when 'Champs::HeaderSectionChamp'
+    add_single_line(pdf, champ.libelle, 18, :bold)
+    pdf.text "\n"
+  when 'Champs::ExplicationChamp'
+    add_libelle(pdf, champ)
+    pdf.text champ.description
+    pdf.text "\n"
+  when 'Champs::AddressChamp',  'Champs::CarteChamp', 'Champs::TextareaChamp'
+    format_in_2_lines(pdf, champ.libelle, 3)
+  when 'Champs::DropDownListChamp'
+    add_libelle(pdf, champ)
+    add_explanation(pdf, 'Cochez la mention applicable, une seule valeur possible')
+    champ.drop_down_list.options.reject(&:blank?).each do |option|
+      format_with_checkbox(pdf, option)
+    end
+    pdf.text "\n"
+  when 'Champs::MultipleDropDownListChamp'
+    add_libelle(pdf, champ)
+    add_explanation(pdf, 'Cochez la mention applicable, plusieurs valeurs possibles')
+    champ.drop_down_list.options.reject(&:blank?).each do |option|
+      format_with_checkbox(pdf, option)
+    end
+    pdf.text "\n"
+  when 'Champs::LinkedDropDownListChamp'
+    add_libelle(pdf, champ)
+    champ.primary_options.reject(&:blank?).each do |o|
+      format_with_checkbox(pdf, o)
+      champ.secondary_options[o].reject(&:blank?).each do |secondary_option|
+        format_with_checkbox(pdf, secondary_option, 15)
+      end
+    end
+    pdf.text "\n"
+  when 'Champs::SiretChamp'
+    add_identite_etablissement(pdf, champ.libelle)
+  else
+    format_in_2_lines(pdf, champ.libelle)
+  end
+end
+
+def add_champs(pdf, champs)
+  champs.each do |champ|
+    if champ.type == 'Champs::RepetitionChamp'
+      add_libelle(pdf, champ)
+      (1..3).each do
+        champ.rows.each do |row|
+          row.each do |inner_champ|
+            render_single_champ(pdf, inner_champ)
+          end
+        end
+      end
+    else
+      render_single_champ(pdf, champ)
+    end
+  end
+end
+
+prawn_document(page_size: "A4") do |pdf|
+  pdf.font_families.update( 'liberation serif' => {
+      normal: Rails.root.join('lib/prawn/fonts/liberation_serif/LiberationSerif-Regular.ttf' ),
+      bold: Rails.root.join('lib/prawn/fonts/liberation_serif/LiberationSerif-Bold.ttf' ),
+      italic: Rails.root.join('lib/prawn/fonts/liberation_serif/LiberationSerif-Italic.ttf' ),
+  })
+  pdf.font 'liberation serif'
+  pdf.svg IO.read("app/assets/images/header/logo-ds-wide.svg"), width: 300, position: :center
+  pdf.move_down(40)
+
+  render_in_2_columns(pdf, 'Démarche', @dossier.procedure.libelle)
+  render_in_2_columns(pdf, 'Organisme', @dossier.procedure.organisation_name)
+  pdf.text "\n"
+
+  add_title(pdf, "Identité du demandeur")
+
+  format_in_2_columns(pdf, "Email")
+  if @dossier.procedure.for_individual?
+    add_identite_individual(pdf, @dossier)
+  else
+    render_identite_etablissement(pdf, @dossier.etablissement) if @dossier.etablissement.present?
+  end
+  pdf.text "\n"
+
+  add_title(pdf, 'Formulaire')
+  add_champs(pdf, @dossier.champs)
+  add_page_numbering(pdf)
+end

--- a/app/views/dossiers/dossier_vide.pdf.prawn
+++ b/app/views/dossiers/dossier_vide.pdf.prawn
@@ -45,6 +45,12 @@ def add_page_numbering(pdf)
   pdf.number_pages string, options
 end
 
+def add_procedure(pdf, dossier)
+  pdf.repeat(lambda {|page| page > 1 })  do
+    pdf.draw_text dossier.procedure.libelle, :at => pdf.bounds.top_left
+  end
+end
+
 def format_date(date)
   I18n.l(date, format: :message_date_with_year)
 end
@@ -186,4 +192,5 @@ prawn_document(page_size: "A4") do |pdf|
   add_title(pdf, 'Formulaire')
   add_champs(pdf, @dossier.champs)
   add_page_numbering(pdf)
+  add_procedure(pdf, @dossier)
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -245,7 +245,7 @@ Rails.application.routes.draw do
       get '/test/:path/dossier_vide', action: 'dossier_vide_pdf_test', as: :dossier_vide_test
       get '/test/:path', action: 'commencer_test', as: :test
       get '/:path', action: 'commencer'
-      get '/:path/dossier_vide', action: 'dossier_vide_pdf'
+      get '/:path/dossier_vide', action: 'dossier_vide_pdf', as: :dossier_vide
       get '/:path/sign_in', action: 'sign_in', as: :sign_in
       get '/:path/sign_up', action: 'sign_up', as: :sign_up
       get '/:path/france_connect', action: 'france_connect', as: :france_connect

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -242,8 +242,10 @@ Rails.application.routes.draw do
 
   scope module: 'users' do
     namespace :commencer do
+      get '/test/:path/dossier_vide', action: 'dossier_vide_pdf_test', as: :dossier_vide_test
       get '/test/:path', action: 'commencer_test', as: :test
       get '/:path', action: 'commencer'
+      get '/:path/dossier_vide', action: 'dossier_vide_pdf'
       get '/:path/sign_in', action: 'sign_in', as: :sign_in
       get '/:path/sign_up', action: 'sign_up', as: :sign_up
       get '/:path/france_connect', action: 'france_connect', as: :france_connect


### PR DESCRIPTION
Premier jet de PDF vide pour dépot papier. 

Exemple de rendu: 
[dossier_vide.pdf](https://github.com/betagouv/demarches-simplifiees.fr/files/4291891/dossier_vide.pdf)
J'ai fait au mieux pour rendre le formulaire exploitable: cases à cocher, numérotation des pages, tentative de champs déroulant lié… Pas dit que ça plaise à tout le monde (et je ne sais pas trop quoi si ces champs font plus de quelques valeurs)
![image](https://user-images.githubusercontent.com/1223316/75964675-e9aaa900-5ec7-11ea-9392-784d1344f49e.png)

Concernant le texte, emplacement du bouton, … ça ne demande qu'à être affiné, mais c'est derrière un feature flag par procédure

![image](https://user-images.githubusercontent.com/1223316/75964791-1eb6fb80-5ec8-11ea-9e80-95e4bb2b565d.png)