### PR TITLE
database seed: administrateur no longer have email field

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,4 +16,4 @@ user = User.create!(
   confirmed_at: Time.zone.now
 )
 user.create_instructeur!
-user.create_administrateur!(email: user.email)
+user.create_administrateur!


### PR DESCRIPTION
Le champ email dans Administrateur n'existe plus et ne doit donc plus etre initialisé lors de l'init de la base.