### PR TITLE
Nettoyage des validations de PJ

### DIFF
--- a/app/models/champs/piece_justificative_champ.rb
+++ b/app/models/champs/piece_justificative_champ.rb
@@ -1,7 +1,8 @@
 class Champs::PieceJustificativeChamp < Champ
-  PIECE_JUSTIFICATIVE_FILE_MAX_SIZE = 200.megabytes
+  MAX_SIZE = 200.megabytes
 
-  PIECE_JUSTIFICATIVE_FILE_ACCEPTED_FORMATS = [
+  ACCEPTED_FORMATS = [
+    "text/plain",
     "application/pdf",
     "application/msword",
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -15,6 +16,13 @@ class Champs::PieceJustificativeChamp < Champ
     "image/png",
     "image/jpeg"
   ]
+
+  # TODO: once we're running on Rails 6, re-enable this validation.
+  # See https://github.com/betagouv/demarches-simplifiees.fr/issues/4926
+  #
+  # validates :piece_justificative_file,
+  #   content_type: ACCEPTED_FORMATS,
+  #   size: { less_than: MAX_SIZE }
 
   def main_value_name
     :piece_justificative_file

--- a/app/models/champs/piece_justificative_champ.rb
+++ b/app/models/champs/piece_justificative_champ.rb
@@ -28,28 +28,6 @@ class Champs::PieceJustificativeChamp < Champ
     mandatory? && !piece_justificative_file.attached?
   end
 
-  def piece_justificative_file_errors
-    errors = []
-
-    if piece_justificative_file.attached? && piece_justificative_file.previous_changes.present?
-      if piece_justificative_file.blob.byte_size > PIECE_JUSTIFICATIVE_FILE_MAX_SIZE
-        errors << "Le fichier #{piece_justificative_file.filename} est trop lourd, il doit faire au plus #{PIECE_JUSTIFICATIVE_FILE_MAX_SIZE.to_s(:human_size, precision: 2)}"
-      end
-
-      if !piece_justificative_file.blob.content_type.in?(PIECE_JUSTIFICATIVE_FILE_ACCEPTED_FORMATS)
-        errors << "Le fichier #{piece_justificative_file.filename} est dans un format que nous n'acceptons pas"
-      end
-
-      # FIXME: add Clamav check
-    end
-
-    if errors.present?
-      piece_justificative_file.purge_later
-    end
-
-    errors
-  end
-
   def for_api
     if piece_justificative_file.attached? && (piece_justificative_file.virus_scanner.safe? || piece_justificative_file.virus_scanner.pending?)
       piece_justificative_file.service_url

--- a/config/locales/active_storage_validations.fr.yml
+++ b/config/locales/active_storage_validations.fr.yml
@@ -1,0 +1,4 @@
+fr:
+  errors:
+    messages:
+      content_type_invalid: n’est pas d’un type accepté

--- a/config/locales/models/champs/fr.yml
+++ b/config/locales/models/champs/fr.yml
@@ -3,3 +3,4 @@ fr:
     attributes:
       champ:
         value: La valeur du champ
+        piece_justificative_file: La pièce justificative

--- a/spec/models/champs/piece_justificative_champ_spec.rb
+++ b/spec/models/champs/piece_justificative_champ_spec.rb
@@ -1,4 +1,19 @@
+require 'active_storage_validations/matchers'
+
 describe Champs::PieceJustificativeChamp do
+  include ActiveStorageValidations::Matchers
+
+  # TODO: once we're running on Rails 6, re-enable the PieceJustificativeChamp validator,
+  # and re-enable this spec.
+  #
+  # See https://github.com/betagouv/demarches-simplifiees.fr/issues/4926
+  describe "validations", pending: true do
+    subject(:champ_pj) { build(:champ_piece_justificative) }
+
+    it { is_expected.to validate_size_of(:piece_justificative_file).less_than(Champs::PieceJustificativeChamp::MAX_SIZE) }
+    it { is_expected.to validate_content_type_of(:piece_justificative_file).allowing(Champs::PieceJustificativeChamp::ACCEPTED_FORMATS) }
+  end
+
   describe '#for_api' do
     let(:champ_pj) { create(:champ_piece_justificative) }
     let(:metadata) { champ_pj.piece_justificative_file.blob.metadata }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -251,7 +251,7 @@ describe User, type: :model do
     context 'with a dossier in instruction' do
       let!(:dossier_en_instruction) { create(:dossier, :en_instruction, user: user) }
       it 'raises' do
-        expect { user.delete_and_keep_track_dossiers(administration) }.to raise_error
+        expect { user.delete_and_keep_track_dossiers(administration) }.to raise_error(RuntimeError)
       end
     end
 


### PR DESCRIPTION
Cette PR nettoie les validations de taille et de format sur les pièces justificatives d'un dossier.

Pour l'instant les validations ne sont pas ré-activées. C'est juste du nettoyage de code mort, et de la préparation des validateurs. Quand on sera passé à Rails 6, normalement on n'aura plus qu'à activer tout ça.

Cf. #4926