### PR TITLE
champ: return the parent dossier even when discarded

### DIFF
--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -1,5 +1,5 @@
 class Champ < ApplicationRecord
-  belongs_to :dossier, inverse_of: :champs, touch: true
+  belongs_to :dossier, -> { with_discarded }, inverse_of: :champs, touch: true
   belongs_to :type_de_champ, inverse_of: :champ
   belongs_to :parent, class_name: 'Champ'
   has_many :commentaires

--- a/spec/models/champ_spec.rb
+++ b/spec/models/champ_spec.rb
@@ -3,6 +3,17 @@ describe Champ do
 
   it_should_behave_like "champ_spec"
 
+  describe "associations" do
+    it { is_expected.to belong_to(:dossier) }
+
+    context 'when the parent dossier is discarded' do
+      let(:discarded_dossier) { create(:dossier, :discarded) }
+      subject(:champ) { discarded_dossier.champs.first }
+
+      it { expect(champ.reload.dossier).to eq discarded_dossier }
+    end
+  end
+
   describe "validations" do
     let(:row) { 1 }
     let(:champ) { create(:champ, type_de_champ: create(:type_de_champ), row: row) }


### PR DESCRIPTION
Dossier has a `default_scope { kept }`.

Because of that, when the parent dossier is discarded, `champ.dossier` will return nil.

We should kill the default scope. But meanwhile, ensure that `champ.dossier` returns even a discarded dossier.