### PR TITLE
[GraphQL] allow to query dossiers by groupe instructeur

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -745,6 +745,69 @@ type GroupeInstructeur {
   id: ID!
   instructeurs: [Profile!]!
   label: String!
+
+  """
+  Le numero du groupe instructeur.
+  """
+  number: Int!
+}
+
+"""
+Un groupe instructeur avec ces dossiers
+"""
+type GroupeInstructeurWithDossiers {
+  """
+  Liste de tous les dossiers d'une démarche.
+  """
+  dossiers(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Dossiers déposés depuis la date.
+    """
+    createdSince: ISO8601DateTime
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    L'ordre des dossiers.
+    """
+    order: Order = ASC
+
+    """
+    Dossiers avec statut.
+    """
+    state: DossierState
+
+    """
+    Dossiers mis à jour depuis la date.
+    """
+    updatedSince: ISO8601DateTime
+  ): DossierConnection!
+  id: ID!
+  instructeurs: [Profile!]!
+  label: String!
+
+  """
+  Le numero du groupe instructeur.
+  """
+  number: Int!
 }
 
 """
@@ -975,6 +1038,16 @@ type Query {
     """
     number: Int!
   ): Dossier!
+
+  """
+  Informations sur un groupe instructeur.
+  """
+  groupeInstructeur(
+    """
+    Numéro du groupe instructeur.
+    """
+    number: Int!
+  ): GroupeInstructeurWithDossiers!
 }
 
 type RepetitionChamp implements Champ {

--- a/app/graphql/types/groupe_instructeur_type.rb
+++ b/app/graphql/types/groupe_instructeur_type.rb
@@ -3,6 +3,7 @@ module Types
     description "Un groupe instructeur"
 
     global_id_field :id
+    field :number, Int, "Le numero du groupe instructeur.", null: false, method: :id
     field :label, String, null: false
     field :instructeurs, [Types::ProfileType], null: false
 

--- a/app/graphql/types/groupe_instructeur_with_dossiers_type.rb
+++ b/app/graphql/types/groupe_instructeur_with_dossiers_type.rb
@@ -1,0 +1,32 @@
+module Types
+  class GroupeInstructeurWithDossiersType < GroupeInstructeurType
+    description "Un groupe instructeur avec ces dossiers"
+
+    field :dossiers, Types::DossierType.connection_type, "Liste de tous les dossiers d'une démarche.", null: false do
+      argument :order, Types::Order, default_value: :asc, required: false, description: "L'ordre des dossiers."
+      argument :created_since, GraphQL::Types::ISO8601DateTime, required: false, description: "Dossiers déposés depuis la date."
+      argument :updated_since, GraphQL::Types::ISO8601DateTime, required: false, description: "Dossiers mis à jour depuis la date."
+      argument :state, Types::DossierType::DossierState, required: false, description: "Dossiers avec statut."
+    end
+
+    def dossiers(updated_since: nil, created_since: nil, state: nil, order:)
+      dossiers = object.dossiers.state_not_brouillon.for_api_v2
+
+      if state.present?
+        dossiers = dossiers.where(state: state)
+      end
+
+      if updated_since.present?
+        dossiers = dossiers.updated_since(updated_since).order_by_updated_at(order)
+      else
+        if created_since.present?
+          dossiers = dossiers.created_since(created_since)
+        end
+
+        dossiers = dossiers.order_by_created_at(order)
+      end
+
+      dossiers
+    end
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -8,6 +8,10 @@ module Types
       argument :number, Int, "Numéro du dossier.", required: true
     end
 
+    field :groupe_instructeur, GroupeInstructeurWithDossiersType, null: false, description: "Informations sur un groupe instructeur." do
+      argument :number, Int, "Numéro du groupe instructeur.", required: true
+    end
+
     def demarche(number:)
       Procedure.for_api_v2.find(number)
     rescue => e
@@ -16,6 +20,12 @@ module Types
 
     def dossier(number:)
       Dossier.for_api_v2.find(number)
+    rescue => e
+      raise GraphQL::ExecutionError.new(e.message, extensions: { code: :not_found })
+    end
+
+    def groupe_instructeur(number:)
+      GroupeInstructeur.for_api_v2.find(number)
     rescue => e
       raise GraphQL::ExecutionError.new(e.message, extensions: { code: :not_found })
     end

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -12,4 +12,5 @@ class GroupeInstructeur < ApplicationRecord
   before_validation -> { label&.strip! }
 
   scope :without_group, -> (group) { where.not(id: group) }
+  scope :for_api_v2, -> { includes(procedure: [:administrateurs]) }
 end

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -201,6 +201,7 @@ describe API::V2::GraphqlController do
               }
               groupeInstructeur {
                 id
+                number
                 label
               }
               messages {
@@ -259,6 +260,7 @@ describe API::V2::GraphqlController do
             ],
             groupeInstructeur: {
               id: dossier.groupe_instructeur.to_typed_id,
+              number: dossier.groupe_instructeur.id,
               label: dossier.groupe_instructeur.label
             },
             demandeur: {
@@ -343,6 +345,36 @@ describe API::V2::GraphqlController do
             }
           })
         end
+      end
+    end
+
+    context "groupeInstructeur" do
+      let(:groupe_instructeur) { procedure.groupe_instructeurs.first }
+      let(:query) do
+        "{
+          groupeInstructeur(number: #{groupe_instructeur.id}) {
+            id
+            number
+            label
+            dossiers {
+              nodes {
+                id
+              }
+            }
+          }
+        }"
+      end
+
+      it "should be returned" do
+        expect(gql_errors).to eq(nil)
+        expect(gql_data).to eq(groupeInstructeur: {
+          id: groupe_instructeur.to_typed_id,
+          number: groupe_instructeur.id,
+          label: groupe_instructeur.label,
+          dossiers: {
+            nodes: dossiers.map { |dossier| { id: dossier.to_typed_id } }
+          }
+        })
       end
     end
 


### PR DESCRIPTION
Nous avons un cas d'usage d'API qui apparait un peu en urgence : récupérer les dossiers uniquement d'un groupe instructeur. Le workaround proposé actuellement est de récupérer tous les dossiers et de faire le trie coté intégration. Mais d'une part je trouve ce cas d'usage légitime et d'autre part l'implémenter réduira la charge sur notre API dans le cadre d'une démarche nationale à forte affluence (aide aux entreprises COVID 19). Le cas se pose, car différents groups instructeurs (Régions) sont gérés par différents prestataires.

* [x] depends on #5020
* [x] Tests

La nouvelle API est construite sur le même modele que `demarche(number)`