### PR TITLE
locales: fix translation of champ value

### DIFF
--- a/app/models/champs/decimal_number_champ.rb
+++ b/app/models/champs/decimal_number_champ.rb
@@ -2,8 +2,8 @@ class Champs::DecimalNumberChamp < Champ
   validates :value, numericality: {
     allow_nil: true,
     allow_blank: true,
-    message: -> (object, data) {
-      "« #{object.libelle} » " + object.errors.generate_message(data[:attribute].downcase, :not_a_number)
+    message: -> (object, _data) {
+      "« #{object.libelle} » " + object.errors.generate_message(:value, :not_a_number)
     }
   }
 

--- a/app/models/champs/integer_number_champ.rb
+++ b/app/models/champs/integer_number_champ.rb
@@ -3,8 +3,8 @@ class Champs::IntegerNumberChamp < Champ
     only_integer: true,
     allow_nil: true,
     allow_blank: true,
-    message: -> (object, data) {
-      "« #{object.libelle} » " + object.errors.generate_message(data[:attribute].downcase, :not_an_integer)
+    message: -> (object, _data) {
+      "« #{object.libelle} » " + object.errors.generate_message(:value, :not_an_integer)
     }
   }
 

--- a/config/locales/models/champs/fr.yml
+++ b/config/locales/models/champs/fr.yml
@@ -1,5 +1,5 @@
 fr:
   activerecord:
     attributes:
-      champs:
+      champ:
         value: La valeur du champ


### PR DESCRIPTION
Due to the extra 's', the names of Champs attributes were never translated.