### PR TITLE
remove orphan services when destroying admin

### DIFF
--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -85,6 +85,11 @@ class Administrateur < ApplicationRecord
       next_administrateur = procedure.administrateurs.where.not(id: self.id).first
       procedure.service.update(administrateur: next_administrateur)
     end
+
+    services.each do |service|
+      service.destroy unless service.procedures.any?
+    end
+
     destroy
   end
 end

--- a/spec/models/administrateur_spec.rb
+++ b/spec/models/administrateur_spec.rb
@@ -59,6 +59,14 @@ describe Administrateur, type: :model do
       expect(Administrateur.find_by(id: administrateur.id)).to be_nil
       expect(service.reload.administrateur).to eq(autre_administrateur)
     end
+
+    it "delete service if not associated to procedures" do
+      service_without_procedure = create(:service, administrateur: administrateur)
+      administrateur.delete_and_transfer_services
+
+      expect(Service.find_by(id: service_without_procedure.id)).to be_nil
+      expect(Administrateur.find_by(id: administrateur.id)).to be_nil
+    end
   end
 
   # describe '#password_complexity' do


### PR DESCRIPTION
close #4888 

Une exception est remontée lorsqu'on essaie de supprimer un administrateur, alors qu'il a encore des services qui n'appartiennent à aucune procédure.

`ActiveRecord::InvalidForeignKey: PG::ForeignKeyViolation: ERROR:  update or delete on table "administrateurs" violates foreign key constraint "fk_rails_3a234077b9" on table "services"`

Cette PR supprime dans ce cas ces services obsolètes.