### PR TITLE
config: fix (again) the CSP when running a LiveReload server locally

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -17,6 +17,6 @@ Rails.application.config.content_security_policy do |policy|
     # pour détecter les erreurs lors de l'ajout d'une nouvelle brique externe durant le développement
     policy.report_uri "http://#{ENV['APP_HOST']}/csp/"
     # En développement, quand bin/webpack-dev-server est utilisé, on autorise les requêtes faites par le live-reload
-    policy.connect_src(*policy.connect_src, "ws://localhost:3035", "localhost:3035")
+    policy.connect_src(*policy.connect_src, "ws://localhost:3035", "http://localhost:3035")
   end
 end


### PR DESCRIPTION
When running the app locally using `bin/webpack-dev-server` (the external
(and fast) assets server), LiveReload is used. We need to explicitely
allow the LiveReload connections in the CSP policy.

Turns out we now need to specify the protocol explicitely to get rid of the CSP warning in the console.