### PR TITLE
javascript: fix FileUploadError stacktraces

### DIFF
--- a/app/javascript/shared/activestorage/file-upload-error.js
+++ b/app/javascript/shared/activestorage/file-upload-error.js
@@ -20,9 +20,19 @@ export const FAILURE_CONNECTIVITY = 'file-upload-failure-connectivity';
 export default class FileUploadError extends Error {
   constructor(message, status, code) {
     super(message);
+
     this.name = 'FileUploadError';
     this.status = status;
     this.code = code;
+
+    // Prevent the constructor stacktrace from being included.
+    // (it messes up with Sentry issues grouping)
+    if (Error.captureStackTrace) {
+      // V8-only
+      Error.captureStackTrace(this, this.constructor);
+    } else {
+      this.stack = new Error().stack;
+    }
   }
 
   /**


### PR DESCRIPTION
When subclassing a JS error, most browsers include the constructor stacktrace itself :/

This is an issue, because:

- The stacktrace is deeper than it should be;
- The stacktrace reaches into a polyfill, for which there is not source
map. Which causes Sentry to infer the issue grouping from the JS file
name ; but the fingerprinted name changes on each release. So for each
release, the stacktrace is different ; and Sentry can't group issues
properly.

See an exemple of an improper stacktrace: https://sentry.io/organizations/demarches-simplifiees/issues/1604873283/events/cf8992f7e0d24c00a0ab0f1630ca303c/

With this, the stacktrace should be good enough for Sentry to group issues properly.