### PR TITLE
specs: remove unused wait-for-ajax helper

### DIFF
--- a/app/javascript/shared/utils.js
+++ b/app/javascript/shared/utils.js
@@ -62,7 +62,6 @@ export function ajax(options) {
 }
 
 export function getJSON(url, data, method = 'get') {
-  incrementActiveRequestsCount();
   data = method !== 'get' ? JSON.stringify(data) : data;
   return Promise.resolve(
     $.ajax({
@@ -72,7 +71,7 @@ export function getJSON(url, data, method = 'get') {
       contentType: 'application/json',
       dataType: 'json'
     })
-  ).finally(decrementActiveRequestsCount);
+  );
 }
 
 export function scrollTo(container, scrollTo) {
@@ -114,16 +113,4 @@ export function timeoutable(promise, timeoutDelay) {
     }, timeoutDelay);
   });
   return Promise.race([promise, timeoutPromise]);
-}
-
-const DATA_ACTIVE_REQUESTS_COUNT = 'data-active-requests-count';
-
-function incrementActiveRequestsCount() {
-  const count = document.body.getAttribute(DATA_ACTIVE_REQUESTS_COUNT) || '0';
-  document.body.setAttribute(DATA_ACTIVE_REQUESTS_COUNT, parseInt(count) + 1);
-}
-
-function decrementActiveRequestsCount() {
-  const count = document.body.getAttribute(DATA_ACTIVE_REQUESTS_COUNT) || '0';
-  document.body.setAttribute(DATA_ACTIVE_REQUESTS_COUNT, parseInt(count) - 1);
 }

--- a/spec/support/wait_for_ajax.rb
+++ b/spec/support/wait_for_ajax.rb
@@ -1,9 +1,0 @@
-module WaitForAjax
-  def wait_for_ajax
-    expect(page).to have_selector('body[data-active-requests-count="0"]')
-  end
-end
-
-RSpec.configure do |config|
-  config.include WaitForAjax, type: :feature
-end


### PR DESCRIPTION
This helper is:
- no longer used;
- buggy (not all requests increment it);
- discouraged (we should instead match an UI change that signals the end
of an ajax request).

Good riddance.