### PR TITLE
#4808 procedure closing date starts now at midnight instead of 00h00 

### DIFF
--- a/app/assets/stylesheets/new_design/forms.scss
+++ b/app/assets/stylesheets/new_design/forms.scss
@@ -52,6 +52,10 @@
     p {
       margin-bottom: $default-spacer;
     }
+
+    input[type='date'] {
+      display: inline;
+    }
   }
 
   .editable-champ {

--- a/app/controllers/new_administrateur/procedures_controller.rb
+++ b/app/controllers/new_administrateur/procedures_controller.rb
@@ -74,6 +74,9 @@ module NewAdministrateur
       else
         params.require(:procedure).permit(*editable_params, :duree_conservation_dossiers_dans_ds, :duree_conservation_dossiers_hors_ds, :for_individual, :path)
       end
+      if permited_params[:auto_archive_on].present?
+        permited_params[:auto_archive_on] = Date.parse(permited_params[:auto_archive_on]) + 1.day
+      end
       permited_params
     end
   end

--- a/app/views/new_administrateur/procedures/_informations.html.haml
+++ b/app/views/new_administrateur/procedures/_informations.html.haml
@@ -106,12 +106,14 @@
     = f.text_field :web_hook_url, class: 'form-control', placeholder: 'https://callback.exemple.fr/'
 
   = f.label :auto_archive_on do
-    Clôture automatique à 00h01 le :
-  = f.date_field :auto_archive_on, id: 'auto_archive_on', value: @procedure.auto_archive_on
-
-  %p.explication
-    La clôture automatique suspend la publication de la démarche et entraîne le passage de tous les dossiers "en construction"
-    (c'est à dire ceux qui ont été déposés), au statut "en instruction", ce qui ne permet plus aux usagers de les modifier.
+    Date limite de dépôt des dossiers
+  %p.notice
+    Si une date est définie, aucun dossier ne pourra plus être déposé ou modifié après cette limite.
+  %p.notice
+    Le
+    - value = @procedure.auto_archive_on ? @procedure.auto_archive_on - 1.day : nil
+    = f.date_field :auto_archive_on, id: 'auto_archive_on', value: value
+    à 23 h 59
 
   = f.label :declarative_with_state do
     Démarche déclarative
@@ -122,3 +124,4 @@
     %br
     %br
     Dans le cadre d’une démarche déclarative, au dépôt, seul l’email associé à l’état choisi est envoyé. (ex: démarche déclarative « accepté » : envoi uniquement de l’email d'acceptation)
+


### PR DESCRIPTION
Comme discuté dans la #4808, la date de cloture est positionnée à minuit au lieu de 00h00 le matin. 
Tout le monde semblait d'accord pour agir sur l'interface et ne pas modifier les dates en base. 
Cela donne 
![image](https://user-images.githubusercontent.com/15379878/75599737-b55c6600-5a4b-11ea-96e9-e363fe1eceb8.png)
@kemenaran vu que personne d'autre que le demandeur peut modifier un dossier j'ai encore simplifié la phrase. 