### PR TITLE
js: fix errors on browsers not supporting window.scroll options

### DIFF
--- a/app/views/users/feedbacks/create.js.erb
+++ b/app/views/users/feedbacks/create.js.erb
@@ -1,3 +1,7 @@
-window.scroll({ top: 0, left: 0, behavior: 'smooth' });
+try {
+  window.scroll({ top: 0, left: 0, behavior: 'smooth' });
+} catch {
+  window.scroll(0, 0);
+}
 <%= remove_element('#user-satisfaction') %>
 <%= render_flash %>


### PR DESCRIPTION
IE and Safari only know about `window.scroll(x, y)`, but not the variant with options.

Fix https://sentry.io/organizations/demarches-simplifiees/issues/1029697026