### PR TITLE
#4955 - ajout d'un bandeau d'informations coronavirus

### DIFF
--- a/app/views/layouts/_coronavirus_banner.html.haml
+++ b/app/views/layouts/_coronavirus_banner.html.haml
@@ -1,0 +1,8 @@
+#strike-banner.site-banner
+  .container
+    .site-banner-icon ⚠️
+    .site-banner-text
+      %strong
+        En raison de l’épidémie du coronavirus, les services fonctionnent en mode dégradé.
+      %br
+      Les délais de prise en charge des dossiers ou de réponses aux questions pourront être perturbés durant cette période.

--- a/app/views/layouts/_new_header.haml
+++ b/app/views/layouts/_new_header.haml
@@ -3,6 +3,14 @@
 - dossier = controller.try(:dossier_for_help)
 - procedure = controller.try(:procedure_for_help)
 
+-# only display the coronavirus to usagers (instructeurs know there are delays) when they are logged in, or on the public pages.
+- if user_signed_in?
+  - if dossier.present? && feature_enabled_for?(:coronavirus_banner, dossier.procedure)
+    = render partial: 'layouts/coronavirus_banner'
+- else
+  - if procedure.present? && feature_enabled_for?(:coronavirus_banner, procedure)
+    = render partial: 'layouts/coronavirus_banner'
+
 %header.new-header{ class: current_page?(root_path) ? nil : "new-header-with-border", role: 'banner' }
   .header-inner-content
 


### PR DESCRIPTION
J'ai repris la `strike-banner` et fait au plus efficace.
Si le besoin se pérénise d'afficher des infos sur une procédure je me dis qu'on pourra y passer plus de temps.

C'est dispo derrière un feature flag:
 - sur les pages non-loggués qui ont une procédure
 - sur les pages usagers pour les dossiers dont les procédures ont la fonctionnalité activée

![image](https://user-images.githubusercontent.com/1223316/77766877-846a5380-7040-11ea-83cd-030a669e7e4f.png)

![image](https://user-images.githubusercontent.com/1223316/77766137-88e23c80-703f-11ea-8b4f-4f3eb4473179.png)
