### PR TITLE
instructeurs: affiche l'effectif moyen pour l'année antérieure

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -687,23 +687,24 @@ enum DossierState {
 }
 
 type Effectif {
-  """
-  Année de l'effectif mensuel
-  """
-  annee: String!
-
-  """
-  Mois de l'effectif mensuel
-  """
-  mois: String!
   nb: Float!
+  periode: String!
 }
 
 type Entreprise {
   capitalSocial: BigInt!
   codeEffectifEntreprise: String!
   dateCreation: ISO8601Date!
-  effectifs: [Effectif!]!
+
+  """
+  effectif moyen d'une année
+  """
+  effectifAnnuel: Effectif
+
+  """
+  effectif pour un mois donné
+  """
+  effectifMensuel: Effectif
   formeJuridique: String!
   formeJuridiqueCode: String!
   inlineAdresse: String!

--- a/app/graphql/types/personne_morale_type.rb
+++ b/app/graphql/types/personne_morale_type.rb
@@ -2,8 +2,7 @@ module Types
   class PersonneMoraleType < Types::BaseObject
     class EntrepriseType < Types::BaseObject
       class EffectifType < Types::BaseObject
-        field :mois, String, null: false, description: "Mois de l'effectif mensuel"
-        field :annee, String, null: false, description: "Année de l'effectif mensuel"
+        field :periode, String, null: false
         field :nb, Float, null: false
       end
 
@@ -16,21 +15,28 @@ module Types
       field :raison_sociale, String, null: false
       field :siret_siege_social, String, null: false
       field :code_effectif_entreprise, String, null: false
-      field :effectifs, [EffectifType], null: false
+      field :effectif_mensuel, EffectifType, null: true, description: "effectif pour un mois donné"
+      field :effectif_annuel, EffectifType, null: true, description: "effectif moyen d'une année"
       field :date_creation, GraphQL::Types::ISO8601Date, null: false
       field :nom, String, null: false
       field :prenom, String, null: false
       field :inline_adresse, String, null: false
 
-      def effectifs
+      def effectif_mensuel
         if object.effectif_mensuel.present?
-          [
-            {
-              mois: object.effectif_mois,
-              annee: object.effectif_annee,
-              nb: object.effectif_mensuel
-            }
-          ]
+          {
+            periode: [object.effectif_mois, object.effectif_annee].join('/'),
+            nb: object.effectif_mensuel
+          }
+        end
+      end
+
+      def effectif_annuel
+        if object.effectif_annuel.present?
+          {
+            periode: object.effectif_annuel_annee,
+            nb: object.effectif_annuel
+          }
         end
       end
     end

--- a/app/lib/api_entreprise/api.rb
+++ b/app/lib/api_entreprise/api.rb
@@ -4,6 +4,7 @@ class ApiEntreprise::API
   EXERCICES_RESOURCE_NAME = "exercices"
   RNA_RESOURCE_NAME = "associations"
   EFFECTIFS_RESOURCE_NAME = "effectifs_mensuels_acoss_covid"
+  EFFECTIFS_ANNUELS_RESOURCE_NAME = "effectifs_annuels_acoss_covid"
 
   TIMEOUT = 15
 
@@ -32,6 +33,10 @@ class ApiEntreprise::API
   def self.effectifs(siren, procedure_id, annee, mois)
     endpoint = [EFFECTIFS_RESOURCE_NAME, annee, mois, "entreprise"].join('/')
     call(endpoint, siren, procedure_id)
+  end
+
+  def self.effectifs_annuels(siren, procedure_id)
+    call(EFFECTIFS_ANNUELS_RESOURCE_NAME, siren, procedure_id)
   end
 
   private

--- a/app/lib/api_entreprise/effectifs_annuels_adapter.rb
+++ b/app/lib/api_entreprise/effectifs_annuels_adapter.rb
@@ -1,0 +1,23 @@
+class ApiEntreprise::EffectifsAnnuelsAdapter < ApiEntreprise::Adapter
+  def initialize(siren, procedure_id)
+    @siren = siren
+    @procedure_id = procedure_id
+  end
+
+  private
+
+  def get_resource
+    ApiEntreprise::API.effectifs_annuels(@siren, @procedure_id)
+  end
+
+  def process_params
+    if data_source[:effectifs_annuels].present?
+      {
+        entreprise_effectif_annuel: data_source[:effectifs_annuels],
+        entreprise_effectif_annuel_annee: data_source[:annee]
+      }
+    else
+      {}
+    end
+  end
+end

--- a/app/models/entreprise.rb
+++ b/app/models/entreprise.rb
@@ -15,6 +15,8 @@ class Entreprise < Hashie::Dash
   property :effectif_mois
   property :effectif_annee
   property :effectif_mensuel
+  property :effectif_annuel
+  property :effectif_annuel_annee
   property :date_creation
   property :nom
   property :prenom

--- a/app/models/etablissement.rb
+++ b/app/models/etablissement.rb
@@ -105,6 +105,8 @@ class Etablissement < ApplicationRecord
       effectif_mensuel: entreprise_effectif_mensuel,
       effectif_mois: entreprise_effectif_mois,
       effectif_annee: entreprise_effectif_annee,
+      effectif_annuel: entreprise_effectif_annuel,
+      effectif_annuel_annee: entreprise_effectif_annuel_annee,
       date_creation: entreprise_date_creation,
       nom: entreprise_nom,
       prenom: entreprise_prenom,

--- a/app/serializers/entreprise_serializer.rb
+++ b/app/serializers/entreprise_serializer.rb
@@ -11,6 +11,8 @@ class EntrepriseSerializer < ActiveModel::Serializer
     :effectif_mois,
     :effectif_annee,
     :effectif_mensuel,
+    :effectif_annuel,
+    :effectif_annuel_annee,
     :date_creation,
     :nom,
     :prenom

--- a/app/services/api_entreprise_service.rb
+++ b/app/services/api_entreprise_service.rb
@@ -29,6 +29,12 @@ class ApiEntrepriseService
       rescue ApiEntreprise::API::RequestFailed
       end
 
+      begin
+        effectifs_annuels_params = ApiEntreprise::EffectifsAnnuelsAdapter.new(entreprise_params[:entreprise_siren], procedure_id).to_params
+        etablissement_params.merge!(effectifs_annuels_params)
+      rescue ApiEntreprise::API::RequestFailed
+      end
+
       etablissement_params.merge(entreprise_params)
     end
   end

--- a/app/views/shared/dossiers/_identite_entreprise.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise.html.haml
@@ -32,10 +32,13 @@
           %th.libelle
             Effectif mensuel
             = try_format_mois_effectif(etablissement)
+            (URSSAF)
           %td= etablissement.entreprise_effectif_mensuel
       %tr
         %th.libelle Effectif de l'organisation :
-        %td= effectif(etablissement)
+        %td
+          = effectif(etablissement)
+          (INSEE)
       %tr
         %th.libelle Code effectif :
         %td= etablissement.entreprise.code_effectif_entreprise

--- a/app/views/shared/dossiers/_identite_entreprise.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise.html.haml
@@ -34,11 +34,16 @@
             = try_format_mois_effectif(etablissement)
             (URSSAF)
           %td= etablissement.entreprise_effectif_mensuel
+        %tr
+          %th.libelle
+            Effectif moyen annuel
+            = etablissement.entreprise_effectif_annuel_annee
+            (URSSAF)
+          %td= etablissement.entreprise_effectif_annuel
       %tr
-        %th.libelle Effectif de l'organisation :
+        %th.libelle Effectif de l'organisation (INSEE) :
         %td
           = effectif(etablissement)
-          (INSEE)
       %tr
         %th.libelle Numéro de TVA intracommunautaire :
         %td= etablissement.entreprise.numero_tva_intracommunautaire

--- a/app/views/shared/dossiers/_identite_entreprise.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise.html.haml
@@ -40,9 +40,6 @@
           = effectif(etablissement)
           (INSEE)
       %tr
-        %th.libelle Code effectif :
-        %td= etablissement.entreprise.code_effectif_entreprise
-      %tr
         %th.libelle Numéro de TVA intracommunautaire :
         %td= etablissement.entreprise.numero_tva_intracommunautaire
       %tr

--- a/db/migrate/20200422090426_add_effectif_annee_anterieure.rb
+++ b/db/migrate/20200422090426_add_effectif_annee_anterieure.rb
@@ -1,0 +1,6 @@
+class AddEffectifAnneeAnterieure < ActiveRecord::Migration[5.2]
+  def change
+    add_column :etablissements, :entreprise_effectif_annuel, :decimal
+    add_column :etablissements, :entreprise_effectif_annuel_annee, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_21_174642) do
+ActiveRecord::Schema.define(version: 2020_04_22_090426) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -314,6 +314,8 @@ ActiveRecord::Schema.define(version: 2020_04_21_174642) do
     t.string "entreprise_effectif_mois"
     t.string "entreprise_effectif_annee"
     t.decimal "entreprise_effectif_mensuel"
