### PR TITLE
5084 appelle api entreprise avec un jeton spécifique à une démarche

### DIFF
--- a/app/controllers/new_administrateur/procedures_controller.rb
+++ b/app/controllers/new_administrateur/procedures_controller.rb
@@ -1,6 +1,6 @@
 module NewAdministrateur
   class ProceduresController < AdministrateurController
-    before_action :retrieve_procedure, only: [:champs, :annotations, :edit, :monavis, :update_monavis]
+    before_action :retrieve_procedure, only: [:champs, :annotations, :edit, :monavis, :update_monavis, :jeton, :update_jeton]
     before_action :procedure_locked?, only: [:champs, :annotations]
 
     def apercu
@@ -57,6 +57,18 @@ module NewAdministrateur
       render 'monavis'
     end
 
+    def jeton
+    end
+
+    def update_jeton
+      if !@procedure.update(procedure_params)
+        flash.now.alert = @procedure.errors.full_messages
+      else
+        flash.notice = 'Le jeton a bien été mis à jour'
+      end
+      render 'jeton'
+    end
+
     private
 
     def apercu_tab
@@ -68,7 +80,7 @@ module NewAdministrateur
     end
 
     def procedure_params
-      editable_params = [:libelle, :description, :organisation, :direction, :lien_site_web, :cadre_juridique, :deliberation, :notice, :web_hook_url, :declarative_with_state, :euro_flag, :logo, :auto_archive_on, :monavis_embed]
+      editable_params = [:libelle, :description, :organisation, :direction, :lien_site_web, :cadre_juridique, :deliberation, :notice, :web_hook_url, :declarative_with_state, :euro_flag, :logo, :auto_archive_on, :monavis_embed, :api_entreprise_token]
       permited_params = if @procedure&.locked?
         params.require(:procedure).permit(*editable_params)
       else

--- a/app/lib/api_entreprise/api.rb
+++ b/app/lib/api_entreprise/api.rb
@@ -74,11 +74,12 @@ class ApiEntreprise::API
       recipient: siret_or_siren,
       object: "procedure_id: #{procedure_id}",
       non_diffusables: true,
-      token: token
+      token: token_for_procedure(procedure_id)
     }
   end
 
-  def self.token
-    Rails.application.secrets.api_entreprise[:key]
+  def self.token_for_procedure(procedure_id)
+    procedure = Procedure.find(procedure_id)
+    procedure.api_entreprise_token.presence || Rails.application.secrets.api_entreprise[:key]
   end
 end

--- a/app/views/layouts/left_panels/_left_panel_admin_procedurescontroller_navbar.html.haml
+++ b/app/views/layouts/left_panels/_left_panel_admin_procedurescontroller_navbar.html.haml
@@ -68,6 +68,10 @@
       .procedure-list-element{ class: ('active' if active == 'MonAvis') }
         MonAvis
 
+    %a#onglet-description{ href: url_for(admin_procedure_jeton_path(@procedure)) }
+      .procedure-list-element
+        Jeton
+
     %a#onglet-description{ href: url_for(admin_procedures_path()) }
       .procedure-list-element
         Sortir

