### PR TITLE
#4978 - Export procédure

### DIFF
--- a/app/controllers/instructeurs/archives_controller.rb
+++ b/app/controllers/instructeurs/archives_controller.rb
@@ -1,0 +1,43 @@
+module Instructeurs
+  class ArchivesController < InstructeurController
+    def index
+      @procedure = procedure
+      if !@procedure.publiee?
+        flash[:alert] = "L'accès aux archives n'est disponible que pour les démarches publiées"
+        return redirect_to url_for(@procedure)
+      end
+
+      @list_of_months = list_of_months
+      @dossiers_termines = @procedure.dossiers.state_termine
+      @poids_total = ProcedureArchiveService.poids_total_procedure(@procedure)
+      @archives = current_instructeur.archives.where(procedure: procedure)
+    end
+
+    def create
+      type = params[:type]
+      month = Date.strptime(params[:month], '%Y-%m') if params[:month].present?
+
+      flash[:notice] = "Votre demande a été prise en compte. Selon le nombre de dossiers, cela peut prendre quelques minutes. Vous recevrez un courriel lorsque le fichier sera disponible."
+      ArchiveCreationJob.perform_later(procedure, current_instructeur, type, month)
+    end
+
+    private
+
+    def list_of_months
+      months = []
+      current_month = procedure.published_at.beginning_of_month
+      while current_month < Time.zone.now.end_of_month
+        months << current_month
+        current_month = current_month.next_month
+      end
+      months.reverse
+    end
+
+    def procedure
+      current_instructeur
+        .procedures
+        .for_download
+        .find(params[:procedure_id])
+    end
+  end
+end

--- a/app/controllers/instructeurs/archives_controller.rb
+++ b/app/controllers/instructeurs/archives_controller.rb
@@ -1,11 +1,9 @@
 module Instructeurs
   class ArchivesController < InstructeurController
+    before_action :ensure_procedure_enabled
+
     def index
       @procedure = procedure
-      if !@procedure.publiee?
-        flash[:alert] = "L'accès aux archives n'est disponible que pour les démarches publiées"
-        return redirect_to url_for(@procedure)
-      end
 
       @list_of_months = list_of_months
       @dossiers_termines = @procedure.dossiers.state_termine
@@ -22,6 +20,13 @@ module Instructeurs
     end
 
     private
+
+    def ensure_procedure_enabled
+      if !Flipper.enabled?(:archive_zip_globale, procedure)
+        flash[:alert] = "L'accès aux archives n'est pas disponible pour cette démarche, merci d'en faire la demande à l'équipe de démarches simplifiees"
+        return redirect_to url_for(procedure)
+      end
+    end
 
     def list_of_months
       months = []

--- a/app/controllers/instructeurs/archives_controller.rb
+++ b/app/controllers/instructeurs/archives_controller.rb
@@ -8,7 +8,7 @@ module Instructeurs
       @list_of_months = list_of_months
       @dossiers_termines = @procedure.dossiers.state_termine
       @poids_total = ProcedureArchiveService.poids_total_procedure(@procedure)
-      @archives = current_instructeur.archives.where(procedure: procedure)
+      @archives = Archive.for_instructeur(current_instructeur)
     end
 
     def create
@@ -16,7 +16,7 @@ module Instructeurs
       month = Date.strptime(params[:month], '%Y-%m') if params[:month].present?
 
       flash[:notice] = "Votre demande a été prise en compte. Selon le nombre de dossiers, cela peut prendre quelques minutes. Vous recevrez un courriel lorsque le fichier sera disponible."
-      ArchiveCreationJob.perform_later(procedure, current_instructeur, type, month)
+      ArchiveCreationJob.perform_now(procedure, current_instructeur, type, month)
     end
 
     private

--- a/app/jobs/archive_creation_job.rb
+++ b/app/jobs/archive_creation_job.rb
@@ -1,0 +1,5 @@
+class ArchiveCreationJob < ApplicationJob
+  def perform(procedure, instructeur, type, month)
+    ProcedureArchiveService.new(procedure).create_archive(instructeur, type, month)
+  end
+end

--- a/app/jobs/archive_creation_job.rb
+++ b/app/jobs/archive_creation_job.rb
@@ -1,5 +1,7 @@
 class ArchiveCreationJob < ApplicationJob
   def perform(procedure, instructeur, type, month)
