### PR TITLE
javascript: make DirectUpload errors return true error objects

### DIFF
--- a/app/javascript/shared/activestorage/uploader.js
+++ b/app/javascript/shared/activestorage/uploader.js
@@ -15,10 +15,10 @@ export default class Uploader {
     this.progressBar.start();
 
     return new Promise((resolve, reject) => {
-      this.directUpload.create((error, attributes) => {
-        if (error) {
-          this.progressBar.error(error);
-          reject(error);
+      this.directUpload.create((errorMsg, attributes) => {
+        if (errorMsg) {
+          this.progressBar.error(errorMsg);
+          reject(new Error(errorMsg));
         } else {
           resolve(attributes.signed_id);
         }


### PR DESCRIPTION
DirectUpload errors are string (instead of error objects).

But Sentry works better if we have true errors, which include the stacktrace.

Convert the error string to an error object before propagating it.