### PR TITLE
circle_ci: failed tests store screenshots

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,9 @@ jobs:
             eval $COMMAND
       - store_test_results:
           path: ~/test_results
+      - store_artifacts:
+          path: tmp/capybara
+          destination: screenshots
   lint:
     <<: *defaults
     steps:


### PR DESCRIPTION
Dans circle_ci, quand des tests plantent, impossible d'accéder au screenshot du test qui a planté. 
Avec cette petite ligne, on obtient ca dans circleci 
![image](https://user-images.githubusercontent.com/15379878/76560267-e2921680-6444-11ea-9b95-50287507b3da.png)
