### PR TITLE
javascript: remove unused jQuery.active bookkeeping

### DIFF
--- a/app/javascript/shared/rails-ujs-fix.js
+++ b/app/javascript/shared/rails-ujs-fix.js
@@ -1,20 +1,5 @@
 import Rails from '@rails/ujs';
 import jQuery from 'jquery';
-import { delegate } from '@utils';
-
-// We use `jQuery.active` in our capybara suit to wait for ajax requests.
-// Newer jQuery-less version of rails-ujs is breaking it.
-// We have to set `ajax:complete` listener on the same element as the one
-// we catch ajax:send on as by the end of the request
-// the old element may be removed from DOM.
-delegate('ajax:send', '[data-remote]', ({ target }) => {
-  let callback = () => {
-    jQuery.active--;
-    target.removeEventListener('ajax:complete', callback);
-  };
-  target.addEventListener('ajax:complete', callback);
-  jQuery.active++;
-});
 
 // `smart_listing` gem is overriding `$.rails.href` method. When using newer
 // jQuery-less version of rails-ujs it breaks.


### PR DESCRIPTION
We no longer use `jQuery.active` in the Capybara suite.