### PR TITLE
Keep operation logs after dossier removal

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -38,7 +38,7 @@ class Dossier < ApplicationRecord
   has_many :previous_followers_instructeurs, -> { distinct }, through: :previous_follows, source: :instructeur
   has_many :avis, inverse_of: :dossier, dependent: :destroy
 
-  has_many :dossier_operation_logs, dependent: :destroy
+  has_many :dossier_operation_logs, dependent: :nullify
 
   belongs_to :groupe_instructeur
   has_one :procedure, through: :groupe_instructeur

--- a/app/models/dossier_operation_log.rb
+++ b/app/models/dossier_operation_log.rb
@@ -12,8 +12,9 @@ class DossierOperationLog < ApplicationRecord
     demander_un_avis: 'demander_un_avis'
   }
 
-  belongs_to :dossier
   has_one_attached :serialized
+
+  belongs_to :dossier, optional: true
   belongs_to :bill_signature, optional: true
 
   def self.create_and_serialize(params)

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1131,4 +1131,17 @@ describe Dossier do
       end
     end
   end
+
+  describe 'dossier_operation_log after dossier deletion' do
+    let(:dossier) { create(:dossier) }
+    let(:dossier_operation_log) { create(:dossier_operation_log, dossier: dossier) }
+
+    it 'should nullify dossier link' do
+      expect(dossier_operation_log.dossier).to eq(dossier)
+      expect(DossierOperationLog.count).to eq(1)
+      dossier.destroy
+      expect(dossier_operation_log.reload.dossier).to be_nil
+      expect(DossierOperationLog.count).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
Je ne suis pas sûr de quoi faire de “dossier operation log” à long terme, mais pour l'instant ça me semble être la bonne solution. Faire le nettoyage sera facile `DossierOperationLog.where(dossier_id: nil)`.

cc @LeSim @kemenaran @Keirua 