### PR TITLE
javascript: move the autosave files to a sub-directory

### DIFF
--- a/app/javascript/new_design/dossiers/auto-save-controller.js
+++ b/app/javascript/new_design/dossiers/auto-save-controller.js
@@ -2,7 +2,7 @@ import { fire, timeoutable } from '@utils';
 
 // Manages a queue of Autosave operations,
 // and sends `autosave:*` events to indicate the state of the requests.
-export default class AutosaveController {
+export default class AutoSaveController {
   constructor() {
     this.timeoutDelay = 60000; // 1mn
     this.latestPromise = Promise.resolve();

--- a/app/javascript/new_design/dossiers/auto-save.js
+++ b/app/javascript/new_design/dossiers/auto-save.js
@@ -1,4 +1,4 @@
-import AutosaveController from './autosave-controller.js';
+import AutoSaveController from './auto-save-controller.js';
 import {
   debounce,
   delegate,
@@ -14,7 +14,7 @@ const AUTOSAVE_DEBOUNCE_DELAY = gon.autosave.debounce_delay;
 const AUTOSAVE_STATUS_VISIBLE_DURATION = gon.autosave.status_visible_duration;
 
 // Create a controller responsible for queuing autosave operations.
-const autosaveController = new AutosaveController();
+const autoSaveController = new AutoSaveController();
 
 // Whenever a 'change' event is triggered on one of the form inputs, try to autosave.
 
@@ -26,13 +26,13 @@ delegate(
   formInputsSelector,
   debounce(() => {
     const form = document.querySelector(formSelector);
-    autosaveController.enqueueAutosaveRequest(form);
+    autoSaveController.enqueueAutosaveRequest(form);
   }, AUTOSAVE_DEBOUNCE_DELAY)
 );
 
 delegate('click', '.autosave-retry', () => {
   const form = document.querySelector(formSelector);
-  autosaveController.enqueueAutosaveRequest(form);
+  autoSaveController.enqueueAutosaveRequest(form);
 });
 
 // Display some UI during the autosave

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -16,13 +16,13 @@ import '../shared/franceconnect';
 import '../shared/toggle-target';
 
 import '../new_design/dropdown';
-import '../new_design/autosave';
 import '../new_design/form-validation';
 import '../new_design/procedure-context';
 import '../new_design/procedure-form';
 import '../new_design/select2';
 import '../new_design/spinner';
 import '../new_design/support';
+import '../new_design/dossiers/auto-save';
 
 import '../new_design/champs/carte';
 import '../new_design/champs/linked-drop-down-list';


### PR DESCRIPTION
Dans le cadre de l'upload automatique des pièces jointes (#4918), cette PR déplace les fichiers de l'autosave dans un sous-dossier (où on pourra mettre aussi les fichiers de l'autoupload plus tard).

C'est juste du bougeage-de-choses, ça ne change rien à part ça :)