### PR TITLE
mailers: in avis requests, replace the small CTA link by a large button

### DIFF
--- a/app/mailers/avis_mailer.rb
+++ b/app/mailers/avis_mailer.rb
@@ -1,5 +1,7 @@
 # Preview all emails at http://localhost:3000/rails/mailers/avis_mailer
 class AvisMailer < ApplicationMailer
+  helper MailerHelper
+
   layout 'mailers/layout'
 
   def avis_invitation(avis)

--- a/app/views/avis_mailer/avis_invitation.html.haml
+++ b/app/views/avis_mailer/avis_invitation.html.haml
@@ -25,9 +25,9 @@
 
 - if @avis.instructeur.present?
   %p
-    = link_to "Cliquez ici pour donner votre avis", avis_link
+    = round_button("Donner votre avis", avis_link, :primary)
 - else
   %p
-    = link_to "Inscrivez-vous pour donner votre avis", avis_link
+    = round_button("Inscrivez-vous pour donner votre avis", avis_link, :primary)
 
 = render partial: "layouts/mailers/signature"


### PR DESCRIPTION
Fix #3402

## Before
<img width="638" alt="Capture d’écran 2020-04-07 à 12 06 13" src="https://user-images.githubusercontent.com/179923/78656802-366b1080-78c8-11ea-9dd0-4ba74e19d2cc.png">


## After

<img width="636" alt="Capture d’écran 2020-04-07 à 12 05 45" src="https://user-images.githubusercontent.com/179923/78656815-39660100-78c8-11ea-8ccf-78d7d54e9dbf.png">