--- a/app/views/new_administrateur/procedures/jeton.html.haml
+++ b/app/views/new_administrateur/procedures/jeton.html.haml
@@ -1,0 +1,24 @@
+= render partial: 'new_administrateur/breadcrumbs',
+  locals: { steps: [link_to('Démarches', admin_procedures_path),
+                    link_to(@procedure.libelle, admin_procedure_path(@procedure)),
+                    'Jeton'] }
+
+.container
+  %h1.page-title
+    Configurer le jeton API Entreprise
+
+.container
+  %h1
+  = form_with model: @procedure, url: url_for({ controller: 'new_administrateur/procedures', action: :update_jeton }), html: { class: 'form' } do |f|
+    %p.explication
+      Démarches Simplifiées utilise
+      = link_to 'API Entreprise', "https://entreprise.api.gouv.fr/"
+      qui permet de récupérer les informations administratives des entreprises et des associations.
+      Si votre démarche nécessite des autorisations spécifiques que Démarches Simplifiées n'a pas par défaut, merci de renseigner ici le jeton
+      = link_to 'API Entreprise', "https://entreprise.api.gouv.fr/demander_un_acces/"
+      propre à votre démarche.
+
+    = f.label :api_entreprise_token, "Jeton"
+    = f.password_field :api_entreprise_token, class: 'form-control'
+    .text-right
+      = f.button 'Enregistrer', class: 'button primary send'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,6 +166,8 @@ Rails.application.routes.draw do
   post 'admin/procedures' => 'new_administrateur/procedures#create'
   get 'admin/procedures/:id/monavis' => 'new_administrateur/procedures#monavis', as: :admin_procedure_monavis
   patch 'admin/procedures/:id/monavis' => 'new_administrateur/procedures#update_monavis', as: :update_monavis
+  get 'admin/procedures/:id/jeton' => 'new_administrateur/procedures#jeton', as: :admin_procedure_jeton
+  patch 'admin/procedures/:id/jeton' => 'new_administrateur/procedures#update_jeton', as: :update_jeton
 
   namespace :admin do
     get 'activate' => '/administrateurs/activate#new'

--- a/db/migrate/20200423171759_add_api_entreprise_token_to_procedures.rb
+++ b/db/migrate/20200423171759_add_api_entreprise_token_to_procedures.rb
@@ -1,0 +1,5 @@
+class AddAPIEntrepriseTokenToProcedures < ActiveRecord::Migration[5.2]
+  def change
+    add_column :procedures, :api_entreprise_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_22_090426) do
+ActiveRecord::Schema.define(version: 2020_04_23_171759) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -515,6 +515,7 @@ ActiveRecord::Schema.define(version: 2020_04_22_090426) do
     t.datetime "closed_at"
     t.datetime "unpublished_at"
     t.bigint "canonical_procedure_id"
+    t.string "api_entreprise_token"
     t.index ["declarative_with_state"], name: "index_procedures_on_declarative_with_state"
     t.index ["hidden_at"], name: "index_procedures_on_hidden_at"
     t.index ["parent_procedure_id"], name: "index_procedures_on_parent_procedure_id"

--- a/spec/controllers/new_administrateur/procedures_controller_spec.rb
+++ b/spec/controllers/new_administrateur/procedures_controller_spec.rb
@@ -301,4 +301,21 @@ describe NewAdministrateur::ProceduresController, type: :controller do
       end
     end
   end
+
+  describe 'GET #jeton' do
+    let(:procedure) { create(:procedure, administrateur: admin) }
+
+    subject { get :jeton, params: { id: procedure.id } }
+
+    it { is_expected.to have_http_status(:success) }
+  end
+
+  describe 'PATCH #jeton' do
+    let(:procedure) { create(:procedure, administrateur: admin) }
+
+    it "update api_entreprise_token" do
+      patch :update_jeton, params: { id: procedure.id, procedure: { api_entreprise_token: 'ceci-est-un-jeton' } }
+      expect(procedure.reload.api_entreprise_token).to eq('ceci-est-un-jeton')
+    end
+  end
 end

--- a/spec/lib/api_entreprise/effectifs_adapter_spec.rb
+++ b/spec/lib/api_entreprise/effectifs_adapter_spec.rb
@@ -1,6 +1,7 @@
 describe ApiEntreprise::EffectifsAdapter do
   let(:siren) { '418166096' }
-  let(:procedure_id) { 22 }
+  let(:procedure) { create(:procedure) }
+  let(:procedure_id) { procedure.id }
   let(:annee) { "2020" }
   let(:mois) { "02" }
   let(:adapter) { described_class.new(siren, procedure_id, annee, mois) }

--- a/spec/lib/api_entreprise/effectifs_annuels_adapter_spec.rb
+++ b/spec/lib/api_entreprise/effectifs_annuels_adapter_spec.rb
@@ -1,6 +1,7 @@
 describe ApiEntreprise::EffectifsAnnuelsAdapter do
   let(:siren) { '418166096' }
