### PR TITLE
#2191 - Permettre aux usagers de rechercher dans le contenu de leurs dossiers

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -219,13 +219,13 @@ module Users
     end
 
     def recherche
-      @dossier_id = params[:q]
-      dossier = current_user.dossiers.find_by(id: @dossier_id)
+      @search_terms = params[:q]
+      @dossiers = DossierSearchService.matching_dossiers_for_user(@search_terms, current_user)
 
-      if dossier
-        redirect_to url_for_dossier(dossier)
+      if @dossiers.present?
+        redirect_to url_for_dossier(@dossiers.first)
       else
-        flash.alert = "Vous n’avez pas de dossier avec le nº #{@dossier_id}."
+        flash.alert = "Vous n’avez pas de dossier contenant «#{@search_terms}»."
         redirect_to dossiers_path
       end
     end

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -220,12 +220,20 @@ module Users
 
     def recherche
       @search_terms = params[:q]
-      @dossiers = DossierSearchService.matching_dossiers_for_user(@search_terms, current_user)
+      return redirect_to dossiers_path if @search_terms.blank?
+
+      @dossiers = DossierSearchService.matching_dossiers_for_user(@search_terms, current_user).page(page)
 
       if @dossiers.present?
-        redirect_to url_for_dossier(@dossiers.first)
+        # we need the page condition when accessing page n with n>1 when the page has only 1 result
+        # in order to avoid an unpleasant redirection when changing page
+        if @dossiers.count == 1 && page == 1
+          redirect_to url_for_dossier(@dossiers.first)
+        else
+          render :index
+        end
       else
-        flash.alert = "Vous n’avez pas de dossier contenant «#{@search_terms}»."
+        flash.alert = "Vous n’avez pas de dossiers contenant « #{@search_terms} »."
         redirect_to dossiers_path
       end
     end

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -219,7 +219,7 @@ module Users
     end
 
     def recherche
-      @dossier_id = params[:dossier_id]
+      @dossier_id = params[:q]
       dossier = current_user.dossiers.find_by(id: @dossier_id)
 
       if dossier

--- a/app/services/dossier_search_service.rb
+++ b/app/services/dossier_search_service.rb
@@ -4,6 +4,11 @@ class DossierSearchService
       .presence || dossier_by_full_text_for_instructeur(search_terms, instructeur)
   end
 
+  def self.matching_dossiers_for_user(search_terms, user)
+    dossier_by_exact_id_for_user(search_terms, user)
+      .presence || dossier_by_full_text_for_user(search_terms, user.dossiers) || dossier_by_full_text_for_user(search_terms, user.dossiers_invites)
+  end
+
   private
 
   def self.dossier_by_exact_id_for_instructeur(search_terms, instructeur)
@@ -24,6 +29,24 @@ class DossierSearchService
     true
   rescue ActiveModel::RangeError
     false
+  end
+
+  def self.dossier_by_full_text_for_user(search_terms, dossiers)
+    ts_vector = "to_tsvector('french', search_terms)"
+    ts_query = "to_tsquery('french', #{Dossier.connection.quote(to_tsquery(search_terms))})"
+
+    dossiers
+      .where("#{ts_vector} @@ #{ts_query}")
+      .order("COALESCE(ts_rank(#{ts_vector}, #{ts_query}), 0) DESC")
+  end
+
+  def self.dossier_by_exact_id_for_user(search_terms, user)
+    id = search_terms.to_i
+    if id != 0 && id_compatible?(id) # Sometimes user is searching dossiers with a big number (ex: SIRET), ActiveRecord can't deal with them and throws ActiveModel::RangeError. id_compatible? prevents this.
+      Dossier.where(id: user.dossiers.where(id: id) + user.dossiers_invites.where(id: id)).distinct
+    else
+      Dossier.none
+    end
   end
 
   def self.dossier_by_full_text_for_instructeur(search_terms, instructeur)

--- a/app/views/layouts/_new_header.haml
+++ b/app/views/layouts/_new_header.haml
@@ -45,21 +45,11 @@
     %ul.header-right-content
       - if nav_bar_profile == :instructeur && instructeur_signed_in?
         %li
-          .header-search{ role: 'search' }
-            = form_tag instructeur_recherche_path, method: :get, class: "form" do
-              = label_tag :dossier_id, "Numéro de dossier", class: 'hidden'
-              = text_field_tag "q", "#{@search_terms if @search_terms.present?}", placeholder: "Rechercher un dossier"
-              %button{ title: "Rechercher" }
-                = image_tag "icons/search-blue.svg", alt: 'Rechercher', 'aria-hidden':'true'
+          = render partial: 'layouts/search_dossiers_form', locals: { search_endpoint: instructeur_recherche_path }
 
       - if nav_bar_profile == :user && user_signed_in? && current_user.dossiers.count > 2
         %li