-    ProcedureArchiveService.new(procedure).create_archive(instructeur, type, month)
+    ProcedureArchiveService
+      .new(procedure)
+      .create_archive(instructeur, type, month)
   end
 end

--- a/app/jobs/purge_stale_archives_job.rb
+++ b/app/jobs/purge_stale_archives_job.rb
@@ -1,0 +1,7 @@
+class PurgeStaleArchivesJob < CronJob
+  self.schedule_expression = "every 5 minutes"
+
+  def perform
+    Archive.stale.destroy_all
+  end
+end

--- a/app/lib/active_storage/downloadable_file.rb
+++ b/app/lib/active_storage/downloadable_file.rb
@@ -7,16 +7,12 @@ class ActiveStorage::DownloadableFile
     end
   end
 
-  def url
-    @url
-  end
-
   def self.create_list_from_dossier(dossier)
     pjs = PiecesJustificativesService.liste_pieces_justificatives(dossier)
     pjs.map do |piece_justificative|
       [
         piece_justificative,
-        self.timestamped_filename(piece_justificative)
+        "dossier-#{dossier.id}/#{self.timestamped_filename(piece_justificative)}"
       ]
     end
   end

--- a/app/mailers/instructeur_mailer.rb
+++ b/app/mailers/instructeur_mailer.rb
@@ -1,5 +1,7 @@
 # Preview all emails at http://localhost:3000/rails/mailers/instructeur_mailer
 class InstructeurMailer < ApplicationMailer
+  helper MailerHelper
+
   layout 'mailers/layout'
 
   def user_to_instructeur(email)
@@ -39,6 +41,13 @@ class InstructeurMailer < ApplicationMailer
   def send_notifications(instructeur, data)
     @data = data
     subject = "Vous avez du nouveau sur vos démarches"
+
+    mail(to: instructeur.email, subject: subject)
+  end
+
+  def send_archive(instructeur, archive)
+    @archive = archive
+    subject = "Votre archive est disponible"
 
     mail(to: instructeur.email, subject: subject)
   end

--- a/app/mailers/instructeur_mailer.rb
+++ b/app/mailers/instructeur_mailer.rb
@@ -45,8 +45,9 @@ class InstructeurMailer < ApplicationMailer
     mail(to: instructeur.email, subject: subject)
   end
 
-  def send_archive(instructeur, archive)
+  def send_archive(instructeur, procedure, archive)
     @archive = archive
+    @procedure = procedure
     subject = "Votre archive est disponible"
 
     mail(to: instructeur.email, subject: subject)

--- a/app/models/archive.rb
+++ b/app/models/archive.rb
@@ -1,0 +1,29 @@
+class Archive < ApplicationRecord
+  include AASM
+
+  MAX_DUREE_CONSERVATION_ARCHIVE = 1.week
+
+  belongs_to :instructeur
+  belongs_to :procedure
+
+  has_one_attached :file
+
+  enum content_type: {
+    everything: 'everything',
+    monthly:    'monthly'
+  }
+
+  enum status: {
+    pending: 'pending',
+    generated: 'generated'
+  }
+
+  aasm whiny_persistence: true, column: :status, enum: true do
+    state :pending, initial: true
+    state :generated
+
+    event :make_available do
+      transitions from: :pending, to: :generated
+    end
+  end
+end

--- a/app/models/archive.rb
+++ b/app/models/archive.rb
@@ -1,6 +1,4 @@
 class Archive < ApplicationRecord
-  scope :stale, -> { where('updated_at < ?', (Time.zone.now - MAX_DUREE_CONSERVATION_EXPORT)) }
-
   include AASM
 
   MAX_DUREE_CONSERVATION_ARCHIVE = 1.week
@@ -9,6 +7,8 @@ class Archive < ApplicationRecord
   belongs_to :procedure
 
   has_one_attached :file
