### PR TITLE
javascript: make utils.ajax() return a promise

### DIFF
--- a/app/javascript/shared/utils.js
+++ b/app/javascript/shared/utils.js
@@ -3,7 +3,7 @@ import $ from 'jquery';
 import debounce from 'debounce';
 
 export { debounce };
-export const { fire, ajax } = Rails;
+export const { fire } = Rails;
 
 export function show(el) {
   el && el.classList.remove('hidden');
@@ -43,6 +43,22 @@ export function delegate(eventNames, selector, callback) {
     .forEach(eventName =>
       Rails.delegate(document, selector, eventName, callback)
     );
+}
+
+export function ajax(options) {
+  return new Promise((resolve, reject) => {
+    Object.assign(options, {
+      success: (response, statusText, xhr) => {
+        resolve({ response, statusText, xhr });
+      },
+      error: (response, statusText, xhr) => {
+        let error = new Error(`Erreur ${xhr.status} : ${statusText}`);
+        Object.assign(error, { response, statusText, xhr });
+        reject(error);
+      }
+    });
+    Rails.ajax(options);
+  });
 }
 
 export function getJSON(url, data, method = 'get') {


### PR DESCRIPTION
_This PR is a part from #4918_

Today `utils.ajax` is just a wrapper around `Rails.ajax`. And `Rails.ajax` uses callbacks to signal success and error – which doesn't allow to use the `await` syntax.

This refactoring allows to use `await ajax(…)`, and still have Rails manage the request, insert the proper headers and tokens, etc.

In the current codebase, `utils.ajax` is used only once – without callbacks. So the change should be transparent.