### PR TITLE
[WIP] instructeur: remplir une démarche en cliquant sur son lien

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   include TrustedDeviceConcern
   include Pundit
+  include Devise::StoreLocationExtension
 
   MAINTENANCE_MESSAGE = 'Le site est actuellement en maintenance. Il sera à nouveau disponible dans un court instant.'
 

--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -1,5 +1,4 @@
 class InvitesController < ApplicationController
-  include Devise::StoreLocationExtension
 
   before_action :authenticate_user!, only: [:create]
   before_action :store_user_location!, only: [:show]

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -1,6 +1,5 @@
 module Users
   class DossiersController < UserController
-    include Devise::StoreLocationExtension
     include DossierHelper
 
     layout 'procedure_context', only: [:identite, :update_identite, :siret, :update_siret]


### PR DESCRIPTION
En tant qu'instructeur, quand je clique sur un lien pour remplir une démarche alors que je ne suis pas identifié et que mon jeton a expiré, alors je suis redirigé vers la démarche lorsque je clique sur le lien contenu dans le mail me permettant de m'identifier à DS

(nouvelle PR suite à exception levée sur plusieurs controllers, voir https://github.com/betagouv/demarches-simplifiees.fr/issues/3366)