### PR TITLE
Fix piece justificative in repetitions

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,6 +49,15 @@ module ApplicationHelper
     end
   end
 
+  def render_champ(champ)
+    champ_selector = ".editable-champ[data-champ-id=\"#{champ.id}\"]"
+    form_html = render 'shared/dossiers/edit', dossier: champ.dossier, apercu: false
+    champ_html = Nokogiri::HTML.fragment(form_html).at_css(champ_selector).to_s
+    # rubocop:disable Rails/OutputSafety
+    raw("document.querySelector('#{champ_selector}').outerHTML = \"#{escape_javascript(champ_html)}\";")
+    # rubocop:enable Rails/OutputSafety
+  end
+
   def remove_element(selector, timeout: 0, inner: false)
     script = "(function() {";
     script << "var el = document.querySelector('#{selector}');"

--- a/app/helpers/champ_helper.rb
+++ b/app/helpers/champ_helper.rb
@@ -33,7 +33,7 @@ module ChampHelper
   end
 
   def auto_attach_url(form, object)
-    if feature_enabled?(:autoupload_dossier_attachments) && object.is_a?(Champ) && object.public?
+    if feature_enabled?(:autoupload_dossier_attachments) && object.is_a?(Champ) && object.persisted? && object.public?
       champs_piece_justificative_url(object.id)
     end
   end

--- a/app/helpers/champ_helper.rb
+++ b/app/helpers/champ_helper.rb
@@ -34,7 +34,7 @@ module ChampHelper
 
   def auto_attach_url(form, object)
     if feature_enabled?(:autoupload_dossier_attachments) && object.is_a?(Champ) && object.public?
-      champs_piece_justificative_url(form.index)
+      champs_piece_justificative_url(object.id)
     end
   end
 end

--- a/app/javascript/new_design/dossiers/auto-upload-controller.js
+++ b/app/javascript/new_design/dossiers/auto-upload-controller.js
@@ -70,7 +70,7 @@ export default class AutoUploadController {
     const attachmentRequest = {
       url: autoAttachUrl,
       type: 'PUT',
-      data: `champ_id=${champId}&blob_signed_id=${blobSignedId}`
+      data: `blob_signed_id=${blobSignedId}`
     };
     await ajax(attachmentRequest);
 

--- a/app/javascript/new_design/dossiers/auto-upload-controller.js
+++ b/app/javascript/new_design/dossiers/auto-upload-controller.js
@@ -23,18 +23,12 @@ export default class AutoUploadController {
         throw new Error('L’attribut "data-auto-attach-url" est manquant');
       }
 
-      const champ = this.input.closest('.editable-champ[data-champ-id]');
-      if (!champ) {
-        throw new Error('Impossible de trouver l’élément ".editable-champ"');
-      }
-      const champId = champ.dataset.champId;
-
       // Upload the file (using Direct Upload)
       let blobSignedId = await this._upload();
 
       // Attach the blob to the champ
       // (The request responds with Javascript, which displays the attachment HTML fragment).
-      await this._attach(champId, blobSignedId, autoAttachUrl);
+      await this._attach(blobSignedId, autoAttachUrl);
 
       // Everything good: clear the original file input value
       this.input.value = null;
@@ -60,10 +54,14 @@ export default class AutoUploadController {
     return await uploader.start();
   }
 
-  async _attach(champId, blobSignedId, autoAttachUrl) {
+  async _attach(blobSignedId, autoAttachUrl) {
     // Now that the upload is done, display a new progress bar
     // to show that the attachment request is still pending.
-    const progressBar = new ProgressBar(this.input, champId, this.file);
+    const progressBar = new ProgressBar(
+      this.input,
+      `${this.input.id}-progress-bar`,
+      this.file
+    );
     progressBar.progress(100);
     progressBar.end();
 

--- a/app/views/champs/piece_justificative/show.js.erb
+++ b/app/views/champs/piece_justificative/show.js.erb
@@ -1,15 +1,4 @@
-<% dossier = @champ.dossier %>
-
-<%= fields_for dossier do |form| %>
-  <%= form.fields_for :champs, dossier.champs.where(id: @champ.id), include_id: false do |champ_form| %>
-    <% render_to_element(".editable-champ[data-champ-id=\"#{@champ.id}\"]",
-      partial: 'shared/dossiers/editable_champs/editable_champ',
-      locals: {
-        champ: @champ,
-        form: champ_form
-      }) %>
-  <% end %>
-<% end %>
+<%= render_champ(@champ) %>
 
 <% attachment = @champ.piece_justificative_file.attachment %>
 <% if attachment.virus_scanner.pending? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,7 +121,7 @@ Rails.application.routes.draw do
     get ':position/dossier_link', to: 'dossier_link#show', as: :dossier_link
     post ':position/carte', to: 'carte#show', as: :carte
     post ':position/repetition', to: 'repetition#show', as: :repetition
-    put ':position/piece_justificative', to: 'piece_justificative#update', as: :piece_justificative
+    put 'piece_justificative/:champ_id', to: 'piece_justificative#update', as: :piece_justificative
   end
 
   get 'attachments/:id', to: 'attachments#show', as: :attachment


### PR DESCRIPTION
Correction de l'envoi automatique des pièces justificatives pour les champs dans des blocs répétables.

On a un problème intéressant : comment, depuis du Javascript, re-rendre un champ arbitraire du formulaire. Sachant que ce champ peut être à la racine du document, dans un bloc répétable, que la position du champ dans le formulaire est importante…

Avant cette PR on essayait de reproduire la structure du formulaire – mais honnêtement c'était foireux.

Maintenant, on demande à Rails de faire un `render` de tout le formulaire dans une chaîne de caractères – et on extrait ensuite le fragment HTML du champ concerné.

Comme ça on garantit que le rendu du champ sera exactement comme si on avait re-rendu tout le formulaire 🙌 

## Bonus

Ça devrait permettre plus tard de simplifier le code qui ajoute un bloc répétable à un formulaire. Au lieu de construire minutieusement le HTML du nouveau bloc, en faisant en sorte qu'il respecte les conventions de nommage des formulaires de Rails, on pourra juste render le form, et extraire le nouveau bloc répétable. Basta.

See #4989