### PR TITLE
send notif only to the right instructeurs

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -153,7 +153,7 @@ module Users
       if passage_en_construction? && errors.blank?
         @dossier.en_construction!
         NotificationMailer.send_initiated_notification(@dossier).deliver_later
-        @dossier.procedure.instructeurs.with_instant_email_dossier_notifications.each do |instructeur|
+        @dossier.groupe_instructeur.instructeurs.with_instant_email_dossier_notifications.each do |instructeur|
           DossierMailer.notify_new_dossier_depose_to_instructeur(@dossier, instructeur.email).deliver_later
         end
         return redirect_to(merci_dossier_path(@dossier))

--- a/spec/factories/assign_to.rb
+++ b/spec/factories/assign_to.rb
@@ -1,7 +1,11 @@
 FactoryBot.define do
   factory :assign_to do
-    after(:build) do |assign_to, _evaluator|
-      assign_to.groupe_instructeur = assign_to.procedure.defaut_groupe_instructeur
+    after(:build) do |assign_to, evaluator|
+      if evaluator.groupe_instructeur.persisted?
+        assign_to.groupe_instructeur = evaluator.groupe_instructeur
+      else
+        assign_to.groupe_instructeur = assign_to.procedure.defaut_groupe_instructeur
+      end
     end
   end
 end


### PR DESCRIPTION
close #5074 

after a dossier creation, only the instructeurs that belong to the group
instructeur of the dossier, and who want notifications will be notified by mail