### PR TITLE
fix missing procedure in AdministrationMailer#dossier_expiration_summary

### DIFF
--- a/app/views/administration_mailer/dossier_expiration_summary.html.haml
+++ b/app/views/administration_mailer/dossier_expiration_summary.html.haml
@@ -5,7 +5,10 @@
   - @expired_dossiers.group_by(&:procedure).each do |procedure, dossiers|
     %dl
       %dt
-        #{procedure.libelle} (#{link_to(procedure.id, manager_procedure_url(procedure))}) :
+        - if procedure.present?
+          #{procedure.libelle} (#{link_to(procedure.id, manager_procedure_url(procedure))}) :
+        - else
+          Procédure supprimée
       %dd
         = dossiers.map { |d| link_to(d.id, manager_dossier_url(d)) }.join(', ').html_safe
 
@@ -14,7 +17,10 @@
   - @expiring_dossiers.group_by(&:procedure).each do |procedure, dossiers|
     %dl
       %dt
-        #{procedure.libelle} (#{link_to(procedure.id, manager_procedure_url(procedure))}) :
+        - if procedure.present?
+          #{procedure.libelle} (#{link_to(procedure.id, manager_procedure_url(procedure))}) :
+        - else
+          Procédure supprimée
       %dd
         = dossiers.map { |d| link_to(d.id, manager_dossier_url(d)) }.join(', ').html_safe
 


### PR DESCRIPTION
Le mail `AdministrationMailer#dossier_expiration_summary` est en échec dans DelayedJob lorsqu'il manque certaines procédures (c'est le cas actuellement, ça bloque l'envoi d'un mail concernant 100000 dossiers !).

Voici le fix.

```
undefined method `libelle' for nil:NilClass
app/views/administration_mailer/dossier_expiration_summary.html.haml:8:in `block in _app_views_administration_mailer_dossier_expiration_summary_html_haml___2691478935976817730_47063683685940'
app/views/administration_mailer/dossier_expiration_summary.html.haml:5:in `each'
app/views/administration_mailer/dossier_expiration_summary.html.haml:5:in `_app_views_administration_mailer_dossier_expiration_summary_html_haml___2691478935976817730_47063683685940'
```