### PR TITLE
4966 envoyer notif lors commentaire

### DIFF
--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -254,7 +254,7 @@ module Instructeurs
     private
 
     def assign_to_params
-      params.require(:assign_to).permit(:daily_email_notifications_enabled, :weekly_email_notifications_enabled)
+      params.require(:assign_to).permit(:instant_email_message_notifications_enabled, :daily_email_notifications_enabled, :weekly_email_notifications_enabled)
     end
 
     def assign_exports

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -197,6 +197,9 @@ module Users
       @commentaire = CommentaireService.build(current_user, dossier, commentaire_params)
 
       if @commentaire.save
+        dossier.followers_instructeurs.each do |instructeur|
+          DossierMailer.notify_new_commentaire_to_instructeur(dossier, instructeur.email).deliver_later
+        end
         flash.notice = "Votre message a bien été envoyé à l’instructeur en charge de votre dossier."
         redirect_to messagerie_dossier_path(dossier)
       else

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -197,7 +197,9 @@ module Users
       @commentaire = CommentaireService.build(current_user, dossier, commentaire_params)
 
       if @commentaire.save
-        dossier.followers_instructeurs.each do |instructeur|
+        dossier.followers_instructeurs
+          .with_instant_email_message_notifications
+          .each do |instructeur|
           DossierMailer.notify_new_commentaire_to_instructeur(dossier, instructeur.email).deliver_later
         end
         flash.notice = "Votre message a bien été envoyé à l’instructeur en charge de votre dossier."

--- a/app/mailers/dossier_mailer.rb
+++ b/app/mailers/dossier_mailer.rb
@@ -29,6 +29,12 @@ class DossierMailer < ApplicationMailer
     end
   end
 
+  def notify_new_commentaire_to_instructeur(dossier, instructeur_email)
+    @dossier = dossier
+    @subject = default_i18n_subject(dossier_id: dossier.id, libelle_demarche: dossier.procedure.libelle)
+    mail(from: NO_REPLY_EMAIL, to: instructeur_email, subject: @subject)
+  end
+
   def notify_revert_to_instruction(dossier)
     @dossier = dossier
     @service = dossier.procedure.service

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -19,6 +19,10 @@ class Instructeur < ApplicationRecord
 
   has_one :user, dependent: :nullify
 
+  scope :with_instant_email_message_notifications, -> {
+    includes(:assign_to).where(assign_tos: { instant_email_message_notifications_enabled: true })
+  }
+
   default_scope { eager_load(:user) }
 
   def self.by_email(email)

--- a/app/views/dossier_mailer/notify_new_commentaire_to_instructeur.html.haml
+++ b/app/views/dossier_mailer/notify_new_commentaire_to_instructeur.html.haml
@@ -1,0 +1,10 @@
+- content_for(:title, "#{@subject}")
+
+%p
+  Bonjour,
+
+%p
+  = t('.body', dossier_id: @dossier.id, libelle_demarche: @dossier.procedure.libelle)
+%p= link_to("Messagerie du dossier n°#{@dossier.id}", messagerie_instructeur_dossier_url(procedure_id: @dossier.procedure.id, dossier_id: @dossier.id))
+
+= render partial: "layouts/mailers/signature"

--- a/app/views/instructeurs/procedures/email_notifications.html.haml
+++ b/app/views/instructeurs/procedures/email_notifications.html.haml
@@ -11,21 +11,37 @@
     .explication
       Configurez sur cette page les notifications que vous souhaitez recevoir par email pour cette démarche.
 
-    = form.label :email_notification, "Recevoir une notification quotidienne"
+    = form.label :email_notification, "Recevoir une notification à chaque message déposé"
 
     %p.notice
-      Cet email vous signale le dépôt de nouveaux dossiers sur cette démarche, ou des changements sur vos dossiers suivis.
+      Cet email vous signale le dépôt d'un nouveau message sur vos dossiers suivis.
     %p.notice
-      Il est envoyé une fois par jour, du lundi au samedi, vers 10 h du matin.
+      il est envoyé à chaque fois qu'un usager dépose un message.
+
+    .radios
+      %label
+        = form.radio_button :instant_email_message_notifications_enabled, true
+        Oui
+
+      %label
+        = form.radio_button :instant_email_message_notifications_enabled, false
+        Non
+
+    = form.label :email_notification, "recevoir une notification quotidienne"
+
+    %p.notice
+      cet email vous signale le dépôt de nouveaux dossiers sur cette démarche, ou des changements sur vos dossiers suivis.
+    %p.notice
+      il est envoyé une fois par jour, du lundi au samedi, vers 10 h du matin.
 
     .radios
       %label
         = form.radio_button :daily_email_notifications_enabled, true
