### PR TITLE
Fix middle-click on "Delete attachment" button

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -8,7 +8,7 @@ class AttachmentsController < ApplicationController
 
     respond_to do |format|
       format.js
-      format.html { redirect_back(fallback_location: @attachment.record&.dossier || root_path) }
+      format.html { redirect_back(fallback_location: root_url) }
     end
   end
 

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -5,6 +5,11 @@ class AttachmentsController < ApplicationController
   def show
     @attachment = @blob.attachments.find(params[:id])
     @user_can_upload = params[:user_can_upload]
+
+    respond_to do |format|
+      format.js
+      format.html { redirect_back(fallback_location: @attachment.record&.dossier || root_path) }
+    end
   end
 
   def destroy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,8 +124,7 @@ Rails.application.routes.draw do
     put 'piece_justificative/:champ_id', to: 'piece_justificative#update', as: :piece_justificative
   end
 
-  get 'attachments/:id', to: 'attachments#show', as: :attachment
-  delete 'attachments/:id', to: 'attachments#destroy'
+  resources :attachments, only: [:show, :destroy]
 
   get "patron" => "root#patron"
   get "accessibilite" => "root#accessibilite"

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -1,5 +1,45 @@
 describe AttachmentsController, type: :controller do
   let(:user) { create(:user) }
+  let(:attachment) { champ.piece_justificative_file.attachment }
+  let(:dossier) { create(:dossier, user: user) }
+  let(:champ) { create(:champ_piece_justificative, dossier_id: dossier.id) }
+  let(:signed_id) { attachment.blob.signed_id }
+
+  describe '#show' do
+    render_views
+
+    let(:format) { :js }
+
+    subject do
+      get :show, params: { id: attachment.id, signed_id: signed_id }, format: format
+    end
+
+    context 'when authenticated' do
+      before { sign_in(user) }
+
+      context 'when requesting Javascript' do
+        let(:format) { :js }
+
+        it { is_expected.to have_http_status(200) }
+
+        it 'renders JS that replaces the attachment HTML' do
+          subject
+          expect(response.body).to have_text(".attachment-link[data-attachment-id=\"#{attachment.id}\"]")
+        end
+      end
+
+      context 'when the user opens the delete link in a new tab' do
+        let(:format) { :html }
+
+        it { is_expected.to have_http_status(302) }
+        it { is_expected.to redirect_to(dossier_path(dossier)) }
+      end
+    end
+
+    context 'when not authenticated' do
+      it { is_expected.to have_http_status(401) }
+    end
+  end
 
   describe '#destroy' do
     render_views
@@ -19,7 +59,7 @@ describe AttachmentsController, type: :controller do
       context 'and dossier is owned by user' do
         it { is_expected.to have_http_status(200) }
 
-        it do
+        it 'removes the attachment' do
           subject
           expect(champ.reload.piece_justificative_file.attached?).to be(false)
         end
@@ -30,7 +70,7 @@ describe AttachmentsController, type: :controller do
 
         it { is_expected.to have_http_status(404) }
 
-        it do
+        it 'doesn’t remove the attachment' do
           subject
           expect(champ.reload.piece_justificative_file.attached?).to be(true)
         end
@@ -40,7 +80,7 @@ describe AttachmentsController, type: :controller do
     context 'when not authenticated' do
       it { is_expected.to have_http_status(401) }
 
-      it do
+      it 'doesn’t remove the attachment' do
         subject
         expect(champ.reload.piece_justificative_file.attached?).to be(true)
       end

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -11,6 +11,7 @@ describe AttachmentsController, type: :controller do
     let(:format) { :js }
 
     subject do
+      request.headers['HTTP_REFERER'] = dossier_url(dossier)
       get :show, params: { id: attachment.id, signed_id: signed_id }, format: format
     end
 


### PR DESCRIPTION
C'est le retour de #5012, qui provoquait des erreurs sur les attachments liés à un autre modèle que des champs.

Maintenant le code ne fait plus le malin, et redirige juste vers le referer. Basta.