### PR TITLE
Discard/Undo Démarches and Dossiers in manager

### DIFF
--- a/app/controllers/admin/procedures_controller.rb
+++ b/app/controllers/admin/procedures_controller.rb
@@ -52,15 +52,14 @@ class Admin::ProceduresController < AdminController
   def destroy
     procedure = current_administrateur.procedures.find(params[:id])
 
-    if procedure.locked?
-      return render json: {}, status: 401
+    if procedure.can_be_deleted_by_administrateur?
+      procedure.discard_and_keep_track!(current_administrateur)
+
+      flash.notice = 'Démarche supprimée'
+      redirect_to admin_procedures_draft_path
+    else
+      render json: {}, status: 403
     end
-
-    procedure.reset!
-    procedure.destroy
-
-    flash.notice = 'Démarche supprimée'
-    redirect_to admin_procedures_draft_path
   end
 
   def publish_validate

--- a/app/controllers/manager/dossiers_controller.rb
+++ b/app/controllers/manager/dossiers_controller.rb
@@ -30,6 +30,15 @@ module Manager
       redirect_to manager_dossier_path(dossier)
     end
 
+    def restore
+      dossier = Dossier.with_discarded.find(params[:id])
+      dossier.restore(current_administration)
+
+      flash[:notice] = "Le dossier #{dossier.id} a été restauré."
+
+      redirect_to manager_dossier_path(dossier)
+    end
+
     def repasser_en_instruction
       dossier = Dossier.find(params[:id])
       dossier.repasser_en_instruction(current_administration)

--- a/app/controllers/manager/procedures_controller.rb
+++ b/app/controllers/manager/procedures_controller.rb
@@ -31,6 +31,14 @@ module Manager
       redirect_to manager_procedure_path(procedure)
     end
 
+    def restore
+      procedure.restore(current_administration)
+
+      flash[:notice] = "La démarche #{procedure.id} a été restauré."
+
+      redirect_to manager_procedure_path(procedure)
+    end
+
     def add_administrateur
       administrateur = Administrateur.by_email(params[:email])
       if administrateur

--- a/app/controllers/manager/procedures_controller.rb
+++ b/app/controllers/manager/procedures_controller.rb
@@ -8,7 +8,7 @@ module Manager
     # this will be used to set the records shown on the `index` action.
     def scoped_resource
       if unfiltered_list?
-        # Don't display deleted dossiers in the unfiltered list…
+        # Don't display discarded demarches in the unfiltered list…
         Procedure.kept
       else
         # … but allow them to be searched and displayed.
@@ -22,10 +22,13 @@ module Manager
       redirect_to manager_procedure_path(procedure)
     end
 
-    def hide
-      procedure.hide!
-      flash[:notice] = "La démarche a bien été supprimée, en cas d'erreur contactez un développeur."
-      redirect_to manager_procedures_path
+    def discard
+      procedure.discard_and_keep_track!(current_administration)
+
+      logger.info("La démarche #{procedure.id} est supprimée par #{current_administration.email}")
+      flash[:notice] = "La démarche #{procedure.id} a été supprimée."
+
+      redirect_to manager_procedure_path(procedure)
     end
 
     def add_administrateur
@@ -51,7 +54,7 @@ module Manager
     private
 
     def procedure
-      Procedure.find(params[:id])
+      @procedure ||= Procedure.with_discarded.find(params[:id])
     end
 
     def type_de_champ

--- a/app/jobs/discarded_procedures_deletion_job.rb
+++ b/app/jobs/discarded_procedures_deletion_job.rb
@@ -1,0 +1,10 @@
+class DiscardedProceduresDeletionJob < CronJob
+  self.cron_expression = "0 7 * * *"
+
+  def perform(*args)
+    Procedure.discarded_expired.find_each do |procedure|
+      procedure.dossiers.with_discarded.destroy_all
+      procedure.destroy
+    end
+  end
+end

