### PR TITLE
Manager: Suppression des administrateurs avec des procédures archivées

### DIFF
--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -81,13 +81,14 @@ class Administrateur < ApplicationRecord
       fail "Impossible de supprimer cet administrateur car il a des démarches où il est le seul administrateur"
     end
 
-    procedures.each do |procedure|
+    procedures.with_discarded.each do |procedure|
       next_administrateur = procedure.administrateurs.where.not(id: self.id).first
       procedure.service.update(administrateur: next_administrateur)
     end
 
     services.each do |service|
-      service.destroy unless service.procedures.any?
+      # We can't destroy a service if it has procedures, even if those procedures are archived
+      service.destroy unless service.procedures.with_discarded.any?
     end
 
     destroy

--- a/spec/models/administrateur_spec.rb
+++ b/spec/models/administrateur_spec.rb
@@ -65,6 +65,15 @@ describe Administrateur, type: :model do
       expect(Service.find_by(id: service_without_procedure.id)).to be_nil
       expect(Administrateur.find_by(id: administrateur.id)).to be_nil
     end
+
+    it "does not delete service if associated to an archived procedure" do
+      service.update(administrateur: administrateur)
+      procedure.discard!
+      administrateur.delete_and_transfer_services
+
+      expect(Service.find_by(id: procedure.service.id)).not_to be_nil
+      expect(Administrateur.find_by(id: administrateur.id)).to be_nil
+    end
   end
 
   # describe '#password_complexity' do


### PR DESCRIPTION
Quand on supprime un administrateur dont les démarches sont archivées, il faut réaffecter ses procédures archivées sinon… la suppression plante.

Corrige https://sentry.io/organizations/demarches-simplifiees/issues/1606183757/
