### PR TITLE
forbid to create champ with same type_de_champ and same row

### DIFF
--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -21,6 +21,8 @@ class Champ < ApplicationRecord
 
   before_create :set_dossier_id, if: :needs_dossier_id?
 
+  validates :type_de_champ_id, uniqueness: { scope: [:dossier_id, :row] }
+
   def public?
     !private?
   end

--- a/spec/models/champ_spec.rb
+++ b/spec/models/champ_spec.rb
@@ -3,6 +3,16 @@ describe Champ do
 
   it_should_behave_like "champ_spec"
 
+  describe "validations" do
+    let(:row) { 1 }
+    let(:champ) { create(:champ, type_de_champ: create(:type_de_champ), row: row) }
+    let(:champ2) { build(:champ, type_de_champ: champ.type_de_champ, row: champ.row, dossier: champ.dossier) }
+
+    it "returns false when champ with same type_de_champ and row already exist" do
+      expect(champ2).not_to be_valid
+    end
+  end
+
   describe '#public?' do
     let(:type_de_champ) { build(:type_de_champ) }
     let(:champ) { type_de_champ.champ.build }

--- a/spec/models/procedure_presentation_spec.rb
+++ b/spec/models/procedure_presentation_spec.rb
@@ -500,8 +500,8 @@ describe ProcedurePresentation do
       let(:type_de_champ) { procedure.types_de_champ.first }
 
       before do
-        type_de_champ.champ.create(dossier: kept_dossier, value: 'keep me')
-        type_de_champ.champ.create(dossier: discarded_dossier, value: 'discard me')
+        kept_dossier.champs.find_by(type_de_champ: type_de_champ).update(value: 'keep me')
+        discarded_dossier.champs.find_by(type_de_champ: type_de_champ).update(value: 'discard me')
       end
 
       it { is_expected.to contain_exactly(kept_dossier.id) }
@@ -517,7 +517,7 @@ describe ProcedurePresentation do
         let(:other_kept_dossier) { create(:dossier, procedure: procedure) }
 
         before do
-          type_de_champ.champ.create(dossier: other_kept_dossier, value: 'and me too')
+          other_kept_dossier.champs.find_by(type_de_champ: type_de_champ).update(value: 'and me too')
         end
 
         it 'returns every dossier that matches any of the search criteria for a given column' do
@@ -534,8 +534,8 @@ describe ProcedurePresentation do
       let(:type_de_champ_private) { procedure.types_de_champ_private.first }
 
       before do
-        type_de_champ_private.champ.create(dossier: kept_dossier, value: 'keep me')
-        type_de_champ_private.champ.create(dossier: discarded_dossier, value: 'discard me')
+        kept_dossier.champs_private.find_by(type_de_champ: type_de_champ_private).update(value: 'keep me')
+        discarded_dossier.champs_private.find_by(type_de_champ: type_de_champ_private).update(value: 'discard me')
       end
 
       it { is_expected.to contain_exactly(kept_dossier.id) }
@@ -551,7 +551,7 @@ describe ProcedurePresentation do
         let(:other_kept_dossier) { create(:dossier, procedure: procedure) }
 
         before do
-          type_de_champ_private.champ.create(dossier: other_kept_dossier, value: 'and me too')
+          other_kept_dossier.champs_private.find_by(type_de_champ: type_de_champ_private).update(value: 'and me too')
         end
 
         it 'returns every dossier that matches any of the search criteria for a given column' do


### PR DESCRIPTION
close #4997 

_work in progress_

Nous avons constaté avec @tchak plusieurs champs avec un même type_de_champ sur la même row.
Cette PR empêche de créer de tels champs.