### PR TITLE
Auto-upload: fixes to the "Retry" mechanics

### DIFF
--- a/app/javascript/new_design/dossiers/auto-upload-controller.js
+++ b/app/javascript/new_design/dossiers/auto-upload-controller.js
@@ -93,7 +93,18 @@ export default class AutoUploadController {
     this.input.disabled = false;
   }
 
+  _isError422(error) {
+    // Ajax errors have an xhr attribute
+    if (error && error.xhr && error.xhr.status == 422) return true;
+    // Rails DirectUpload errors are returned as a String, e.g. 'Error creating Blob for "Demain.txt". Status: 422'
+    if (error && error.toString().includes('422')) return true;
+
+    return false;
+  }
+
   _messageFromError(error) {
+    let allowRetry = !this._isError422(error);
+
     if (
       error.xhr &&
       error.xhr.status == 422 &&
@@ -104,13 +115,13 @@ export default class AutoUploadController {
       return {
         title: error.response.errors[0],
         description: '',
-        retry: false
+        retry: allowRetry
       };
     } else {
       return {
         title: 'Une erreur s’est produite pendant l’envoi du fichier.',
         description: error.message || error.toString(),
-        retry: true
+        retry: allowRetry
       };
     }
   }

--- a/app/javascript/new_design/dossiers/auto-upload.js
+++ b/app/javascript/new_design/dossiers/auto-upload.js
@@ -16,8 +16,8 @@ delegate('change', fileInputSelector, event => {
 });
 
 const retryButtonSelector = `button.attachment-error-retry`;
-delegate('click', retryButtonSelector, event => {
-  const inputSelector = event.target.dataset.inputTarget;
+delegate('click', retryButtonSelector, function() {
+  const inputSelector = this.dataset.inputTarget;
   const input = document.querySelector(inputSelector);
   startUpload(input);
 });

--- a/app/views/users/feedbacks/create.js.erb
+++ b/app/views/users/feedbacks/create.js.erb
@@ -1,6 +1,6 @@
 try {
   window.scroll({ top: 0, left: 0, behavior: 'smooth' });
-} catch {
+} catch(e) {
   window.scroll(0, 0);
 }
 <%= remove_element('#user-satisfaction') %>


### PR DESCRIPTION
## Overview

1. Fix an issue where clicking on the icon of the "Retry" button would fail.
2. When the creation of the blob fail because the token is invalid, don't suggest to retry (as it is unlikely to work).

## Details for 2.

When the authenticity token is invalid, the creation of the blob before the direct upload returns a 422.

In that case, the token will never become valid again, and it is useless to try again. Don’t show the "Retry" button in this case.

NB: of course the real fix is to understand why the authenticity token is so often invalid – but this will be for later.

<img width="510" alt="Capture d’écran 2020-04-08 à 12 44 50" src="https://user-images.githubusercontent.com/179923/78775681-e8710e00-7996-11ea-8e26-9f98644ca3d7.png">
_No more retry button in these cases_