--- a/app/models/deleted_dossier.rb
+++ b/app/models/deleted_dossier.rb
@@ -20,4 +20,8 @@ class DeletedDossier < ApplicationRecord
       deleted_at: Time.zone.now
     )
   end
+
+  def procedure_removed?
+    reason == self.class.reasons.fetch(:procedure_removed)
+  end
 end

--- a/app/models/deleted_dossier.rb
+++ b/app/models/deleted_dossier.rb
@@ -1,5 +1,5 @@
 class DeletedDossier < ApplicationRecord
-  belongs_to :procedure
+  belongs_to :procedure, -> { with_discarded }, inverse_of: :deleted_dossiers
 
   validates :dossier_id, uniqueness: true
 

--- a/app/models/deleted_dossier.rb
+++ b/app/models/deleted_dossier.rb
@@ -4,10 +4,11 @@ class DeletedDossier < ApplicationRecord
   validates :dossier_id, uniqueness: true
 
   enum reason: {
-    user_request:    'user_request',
-    manager_request: 'manager_request',
-    user_removed:    'user_removed',
-    expired:         'expired'
+    user_request:      'user_request',
+    manager_request:   'manager_request',
+    user_removed:      'user_removed',
+    procedure_removed: 'procedure_removed',
+    expired:           'expired'
   }
 
   def self.create_from_dossier(dossier, reason)

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -212,9 +212,7 @@ class Dossier < ApplicationRecord
     with_discarded
       .discarded
       .state_en_construction
-      .joins(:procedure)
       .where('dossiers.hidden_at < ?', 1.month.ago)
-      .where(procedures: { hidden_at: nil })
   end
 
   scope :brouillon_near_procedure_closing_date, -> do

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -487,6 +487,19 @@ class Dossier < ApplicationRecord
     discard!
   end
 
+  def restore(author, only_discarded_with_procedure = false)
+    if discarded?
+      deleted_dossier = DeletedDossier.find_by(dossier_id: id)
+
+      if !only_discarded_with_procedure || deleted_dossier&.procedure_removed?
+        if undiscard && keep_track_on_deletion? && en_construction?
+          deleted_dossier&.destroy
+          log_dossier_operation(author, :restaurer, self)
+        end
+      end
+    end
+  end
+
   def after_passer_en_instruction(instructeur)
     instructeur.follow(self)
 

--- a/app/models/dossier_operation_log.rb
+++ b/app/models/dossier_operation_log.rb
@@ -8,6 +8,7 @@ class DossierOperationLog < ApplicationRecord
     refuser: 'refuser',
     classer_sans_suite: 'classer_sans_suite',
     supprimer: 'supprimer',
+    restaurer: 'restaurer',
     modifier_annotation: 'modifier_annotation',
     demander_un_avis: 'demander_un_avis'
   }

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -1,6 +1,6 @@
 class GroupeInstructeur < ApplicationRecord
   DEFAULT_LABEL = 'défaut'
-  belongs_to :procedure
+  belongs_to :procedure, -> { with_discarded }, inverse_of: :groupe_instructeurs
   has_many :assign_tos
   has_many :instructeurs, through: :assign_tos, dependent: :destroy
   has_many :dossiers

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -511,9 +511,16 @@ class Procedure < ApplicationRecord
     groupe_instructeurs.count > 1
   end
 
-  def hide!
+  def can_be_deleted_by_manager?
+    kept? && dossiers.state_instruction_commencee.empty?
+  end
+
+  def discard_and_keep_track!(author)
+    dossiers.each do |dossier|
+      dossier.discard_and_keep_track!(author, :procedure_removed)
+    end
+
     discard!
-    dossiers.discard_all
   end
 
   def flipper_id

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -53,6 +53,12 @@ class Procedure < ApplicationRecord
   scope :cloned_from_library,   -> { where(cloned_from_library: true) }
   scope :declarative,           -> { where.not(declarative_with_state: nil) }
 