+    t.decimal "entreprise_effectif_annuel"
+    t.string "entreprise_effectif_annuel_annee"
     t.index ["dossier_id"], name: "index_etablissements_on_dossier_id"
   end
 

--- a/spec/controllers/api/v1/dossiers_controller_spec.rb
+++ b/spec/controllers/api/v1/dossiers_controller_spec.rb
@@ -200,6 +200,8 @@ describe API::V1::DossiersController do
               :effectif_mois,
               :effectif_annee,
               :effectif_mensuel,
+              :effectif_annuel,
+              :effectif_annuel_annee,
               :date_creation,
               :nom,
               :prenom

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -212,6 +212,9 @@ describe Users::DossiersController, type: :controller do
     let(:annee) { "2020" }
     let(:mois) { "02" }
 
+    let(:api_entreprise_effectifs_annuels_status) { 200 }
+    let(:api_entreprise_effectifs_annuels_body) { File.read('spec/fixtures/files/api_entreprise/effectifs_annuels.json') }
+
     let(:api_exercices_status) { 200 }
     let(:api_exercices_body) { File.read('spec/fixtures/files/api_entreprise/exercices.json') }
 
@@ -229,6 +232,8 @@ describe Users::DossiersController, type: :controller do
         .to_return(status: api_association_status, body: api_association_body)
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/effectifs_mensuels_acoss_covid\/#{annee}\/#{mois}\/entreprise\/#{siren}?.*token=/)
         .to_return(body: api_entreprise_effectifs_mensuels_body, status: api_entreprise_effectifs_mensuels_status)
