### PR TITLE
Improve identite required fields

### DIFF
--- a/app/views/users/dossiers/identite.html.haml
+++ b/app/views/users/dossiers/identite.html.haml
@@ -17,10 +17,10 @@
         = f.label :gender, class: "required"
       .radios
         %label
-          = f.radio_button :gender, Individual::GENDER_MALE
+          = f.radio_button :gender, Individual::GENDER_MALE, required: true
           = Individual::GENDER_MALE
         %label
-          = f.radio_button :gender, Individual::GENDER_FEMALE
+          = f.radio_button :gender, Individual::GENDER_FEMALE, required: true
           = Individual::GENDER_FEMALE
 
     .flex

--- a/app/views/users/dossiers/identite.html.haml
+++ b/app/views/users/dossiers/identite.html.haml
@@ -8,13 +8,9 @@
 
     %p.mb-1 Merci de remplir vos informations personnelles pour accéder à la démarche.
 
-    %span.form-label
-      %span.mandatory *
-      champs requis
-
     %fieldset
       %legend
-        = f.label :gender, class: "required"
+        = f.label :gender
       .radios
         %label
           = f.radio_button :gender, Individual::GENDER_MALE, required: true
@@ -25,14 +21,14 @@
 
     .flex
       .inline-champ
-        = f.label :prenom, class: "required"
+        = f.label :prenom
         = f.text_field :prenom, class: "small", required: true, autocomplete: 'given-name'
       .inline-champ
-        = f.label :nom, class: "required"
+        = f.label :nom
         = f.text_field :nom, class: "small", required: true, autocomplete: 'family-name'
 
     - if @dossier.procedure.ask_birthday?
-      = f.label :birthdate, class: "required"
+      = f.label :birthdate
       = f.date_field :birthdate, value: @dossier.individual.birthdate, placeholder: 'format : AAAA-MM-JJ', required: true, class: "small"
 
     = f.submit "Continuer", class: "button large primary expand"


### PR DESCRIPTION
Quand tous les champs d'un formulaire sont requis, la mention `Champs requis` est plus perturbante qu'autre chose. Ça rajoute juste du bruit visuel.

Avec cette PR :

- Les champs sont maintenant _réellement_ marqués comme `required="required"` dans le HTML ;
- Suppression des `*` disgracieux.

## Avant

<img width="562" alt="Capture d’écran 2020-03-31 à 16 30 46" src="https://user-images.githubusercontent.com/179923/78038425-20f86280-736d-11ea-9da0-fe3573015b3f.png">

## Après

<img width="567" alt="Capture d’écran 2020-03-31 à 16 30 15" src="https://user-images.githubusercontent.com/179923/78038439-25248000-736d-11ea-9017-8e8d5a6de100.png">