+  scope :discarded_expired, -> do
+    with_discarded
+      .discarded
+      .where('hidden_at < ?', 1.month.ago)
+  end
+
   scope :for_api, -> {
     includes(
       :administrateurs,

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -523,6 +523,14 @@ class Procedure < ApplicationRecord
     discard!
   end
 
+  def restore(author)
+    if discarded? && undiscard
+      dossiers.with_discarded.discarded.find_each do |dossier|
+        dossier.restore(author, true)
+      end
+    end
+  end
+
   def flipper_id
     "Procedure;#{id}"
   end

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -517,11 +517,21 @@ class Procedure < ApplicationRecord
     groupe_instructeurs.count > 1
   end
 
+  def can_be_deleted_by_administrateur?
+    brouillon? || dossiers.state_instruction_commencee.empty?
+  end
+
   def can_be_deleted_by_manager?
-    kept? && dossiers.state_instruction_commencee.empty?
+    kept? && can_be_deleted_by_administrateur?
   end
 
   def discard_and_keep_track!(author)
+    if brouillon?
+      reset!
+    elsif publiee?
+      close!
+    end
+
     dossiers.each do |dossier|
       dossier.discard_and_keep_track!(author, :procedure_removed)
     end

--- a/app/views/admin/procedures/_list.html.haml
+++ b/app/views/admin/procedures/_list.html.haml
@@ -25,7 +25,7 @@
           %td= link_to(try_format_datetime(procedure.created_at), admin_procedure_href)
         %td
           = link_to('Cloner', admin_procedure_clone_path(procedure.id), data: { method: :put }, class: 'btn-sm btn-primary clone-btn')
-          - if !procedure.locked?
+          - if !procedure.can_be_deleted_by_administrateur?
             = link_to('X', url_for(controller: 'admin/procedures', action: :destroy, id: procedure.id), data: { method: :delete, confirm: "Confirmez-vous la suppression de la démarche ? \n\n Attention : toute suppression est définitive et s’appliquera aux éventuels autres administrateurs de cette démarche !" }, class: 'btn-sm btn-danger')
 
   = smart_listing.paginate

--- a/app/views/manager/dossiers/show.html.erb
+++ b/app/views/manager/dossiers/show.html.erb
@@ -33,6 +33,8 @@ as well as a link to its edit page.
     <% end %>
     <% if dossier.can_be_deleted_by_manager? %>
       <%= link_to 'Supprimer le dossier', discard_manager_dossier_path(dossier), method: :post, class: 'button', data: { confirm: "Confirmez vous la suppression du dossier ?" } %>
+    <% elsif dossier.discarded? && !dossier.procedure.discarded? %>
+      <%= link_to 'Restaurer le dossier', restore_manager_dossier_path(dossier), method: :post, class: 'button', data: { confirm: "Confirmez vous la restauration du dossier ?" } %>
     <% end %>
   </div>
 </header>

--- a/app/views/manager/procedures/show.html.erb
+++ b/app/views/manager/procedures/show.html.erb
@@ -44,6 +44,8 @@ as well as a link to its edit page.
 
     <% if procedure.can_be_deleted_by_manager? %>
       <%= link_to 'Supprimer la démarche', discard_manager_procedure_path(procedure), method: :post, class: 'button', data: { confirm: "Confirmez-vous la suppression de la démarche ?" } %>
+    <% elsif procedure.discarded? %>
+      <%= link_to 'Restaurer la démarche', restore_manager_procedure_path(procedure), method: :post, class: 'button', data: { confirm: "Confirmez-vous la restauration de la démarche ?" } %>
     <% end %>
   <div>
 

--- a/app/views/manager/procedures/show.html.erb
+++ b/app/views/manager/procedures/show.html.erb
@@ -22,6 +22,9 @@ as well as a link to its edit page.
 <header class="main-content__header" role="banner">
   <h1 class="main-content__page-title">
     <%= content_for(:title) %>
+    <% if procedure.discarded? %>
+      (Supprimé)
+    <% end %>
   </h1>
 
   <div>
@@ -39,8 +42,8 @@ as well as a link to its edit page.
       <%= link_to 'whitelister', whitelist_manager_procedure_path(procedure), method: :post, class: 'button' %>
     <% end %>
 
-    <% if !procedure.discarded? %>
-      <%= link_to 'supprimer la démarche', hide_manager_procedure_path(procedure), method: :post, class: 'button', data: { confirm: "Confirmez-vous la suppression de la démarche ?" } %>
+    <% if procedure.can_be_deleted_by_manager? %>
+      <%= link_to 'Supprimer la démarche', discard_manager_procedure_path(procedure), method: :post, class: 'button', data: { confirm: "Confirmez-vous la suppression de la démarche ?" } %>
     <% end %>
   <div>
 

--- a/config/locales/models/deleted_dossier/fr.yml
+++ b/config/locales/models/deleted_dossier/fr.yml
@@ -6,6 +6,6 @@ fr:
           user_request: Demande d’usager
           manager_request: Demande d’administration
           user_removed: Suppression d’un compte usager
+          procedure_removed: Suppression d’une démarche
           expired: Expiration
           unknown: Inconnue
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,12 +10,14 @@ Rails.application.routes.draw do
       post 'whitelist', on: :member
       post 'draft', on: :member
       post 'discard', on: :member
+      post 'restore', on: :member
       post 'add_administrateur', on: :member
       post 'change_piece_justificative_template', on: :member
     end
 
     resources :dossiers, only: [:index, :show] do
       post 'discard', on: :member
+      post 'restore', on: :member
       post 'repasser_en_instruction', on: :member
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     resources :procedures, only: [:index, :show] do
       post 'whitelist', on: :member
       post 'draft', on: :member
-      post 'hide', on: :member
+      post 'discard', on: :member
       post 'add_administrateur', on: :member
       post 'change_piece_justificative_template', on: :member
     end

--- a/spec/controllers/admin/procedures_controller_spec.rb
+++ b/spec/controllers/admin/procedures_controller_spec.rb
@@ -95,51 +95,65 @@ describe Admin::ProceduresController, type: :controller do
   end
 
   describe 'DELETE #destroy' do
-    let(:procedure_draft)     { create :procedure_with_dossiers, administrateur: admin, instructeurs: [admin.instructeur], published_at: nil, closed_at: nil }
-    let(:procedure_published) { create :procedure_with_dossiers, administrateur: admin, instructeurs: [admin.instructeur], aasm_state: :publiee, published_at: Time.zone.now, closed_at: nil }
-    let(:procedure_closed)    { create :procedure_with_dossiers, administrateur: admin, instructeurs: [admin.instructeur], aasm_state: :close, published_at: nil, closed_at: Time.zone.now }
+    let(:procedure_draft)     { create(:procedure, administrateurs: [admin]) }
+    let(:procedure_published) { create(:procedure, :published, administrateurs: [admin]) }
+    let(:procedure_closed)    { create(:procedure, :closed, administrateurs: [admin]) }
+    let(:procedure) { dossier.procedure }
 
-    subject { delete :destroy, params: { id: procedure.id } }
+    subject { delete :destroy, params: { id: procedure } }
 
-    context 'when the procedure is a draft' do
-      let!(:procedure) { procedure_draft }
+    context 'when the procedure is a brouillon' do
+      let(:dossier) { create(:dossier, :en_instruction, procedure: procedure_draft) }
 
-      it 'destroys the procedure' do
-        expect { subject }.to change { Procedure.count }.by(-1)
+      before { subject }
+
+      it 'discard the procedure' do
+        expect(procedure.reload.discarded?).to be_truthy
       end
 
       it 'deletes associated dossiers' do
-        subject
-        expect(Dossier.find_by(procedure_id: procedure.id)).to be_blank
+        expect(procedure.dossiers.with_discarded.count).to eq(0)
       end
 
       it 'redirects to the procedure drafts page' do
-        subject
         expect(response).to redirect_to admin_procedures_draft_path
         expect(flash[:notice]).to be_present
       end
     end
 
     context 'when procedure is published' do
-      let!(:procedure) { procedure_published }
+      let(:dossier) { create(:dossier, :en_instruction, procedure: procedure_published) }
 
-      it { expect { subject }.not_to change { Procedure.count } }
-      it { expect { subject }.not_to change { Dossier.count } }
-      it { expect(subject.status).to eq 401 }
+      before { subject }
+
+      it { expect(response.status).to eq 403 }
+
+      context 'when dossier is en_construction' do
+        let(:dossier) { create(:dossier, :en_construction, procedure: procedure_published) }
+
+        it { expect(procedure.reload.close?).to be_truthy }
+        it { expect(procedure.reload.discarded?).to be_truthy }
+        it { expect(dossier.reload.discarded?).to be_truthy }
+      end
     end
 
     context 'when procedure is closed' do
-      let!(:procedure) { procedure_closed }
+      let(:dossier) { create(:dossier, :en_instruction, procedure: procedure_closed) }
 
-      it { expect { subject }.not_to change { Procedure.count } }
-      it { expect { subject }.not_to change { Dossier.count } }
-      it { expect(subject.status).to eq 401 }
+      before { subject }
+
+      it { expect(response.status).to eq 403 }
+
+      context 'when dossier is en_construction' do
+        let(:dossier) { create(:dossier, :en_construction, procedure: procedure_published) }
+
+        it { expect(procedure.reload.discarded?).to be_truthy }
+        it { expect(dossier.reload.discarded?).to be_truthy }
+      end
     end
 
     context "when administrateur does not own the procedure" do
-      let(:procedure_not_owned) { create :procedure, administrateur: create(:administrateur), published_at: nil, closed_at: nil }
-
-      subject { delete :destroy, params: { id: procedure_not_owned.id } }
+      let(:dossier) { create(:dossier) }
 
       it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
     end

--- a/spec/controllers/manager/dossiers_controller_spec.rb
+++ b/spec/controllers/manager/dossiers_controller_spec.rb
@@ -1,23 +1,43 @@
 describe Manager::DossiersController, type: :controller do
+  let(:administration) { create :administration }
+  let(:deleted_dossier) { DeletedDossier.find_by(dossier_id: dossier) }
+  let(:operations) { dossier.dossier_operation_logs.map(&:operation).map(&:to_sym) }
+
+  before { sign_in administration }
+
   describe '#discard' do
-    let(:administration) { create :administration }
-    let(:dossier) { create(:dossier) }
+    let(:dossier) { create(:dossier, :en_construction) }
 
     before do
-      sign_in administration
       post :discard, params: { id: dossier.id }
       dossier.reload
     end
 
     it { expect(dossier.discarded?).to be_truthy }
+    it { expect(deleted_dossier).not_to be_nil }
+    it { expect(deleted_dossier.reason).to eq("manager_request") }
+    it { expect(operations).to eq([:supprimer]) }
+  end
+
+  describe '#restore' do
+    let(:dossier) { create(:dossier, :en_construction) }
+
+    before do
+      dossier.discard_and_keep_track!(administration, :manager_request)
+
+      post :restore, params: { id: dossier.id }
+      dossier.reload
+    end
+
+    it { expect(dossier.kept?).to be_truthy }
+    it { expect(deleted_dossier).to be_nil }
+    it { expect(operations).to eq([:supprimer, :restaurer]) }
   end
 
   describe '#repasser_en_instruction' do
-    let(:administration) { create :administration }
     let(:dossier) { create(:dossier, :accepte) }
 
     before do
-      sign_in administration
       post :repasser_en_instruction, params: { id: dossier.id }
       dossier.reload
     end

--- a/spec/controllers/manager/procedures_controller_spec.rb
+++ b/spec/controllers/manager/procedures_controller_spec.rb
@@ -1,7 +1,7 @@
 describe Manager::ProceduresController, type: :controller do
   describe '#whitelist' do
     let(:administration) { create :administration }
-    let!(:procedure) { create(:procedure) }
+    let(:procedure) { create(:procedure) }
 
     before do
       sign_in administration
@@ -16,7 +16,7 @@ describe Manager::ProceduresController, type: :controller do
     render_views
 
     let(:administration) { create(:administration) }
-    let!(:procedure) { create(:procedure, :with_repetition) }
+    let(:procedure) { create(:procedure, :with_repetition) }
 
     before do
       sign_in(administration)
@@ -24,6 +24,19 @@ describe Manager::ProceduresController, type: :controller do
     end
 
     it { expect(response.body).to include('sub type de champ') }
+  end
+
+  describe '#discard' do
+    let(:administration) { create :administration }
+    let(:procedure) { create(:procedure) }
+
+    before do
+      sign_in administration
+      post :discard, params: { id: procedure.id }
+      procedure.reload
+    end
+
+    it { expect(procedure.discarded?).to be_truthy }
   end
 
   describe '#index' do

--- a/spec/controllers/manager/procedures_controller_spec.rb
+++ b/spec/controllers/manager/procedures_controller_spec.rb
@@ -1,25 +1,25 @@
 describe Manager::ProceduresController, type: :controller do
+  let(:administration) { create :administration }
+
+  before { sign_in administration }
+
   describe '#whitelist' do
-    let(:administration) { create :administration }
     let(:procedure) { create(:procedure) }
 
     before do
-      sign_in administration
       post :whitelist, params: { id: procedure.id }
       procedure.reload
     end
 
-    it { expect(procedure.whitelisted_at).not_to be_nil }
+    it { expect(procedure.whitelisted?).to be_truthy }
   end
 
   describe '#show' do
     render_views
 
-    let(:administration) { create(:administration) }
     let(:procedure) { create(:procedure, :with_repetition) }
 
     before do
-      sign_in(administration)
       get :show, params: { id: procedure.id }
     end
 
@@ -27,27 +27,50 @@ describe Manager::ProceduresController, type: :controller do
   end
 
   describe '#discard' do
-    let(:administration) { create :administration }
-    let(:procedure) { create(:procedure) }
+    let(:dossier) { create(:dossier, :en_construction) }
+    let(:procedure) { dossier.procedure }
+    let(:deleted_dossier) { DeletedDossier.find_by(dossier_id: dossier.id) }
+    let(:operations) { dossier.dossier_operation_logs.map(&:operation).map(&:to_sym) }
 
     before do
-      sign_in administration
       post :discard, params: { id: procedure.id }
       procedure.reload
+      dossier.reload
     end
 
     it { expect(procedure.discarded?).to be_truthy }
+    it { expect(dossier.discarded?).to be_truthy }
+    it { expect(deleted_dossier).not_to be_nil }
+    it { expect(deleted_dossier.reason).to eq("procedure_removed") }
+    it { expect(operations).to eq([:supprimer]) }
+  end
+
+  describe '#restore' do
+    let(:dossier) { create(:dossier, :en_construction) }
+    let(:procedure) { dossier.procedure }
+    let(:deleted_dossier) { DeletedDossier.find_by(dossier_id: dossier.id) }
+    let(:operations) { dossier.dossier_operation_logs.map(&:operation).map(&:to_sym) }
+
+    before do
+      procedure.discard_and_keep_track!(administration)
+
+      post :restore, params: { id: procedure.id }
+      procedure.reload
+    end
+
+    it { expect(procedure.kept?).to be_truthy }
+    it { expect(dossier.kept?).to be_truthy }
+    it { expect(deleted_dossier).to be_nil }
+    it { expect(operations).to eq([:supprimer, :restaurer]) }
   end
 
   describe '#index' do
     render_views
 
-    let(:administration) { create(:administration) }
-    let!(:dossier) { create(:dossier) }
-
     context 'sort by dossiers' do
+      let!(:dossier) { create(:dossier) }
+
       before do
-        sign_in(administration)
         get :index, params: { procedure: { direction: 'asc', order: 'dossiers' } }
       end
 

--- a/spec/factories/deleted_dossier.rb
+++ b/spec/factories/deleted_dossier.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :deleted_dossier do
     dossier_id  { 1111 }
     state       { Dossier.states.fetch(:en_construction) }
+    reason      { DeletedDossier.reasons.fetch(:user_request) }
     deleted_at  { Time.zone.now }
 
     association :procedure, :published

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -194,11 +194,7 @@ FactoryBot.define do
     end
 
     trait :discarded do
-      after(:build) do |procedure, _evaluator|
-        procedure.path = generate(:published_path)
-        procedure.publish!
-        procedure.hide!
-      end
+      hidden_at { Time.zone.now }
     end
 
     trait :whitelisted do

--- a/spec/models/deleted_dossier_spec.rb
+++ b/spec/models/deleted_dossier_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe DeletedDossier do
+  let(:deleted_dossier) { create(:deleted_dossier) }
+
+  describe 'with discarded procedure' do
+    before do
+      deleted_dossier.procedure.discard!
+      deleted_dossier.reload
+    end
+
+    it { expect(deleted_dossier.procedure).not_to be_nil }
+  end
+end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1226,6 +1226,8 @@ describe Dossier do
   end
 
   describe 'discarded_brouillon_expired and discarded_en_construction_expired' do
+    let(:administration) { create(:administration) }
+
     before do
       create(:dossier)
       create(:dossier, :en_construction)
@@ -1236,8 +1238,8 @@ describe Dossier do
         create(:dossier).discard!
         create(:dossier, :en_construction).discard!
 
-        create(:dossier).procedure.hide!
-        create(:dossier, :en_construction).procedure.hide!
+        create(:dossier).procedure.discard_and_keep_track!(administration)
+        create(:dossier, :en_construction).procedure.discard_and_keep_track!(administration)
       end
       Timecop.travel(1.week.ago) do
         create(:dossier).discard!

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1250,4 +1250,14 @@ describe Dossier do
     it { expect(Dossier.discarded_brouillon_expired.count).to eq(2) }
     it { expect(Dossier.discarded_en_construction_expired.count).to eq(2) }
   end
+
+  describe "discarded procedure dossier should be able to access it's procedure" do
+    let(:dossier) { create(:dossier) }
+    let(:procedure) { dossier.reload.procedure }
+
+    before { dossier.procedure.discard! }
+
+    it { expect(procedure).not_to be_nil }
+    it { expect(procedure.discarded?).to be_truthy }
+  end
 end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1248,6 +1248,6 @@ describe Dossier do
     end
 
     it { expect(Dossier.discarded_brouillon_expired.count).to eq(2) }
-    it { expect(Dossier.discarded_en_construction_expired.count).to eq(1) }
+    it { expect(Dossier.discarded_en_construction_expired.count).to eq(2) }
   end
 end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -836,7 +836,8 @@ describe Procedure do
     end
   end
 
-  describe "#hide!" do
+  describe "#discard_and_keep_track!" do
+    let(:administration) { create(:administration) }
     let(:procedure) { create(:procedure) }
     let!(:dossier) { create(:dossier, procedure: procedure) }
     let!(:dossier2) { create(:dossier, procedure: procedure) }
@@ -845,10 +846,10 @@ describe Procedure do
     it { expect(Dossier.count).to eq(2) }
     it { expect(Dossier.all).to include(dossier, dossier2) }
 
-    context "when hidding procedure" do
+    context "when discarding procedure" do
       before do
         instructeur.followed_dossiers << dossier
-        procedure.hide!
+        procedure.discard_and_keep_track!(administration)
         instructeur.reload
       end
 


### PR DESCRIPTION
Cette PR durcie les contraintes sur la suppression des dossiers et démarches depuis le manager, mais en même temps elle rend la suppression des démarches plus cohérentes avec la suppression des dossiers et elle permet le undo des deux opérations pendent un mois.