+      stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/effectifs_annuels_acoss_covid\/#{siren}?.*token=/)
+        .to_return(body: api_entreprise_effectifs_annuels_body, status: api_entreprise_effectifs_annuels_status)
     end
 
     before do
@@ -328,6 +333,7 @@ describe Users::DossiersController, type: :controller do
           expect(dossier.etablissement.exercices).to be_present
           expect(dossier.etablissement.association?).to be(true)
           expect(dossier.etablissement.entreprise_effectif_mensuel).to be_present
+          expect(dossier.etablissement.entreprise_effectif_annuel).to be_present
         end
       end
     end

--- a/spec/features/users/dossier_creation_spec.rb
+++ b/spec/features/users/dossier_creation_spec.rb
@@ -76,6 +76,8 @@ feature 'Creating a new dossier:' do
           .to_return(status: 404, body: '')
         stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/effectifs_mensuels_acoss_covid\/2020\/02\/entreprise\/#{siren}?.*token=/)
           .to_return(status: 404, body: '')
+        stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/effectifs_annuels_acoss_covid\/#{siren}?.*token=/)
+          .to_return(status: 404, body: '')
       end
       before { Timecop.freeze(Time.zone.local(2020, 3, 14)) }
       after { Timecop.return }

--- a/spec/fixtures/files/api_entreprise/effectifs_annuels.json
+++ b/spec/fixtures/files/api_entreprise/effectifs_annuels.json
@@ -1,0 +1,5 @@
+{
+  "siren": "418166096",
+  "annee": "2019",
+  "effectifs_annuels": 100.5
+}

