### PR TITLE
fix error message during admin activation error

### DIFF
--- a/app/controllers/administrateurs/activate_controller.rb
+++ b/app/controllers/administrateurs/activate_controller.rb
@@ -31,7 +31,7 @@ class Administrateurs::ActivateController < ApplicationController
       flash.notice = "Mot de passe enregistré"
       redirect_to admin_procedures_path
     else
-      flash.alert = administrateur.errors.full_messages
+      flash.alert = user.administrateur.errors.full_messages
       redirect_to admin_activate_path(token: update_administrateur_params[:reset_password_token])
     end
   end


### PR DESCRIPTION
fix pour
```
rails : NameError: undefined local variable or method `administrateur' for #<Administrateurs::ActivateController:0x00007f09e55db808>
```