### PR TITLE
javascript: report upload FileReader errors to Sentry

### DIFF
--- a/app/javascript/new_design/dossiers/auto-uploads-controllers.js
+++ b/app/javascript/new_design/dossiers/auto-uploads-controllers.js
@@ -1,6 +1,12 @@
 import Rails from '@rails/ujs';
 import AutoUploadController from './auto-upload-controller.js';
+import { fire } from '@utils';
 import { FAILURE_CONNECTIVITY } from '../../shared/activestorage/file-upload-error';
+
+//
+// DEBUG
+//
+const originalImpl = FileReader.prototype.addEventListener;
 
 // Manage multiple concurrent uploads.
 //
@@ -36,6 +42,25 @@ export default class AutoUploadsControllers {
         .querySelectorAll('button[type=submit]')
         .forEach(submitButton => Rails.disableElement(submitButton));
     }
+
+    //
+    // DEBUG: hook into FileReader onload event
+    //
+    if (FileReader.prototype.addEventListener === originalImpl) {
+      FileReader.prototype.addEventListener = function() {
+        // When DirectUploads attempts to add an event listener for "error",
+        // also insert a custom event listener of our that will report errors to Sentry.
+        if (arguments[0] == 'error') {
+          let handler = event => {
+            let message = `FileReader ${event.target.error.name}: ${event.target.error.message}`;
+            fire(document, 'sentry:capture-exception', new Error(message));
+          };
+          originalImpl.apply(this, ['error', handler]);
+        }
+        // Add the originally requested event listener
+        return originalImpl.apply(this, arguments);
+      };
+    }
   }
 
   _decrementInFlightUploads(form) {
@@ -47,6 +72,13 @@ export default class AutoUploadsControllers {
       form
         .querySelectorAll('button[type=submit]')
         .forEach(submitButton => Rails.enableElement(submitButton));
+    }
+
+    //
+    // DEBUG: remove the FileReader hook we set before.
+    //
+    if (this.inFlightUploadsCount == 0) {
+      FileReader.prototype.addEventListener = originalImpl;
     }
   }
 }


### PR DESCRIPTION
Cette PR est une tentative de mieux comprendre une des autres erreurs qui se produisent fréquemment lors de l'upload de fichier: les messages "Error reading file".

Apparemment ça indique que le FileReader n'arrive pas à lire le fichier en local – mais on n'a pas la raison de l'erreur :/

### Message de commit avec les détails

We have quite a lot of `Error reading file` errors when uploading files.
These errors are generated by ActiveStorage `file_checksum.js` component
but it eats the actual reason of errors.

(See https://github.com/rails/rails/blob/5-2-stable/activestorage/app/javascript/activestorage/file_checksum.js#L38)

We can't really override the class to generate better errors, as they
are deeply nested in ActiveStorage class hierarchy, and not exported to
external code.

Instead, we hook into the FileReader event handler, to insert a logger
when this error occur. The original event handler will also still be
called as usual.

---

@tchak tu en penses quoi ? Trop sale, ou on tente ?