### PR TITLE
[instructeur] remplir une démarche en cliquant sur son lien

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -198,7 +198,7 @@ class ApplicationController < ActionController::Base
 
       # return at this location
       # after the device is trusted
-      store_location_for(:user, request.fullpath)
+      store_location_for(:user, request.fullpath) if get_stored_location_for(:user).blank?
 
       send_login_token_or_bufferize(current_instructeur)
       redirect_to link_sent_path(email: current_instructeur.email)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -164,6 +164,7 @@ describe ApplicationController, type: :controller do
       allow(@controller).to receive(:instructeur_signed_in?).and_return(instructeur_signed_in)
       allow(@controller).to receive(:sensitive_path).and_return(sensitive_path)
       allow(@controller).to receive(:send_login_token_or_bufferize)
+      allow(@controller).to receive(:get_stored_location_for).and_return(nil)
       allow(@controller).to receive(:store_location_for)
       allow(IPService).to receive(:ip_trusted?).and_return(ip_trusted)
     end

--- a/spec/features/users/dossier_creation_spec.rb
+++ b/spec/features/users/dossier_creation_spec.rb
@@ -110,4 +110,16 @@ feature 'Creating a new dossier:' do
       end
     end
   end
+
+  context 'when the user is not signed in' do
+    let(:instructeur) { create(:instructeur) }
+    let(:procedure) { create(:procedure, :published) }
+    scenario 'the user is an instructeur with untrusted device' do
+      visit commencer_path(path: procedure.path)
+      click_on "J’ai déjà un compte"
+      sign_in_with(instructeur.email, instructeur.user.password, true)
+
+      expect(page).to have_current_path(commencer_path(path: procedure.path))
+    end
+  end
 end


### PR DESCRIPTION
close #3366 

En tant qu'instructeur, quand je clique sur un lien pour remplir une démarche alors que je ne suis pas identifié et que mon jeton a expiré, alors je suis redirigé vers la démarche lorsque je clique sur le lien contenu dans le mail me permettant de m'identifier à DS