+
+  scope :stale, -> { where('updated_at < ?', (Time.zone.now - MAX_DUREE_CONSERVATION_ARCHIVE)) }
 
   enum content_type: {
     everything: 'everything',
@@ -27,5 +27,9 @@ class Archive < ApplicationRecord
     event :make_available do
       transitions from: :pending, to: :generated
     end
+  end
+
+  def available?
+    status == 'generated' && file.attached?
   end
 end

--- a/app/models/archive.rb
+++ b/app/models/archive.rb
@@ -1,4 +1,6 @@
 class Archive < ApplicationRecord
+  scope :stale, -> { where('updated_at < ?', (Time.zone.now - MAX_DUREE_CONSERVATION_EXPORT)) }
+
   include AASM
 
   MAX_DUREE_CONSERVATION_ARCHIVE = 1.week

--- a/app/models/archive.rb
+++ b/app/models/archive.rb
@@ -1,10 +1,20 @@
+# == Schema Information
+#
+# Table name: archives
+#
+#  id           :bigint           not null, primary key
+#  content_type :string
+#  month        :datetime
+#  status       :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
 class Archive < ApplicationRecord
   include AASM
 
   MAX_DUREE_CONSERVATION_ARCHIVE = 1.week
 
-  belongs_to :instructeur
-  belongs_to :procedure
+  has_and_belongs_to_many :groupe_instructeurs
 
   has_one_attached :file
 

--- a/app/models/archive.rb
+++ b/app/models/archive.rb
@@ -19,6 +19,12 @@ class Archive < ApplicationRecord
   has_one_attached :file
 
   scope :stale, -> { where('updated_at < ?', (Time.zone.now - MAX_DUREE_CONSERVATION_ARCHIVE)) }
+  scope :for_instructeur, -> (instructeur) {
+    joins(:archives_groupe_instructeurs)
+      .where(
+        archives_groupe_instructeurs: { groupe_instructeur: instructeur.groupe_instructeurs }
+      )
+  }
 
   enum content_type: {
     everything: 'everything',

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -158,8 +158,8 @@ class Dossier < ApplicationRecord
   scope :termine,                     -> { not_archived.state_termine }
   scope :termine_durant,              -> (month) do
     state_termine
-        .joins(:traitements)
-        .where(traitements: { processed_at: month.beginning_of_month..month.end_of_month })
+      .joins(:traitements)
+      .where(traitements: { processed_at: month.beginning_of_month..month.end_of_month })
   end
   scope :downloadable_sorted, -> {
     state_not_brouillon

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -156,7 +156,12 @@ class Dossier < ApplicationRecord
   scope :en_construction,             -> { not_archived.state_en_construction }
   scope :en_instruction,              -> { not_archived.state_en_instruction }
   scope :termine,                     -> { not_archived.state_termine }
-  scope :downloadable_sorted,         -> {
+  scope :termine_durant,              -> (month) do
+    state_termine
+        .joins(:traitements)
+        .where(traitements: { processed_at: month.beginning_of_month..month.end_of_month })
+  end
+  scope :downloadable_sorted, -> {
     state_not_brouillon
       .includes(
         :user,

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -26,6 +26,7 @@ class Instructeur < ApplicationRecord
   has_many :avis
   has_many :dossiers_from_avis, through: :avis, source: :dossier
   has_many :trusted_device_tokens, dependent: :destroy
+  has_many :archives
 
   has_one :user, dependent: :nullify
 

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -178,6 +178,20 @@ class Procedure < ApplicationRecord
     includes(:draft_revision, :published_revision, administrateurs: :user)
   }
 
+  scope :for_download, -> {
+    includes(
+      :groupe_instructeurs,
+      dossiers: {
+        champs: [
+          piece_justificative_file_attachment: :blob,
+          champs: [
+            piece_justificative_file_attachment: :blob
+          ]
+        ]
+      }
+    )
+  }
+
   validates :libelle, presence: true, allow_blank: false, allow_nil: false
   validates :description, presence: true, allow_blank: false, allow_nil: false
   validates :administrateurs, presence: true

--- a/app/services/procedure_archive_service.rb
+++ b/app/services/procedure_archive_service.rb
@@ -1,0 +1,95 @@
+require 'tempfile'
+
+class ProcedureArchiveService
+  def initialize(procedure)
+    @procedure = procedure
+  end
+
+  def create_archive(instructeur, type, month = nil)
+    if type == 'everything'
+      dossiers = @procedure.dossiers.state_termine
+      filename = "procedure-#{@procedure.id}.zip"
+    else
+      dossiers = @procedure.dossiers.termine_durant(month)
+      filename = "procedure-#{@procedure.id}-mois-#{I18n.l(month, format: '%Y-%m')}.zip"
+    end
+    files = create_list_of_attachments(dossiers)
+
+    archive = Archive.create(
+      content_type: type,
+      month: month,
+      procedure: @procedure,
+      instructeur: instructeur
+    )
+    tmp_file = Tempfile.new(['tc', '.zip'])
+
+    Zip::OutputStream.open(tmp_file) do |zipfile|
+      # Les pièces justificatives
+      files.each do |attachment, pj_filename|
+        zipfile.put_next_entry(pj_filename)
+        zipfile.puts(attachment.download)
+      end
+
+      # L'export PDF des dossier
+      dossiers.each do |dossier|
+        zipfile.put_next_entry("dossier-#{dossier.id}/dossier-#{dossier.id}.pdf")
+        zipfile.puts(ApplicationController.render(template: 'dossiers/show',
+                        formats: [:pdf],
+                        assigns: {
+                          include_infos_administration: false,
+                          dossier: dossier
+                        }))
+      end
+    end
+
+    archive.file.attach(io: File.open(tmp_file), filename: filename)
+    tmp_file.delete
+    archive.make_available!
+    InstructeurMailer.send_archive(instructeur, archive).deliver_now
+  end
+
+  def self.poids_total_procedure(procedure)
+    poids_total_dossiers(procedure.dossiers)
+  end
+
+  def self.poids_total_dossiers(dossiers)
+    dossiers.map do |dossier|
+      liste_pieces_justificatives(dossier).sum(&:byte_size)
+    end.sum
+  end
+
+  def create_list_of_attachments(dossiers)
+    dossiers.flat_map do |dossier|
+      ActiveStorage::DownloadableFile.create_list_from_dossier(dossier)
+    end
+  end
+
+  private
+
+  def self.champs_pieces_justificatives_with_attachments(champs)
+    champs
+      .filter { |c| c.type_champ == TypeDeChamp.type_champs.fetch(:piece_justificative) }
+      .filter { |pj| pj.piece_justificative_file.attached? }
+      .map(&:piece_justificative_file)
+  end
+
+  def self.liste_pieces_justificatives(dossier)
+    champs_blocs_repetables = dossier.champs
+      .filter { |c| c.type_champ == TypeDeChamp.type_champs.fetch(:repetition) }
+      .flat_map(&:champs)
+
+    champs_pieces_justificatives_with_attachments(champs_blocs_repetables + dossier.champs)
+  end
+
+  def dossier_pdf_link(dossier)
+    Rails.application.routes.url_helpers.instructeur_dossier_url(@procedure, dossier, format: :pdf)
+  end
+
+  def empty_procedure_pdf_link
+    if @procedure.brouillon?
+      Rails.application.routes.url_helpers.commencer_dossier_vide_test_url(path: @procedure.path, format: :pdf)
+    else
+      Rails.application.routes.url_helpers.commencer_dossier_vide_url(path: @procedure.path, format: :pdf)
+    end
+  end
+end

--- a/app/views/instructeur_mailer/send_archive.html.haml
+++ b/app/views/instructeur_mailer/send_archive.html.haml
@@ -1,0 +1,19 @@
+- content_for(:title, 'Votre archive est disponible')
+
+%p
+  Bonjour,
+
+%p
+  Votre archive pour la procédure #{@archive.procedure.id} est disponible.
+  Vous pouvez la télécharger dans votre espace de gestion des archives.
+
+%p
+  = round_button('Consulter mes archives', instructeur_archives_url(@archive.procedure), :primary)
+
+%p
+  Ce fichier est
+  %b valide une semaine
+  et peut-être téléchargé
+  %b plusieurs fois.
+
+= render partial: "layouts/mailers/signature"

--- a/app/views/instructeur_mailer/send_archive.html.haml
+++ b/app/views/instructeur_mailer/send_archive.html.haml
@@ -4,11 +4,13 @@
   Bonjour,
 
 %p
-  Votre archive pour la procédure #{@archive.procedure.id} est disponible.
+  Votre archive pour la démarche
+  = link_to("#{@procedure.id} − #{@procedure.libelle}", instructeur_procedure_url(@procedure.id))
+  est disponible.
   Vous pouvez la télécharger dans votre espace de gestion des archives.
 
 %p
-  = round_button('Consulter mes archives', instructeur_archives_url(@archive.procedure), :primary)
+  = round_button('Consulter mes archives', instructeur_archives_url(@procedure), :primary)
 
 %p
   Ce fichier est

--- a/app/views/instructeurs/archives/create.js.haml
+++ b/app/views/instructeurs/archives/create.js.haml
@@ -1,0 +1,1 @@
+= render_flash(sticky: true)

--- a/app/views/instructeurs/archives/index.html.haml
+++ b/app/views/instructeurs/archives/index.html.haml
@@ -1,0 +1,93 @@
+- content_for(:title, "Archives pour #{@procedure.libelle}")
+
+= render partial: 'new_administrateur/breadcrumbs',
+  locals: { steps: [link_to(@procedure.libelle, instructeur_procedure_path(@procedure)),
+                    'Archives'] }
+
+.container
+  %h1 Archives
+
+  .card.featured
+    .card-title Gestion de vos archives
+    %p
+      Vous pouvez télécharger les archives des dossiers terminés depuis la publication de la procédure au format Zip.
+
+    %p
+      Cet export contient les demande déposée par l'usager et la liste des pièces justificatives transmises.
+
+    %p
+      Cet export n'est pas possible pour le moment pour les démarches à forte volumétrie.
+      Nous vous invitons à regarder
+      = link_to 'la documentation', ARCHIVAGE_DOC_URL
+      afin de voir les options à votre disposition pour mettre en place un système d'archive.
+
+  %table.table.hoverable
+    %thead
+      %tr
+        %th &nbsp;
+        %th Nombre de dossiers terminés
+        %th Poids estimé
+        %th Télécharger
+
+    %tbody
+    - if @dossiers_termines.count < 100 && @poids_total < 1.gigabyte
+      %tr
+        - matching_archive = @archives.find_by(content_type: 'everything')
+        %td
+          Tous les dossiers
+        %td
+          = @dossiers_termines.count
+        %td
+          - if matching_archive.present? && matching_archive.available?
+            - weight = matching_archive.file.byte_size
+          - else
+            - weight = @poids_total
+          = number_to_human_size(weight)
+        %td
+          - if @dossiers_termines.count > 0
+            - if matching_archive.present?
+              - if matching_archive.available?
+                = link_to url_for(matching_archive.file), class: 'button primary' do
+                  %span.icon.download-white
+                  Télécharger
+              - else
+                %span.icon.retry
+                Archive en cours de création
+            - else
+              = link_to instructeur_archives_path(@procedure, type: 'everything'), method: :post, class: "button", remote: true do
+                %span.icon.new-folder
+                Démander la création
+          - else
+            Rien à télécharger !
+    - @list_of_months.each do |month|
+      - dossiers_termines = @procedure.dossiers.termine_durant(month)
+      - nb_dossiers_termines = dossiers_termines.count
+      - matching_archive = @archives.find_by(content_type: 'monthly', month: month)
+      %tr
+        %td
+          = I18n.l(month, format: "%B %Y")
+        %td
+          = nb_dossiers_termines
+        %td
+          - if matching_archive.present? && matching_archive.available?
+            - weight = matching_archive.file.byte_size
+          - else
+            - weight = ProcedureArchiveService::poids_total_dossiers(dossiers_termines)
+          = number_to_human_size(weight)
+        %td
+          - if nb_dossiers_termines > 0
+            - if matching_archive.present?
+              - if matching_archive.status == 'generated' && matching_archive.file.attached?
+                = link_to url_for(matching_archive.file), class: 'button primary' do
+                  %span.icon.download-white
+                  Télécharger
+              - else
+                %span.icon.retry
+                Archive en cours de création
+            - else
+              = link_to instructeur_archives_path(@procedure, type:'monthly', month: month.strftime('%Y-%m')), method: :post, class: "button", remote: true do
+                %span.icon.new-folder
+                Démander la création
+          - else
+            Rien à télécharger !
+

--- a/app/views/instructeurs/procedures/_download_dossiers.html.haml
+++ b/app/views/instructeurs/procedures/_download_dossiers.html.haml
@@ -15,3 +15,6 @@
               = link_to "Télécharger l'export au format .#{format}", export.file.service_url, target: "_blank", rel: "noopener"
             - else
               %span{ 'data-export-poll-url': download_export_instructeur_procedure_path(procedure, export_format: format, no_progress_notification: true) }
+        - if procedure.publiee?
+          %li
+            = link_to "Télécharger une archive au format .zip de tous les dossiers et leurs pièces jointes", instructeur_archives_path(procedure)

--- a/app/views/instructeurs/procedures/_download_dossiers.html.haml
+++ b/app/views/instructeurs/procedures/_download_dossiers.html.haml
@@ -15,6 +15,6 @@
               = link_to "Télécharger l'export au format .#{format}", export.file.service_url, target: "_blank", rel: "noopener"
             - else
               %span{ 'data-export-poll-url': download_export_instructeur_procedure_path(procedure, export_format: format, no_progress_notification: true) }
-        - if procedure.publiee?
+        - if feature_enabled_for?(:archive_zip_globale, procedure)
           %li
             = link_to "Télécharger une archive au format .zip de tous les dossiers et leurs pièces jointes", instructeur_archives_path(procedure)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -350,6 +350,8 @@ Rails.application.routes.draw do
             get 'telecharger_pjs' => 'dossiers#telecharger_pjs'
           end
         end
+
+        resources :archives, only: [:index, :create, :show], controller: 'archives'
       end
     end
     get "recherche" => "recherche#index"

--- a/db/migrate/20200416123601_create_archives.rb
+++ b/db/migrate/20200416123601_create_archives.rb
@@ -1,0 +1,12 @@
+class CreateArchives < ActiveRecord::Migration[5.2]
+  def change
+    create_table :archives do |t|
+      t.string :status
+      t.datetime :month
+      t.string :content_type
+      t.references :instructeur, foreign_key: true
+      t.references :procedure, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201104163658_create_archive_for_groupe_instructeur.rb
+++ b/db/migrate/20201104163658_create_archive_for_groupe_instructeur.rb
@@ -1,0 +1,21 @@
+require_relative '20200416123601_create_archives'
+
+class CreateArchiveForGroupeInstructeur < ActiveRecord::Migration[6.0]
+  def change
+    revert CreateArchives
+
+    create_table :archives do |t|
+      t.string :status
+      t.datetime :month
+      t.string :content_type
+      t.timestamps
+    end
+
+    create_table "archives_groupe_instructeurs", force: :cascade do |t|
+      t.bigint "archive_id", null: false
+      t.bigint "groupe_instructeur_id", null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -86,6 +86,13 @@ ActiveRecord::Schema.define(version: 2020_11_05_131443) do
     t.index ["procedure_id"], name: "index_archives_on_procedure_id"
   end
 
+  create_table "archives_groupe_instructeurs", force: :cascade do |t|
+    t.bigint "archive_id", null: false
+    t.bigint "groupe_instructeur_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "assign_tos", id: :serial, force: :cascade do |t|
     t.integer "instructeur_id"
     t.integer "procedure_id"
@@ -710,8 +717,6 @@ ActiveRecord::Schema.define(version: 2020_11_05_131443) do
     t.index ["procedure_id"], name: "index_without_continuation_mails_on_procedure_id"
   end
 
-  add_foreign_key "archives", "instructeurs"
-  add_foreign_key "archives", "procedures"
   add_foreign_key "assign_tos", "groupe_instructeurs"
   add_foreign_key "attestation_templates", "procedures"
   add_foreign_key "attestations", "dossiers"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -74,6 +74,18 @@ ActiveRecord::Schema.define(version: 2020_11_05_131443) do
     t.index ["procedure_id"], name: "index_administrateurs_procedures_on_procedure_id"
   end
 
+  create_table "archives", force: :cascade do |t|
+    t.string "status"
+    t.datetime "month"
+    t.string "content_type"
+    t.bigint "instructeur_id"
+    t.bigint "procedure_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["instructeur_id"], name: "index_archives_on_instructeur_id"
+    t.index ["procedure_id"], name: "index_archives_on_procedure_id"
+  end
+
   create_table "assign_tos", id: :serial, force: :cascade do |t|
     t.integer "instructeur_id"
     t.integer "procedure_id"
@@ -698,6 +710,8 @@ ActiveRecord::Schema.define(version: 2020_11_05_131443) do
     t.index ["procedure_id"], name: "index_without_continuation_mails_on_procedure_id"
   end
 
+  add_foreign_key "archives", "instructeurs"
+  add_foreign_key "archives", "procedures"
   add_foreign_key "assign_tos", "groupe_instructeurs"
   add_foreign_key "attestation_templates", "procedures"
   add_foreign_key "attestations", "dossiers"

--- a/spec/factories/archive.rb
+++ b/spec/factories/archive.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :archive do
+    groupe_instructeurs { [association(:groupe_instructeur)] }
+
+    trait :pending do
+      status { 'pending' }
+    end
+
+    trait :generated do
+      status { 'generated' }
+    end
+  end
+end

--- a/spec/models/archive_spec.rb
+++ b/spec/models/archive_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Archive, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/archive_spec.rb
+++ b/spec/models/archive_spec.rb
@@ -1,5 +1,48 @@
-require 'rails_helper'
+describe Dossier do
+  include ActiveJob::TestHelper
 
-RSpec.describe Archive, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  before { Timecop.freeze(Time.zone.now) }
+  after { Timecop.return }
+
+  let(:archive) { create(:archive) }
+
+  describe 'scopes' do
+    describe 'staled' do
+      let(:recent_archive) { create(:archive) }
+      let(:staled_archive) { create(:archive, updated_at: (Archive::MAX_DUREE_CONSERVATION_ARCHIVE + 2).days.ago) }
+
+      subject { Archive.stale }
+
+      it { is_expected.to match_array([staled_archive]) }
+    end
+  end
+
+  describe '.status' do
+    it { expect(archive.status).to eq('pending') }
+  end
+
+  describe '#make_available!' do
+    before { archive.make_available! }
+    it { expect(archive.status).to eq('generated') }
+  end
+
+  describe '#available?' do
+    subject { archive.available? }
+    context 'without attachment' do
+      let(:archive) { create(:archive, file: nil) }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'with an attachment' do
+      context 'when the attachment was created but the process was not over' do
+        let(:archive) { create(:archive, :pending, file: Rack::Test::UploadedFile.new('spec/fixtures/files/file.pdf', 'application/pdf')) }
+        it { is_expected.to eq(false) }
+      end
+
+      context 'when the attachment was created but the process was not over' do
+        let(:archive) { create(:archive, :generated, file: Rack::Test::UploadedFile.new('spec/fixtures/files/file.pdf', 'application/pdf')) }
+        it { is_expected.to eq(true) }
+      end
+    end
+  end
 end

--- a/spec/views/instructeur/procedures/_download_dossiers.html.haml_spec.rb
+++ b/spec/views/instructeur/procedures/_download_dossiers.html.haml_spec.rb
@@ -16,5 +16,15 @@ describe 'instructeurs/procedures/_download_dossiers.html.haml', type: :view do
   context "when procedure has at least 1 dossier en construction" do
     let!(:dossier) { create(:dossier, :en_construction, procedure: procedure) }
     it { is_expected.to include("Télécharger tous les dossiers") }
+
+    context "With zip archive enabled" do
+      before { Flipper.enable(:archive_zip_globale, procedure) }
+      it { is_expected.to include("Télécharger une archive au format .zip") }
+    end
+
+    context "With zip archive enabled" do
+      before { Flipper.disable(:archive_zip_globale, procedure) }
+      it { is_expected.not_to include("Télécharger une archive au format .zip") }
+    end
   end
 end


### PR DESCRIPTION
brouillon pour alimenter la discussion sur comment proposer cette fonctionnalité (en plus du fait que c'est pas terminé).

dans l'idée:
 - un écran dédié à la gestion des exports. La liste déroulante s'y prête mal.
 - 2 types d'exports, un "complet" et un "mensuel"
 - selon le volume de dossiers (à voir ?), on propose soit l'export mensuel soit l'export total
 - génération du zip en créant un fichier temporaire puis réupload

![image](https://user-images.githubusercontent.com/1223316/80353338-827cf580-8875-11ea-8049-78a67d191eab.png)

![download-monthly](https://user-images.githubusercontent.com/1223316/80353370-8f99e480-8875-11ea-8e68-bfd5db09fcd6.png)
![download-zip](https://user-images.githubusercontent.com/1223316/80353373-90cb1180-8875-11ea-8bf8-d13375896125.png)

![image](https://user-images.githubusercontent.com/1223316/80354163-aa208d80-8876-11ea-9d15-c3ba9b7af63c.png)

