### PR TITLE
champs editor: fix bottom padding of the list

### DIFF
--- a/app/assets/stylesheets/new_design/procedure_champs_editor.scss
+++ b/app/assets/stylesheets/new_design/procedure_champs_editor.scss
@@ -123,7 +123,7 @@
 
 .champs-editor {
   .footer {
-    margin-bottom: 50px;
+    height: 50px;
   }
 
   .buttons {


### PR DESCRIPTION
Turns out Safari (and maybe IE) collapse the margins together. So we need to give the footer an explicite height.

Fix #3570