### PR TITLE
fix to_tsquery disallowed chars

### DIFF
--- a/app/services/dossier_search_service.rb
+++ b/app/services/dossier_search_service.rb
@@ -62,8 +62,8 @@ class DossierSearchService
 
   def self.to_tsquery(search_terms)
     (search_terms || "")
-      .strip
       .gsub(/['?\\:&|!<>\(\)]/, "") # drop disallowed characters
+      .strip
       .split(/\s+/)           # split words
       .map { |x| "#{x}:*" }   # enable prefix matching
       .join(" & ")

--- a/spec/services/dossier_search_service_spec.rb
+++ b/spec/services/dossier_search_service_spec.rb
@@ -198,5 +198,11 @@ describe DossierSearchService do
 
       it { expect(subject.size).to eq(1) }
     end
+
+    describe 'search with a single forbidden character should not crash postgres' do
+      let(:terms) { '? OCTO' }
+
+      it { expect(subject.size).to eq(3) }
+    end
   end
 end


### PR DESCRIPTION
Actuellement on fait le `strip` trop tot, ce qui, dans le cas de test que j'ai ajouté, fait planter la requête SQL en créant une chaine [ts_query](https://www.postgresql.org/docs/current/textsearch-controls.html#TEXTSEARCH-PARSING-QUERIES) invalide.