### PR TITLE
added eIDAS level to France Connect authorization call

### DIFF
--- a/app/services/france_connect_service.rb
+++ b/app/services/france_connect_service.rb
@@ -5,7 +5,8 @@ class FranceConnectService
     client.authorization_uri(
       scope: [:profile, :email],
       state: SecureRandom.hex(16),
-      nonce: SecureRandom.hex(16)
+      nonce: SecureRandom.hex(16),
+      acr_values: 'eidas1'
     )
   end
 


### PR DESCRIPTION
France Connect demande maintenant à ce que le niveau de sécurité eIDAS soit spécifié dans l'appel. 
Cf page https://partenaires.franceconnect.gouv.fr/fcp/fournisseur-service
Rechercher sur la page 'acr_values'.
Je pense que les niveaux 2 (double authentification) et 3 (avec dispositifs biométriques etc...) sont trop élevés pour DS d'où le fait de spécifier le niveau 1 (login/pwd) ;-)