-        Oui
+        oui
 
       %label
         = form.radio_button :daily_email_notifications_enabled, false
-        Non
+        non
 
     = form.label :email_notification, "Recevoir un récapitulatif hebdomadaire"
     %p.notice

--- a/app/views/instructeurs/procedures/email_notifications.html.haml
+++ b/app/views/instructeurs/procedures/email_notifications.html.haml
@@ -16,7 +16,7 @@
     %p.notice
       Cet email vous signale le dépôt d'un nouveau message sur vos dossiers suivis.
     %p.notice
-      il est envoyé à chaque fois qu'un usager dépose un message.
+      Il est envoyé à chaque fois qu'un usager dépose un message.
 
     .radios
       %label
@@ -27,21 +27,21 @@
         = form.radio_button :instant_email_message_notifications_enabled, false
         Non
 
-    = form.label :email_notification, "recevoir une notification quotidienne"
+    = form.label :email_notification, "Recevoir une notification quotidienne"
 
     %p.notice
-      cet email vous signale le dépôt de nouveaux dossiers sur cette démarche, ou des changements sur vos dossiers suivis.
+      Cet email vous signale le dépôt de nouveaux dossiers sur cette démarche, ou des changements sur vos dossiers suivis.
     %p.notice
-      il est envoyé une fois par jour, du lundi au samedi, vers 10 h du matin.
+      Il est envoyé une fois par jour, du lundi au samedi, vers 10 h du matin.
 
     .radios
       %label
         = form.radio_button :daily_email_notifications_enabled, true
-        oui
+        Oui
 
       %label
         = form.radio_button :daily_email_notifications_enabled, false
-        non
+        Non
 
     = form.label :email_notification, "Recevoir un récapitulatif hebdomadaire"
     %p.notice

--- a/config/locales/views/dossier_mailer/notify_new_commentaire_to_instructeur/fr.yml
+++ b/config/locales/views/dossier_mailer/notify_new_commentaire_to_instructeur/fr.yml
@@ -1,0 +1,5 @@
+fr:
+  dossier_mailer:
+    notify_new_commentaire_to_instructeur:
+      subject: Nouveau commentaire déposé sur le dossier n°%{dossier_id}
+      body: Un nouveau commentaire a été déposé par l'usager sur le dossier n° %{dossier_id} de la démarche %{libelle_demarche}

--- a/db/migrate/20200401161821_add_instant_email_message_notifications_to_assign_tos.rb
+++ b/db/migrate/20200401161821_add_instant_email_message_notifications_to_assign_tos.rb
@@ -1,0 +1,5 @@
+class AddInstantEmailMessageNotificationsToAssignTos < ActiveRecord::Migration[5.2]
+  def change
+    add_column :assign_tos, :instant_email_message_notifications_enabled, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_19_103836) do
+ActiveRecord::Schema.define(version: 2020_04_07_135256) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -103,6 +103,7 @@ ActiveRecord::Schema.define(version: 2020_03_19_103836) do
     t.bigint "groupe_instructeur_id"
     t.boolean "weekly_email_notifications_enabled", default: true, null: false
     t.boolean "daily_email_notifications_enabled", default: false, null: false
+    t.boolean "instant_email_message_notifications_enabled", default: false, null: false
     t.index ["groupe_instructeur_id", "instructeur_id"], name: "unique_couple_groupe_instructeur_instructeur", unique: true
     t.index ["groupe_instructeur_id"], name: "index_assign_tos_on_groupe_instructeur_id"
     t.index ["instructeur_id", "procedure_id"], name: "index_assign_tos_on_instructeur_id_and_procedure_id", unique: true


### PR DESCRIPTION
closes #4966 

Lorsqu'un usager dépose un commentaire dans la messagerie de son dossier, cela envoie une notification par mail aux instructeurs suivant le dossier et souhaitant être prévenu immédiatement.

![notif](https://user-images.githubusercontent.com/1111966/78227245-443a2380-74cd-11ea-9e36-2277ccc9e172.png)
