### PR TITLE
Nom du demandeur dans liste des dossiers usagers

### DIFF
--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -1,4 +1,6 @@
 module DossierHelper
+  include EtablissementHelper
+
   def button_or_label_class(dossier)
     if dossier.accepte?
       'accepted'
@@ -99,6 +101,18 @@ module DossierHelper
     end
 
     content_tag(:span, status_text, class: "label #{status_class} ")
+  end
+
+  def demandeur_dossier(dossier)
+    if dossier.procedure.for_individual?
+      "#{dossier&.individual&.nom} #{dossier&.individual&.prenom}"
+    else
+      if dossier.etablissement.present?
+        raison_sociale_or_name(dossier.etablissement)
+      else
+        ""
+      end
+    end
   end
 
   private

--- a/app/views/users/dossiers/index.html.haml
+++ b/app/views/users/dossiers/index.html.haml
@@ -32,6 +32,8 @@
           %th.notification-col
           %th.number-col Nº dossier
           %th Démarche
+          - if @dossiers.count > 1
+            %th Demandeur
           %th.status-col Statut
           %th.updated-at-col Mis à jour
           %th
@@ -47,6 +49,9 @@
             %td
               = link_to(url_for_dossier(dossier), class: 'cell-link') do
                 = procedure_libelle(dossier.procedure)
+            - if @dossiers.count > 1
+              %td.number-col
+                = demandeur_dossier(dossier)
             %td.status-col
               = link_to(url_for_dossier(dossier), class: 'cell-link') do
                 = status_badge(dossier.state)

--- a/spec/helpers/dossier_helper_spec.rb
+++ b/spec/helpers/dossier_helper_spec.rb
@@ -38,6 +38,40 @@ RSpec.describe DossierHelper, type: :helper do
     end
   end
 
+  describe ".demandeur_dossier" do
+    subject { demandeur_dossier(dossier) }
+
+    let(:individual) { create(:individual) }
+    let(:etablissement) { create(:etablissement) }
+    let(:dossier) { create(:dossier, procedure: procedure, individual: individual, etablissement: etablissement) }
+
+    context "when the dossier is for an individual" do
+      let(:procedure) { create(:simple_procedure, :for_individual) }
+
+      context "when the individual is not provided" do
+        let(:individual) { nil }
+        it { is_expected.to be_blank }
+      end
+
+      context "when the individual has name information" do
+        it { is_expected.to eq "#{individual.nom} #{individual.prenom}" }
+      end
+    end
+
+    context "when the dossier is for a company" do
+      let(:procedure) { create(:procedure, for_individual: false) }
+
+      context "when the company is not provided" do
+        let(:etablissement) { nil }
+        it { is_expected.to be_blank }
+      end
+
+      context "when the company has name information" do
+        it { is_expected.to eq raison_sociale_or_name(etablissement) }
+      end
+    end
+  end
+
   describe ".dossier_submission_is_closed?" do
     let(:dossier) { create(:dossier, state: state) }
     let(:state) { Dossier.states.fetch(:brouillon) }


### PR DESCRIPTION
Toujours pour https://github.com/betagouv/demarches-simplifiees.fr/issues/2191
Avoir le nom du demandeur pour ceux qui déposent plusieurs dossiers

## 1 dossier

![1dossier](https://user-images.githubusercontent.com/1223316/78893745-212ee700-7a6c-11ea-9127-685aa2b4a24c.png)

## 2 dossiers

![2 dossiers et plus](https://user-images.githubusercontent.com/1223316/78893742-20965080-7a6c-11ea-92f4-6fd629d35224.png)

## Moult dossiers

![nom-demandeur-plusieurs-dossiers](https://user-images.githubusercontent.com/1223316/78893822-44599680-7a6c-11ea-8754-134cda026608.png)

## ça marche aussi pour les entreprises

![image](https://user-images.githubusercontent.com/1223316/78894125-d2358180-7a6c-11ea-9dbb-717fdf621d5e.png)


