### PR TITLE
Fix attestation preview

### DIFF
--- a/app/views/admin/attestation_templates/show.pdf.prawn
+++ b/app/views/admin/attestation_templates/show.pdf.prawn
@@ -38,12 +38,12 @@ prawn_document(margin: [top_margin, right_margin, bottom_margin, left_margin], p
 
   pdf.bounding_box([0, pdf.cursor], width: body_width, height: body_height) do
     if logo.present?
-      logo_file = if logo.is_a?(ActiveStorage::Attached::One)
+      logo_content = if logo.is_a?(ActiveStorage::Attached::One)
         logo.download
       else
-        logo.read
+        logo.rewind && logo.read
       end
-      pdf.image StringIO.new(logo_file), fit: [max_logo_width , max_logo_height], position: :center
+      pdf.image StringIO.new(logo_content), fit: [max_logo_width , max_logo_height], position: :center
     end
 
     pdf.fill_color grey
@@ -57,12 +57,12 @@ prawn_document(margin: [top_margin, right_margin, bottom_margin, left_margin], p
 
     if signature.present?
       pdf.pad_top(40) do
-        signature_file = if signature.is_a?(ActiveStorage::Attached::One)
+        signature_content = if signature.is_a?(ActiveStorage::Attached::One)
           signature.download
         else
-          signature.read
+          signature.rewind && signature.read
         end
-        pdf.image StringIO.new(signature_file), fit: [max_signature_size , max_signature_size], position: :right
+        pdf.image StringIO.new(signature_content), fit: [max_signature_size , max_signature_size], position: :right
       end
     end
   end

--- a/spec/controllers/admin/attestation_templates_controller_spec.rb
+++ b/spec/controllers/admin/attestation_templates_controller_spec.rb
@@ -46,6 +46,14 @@ describe Admin::AttestationTemplatesController, type: :controller do
     context 'if an attestation template does not exist on the procedure' do
       let(:attestation_template) { nil }
 
+      context 'with images' do
+        let(:upload_params) { { title: 't', body: 'b', footer: 'f', logo: interlaced_logo } }
+
+        it { expect(assigns(:attestation)).to include({ title: 't', body: 'b', footer: 'f' }) }
+        it { expect(assigns(:attestation)[:logo]).to be_present }
+        it_behaves_like 'rendering a PDF successfully'
+      end
+
       context 'without images' do
         let(:upload_params) { { title: 't', body: 'b', footer: 'f' } }
 

--- a/spec/controllers/admin/attestation_templates_controller_spec.rb
+++ b/spec/controllers/admin/attestation_templates_controller_spec.rb
@@ -1,4 +1,5 @@
 include ActionDispatch::TestProcess
+
 describe Admin::AttestationTemplatesController, type: :controller do
   let!(:attestation_template) { create(:attestation_template) }
   let(:admin) { create(:administrateur) }
@@ -16,6 +17,14 @@ describe Admin::AttestationTemplatesController, type: :controller do
   end
 
   after { Timecop.return }
+
+  shared_examples 'rendering a PDF successfully' do
+    render_views
+    it 'renders a PDF' do
+      expect(subject.status).to eq(200)
+      expect(subject.content_type).to eq('application/pdf')
+    end
+  end
 
   describe 'POST #preview' do
     let(:upload_params) { { title: 't', body: 'b', footer: 'f' } }
@@ -36,31 +45,36 @@ describe Admin::AttestationTemplatesController, type: :controller do
 
     context 'if an attestation template does not exist on the procedure' do
       let(:attestation_template) { nil }
-      it { expect(subject.status).to eq(200) }
-      it { expect(assigns(:attestation)).to include(upload_params) }
+
+      context 'without images' do
+        let(:upload_params) { { title: 't', body: 'b', footer: 'f' } }
+
+        it { expect(assigns(:attestation)).to include(upload_params) }
+        it_behaves_like 'rendering a PDF successfully'
+      end
     end
 
     context 'if an attestation template exists on the procedure' do
       after { procedure.attestation_template.destroy }
 
-      context 'with logos' do
+      context 'with images' do
         let!(:attestation_template) do
           create(:attestation_template, logo: logo, signature: signature)
         end
 
-        it { expect(subject.status).to eq(200) }
         it { expect(assigns(:attestation)).to include(upload_params) }
         it { expect(assigns(:attestation)[:created_at]).to eq(Time.zone.now) }
         it { expect(assigns(:attestation)[:logo].download).to eq(logo2.read) }
         it { expect(assigns(:attestation)[:signature].download).to eq(signature2.read) }
+        it_behaves_like 'rendering a PDF successfully'
       end
 
-      context 'with empty logo' do
-        it { expect(subject.status).to eq(200) }
+      context 'without images' do
         it { expect(assigns(:attestation)).to include(upload_params) }
         it { expect(assigns(:attestation)[:created_at]).to eq(Time.zone.now) }
         it { expect(assigns(:attestation)[:logo]).to eq(nil) }
         it { expect(assigns(:attestation)[:signature]).to eq(nil) }
+        it_behaves_like 'rendering a PDF successfully'
       end
     end
   end


### PR DESCRIPTION
Turns out that assigning the params to the procedure calls `read` on the images files. Calling `read` moves the seek offset to the end of the file; which means that subsequent calls to `read` return an empty
string.

Fix the issue by calling `rewind` before attempting to `read` the file, to ensure the seek offset is at the beginning of the file.

Fix #4958