### PR TITLE
ameliore la découvrabilité du fichier téléchargé

### DIFF
--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -207,7 +207,7 @@ module Instructeurs
           format.js do
             @procedure = procedure
             assign_exports
-            flash.notice = "L’export au format \"#{export_format}\" est prêt."
+            flash.notice = "L’export au format \"#{export_format}\" est prêt. Vous pouvez le <a href=\"#{export.file.service_url}\">télécharger</a>"
           end
 
           format.html do

--- a/app/views/instructeurs/procedures/download_export.js.erb
+++ b/app/views/instructeurs/procedures/download_export.js.erb
@@ -7,4 +7,4 @@
   <% end %>
 <% end %>
 
-<%= render_flash(timeout: 20000) %>
+<%= render_flash %>


### PR DESCRIPTION
Lorsqu'un instructeur demande de télécharger tous les dossiers, le fichier généré est accessible dans le message flash.

![flash](https://user-images.githubusercontent.com/1111966/78258851-1ae4bc00-74fc-11ea-9e4e-3aab436d4968.png)
