### PR TITLE
Use human readable expressions instead of cron gibberish

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'dotenv-rails', require: 'dotenv/rails-now' # dotenv should always be loaded
 gem 'flipper'
 gem 'flipper-active_record'
 gem 'flipper-ui'
+gem 'fugit'
 gem 'geocoder'
 gem 'gon'
 gem 'graphiql-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,6 +203,8 @@ GEM
       http_parser.rb (~> 0.6.0)
     erubi (1.9.0)
     erubis (2.7.0)
+    et-orbi (1.2.4)
+      tzinfo
     ethon (0.11.0)
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
@@ -235,6 +237,9 @@ GEM
       fog-json (>= 1.0)
       ipaddress (>= 0.8)
     formatador (0.2.5)
+    fugit (1.3.3)
+      et-orbi (~> 1.1, >= 1.1.8)
+      raabro (~> 1.1)
     geocoder (1.6.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -452,6 +457,7 @@ GEM
     puma (3.12.4)
     pundit (2.0.1)
       activesupport (>= 3.0.0)
+    raabro (1.1.6)
     rack (2.2.2)
     rack-attack (6.0.0)
       rack (>= 1.0, < 3)
@@ -746,6 +752,7 @@ DEPENDENCIES
   flipper
   flipper-active_record
   flipper-ui
+  fugit
   geocoder
   gon
   graphiql-rails

--- a/app/jobs/administrateur_activate_before_expiration_job.rb
+++ b/app/jobs/administrateur_activate_before_expiration_job.rb
@@ -1,5 +1,5 @@
 class AdministrateurActivateBeforeExpirationJob < CronJob
-  self.cron_expression = "0 8 * * *"
+  self.schedule_expression = "every day at 8 am"
 
   def perform(*args)
     Administrateur

--- a/app/jobs/auto_archive_procedure_job.rb
+++ b/app/jobs/auto_archive_procedure_job.rb
@@ -1,5 +1,5 @@
 class AutoArchiveProcedureJob < CronJob
-  self.cron_expression = "* * * * *"
+  self.schedule_expression = "every 1 minute"
 
   def perform(*args)
     Procedure.publiees.where("auto_archive_on <= ?", Time.zone.today).each do |procedure|

--- a/app/jobs/cron_job.rb
+++ b/app/jobs/cron_job.rb
@@ -1,6 +1,6 @@
 class CronJob < ApplicationJob
   queue_as :cron
-  class_attribute :cron_expression
+  class_attribute :schedule_expression
 
   class << self
     def schedule
@@ -10,6 +10,10 @@ class CronJob < ApplicationJob
 
     def remove
       delayed_job.destroy if scheduled?
+    end
+
+    def display_schedule
+      pp "#{name}: #{schedule_expression} cron(#{cron_expression})"
     end
 
     def scheduled?
@@ -24,6 +28,10 @@ class CronJob < ApplicationJob
       Delayed::Job
         .where('handler LIKE ?', "%job_class: #{name}%")
         .first
+    end
+
+    def cron_expression
+      Fugit.do_parse(schedule_expression, multi: :fail).to_cron_s
     end
   end
 end

--- a/app/jobs/declarative_procedures_job.rb
+++ b/app/jobs/declarative_procedures_job.rb
@@ -1,5 +1,5 @@
 class DeclarativeProceduresJob < CronJob
-  self.cron_expression = "* * * * *"
+  self.schedule_expression = "every 1 minute"
 
   def perform(*args)
     Procedure.declarative.find_each(&:process_dossiers!)

--- a/app/jobs/discarded_dossiers_deletion_job.rb
+++ b/app/jobs/discarded_dossiers_deletion_job.rb
@@ -1,5 +1,5 @@
 class DiscardedDossiersDeletionJob < CronJob
-  self.cron_expression = "0 7 * * *"
+  self.schedule_expression = "every day at 2 am"
 
   def perform(*args)
     Dossier.discarded_brouillon_expired.destroy_all

--- a/app/jobs/discarded_procedures_deletion_job.rb
+++ b/app/jobs/discarded_procedures_deletion_job.rb
@@ -1,5 +1,5 @@
 class DiscardedProceduresDeletionJob < CronJob
-  self.cron_expression = "0 7 * * *"
+  self.schedule_expression = "every day at 1 am"
 
   def perform(*args)
     Procedure.discarded_expired.find_each do |procedure|

--- a/app/jobs/expired_dossiers_deletion_job.rb
+++ b/app/jobs/expired_dossiers_deletion_job.rb
@@ -1,5 +1,5 @@
 class ExpiredDossiersDeletionJob < CronJob
-  self.cron_expression = "0 7 * * *"
+  self.schedule_expression = "every day at 7 am"
 
   def perform(*args)
     ExpiredDossiersDeletionService.process_expired_dossiers_brouillon

--- a/app/jobs/find_dubious_procedures_job.rb
+++ b/app/jobs/find_dubious_procedures_job.rb
@@ -1,5 +1,5 @@
 class FindDubiousProceduresJob < CronJob
-  self.cron_expression = "0 0 * * *"
+  self.schedule_expression = "every day at midnight"
 
   FORBIDDEN_KEYWORDS = [
     'NIR', 'NIRPP', 'race', 'religion',

--- a/app/jobs/instructeur_email_notification_job.rb
+++ b/app/jobs/instructeur_email_notification_job.rb
@@ -1,5 +1,5 @@
 class InstructeurEmailNotificationJob < CronJob
-  self.cron_expression = "0 10 * * MON-FRI"
+  self.schedule_expression = "from monday through friday at 10 am"
 
   def perform(*args)
     NotificationService.send_instructeur_email_notification

--- a/app/jobs/notify_draft_not_submitted_job.rb
+++ b/app/jobs/notify_draft_not_submitted_job.rb
@@ -1,5 +1,5 @@
 class NotifyDraftNotSubmittedJob < CronJob
-  self.cron_expression = "0 7 * * *"
+  self.schedule_expression = "from monday through friday at 7 am"
 
   def perform(*args)
     Dossier.notify_draft_not_submitted

--- a/app/jobs/operations_signature_job.rb
+++ b/app/jobs/operations_signature_job.rb
@@ -1,5 +1,5 @@
 class OperationsSignatureJob < CronJob
-  self.cron_expression = "0 6 * * *"
+  self.schedule_expression = "every day at 6 am"
 
   def perform(*args)
     last_midnight = Time.zone.today.beginning_of_day

--- a/app/jobs/purge_stale_exports_job.rb
+++ b/app/jobs/purge_stale_exports_job.rb
@@ -1,5 +1,5 @@
 class PurgeStaleExportsJob < CronJob
-  self.cron_expression = "*/5 * * * *"
+  self.schedule_expression = "every 5 minutes"
 
   def perform
     Export.stale.destroy_all

--- a/app/jobs/purge_unattached_blobs_job.rb
+++ b/app/jobs/purge_unattached_blobs_job.rb
@@ -1,5 +1,5 @@
 class PurgeUnattachedBlobsJob < CronJob
-  self.cron_expression = "0 0 * * *"
+  self.schedule_expression = "every day at midnight"
 
   def perform(*args)
     ActiveStorage::Blob.unattached

--- a/app/jobs/update_administrateur_usage_statistics_job.rb
+++ b/app/jobs/update_administrateur_usage_statistics_job.rb
@@ -1,5 +1,5 @@
 class UpdateAdministrateurUsageStatisticsJob < CronJob
-  self.cron_expression = "0 10 * * *"
+  self.schedule_expression = "every day at 10 am"
 
   def perform
     AdministrateurUsageStatisticsService.new.update_administrateurs

--- a/app/jobs/warn_expiring_dossiers_job.rb
+++ b/app/jobs/warn_expiring_dossiers_job.rb
@@ -1,5 +1,5 @@
 class WarnExpiringDossiersJob < CronJob
-  self.cron_expression = "0 0 1 * *"
+  self.schedule_expression = "every 1 month at midnight"
 
   def perform(*args)
     expiring, expired = Dossier

--- a/app/jobs/weekly_overview_job.rb
+++ b/app/jobs/weekly_overview_job.rb
@@ -1,5 +1,5 @@
 class WeeklyOverviewJob < CronJob
-  self.cron_expression = "0 7 * * MON"
+  self.schedule_expression = "every monday at 7 am"
 
   def perform(*args)
     # Feature flipped to avoid mails in staging due to unprocessed dossier

--- a/lib/tasks/jobs.rake
+++ b/lib/tasks/jobs.rake
@@ -5,4 +5,11 @@ namespace :jobs do
     Dir.glob(glob).each { |f| require f }
     CronJob.subclasses.each(&:schedule)
   end
+
+  desc 'Display schedule for all cron jobs'
+  task display_schedule: :environment do
+    glob = Rails.root.join('app', 'jobs', '**', '*_job.rb')
+    Dir.glob(glob).each { |f| require f }
+    CronJob.subclasses.each(&:display_schedule)
+  end
 end


### PR DESCRIPTION
https://github.com/floraison/fugit#fugitnat

Perso je trouve que les expressions cron c'est une aberration :) Mais je comprendrai si vous me dit que je suis le seul à penser ça. Donc n'hésitez pas à rejeter la PR.

Je trouve que c'est plutôt safe dans la mesure ou si vous écrivez un truc qui parse pas `fugit` crachera avec une erreur qui vous explique ce qui ne va pas dans votre expression.