-          .header-search{ role: 'search' }
-            = form_tag recherche_dossiers_path, method: :get, class: "form" do
-              = label_tag :dossier_id, "Numéro de dossier", class: 'hidden'
-              = text_field_tag "q", "#{@search_terms if @search_terms.present?}", placeholder: "Rechercher un dossier"
-              %button{ title: "Rechercher" }
-                = image_tag "icons/search-blue.svg", alt: 'Rechercher', 'aria-hidden':'true'
+          = render partial: 'layouts/search_dossiers_form', locals: { search_endpoint: recherche_dossiers_path }
 
       - if instructeur_signed_in? || user_signed_in?
         %li

--- a/app/views/layouts/_new_header.haml
+++ b/app/views/layouts/_new_header.haml
@@ -47,16 +47,17 @@
         %li
           .header-search{ role: 'search' }
             = form_tag instructeur_recherche_path, method: :get, class: "form" do
+              = label_tag :dossier_id, "Numéro de dossier", class: 'hidden'
               = text_field_tag "q", "#{@search_terms if @search_terms.present?}", placeholder: "Rechercher un dossier"
               %button{ title: "Rechercher" }
-                = image_tag "icons/search-blue.svg", alt: ''
+                = image_tag "icons/search-blue.svg", alt: 'Rechercher', 'aria-hidden':'true'
 
       - if nav_bar_profile == :user && user_signed_in? && current_user.dossiers.count > 2
         %li
           .header-search{ role: 'search' }
-            = form_tag recherche_dossiers_path, method: :post, class: "form" do
+            = form_tag recherche_dossiers_path, method: :get, class: "form" do
               = label_tag :dossier_id, "Numéro de dossier", class: 'hidden'
-              = text_field_tag :dossier_id, "", placeholder: "Numéro de dossier"
+              = text_field_tag "q", "#{@search_terms if @search_terms.present?}", placeholder: "Rechercher un dossier"
               %button{ title: "Rechercher" }
                 = image_tag "icons/search-blue.svg", alt: 'Rechercher', 'aria-hidden':'true'
 

--- a/app/views/layouts/_search_dossiers_form.html.haml
+++ b/app/views/layouts/_search_dossiers_form.html.haml
@@ -1,0 +1,6 @@
+.header-search{ role: 'search' }
+  = form_tag "#{search_endpoint}", method: :get, class: "form" do
+    = label_tag :q, "Numéro de dossier", class: 'hidden'
+    = text_field_tag "q", "#{@search_terms if @search_terms.present?}", placeholder: "Rechercher un dossier"
+    %button{ title: "Rechercher" }
+      = image_tag "icons/search-blue.svg", alt: 'Rechercher', 'aria-hidden':'true'

--- a/app/views/users/dossiers/index.html.haml
+++ b/app/views/users/dossiers/index.html.haml
@@ -1,11 +1,16 @@
-- content_for(:title, "Dossiers")
+- if @search_terms.present?
+  - content_for(:title, "Recherche : #{@search_terms}")
+- else
+  - content_for(:title, "Dossiers")
 
 - content_for :footer do
   = render partial: "users/dossiers/index_footer"
 
 .dossiers-headers.sub-header
   .container
-    - if @dossiers_invites.count == 0
+    - if @search_terms.present?
+      %h1.page-title Résultat de la recherche pour « #{@search_terms} »
+    - elsif @dossiers_invites.count == 0
       %h1.page-title Mes dossiers
 
     - else

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -275,7 +275,7 @@ Rails.application.routes.draw do
       end
 
       collection do
-        post 'recherche'
+        get 'recherche'
       end
     end
     resource :feedback, only: [:create]

--- a/spec/features/users/list_dossiers_spec.rb
+++ b/spec/features/users/list_dossiers_spec.rb
@@ -85,13 +85,13 @@ describe 'user access to the list of their dossiers' do
   describe "recherche" do
     context "when the dossier does not exist" do
       before do
-        page.find_by_id('dossier_id').set(10000000)
+        page.find_by_id('q').set(10000000)
         click_button("Rechercher")
       end
 
       it "shows an error message on the dossiers page" do
         expect(current_path).to eq(dossiers_path)
-        expect(page).to have_content("Vous n’avez pas de dossier avec le nº 10000000.")
+        expect(page).to have_content("Vous n’avez pas de dossiers contenant « 10000000 ».")
       end
     end
 
@@ -99,19 +99,19 @@ describe 'user access to the list of their dossiers' do
       let!(:dossier_other_user) { create(:dossier) }
 
       before do
-        page.find_by_id('dossier_id').set(dossier_other_user.id)
+        page.find_by_id('q').set(dossier_other_user.id)
         click_button("Rechercher")
       end
 
       it "shows an error message on the dossiers page" do
         expect(current_path).to eq(dossiers_path)
-        expect(page).to have_content("Vous n’avez pas de dossier avec le nº #{dossier_other_user.id}.")
+        expect(page).to have_content("Vous n’avez pas de dossiers contenant « #{dossier_other_user.id} ».")
       end
     end
 
     context "when the dossier belongs to the user" do
       before do
-        page.find_by_id('dossier_id').set(dossier_en_construction.id)
+        page.find_by_id('q').set(dossier_en_construction.id)
         click_button("Rechercher")
       end
 

