### PR TITLE
Process expired dossiers en construction

### DIFF
--- a/lib/tasks/deployment/20200401123317_process_expired_dossiers_en_construction.rake
+++ b/lib/tasks/deployment/20200401123317_process_expired_dossiers_en_construction.rake
@@ -1,0 +1,25 @@
+namespace :after_party do
+  desc 'Deployment task: process_expired_dossiers_en_construction'
+  task process_expired_dossiers_en_construction: :environment do
+    puts "Running deploy task 'process_expired_dossiers_en_construction'"
+
+    dossiers_close_to_expiration = Dossier
+      .en_construction_close_to_expiration
+      .without_en_construction_expiration_notice_sent
+
+    ExpiredDossiersDeletionService.send_expiration_notices(dossiers_close_to_expiration)
+
+    BATCH_SIZE = 1000
+
+    ((dossiers_close_to_expiration.count / BATCH_SIZE).ceil + 1).times do |n|
+      dossiers_close_to_expiration
+        .offset(n * BATCH_SIZE)
+        .limit(BATCH_SIZE)
+        .update_all(en_construction_close_to_expiration_notice_sent_at: Time.zone.now + n.days)
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord.create version: '20200401123317'
+  end
+end

--- a/lib/tasks/deployment/20200401123317_process_expired_dossiers_en_construction.rake
+++ b/lib/tasks/deployment/20200401123317_process_expired_dossiers_en_construction.rake
@@ -3,19 +3,21 @@ namespace :after_party do
   task process_expired_dossiers_en_construction: :environment do
     puts "Running deploy task 'process_expired_dossiers_en_construction'"
 
-    dossiers_close_to_expiration = Dossier
-      .en_construction_close_to_expiration
-      .without_en_construction_expiration_notice_sent
+    if ENV['APP_NAME'] == 'tps'
+      dossiers_close_to_expiration = Dossier
+        .en_construction_close_to_expiration
+        .without_en_construction_expiration_notice_sent
 
-    ExpiredDossiersDeletionService.send_expiration_notices(dossiers_close_to_expiration)
+      ExpiredDossiersDeletionService.send_expiration_notices(dossiers_close_to_expiration)
 
-    BATCH_SIZE = 1000
+      BATCH_SIZE = 1000
 
-    ((dossiers_close_to_expiration.count / BATCH_SIZE).ceil + 1).times do |n|
-      dossiers_close_to_expiration
-        .offset(n * BATCH_SIZE)
-        .limit(BATCH_SIZE)
-        .update_all(en_construction_close_to_expiration_notice_sent_at: Time.zone.now + n.days)
+      ((dossiers_close_to_expiration.count / BATCH_SIZE).ceil + 1).times do |n|
+        dossiers_close_to_expiration
+          .offset(n * BATCH_SIZE)
+          .limit(BATCH_SIZE)
+          .update_all(en_construction_close_to_expiration_notice_sent_at: Time.zone.now + n.days)
+      end
     end
 
     # Update task as completed.  If you remove the line below, the task will


### PR DESCRIPTION
L'idée de cette tache est de faire la même chose que `ExpiredDossiersDeletionService.send_en_construction_expiration_notices` mais avec une répartition par batch/jour de la suppression pour éviter que dans un mois un jour la tache de suppression s'étouffe avec 10 000 dossiers