### PR TITLE
helpers: ignore missing javascript elements

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,7 +27,7 @@ module ApplicationHelper
     method = outer ? 'outerHTML' : 'innerHTML'
     html = escape_javascript(render partial: partial, locals: locals)
     # rubocop:disable Rails/OutputSafety
-    raw("document.querySelector('#{selector}').#{method} = \"#{html}\";")
+    raw("document.querySelector('#{selector}') && document.querySelector('#{selector}').#{method} = \"#{html}\";")
     # rubocop:enable Rails/OutputSafety
   end
 


### PR DESCRIPTION
Turbolinks sucks, episode #32234. Consider a scenario where:

1. A page makes a remote JS request to Rails;
2. While the request is in-flight, the user navigates to another page;
3. The JS response arrives, and attempts to update a DOM element.

As the user navigated to another page, the response should never arrive, and the JS code it contains never be executed.

But no, because we're using Turbolinks! The whole page changed, but the JS response is still received and executed. And because the page change, our DOM element no longer exists, and the JS throws an error. Yikes!

This causes [many errors in Sentry](https://sentry.io/organizations/demarches-simplifiees/issues/1046448164/?project=1429547&query=is%3Aunresolved&statsPeriod=1h), which creates a lot of noise. And we can't really mute the Sentry issue: maybe there are legitimate problems here

There are several solutions to this:

## 1. Explicitely add a "ignore_errors" mode

```ruby
render_to_element('shared/attachment', ignore_errors: true)
```

- Pro: it is very explicit.
- Con: it is very verbose

## 2. Add an implicit "ignore_errors" mode

```ruby
render_to_element('shared/attachment') # errors are ignored by default
render_to_element('shared/attachment', ignore_errors: true) # will throw in case of error
```

- Pro: concise
- Con: not explicit

## 3. Ignore errors anyway

```ruby
render_to_element('shared/attachment') # errors are always ignored
```

- Pro: concise; also we can throw in development and not in production
- Con: not explicit

## 4. Screw it, disable Turbolinks

Turbolinks has been the source of countless javascript errors. Keeping
the same page alive while we navigate is **hard**, and we shouldn't do
it by default. Even browsers are faster at updating a whole new HTML
page than Turbolinks.

The only use of Turbolinks is not re-parsing the JS each time. This
should be fixed by making our JS payloads smaller, not with this shitty
mecanism.