### PR TITLE
4822 fix bug entreprises non diffusables

### DIFF
--- a/app/lib/api_entreprise/api.rb
+++ b/app/lib/api_entreprise/api.rb
@@ -62,6 +62,7 @@ class ApiEntreprise::API
       context: "demarches-simplifiees.fr",
       recipient: siret_or_siren,
       object: "procedure_id: #{procedure_id}",
+      non_diffusables: true,
       token: token
     }
   end

--- a/app/lib/api_entreprise/etablissement_adapter.rb
+++ b/app/lib/api_entreprise/etablissement_adapter.rb
@@ -24,7 +24,8 @@ class ApiEntreprise::EtablissementAdapter < ApiEntreprise::Adapter
       :siret,
       :siege_social,
       :naf,
-      :libelle_naf
+      :libelle_naf,
+      :diffusable_commercialement
     ]
   end
 

--- a/app/views/shared/dossiers/_identite_entreprise.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise.html.haml
@@ -1,76 +1,80 @@
 %table.table.vertical.dossier-champs
   %tbody
-    %tr
-      %th.libelle Dénomination :
-      %td= raison_sociale_or_name(etablissement)
-    %tr
-      %th.libelle SIRET :
-      %td= etablissement.siret
+    - if etablissement.diffusable_commercialement == false && profile != 'instructeur'
+      %tr
+        %td= t('warning_for_private_info', etablissement: raison_sociale_or_name(etablissement), scope: 'views.shared.dossiers.identite_entreprise')
+    - else
+      %tr
+        %th.libelle Dénomination :
+        %td= raison_sociale_or_name(etablissement)
+      %tr
+        %th.libelle SIRET :
+        %td= etablissement.siret
 
-    - if etablissement.siret != etablissement.entreprise.siret_siege_social
+      - if etablissement.siret != etablissement.entreprise.siret_siege_social
+        %tr
+          %th.libelle SIRET du siège social:
+          %td= etablissement.entreprise.siret_siege_social
       %tr
-        %th.libelle SIRET du siège social:
-        %td= etablissement.entreprise.siret_siege_social
-    %tr
-      %th.libelle Forme juridique :
-      %td= sanitize(etablissement.entreprise.forme_juridique)
-    %tr
-      %th.libelle Libellé NAF :
-      %td= etablissement.libelle_naf
-    %tr
-      %th.libelle Code NAF :
-      %td= etablissement.naf
-    %tr
-      %th.libelle Date de création :
-      %td= try_format_date(etablissement.entreprise.date_creation)
-    %tr
-      %th.libelle Effectif de l'organisation :
-      %td= effectif(etablissement)
-    %tr
-      %th.libelle Code effectif :
-      %td= etablissement.entreprise.code_effectif_entreprise
-    %tr
-      %th.libelle Numéro de TVA intracommunautaire :
-      %td= etablissement.entreprise.numero_tva_intracommunautaire
-    %tr
-      %th.libelle Adresse :
-      %td
-        - etablissement.adresse.split("\n").each do |line|
-          = line
-          %br
-    %tr
-      %th.libelle Capital social :
-      %td= pretty_currency(etablissement.entreprise.capital_social)
-    %tr
-      %th.libelle Exercices :
-      %td
-        - if profile == 'instructeur'
-          - etablissement.exercices.each_with_index do |exercice, index|
-            = "#{exercice.date_fin_exercice.year} : "
-            = pretty_currency(exercice.ca)
-            %br
-        - elsif etablissement.exercices.present?
-          = t('activemodel.models.exercices_summary', count: etablissement.exercices.count)
-
-    - if etablissement.association?
+        %th.libelle Forme juridique :
+        %td= sanitize(etablissement.entreprise.forme_juridique)
       %tr
-        %th.libelle Numéro RNA :
-        %td= etablissement.association_rna
+        %th.libelle Libellé NAF :
+        %td= etablissement.libelle_naf
       %tr
-        %th.libelle Titre :
-        %td= etablissement.association_titre
-      %tr
-        %th.libelle Objet :
-        %td= etablissement.association_objet
+        %th.libelle Code NAF :
+        %td= etablissement.naf
       %tr
         %th.libelle Date de création :
-        %td= try_format_date(etablissement.association_date_creation)
+        %td= try_format_date(etablissement.entreprise.date_creation)
       %tr
-        %th.libelle Date de publication :
-        %td= try_format_date(etablissement.association_date_publication)
+        %th.libelle Effectif de l'organisation :
+        %td= effectif(etablissement)
       %tr
