### PR TITLE
credentials: add autocomplete attributes

### DIFF
--- a/app/views/users/dossiers/identite.html.haml
+++ b/app/views/users/dossiers/identite.html.haml
@@ -26,10 +26,10 @@
     .flex
       .inline-champ
         = f.label :prenom, class: "required"
-        = f.text_field :prenom, class: "small", required: true
+        = f.text_field :prenom, class: "small", required: true, autocomplete: 'given-name'
       .inline-champ
         = f.label :nom, class: "required"
-        = f.text_field :nom, class: "small", required: true
+        = f.text_field :nom, class: "small", required: true, autocomplete: 'family-name'
 
     - if @dossier.procedure.ask_birthday?
       = f.label :birthdate, class: "required"

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -6,7 +6,7 @@
     %h1 Créez-vous un compte demarches-simplifiees.fr
 
     = f.label :email, "Email"
-    = f.text_field :email, autofocus: true, placeholder: "Votre adresse email"
+    = f.text_field :email, type: :email, autocomplete: 'username', autofocus: true, placeholder: "Votre adresse email"
 
     .suspect-email.hidden
       .email-suggestion-title
@@ -20,7 +20,7 @@
           Non
 
     = f.label :password, "Mot de passe"
-    = f.password_field :password, value: @user.password, placeholder: "8 caractères minimum", 'aria-describedby':'8 caractères minimum'
+    = f.password_field :password, autocomplete: 'new-password', value: @user.password, placeholder: "8 caractères minimum", 'aria-describedby':'8 caractères minimum'
 
     = f.submit "Créer un compte", class: "button large primary expand"
 

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -6,10 +6,10 @@
     %h2.huge-title Connectez-vous
 
     = f.label :email, "Email"
-    = f.text_field :email, autofocus: true
+    = f.text_field :email, type: :email, autocomplete: 'username', autofocus: true
 
     = f.label :password, "Mot de passe"
-    = f.password_field :password
+    = f.password_field :password, autocomplete: 'current-password'
 
     .auth-options
       %div


### PR DESCRIPTION
Allow browsers to autofill more informations.

References:
- MDN: Autofill (https://developer.mozilla.org/fr/docs/Web/HTML/Attributs/autocomplete)
- Safari Password Autofill (https://developer.apple.com/documentation/security/password_autofill/enabling_password_autofill_on_an_html_input_element)