### PR TITLE
Better wording for declarative procedure

### DIFF
--- a/app/views/new_administrateur/procedures/_informations.html.haml
+++ b/app/views/new_administrateur/procedures/_informations.html.haml
@@ -115,10 +115,8 @@
 
   = f.label :declarative_with_state do
     Démarche déclarative
+  %p.notice
+    Par défaut, un dossier déposé peut être complété ou corrigé par le demandeur jusqu'à sa mise en instruction.<br>
+    Dans une démarche déclarative, une fois déposé, un dossier ne peut plus être modifié.
+    Soit il passe immédiatement « en instruction » pour être traité soit il est immédiatement « accepté ».
   = f.select :declarative_with_state, Procedure.declarative_attributes_for_select, { prompt: 'Non' }, class: 'form-control'
-
-  %p.explication
-    Par défaut, une démarche n’est pas déclarative ; à son dépôt, un dossier est « en construction ». Vous pouvez choisir de la rendre déclarative, afin que tous les dossiers déposés passent immédiatement au statut « en instruction » ou « accepté ».
-    %br
-    %br
-    Dans le cadre d’une démarche déclarative, au dépôt, seul l’email associé à l’état choisi est envoyé. (ex: démarche déclarative « accepté » : envoi uniquement de l’email d'acceptation)


### PR DESCRIPTION
Dans les formulaires et sur cette page descriptive de la procédure, on a toujours 
- un titre, 
- une description 
- le champ lui-même 

Sauf justement pour le champ _procedure declarative_. 

De plus le texte est difficile à comprendre. 
Donc dans la lignée de la date limite de cloture, je tente une reformulation: 
![image](https://user-images.githubusercontent.com/15379878/75599792-682cc400-5a4c-11ea-8670-3892266c7a53.png)
Notez que j'ai supprimé le paragraphe sur les notifications: cela me parait évident que la plateforme va adapter les notifications à la forme déclarative donc pas besoin de rassurer plus que ca l'admin.
Comme toujours c'est une proposition, les demandes de corrections sont les bienvenues et on peut très bien garder la formulation initiale et uniformiser uniquement l'affichage. 