--- a/spec/lib/api_entreprise/effectifs_annuels_adapter_spec.rb
+++ b/spec/lib/api_entreprise/effectifs_annuels_adapter_spec.rb
@@ -1,0 +1,24 @@
+describe ApiEntreprise::EffectifsAnnuelsAdapter do
+  let(:siren) { '418166096' }
+  let(:procedure_id) { 22 }
+  let(:adapter) { described_class.new(siren, procedure_id) }
+  subject { adapter.to_params }
+
+  before do
+    stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/effectifs_annuels_acoss_covid\/#{siren}?.*token=/)
+      .to_return(body: body, status: status)
+  end
+
+  context "when the SIREN is valid" do
+    let(:body) { File.read('spec/fixtures/files/api_entreprise/effectifs_annuels.json') }
+    let(:status) { 200 }
+
+    it '#to_params class est une Hash ?' do
+      expect(subject).to be_an_instance_of(Hash)
+    end
+
+    it "renvoie les effectifs de l'année antérieure" do
+      expect(subject[:entreprise_effectif_annuel]).to eq(100.5)
+    end
+  end
+end

--- a/spec/services/api_entreprise_service_spec.rb
+++ b/spec/services/api_entreprise_service_spec.rb
@@ -11,6 +11,8 @@ describe ApiEntrepriseService do
         .to_return(body: associations_body, status: associations_status)
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/effectifs_mensuels_acoss_covid\/#{annee}\/#{mois}\/entreprise\/#{siren}?.*token=/)
         .to_return(body: effectifs_mensuels_body, status: effectifs_mensuels_status)
+      stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/effectifs_annuels_acoss_covid\/#{siren}?.*token=/)
+        .to_return(body: effectifs_annuels_body, status: effectifs_annuels_status)
     end
 
     before { Timecop.freeze(Time.zone.local(2020, 3, 14)) }
@@ -32,6 +34,10 @@ describe ApiEntrepriseService do
     let(:mois) { "02" }
     let(:effectif_mensuel) { 100.5 }
 
+    let(:effectifs_annuels_status) { 200 }
+    let(:effectifs_annuels_body) { File.read('spec/fixtures/files/api_entreprise/effectifs_annuels.json') }
+    let(:effectif_annuel) { 100.5 }
+
     let(:exercices_status) { 200 }
     let(:exercices_body) { File.read('spec/fixtures/files/api_entreprise/exercices.json') }
 
@@ -47,6 +53,7 @@ describe ApiEntrepriseService do
         expect(result[:association_rna]).to eq(rna)
         expect(result[:exercices_attributes]).to_not be_empty
         expect(result[:entreprise_effectif_mensuel]).to eq(effectif_mensuel)
+        expect(result[:entreprise_effectif_annuel]).to eq(effectif_annuel)
       end
     end
 


### PR DESCRIPTION
close #5068 

- Affiche pour l'instructeur l'effectif moyen d'une entreprise pour l'année antérieure à celle de la création du dossier.
- précise la source (insee ou urssaf) des données effectifs
- Supprime le code effectifs
- expose l'effectif annuel dans l'api graphql

![effectifs](https://user-images.githubusercontent.com/1111966/80011654-7509e900-84cc-11ea-935b-e715587fca78.png)