--- a/spec/services/dossier_search_service_spec.rb
+++ b/spec/services/dossier_search_service_spec.rb
@@ -95,4 +95,108 @@ describe DossierSearchService do
       it { expect(subject.size).to eq(1) }
     end
   end
+
+  describe '#matching_dossiers_for_user' do
+    subject { liste_dossiers }
+
+    let(:liste_dossiers) do
+      described_class.matching_dossiers_for_user(terms, user_1)
+    end
+
+    let(:user_1) { create(:user, email: 'bidou@clap.fr') }
+    let(:user_2) { create(:user) }
+
+    let(:procedure_1) { create(:procedure, :published) }
+    let(:procedure_2) { create(:procedure, :published) }
+
+    let!(:dossier_0) { create(:dossier, state: Dossier.states.fetch(:brouillon), procedure: procedure_1, user: user_1) }
+    let!(:dossier_0b) { create(:dossier, state: Dossier.states.fetch(:brouillon), procedure: procedure_1, user: user_2) }
+
+    let!(:etablissement_1) { create(:etablissement, entreprise_raison_sociale: 'OCTO Academy', siret: '41636169600051') }
+    let!(:dossier_1) { create(:dossier, state: Dossier.states.fetch(:en_construction), procedure: procedure_1, user: user_1, etablissement: etablissement_1) }
+
+    let!(:etablissement_2) { create(:etablissement, entreprise_raison_sociale: 'Plop octo', siret: '41816602300012') }
+    let!(:dossier_2) { create(:dossier, state: Dossier.states.fetch(:en_construction), procedure: procedure_1, user: user_1, etablissement: etablissement_2) }
+
+    let!(:etablissement_3) { create(:etablissement, entreprise_raison_sociale: 'OCTO Technology', siret: '41816609600051') }
+    let!(:dossier_3) { create(:dossier, state: Dossier.states.fetch(:en_construction), procedure: procedure_2, user: user_1, etablissement: etablissement_3) }
+
+    let!(:dossier_archived) { create(:dossier, state: Dossier.states.fetch(:en_construction), procedure: procedure_1, archived: true, user: user_1) }
+
+    describe 'search is empty' do
+      let(:terms) { '' }
+
+      it { expect(subject.size).to eq(0) }
+    end
+
+    describe 'search by dossier id' do
+      context 'when the user owns the dossier' do
+        let(:terms) { dossier_0.id.to_s }
+
+        it { expect(subject.size).to eq(1) }
+      end
+
+      context 'when the user does not own the dossier' do
+        let(:terms) { dossier_0b.id.to_s }
+
+        it { expect(subject.size).to eq(0) }
+      end
+    end
+
+    describe 'search brouillon file' do
+      let(:terms) { 'brouillon' }
+
+      it { expect(subject.size).to eq(0) }
+    end
+
+    describe 'search on contact email' do
+      let(:terms) { 'bidou@clap.fr' }
+
+      it { expect(subject.size).to eq(5) }
+    end
+
+    describe 'search on contact name' do
+      let(:terms) { 'bidou@clap.fr' }
+
+      it { expect(subject.size).to eq(5) }
+    end
+
+    describe 'search on SIRET' do
+      context 'when is part of SIRET' do
+        let(:terms) { '4181' }
+
+        it { expect(subject.size).to eq(2) }
+      end
+
+      context 'when is a complet SIRET' do
+        let(:terms) { '41816602300012' }
+
+        it { expect(subject.size).to eq(1) }
+      end
+    end
+
+    describe 'search on raison social' do
+      let(:terms) { 'OCTO' }
+
+      it { expect(subject.size).to eq(3) }
+    end
+
+    describe 'search terms surrounded with spurious spaces' do
+      let(:terms) { ' OCTO ' }
+
+      it { expect(subject.size).to eq(3) }
+    end
+
+    describe 'search on multiple fields' do
+      let(:terms) { 'octo plop' }
+
+      it { expect(subject.size).to eq(1) }
+    end
+
+    describe 'search with characters disallowed by the tsquery parser' do
+      let(:terms) { "'?\\:&!(OCTO) <plop>" }
+
+      it { expect(subject.size).to eq(1) }
+    end
+  end
 end


### PR DESCRIPTION
J'ai branché le travail fait pour la recherche instructeur avec l'écran de listing des dossiers usagers:
 - on est toujours redirigé sur le dossier si ça matche avec un id ou si on a un seul résultat
 - sinon on affiche la liste paginée des résultats

![recherche-usager](https://user-images.githubusercontent.com/1223316/78377614-1b4e8700-75d0-11ea-9e2f-42cf5929e32d.gif)

*Note*: Bahubali que je recherche au début, c'est un blockbuster indien en 2 parties avec des [scènes de ouf](https://www.youtube.com/watch?v=iToRAfA-V0s) dans un univers qu'on a pas coutume de voir. Faut se laisser porter car c'est souvent déroutant ou surprenant, mais je conseille !