-  let(:procedure_id) { 22 }
+  let(:procedure) { create(:procedure) }
+  let(:procedure_id) { procedure.id }
   let(:adapter) { described_class.new(siren, procedure_id) }
   subject { adapter.to_params }
 

--- a/spec/lib/api_entreprise/entreprise_adapter_spec.rb
+++ b/spec/lib/api_entreprise/entreprise_adapter_spec.rb
@@ -1,6 +1,7 @@
 describe ApiEntreprise::EntrepriseAdapter do
   let(:siren) { '418166096' }
-  let(:procedure_id) { 22 }
+  let(:procedure) { create(:procedure) }
+  let(:procedure_id) { procedure.id }
   let(:adapter) { described_class.new(siren, procedure_id) }
   subject { adapter.to_params }
 

--- a/spec/lib/api_entreprise/etablissement_adapter_spec.rb
+++ b/spec/lib/api_entreprise/etablissement_adapter_spec.rb
@@ -1,5 +1,6 @@
 describe ApiEntreprise::EtablissementAdapter do
-  let(:procedure_id) { 33 }
+  let(:procedure) { create(:procedure) }
+  let(:procedure_id) { procedure.id }
 
   context 'SIRET valide avec infos diffusables' do
     let(:siret) { '41816609600051' }
@@ -88,7 +89,7 @@ describe ApiEntreprise::EtablissementAdapter do
 
   context 'when siret is not found' do
     let(:bad_siret) { 11_111_111_111_111 }
-    subject { described_class.new(bad_siret, 12).to_params }
+    subject { described_class.new(bad_siret, procedure_id).to_params }
 
     before do
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/etablissements\/#{bad_siret}?.*token=/)

--- a/spec/lib/api_entreprise/exercices_adapter_spec.rb
+++ b/spec/lib/api_entreprise/exercices_adapter_spec.rb
@@ -1,7 +1,7 @@
 describe ApiEntreprise::ExercicesAdapter do
   let(:siret) { '41816609600051' }
-  let(:procedure_id) { 11 }
-  subject { described_class.new(siret, procedure_id).to_params }
+  let(:procedure) { create(:procedure) }
+  subject { described_class.new(siret, procedure.id).to_params }
 
   before do
     stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/exercices\/.*token=/)

--- a/spec/lib/api_entreprise/rna_adapter_spec.rb
+++ b/spec/lib/api_entreprise/rna_adapter_spec.rb
@@ -1,6 +1,7 @@
 describe ApiEntreprise::RNAAdapter do
   let(:siret) { '50480511000013' }
-  let(:procedure_id) { 22 }
+  let(:procedure) { create(:procedure) }
+  let(:procedure_id) { procedure.id }
   let(:body) { File.read('spec/fixtures/files/api_entreprise/associations.json') }
   let(:status) { 200 }
   let(:adapter) { described_class.new(siret, procedure_id) }

--- a/spec/services/api_entreprise_service_spec.rb
+++ b/spec/services/api_entreprise_service_spec.rb
@@ -44,7 +44,8 @@ describe ApiEntrepriseService do
     let(:associations_status) { 200 }
     let(:associations_body) { File.read('spec/fixtures/files/api_entreprise/associations.json') }
 
-    let(:result) { ApiEntrepriseService.get_etablissement_params_for_siret(siret, '1') }
+    let(:procedure) { create(:procedure) }
+    let(:result) { ApiEntrepriseService.get_etablissement_params_for_siret(siret, procedure.id) }
 
     context 'when service is up' do
       it 'should fetch etablissement params' do


### PR DESCRIPTION
close #5084

Cette PR permet à un administrateur d'indiquer un jeton api_entreprise spécifique à sa démarche. Les appels à api-entreprise se feront alors avec ce jeton.

![jeton](https://user-images.githubusercontent.com/1111966/80491269-c6015d80-8962-11ea-9467-cadcb7e9632e.png)
