### PR TITLE
javascript: ignore errors of attachments pooler

### DIFF
--- a/app/javascript/shared/remote-poller.js
+++ b/app/javascript/shared/remote-poller.js
@@ -67,7 +67,9 @@ class RemotePoller {
     let urls = this.urls;
     this.reset();
     for (let url of urls) {
-      ajax({ url, type: 'get' });
+      // Start the request. The JS payload in the response will update the page.
+      // (Errors are ignored, because background tasks shouldn't report errors to the user.)
+      ajax({ url, type: 'get' }).catch(() => {});
     }
   }
 


### PR DESCRIPTION
Pooling for attachment status is a background operation. Errors should not be reported to the user, who didn't even ask for this operation to take place.

This is why we ignore all errors from the Remote Pooler requests, whether Javascript exceptions or network errors.

Fix https://sentry.io/organizations/demarches-simplifiees/issues/1577350596/