-        %th.libelle Date de déclaration :
-        %td= try_format_date(etablissement.association_date_declaration)
+        %th.libelle Code effectif :
+        %td= etablissement.entreprise.code_effectif_entreprise
+      %tr
+        %th.libelle Numéro de TVA intracommunautaire :
+        %td= etablissement.entreprise.numero_tva_intracommunautaire
+      %tr
+        %th.libelle Adresse :
+        %td
+          - etablissement.adresse.split("\n").each do |line|
+            = line
+            %br
+      %tr
+        %th.libelle Capital social :
+        %td= pretty_currency(etablissement.entreprise.capital_social)
+      %tr
+        %th.libelle Exercices :
+        %td
+          - if profile == 'instructeur'
+            - etablissement.exercices.each_with_index do |exercice, index|
+              = "#{exercice.date_fin_exercice.year} : "
+              = pretty_currency(exercice.ca)
+              %br
+          - elsif etablissement.exercices.present?
+            = t('activemodel.models.exercices_summary', count: etablissement.exercices.count)
+
+      - if etablissement.association?
+        %tr
+          %th.libelle Numéro RNA :
+          %td= etablissement.association_rna
+        %tr
+          %th.libelle Titre :
+          %td= etablissement.association_titre
+        %tr
+          %th.libelle Objet :
+          %td= etablissement.association_objet
+        %tr
+          %th.libelle Date de création :
+          %td= try_format_date(etablissement.association_date_creation)
+        %tr
+          %th.libelle Date de publication :
+          %td= try_format_date(etablissement.association_date_publication)
+        %tr
+          %th.libelle Date de déclaration :
+          %td= try_format_date(etablissement.association_date_declaration)
 
 %p
   = link_to '➡ Autres informations sur l’organisme sur « entreprise.data.gouv.fr »',

--- a/app/views/users/dossiers/etablissement.html.haml
+++ b/app/views/users/dossiers/etablissement.html.haml
@@ -7,20 +7,25 @@
   .container
     %h1 Informations sur l’établissement
 
-    %p
-      Nous avons récupéré auprès de l’INSEE et d’Infogreffe les informations suivantes concernant votre établissement.
+    - etablissement = @dossier.etablissement
+    - if etablissement.diffusable_commercialement == false
+      %p= t('warning_for_private_info', etablissement: raison_sociale_or_name(etablissement), scope: 'views.shared.dossiers.identite_entreprise')
 
-    %p
-      Ces informations seront jointes à votre dossier.
+    - else
+      %p
+        Nous avons récupéré auprès de l’INSEE et d’Infogreffe les informations suivantes concernant votre établissement.
 
-    .etablissement-infos.card.featured
-      - etablissement = @dossier.etablissement
-      %h2.card-title= raison_sociale_or_name(etablissement)
+      %p
+        Ces informations seront jointes à votre dossier.
 
-      = render partial: 'users/dossiers/etablissement/infos_entreprise', locals: { etablissement: etablissement }
+      .etablissement-infos.card.featured
 
-      - if etablissement.association?
-        = render partial: 'users/dossiers/etablissement/infos_association', locals: { etablissement: etablissement }
+        %h2.card-title= raison_sociale_or_name(etablissement)
+
+        = render partial: 'users/dossiers/etablissement/infos_entreprise', locals: { etablissement: etablissement }
+
+        - if etablissement.association?
+          = render partial: 'users/dossiers/etablissement/infos_association', locals: { etablissement: etablissement }
 
     .actions
       = link_to 'Utiliser un autre numéro SIRET', siret_dossier_path(@dossier), class: 'button'

--- a/config/locales/views/shared/fr.yml
+++ b/config/locales/views/shared/fr.yml
@@ -1,0 +1,6 @@
+fr:
+  views:
+    shared:
+      dossiers:
+        identite_entreprise:
+          warning_for_private_info: "L'établissement %{etablissement} a exercé son droit à la non publication des informations relatives à son identité. Les informations ne seront donc visibles que de la part des services instructeurs"

--- a/db/migrate/20200304155418_add_diffusable_commercialement_to_etablissements.rb
+++ b/db/migrate/20200304155418_add_diffusable_commercialement_to_etablissements.rb
@@ -1,0 +1,5 @@
+class AddDiffusableCommercialementToEtablissements < ActiveRecord::Migration[5.2]
+  def change
+    add_column :etablissements, :diffusable_commercialement, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_27_100001) do
+ActiveRecord::Schema.define(version: 2020_03_04_155418) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -304,6 +304,7 @@ ActiveRecord::Schema.define(version: 2020_02_27_100001) do
     t.date "association_date_publication"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean "diffusable_commercialement"
     t.index ["dossier_id"], name: "index_etablissements_on_dossier_id"
   end
 

