### PR TITLE
Add default order to dossier.dossier_operation_logs

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -43,7 +43,7 @@ class Dossier < ApplicationRecord
   has_many :previous_followers_instructeurs, -> { distinct }, through: :previous_follows, source: :instructeur
   has_many :avis, inverse_of: :dossier, dependent: :destroy
 
-  has_many :dossier_operation_logs, dependent: :nullify
+  has_many :dossier_operation_logs, -> { order(:created_at) }, dependent: :nullify, inverse_of: :dossier
 
   belongs_to :groupe_instructeur
   has_one :procedure, through: :groupe_instructeur


### PR DESCRIPTION
La liste des opérations logs devrait être dans un ordre déterministe. Ça corrige aussi l'instabilité dans les tests.