### PR TITLE
Fix 4876 copy groupe instructeurs in procedure clone

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -291,6 +291,7 @@ class Procedure < ApplicationRecord
     populate_champ_stable_ids
     procedure = self.deep_clone(include:
       {
+        groupe_instructeurs: :instructeurs,
         attestation_template: nil,
         types_de_champ: [:drop_down_list, types_de_champ: :drop_down_list],
         types_de_champ_private: [:drop_down_list, types_de_champ: :drop_down_list]
@@ -330,8 +331,6 @@ class Procedure < ApplicationRecord
     end
 
     procedure.save
-
-    admin.instructeur.assign_to_procedure(procedure)
 
     procedure
   end

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -289,13 +289,13 @@ class Procedure < ApplicationRecord
     is_different_admin = !admin.owns?(self)
 
     populate_champ_stable_ids
-    procedure = self.deep_clone(include:
-      {
-        groupe_instructeurs: :instructeurs,
-        attestation_template: nil,
-        types_de_champ: [:drop_down_list, types_de_champ: :drop_down_list],
-        types_de_champ_private: [:drop_down_list, types_de_champ: :drop_down_list]
-      }, &method(:clone_attachments))
+    include_list = {
+      attestation_template: nil,
+      types_de_champ: [:drop_down_list, types_de_champ: :drop_down_list],
+      types_de_champ_private: [:drop_down_list, types_de_champ: :drop_down_list]
+    }
+    include_list[:groupe_instructeurs] = :instructeurs if !is_different_admin
+    procedure = self.deep_clone(include: include_list, &method(:clone_attachments))
     procedure.path = SecureRandom.uuid
     procedure.aasm_state = :brouillon
     procedure.closed_at = nil

--- a/spec/features/admin/procedure_cloning_spec.rb
+++ b/spec/features/admin/procedure_cloning_spec.rb
@@ -6,7 +6,7 @@ feature 'As an administrateur I wanna clone a procedure', js: true do
   let(:administrateur) { create(:administrateur) }
 
   before do
-    create :procedure, :with_service,
+    create :procedure, :with_service, :with_instructeur,
       aasm_state: :publiee, published_at: Time.zone.now,
       administrateurs: [administrateur],
       libelle: 'libellé de la procédure',

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -500,6 +500,17 @@ describe Procedure do
       it 'should have one administrateur' do
         expect(subject.administrateurs).to eq([administrateur])
       end
+
+      it "should discard the existing groupe instructeurs" do
+        expect(subject.groupe_instructeurs.size).not_to eq(procedure.groupe_instructeurs.size)
+        expect(subject.groupe_instructeurs.where(label: "groupe_1").first).to be nil
+      end
+
+      it 'should have a default groupe instructeur' do
+        expect(subject.groupe_instructeurs.size).to eq(1)
+        expect(subject.groupe_instructeurs.first.label).to eq(GroupeInstructeur::DEFAULT_LABEL)
+        expect(subject.groupe_instructeurs.first.instructeurs.size).to eq(0)
+      end
     end
 
     it 'should duplicate existing mail_templates' do

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -384,6 +384,12 @@ describe Procedure do
     let(:from_library) { false }
     let(:administrateur) { procedure.administrateurs.first }
 
+    let!(:groupe_instructeur_1) { create(:groupe_instructeur, procedure: procedure, label: "groupe_1") }
+    let!(:instructeur_1) { create(:instructeur) }
+    let!(:instructeur_2) { create(:instructeur) }
+    let!(:assign_to_1) { create(:assign_to, procedure: procedure, groupe_instructeur: groupe_instructeur_1, instructeur: instructeur_1) }
+    let!(:assign_to_2) { create(:assign_to, procedure: procedure, groupe_instructeur: groupe_instructeur_1, instructeur: instructeur_2) }
+
     before do
       @logo = File.open('spec/fixtures/files/white.png')
       @signature = File.open('spec/fixtures/files/black.png')
@@ -400,7 +406,18 @@ describe Procedure do
     subject { @procedure }
 
     it { expect(subject.parent_procedure).to eq(procedure) }
-    it { expect(subject.defaut_groupe_instructeur.instructeurs.map(&:email)).to eq([administrateur.email]) }
+
+    describe "should keep groupe instructeurs " do
+      it "should clone groupe instructeurs" do
+        expect(subject.groupe_instructeurs.size).to eq(2)
+        expect(subject.groupe_instructeurs.size).to eq(procedure.groupe_instructeurs.size)
+        expect(subject.groupe_instructeurs.where(label: "groupe_1").first).not_to be nil
+      end
+
+      it "should clone instructeurs in the groupe" do
+        expect(subject.groupe_instructeurs.where(label: "groupe_1").first.instructeurs.map(&:email)).to eq(procedure.groupe_instructeurs.where(label: "groupe_1").first.instructeurs.map(&:email))
+      end
+    end
 
     it 'should duplicate specific objects with different id' do
       expect(subject.id).not_to eq(procedure.id)


### PR DESCRIPTION
Pour #4876: Variante de https://github.com/betagouv/demarches-simplifiees.fr/pull/4880 avec la modif évoquée: si on est pas admin, on ne clone pas les groupes instructeurs.

Par contre je me dis que si on est admin de la démarche, tant qu'on y est ca vaut le coup de garder les instructeurs.