--- a/spec/factories/etablissement.rb
+++ b/spec/factories/etablissement.rb
@@ -29,6 +29,10 @@ FactoryBot.define do
         create(:exercice, etablissement: etablissement)
       end
     end
+
+    trait :non_diffusable do
+      diffusable_commercialement { false }
+    end
   end
 
   trait :is_association do

--- a/spec/fixtures/files/api_entreprise/etablissements_private.json
+++ b/spec/fixtures/files/api_entreprise/etablissements_private.json
@@ -26,7 +26,7 @@
       "code": null,
       "value": null
     },
-    "diffusable_commercialement": true,
+    "diffusable_commercialement": false,
     "adresse": {
       "l1": "OCTO TECHNOLOGY",
       "l2": null,

--- a/spec/lib/api_entreprise/api_spec.rb
+++ b/spec/lib/api_entreprise/api_spec.rb
@@ -55,7 +55,7 @@ describe ApiEntreprise::API do
   describe '.etablissement' do
     subject { described_class.etablissement(siret, procedure_id) }
     before do
-      stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/etablissements\/#{siret}?.*token=/)
+      stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/etablissements\/#{siret}?.*non_diffusables=true&.*token=/)
         .to_return(status: status, body: body)
     end
 

--- a/spec/lib/api_entreprise/etablissement_adapter_spec.rb
+++ b/spec/lib/api_entreprise/etablissement_adapter_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe ApiEntreprise::EtablissementAdapter do
   let(:procedure_id) { 33 }
 
-  context 'SIRET valide' do
+  context 'SIRET valide avec infos diffusables' do
     let(:siret) { '41816609600051' }
     subject { described_class.new(siret, procedure_id).to_params }
 
@@ -31,6 +31,10 @@ describe ApiEntreprise::EtablissementAdapter do
 
       it 'L\'entreprise contient bien un libelle_naf' do
         expect(subject[:libelle_naf]).to eq('Conseil en systèmes et logiciels informatiques')
+      end
+
+      it 'L\'entreprise contient bien un diffusable_commercialement qui vaut true' do
+        expect(subject[:diffusable_commercialement]).to eq(true)
       end
 
       context 'Concaténation lignes adresse' do
@@ -67,6 +71,20 @@ describe ApiEntreprise::EtablissementAdapter do
           expect(subject[:code_insee_localite]).to eq('75108')
         end
       end
+    end
+  end
+
+  context 'SIRET valide avec infos non diffusables' do
+    let(:siret) { '41816609600051' }
+    subject { described_class.new(siret, procedure_id).to_params }
+
+    before do
+      stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/etablissements\/#{siret}?.*token=/)
+        .to_return(body: File.read('spec/fixtures/files/api_entreprise/etablissements_private.json', status: 200))
+    end
+
+    it 'L\'entreprise contient bien un diffusable_commercialement qui vaut false' do
+      expect(subject[:diffusable_commercialement]).to eq(false)
     end
   end
 

--- a/spec/views/shared/dossiers/_identite_entreprise.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_identite_entreprise.html.haml_spec.rb
@@ -12,4 +12,13 @@ describe 'shared/dossiers/identite_entreprise.html.haml', type: :view do
       end
     end
   end
+
+  context "for an entreprise with private infos" do
+    let(:etablissement) { create(:etablissement, :non_diffusable) }
+
+    it "displays only public infos" do
+      expect(rendered).to have_text(etablissement.entreprise_raison_sociale)
+      expect(rendered).not_to have_text(etablissement.entreprise.forme_juridique)
+    end
+  end
 end

--- a/spec/views/users/dossiers/etablissement.html.haml_spec.rb
+++ b/spec/views/users/dossiers/etablissement.html.haml_spec.rb
@@ -29,6 +29,14 @@ describe 'users/dossiers/etablissement.html.haml', type: :view do
     end
   end
 
+  context 'etablissement avec infos non diffusables' do
+    let(:etablissement) { create(:etablissement, :with_exercices, :non_diffusable) }
+    it "affiche uniquement le nom de l'établissement si infos non diffusables" do
+      expect(rendered).to have_text(etablissement.entreprise_raison_sociale)
+      expect(rendered).not_to have_text(etablissement.entreprise.forme_juridique)
+    end
+  end
+
   it 'prépare le footer' do
     expect(footer).to have_selector('footer')
   end


### PR DESCRIPTION
close #4822 

- permet à un usager de type "entreprise" de s'inscrire à DS même si cette entreprise n'a pas souhaité que ses infos soient diffusables

- affiche les infos de l'entreprise uniquement dans la vue Instructeur

- permet également à un usager d'ajouter dans un champ de type SIRET le siret d'une entreprise qui n'a pas souhaité que ses infos soient diffusables (ces infos ne seront visibles que par les instructeurs)
