### PR TITLE
5086 afficher attestation sociale

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'groupdate'
 gem 'haml-rails'
 gem 'hashie'
 gem 'jquery-rails' # Use jquery as the JavaScript library
+gem 'jwt'
 gem 'kaminari', '= 1.1.1' # Pagination
 gem 'lograge'
 gem 'logstash-event'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -775,6 +775,7 @@ DEPENDENCIES
   haml-rails
   hashie
   jquery-rails
+  jwt
   kaminari (= 1.1.1)
   launchy
   letter_opener_web

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -112,7 +112,9 @@ module Users
         return render_siret_error(t('errors.messages.siret_unknown'))
       end
 
+      attestation_sociale_url = etablissement_attributes.delete(:entreprise_attestation_sociale_url)
       etablissement = @dossier.build_etablissement(etablissement_attributes)
+      etablissement.upload_attestation_sociale(attestation_sociale_url) if attestation_sociale_url.present?
       etablissement.save!
       current_user.update!(siret: sanitized_siret)
       @dossier.update!(autorisation_donnees: true)

--- a/app/lib/api_entreprise/api.rb
+++ b/app/lib/api_entreprise/api.rb
@@ -86,6 +86,6 @@ class ApiEntreprise::API
 
   def self.token_for_procedure(procedure_id)
     procedure = Procedure.find(procedure_id)
-    procedure.api_entreprise_token.presence || Rails.application.secrets.api_entreprise[:key]
+    procedure.api_entreprise_token
   end
 end

--- a/app/lib/api_entreprise/api.rb
+++ b/app/lib/api_entreprise/api.rb
@@ -5,6 +5,7 @@ class ApiEntreprise::API
   RNA_RESOURCE_NAME = "associations"
   EFFECTIFS_RESOURCE_NAME = "effectifs_mensuels_acoss_covid"
   EFFECTIFS_ANNUELS_RESOURCE_NAME = "effectifs_annuels_acoss_covid"
+  ATTESTATION_SOCIALE_RESOURCE_NAME = "attestations_sociales_acoss"
 
   TIMEOUT = 15
 
@@ -37,6 +38,10 @@ class ApiEntreprise::API
 
   def self.effectifs_annuels(siren, procedure_id)
     call(EFFECTIFS_ANNUELS_RESOURCE_NAME, siren, procedure_id)
+  end
+
+  def self.attestation_sociale(siren, procedure_id)
+    call(ATTESTATION_SOCIALE_RESOURCE_NAME, siren, procedure_id)
   end
 
   private

--- a/app/lib/api_entreprise/api.rb
+++ b/app/lib/api_entreprise/api.rb
@@ -41,7 +41,8 @@ class ApiEntreprise::API
   end
 
   def self.attestation_sociale(siren, procedure_id)
-    call(ATTESTATION_SOCIALE_RESOURCE_NAME, siren, procedure_id)
+    procedure = Procedure.find(procedure_id)
+    call(ATTESTATION_SOCIALE_RESOURCE_NAME, siren, procedure_id) if procedure.api_entreprise_role?("attestations_sociales")
   end
 
   private

--- a/app/lib/api_entreprise/attestation_sociale_adapter.rb
+++ b/app/lib/api_entreprise/attestation_sociale_adapter.rb
@@ -1,0 +1,22 @@
+class ApiEntreprise::AttestationSocialeAdapter < ApiEntreprise::Adapter
+  def initialize(siren, procedure_id)
+    @siren = siren
+    @procedure_id = procedure_id
+  end
+
+  private
+
+  def get_resource
+    ApiEntreprise::API.attestation_sociale(@siren, @procedure_id)
+  end
+
+  def process_params
+    if data_source[:url].present?
+      {
+        entreprise_attestation_sociale_url: data_source[:url]
+      }
+    else
+      {}
+    end
+  end
+end

--- a/app/models/etablissement.rb
+++ b/app/models/etablissement.rb
@@ -4,6 +4,8 @@ class Etablissement < ApplicationRecord
   has_one :champ, class_name: 'Champs::SiretChamp'
   has_many :exercices, dependent: :destroy
 
+  has_one_attached :entreprise_attestation_sociale
+
   accepts_nested_attributes_for :exercices
 
   validates :siret, presence: true
@@ -112,6 +114,19 @@ class Etablissement < ApplicationRecord
       prenom: entreprise_prenom,
       inline_adresse: inline_adresse
     )
+  end
+
+  def upload_attestation_sociale(url)
+    filename = File.basename(URI.parse(url).path)
+    response = Typhoeus.get(url)
+
+    if response.success?
+      entreprise_attestation_sociale.attach(
+        io: StringIO.new(response.body),
+        filename: filename,
+        metadata: { virus_scan_result: ActiveStorage::VirusScanner::SAFE }
+      )
+    end
   end
 
   private

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -552,7 +552,11 @@ class Procedure < ApplicationRecord
   end
 
   def api_entreprise_role?(role)
-    api_entreprise_roles&.include?(role)
+    api_entreprise_roles.include?(role)
+  end
+
+  def api_entreprise_token
+    self[:api_entreprise_token].presence || Rails.application.secrets.api_entreprise[:key]
   end
 
   private

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -547,6 +547,14 @@ class Procedure < ApplicationRecord
     "Procedure;#{id}"
   end
 
+  def api_entreprise_roles
+    JWT.decode(api_entreprise_token, nil, false)[0]["roles"] if api_entreprise_token.present?
+  end
+
+  def api_entreprise_role?(role)
+    api_entreprise_roles&.include?(role)
+  end
+
   private
 
   def move_type_de_champ_attributes(types_de_champ, type_de_champ, new_index)

--- a/app/services/api_entreprise_service.rb
+++ b/app/services/api_entreprise_service.rb
@@ -35,6 +35,12 @@ class ApiEntrepriseService
       rescue ApiEntreprise::API::RequestFailed
       end
 
+      begin
+        attestation_sociale_params = ApiEntreprise::AttestationSocialeAdapter.new(entreprise_params[:entreprise_siren], procedure_id).to_params
+        etablissement_params.merge!(attestation_sociale_params)
+      rescue ApiEntreprise::API::RequestFailed
+      end
+
       etablissement_params.merge(entreprise_params)
     end
   end

--- a/app/views/shared/dossiers/_identite_entreprise.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise.html.haml
@@ -67,6 +67,10 @@
           - elsif etablissement.exercices.present?
             = t('activemodel.models.exercices_summary', count: etablissement.exercices.count)
 
+      - if etablissement.entreprise_attestation_sociale.attached?
+        %tr
+          %th.libelle Attestation sociale
+          %td= link_to "Consulter l'attestation", url_for(etablissement.entreprise_attestation_sociale)
       - if etablissement.association?
         %tr
           %th.libelle Numéro RNA :

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -221,6 +221,9 @@ describe Users::DossiersController, type: :controller do
     let(:api_association_status) { 200 }
     let(:api_association_body) { File.read('spec/fixtures/files/api_entreprise/associations.json') }
 
+    let(:api_entreprise_attestation_sociale_status) { 200 }
+    let(:api_entreprise_attestation_sociale_body) { File.read('spec/fixtures/files/api_entreprise/attestation_sociale.json') }
+
     def stub_api_entreprise_requests
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/etablissements\/#{siret}?.*token=/)
         .to_return(status: api_etablissement_status, body: api_etablissement_body)
@@ -234,11 +237,16 @@ describe Users::DossiersController, type: :controller do
         .to_return(body: api_entreprise_effectifs_mensuels_body, status: api_entreprise_effectifs_mensuels_status)
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/effectifs_annuels_acoss_covid\/#{siren}?.*token=/)
         .to_return(body: api_entreprise_effectifs_annuels_body, status: api_entreprise_effectifs_annuels_status)
+      stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/attestations_sociales_acoss\/#{siren}?.*token=/)
+        .to_return(body: api_entreprise_attestation_sociale_body, status: api_entreprise_attestation_sociale_status)
+      stub_request(:get, "https://storage.entreprise.api.gouv.fr/siade/1569156881-f749d75e2bfd443316e2e02d59015f-attestation_vigilance_acoss.pdf")
+        .to_return(body: "body attestation", status: 200)
     end
 
     before do
       sign_in(user)
       stub_api_entreprise_requests
+      allow_any_instance_of(Procedure).to receive(:api_entreprise_roles).and_return(["entreprises", "attestations_sociales"])
     end
     before { Timecop.freeze(Time.zone.local(2020, 3, 14)) }
     after { Timecop.return }
@@ -334,6 +342,7 @@ describe Users::DossiersController, type: :controller do
           expect(dossier.etablissement.association?).to be(true)
           expect(dossier.etablissement.entreprise_effectif_mensuel).to be_present
           expect(dossier.etablissement.entreprise_effectif_annuel).to be_present
+          expect(dossier.etablissement.entreprise_attestation_sociale).to be_attached
         end
       end
     end

--- a/spec/features/users/dossier_creation_spec.rb
+++ b/spec/features/users/dossier_creation_spec.rb
@@ -78,6 +78,7 @@ feature 'Creating a new dossier:' do
           .to_return(status: 404, body: '')
         stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/effectifs_annuels_acoss_covid\/#{siren}?.*token=/)
           .to_return(status: 404, body: '')
+        allow_any_instance_of(Procedure).to receive(:api_entreprise_roles).and_return([])
       end
       before { Timecop.freeze(Time.zone.local(2020, 3, 14)) }
       after { Timecop.return }

--- a/spec/fixtures/files/api_entreprise/attestation_sociale.json
+++ b/spec/fixtures/files/api_entreprise/attestation_sociale.json
@@ -1,0 +1,4 @@
+{
+  "url":
+  "https://storage.entreprise.api.gouv.fr/siade/1569156881-f749d75e2bfd443316e2e02d59015f-attestation_vigilance_acoss.pdf"
+}

--- a/spec/lib/api_entreprise/api_spec.rb
+++ b/spec/lib/api_entreprise/api_spec.rb
@@ -158,4 +158,31 @@ describe ApiEntreprise::API do
       it { expect(subject).to eq(JSON.parse(body, symbolize_names: true)) }
     end
   end
+
+  describe '.attestation_sociale' do
+    let(:procedure) { create(:procedure, api_entreprise_token: token) }
+    let(:siren) { '418166096' }
+    let(:status) { 200 }
+    let(:body) { File.read('spec/fixtures/files/api_entreprise/attestation_sociale.json') }
+
+    before do
+      allow_any_instance_of(Procedure).to receive(:api_entreprise_roles).and_return(roles)
+      stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/attestations_sociales_acoss\/#{siren}?.*token=/)
+        .to_return(body: body, status: status)
+    end
+
+    subject { described_class.attestation_sociale(siren, procedure.id) }
+
+    context 'when token not authorized' do
+      let(:roles) { ["entreprises"] }
+
+      it { expect(subject).to eq(nil) }
+    end
+
+    context 'when token is authorized' do
+      let(:roles) { ["attestations_sociales"] }
+
+      it { expect(subject).to eq(JSON.parse(body, symbolize_names: true)) }
+    end
+  end
 end

--- a/spec/lib/api_entreprise/attestation_sociale_adapter_spec.rb
+++ b/spec/lib/api_entreprise/attestation_sociale_adapter_spec.rb
@@ -1,0 +1,24 @@
+describe ApiEntreprise::AttestationSocialeAdapter do
+  let(:siren) { '418166096' }
+  let(:procedure_id) { 22 }
+  let(:adapter) { described_class.new(siren, procedure_id) }
+  subject { adapter.to_params }
+
+  before do
+    stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/attestations_sociales_acoss\/#{siren}?.*token=/)
+      .to_return(body: body, status: status)
+  end
+
+  context "when the SIREN is valid" do
+    let(:body) { File.read('spec/fixtures/files/api_entreprise/attestation_sociale.json') }
+    let(:status) { 200 }
+
+    it '#to_params class est une Hash ?' do
+      expect(subject).to be_an_instance_of(Hash)
+    end
+
+    it "renvoie l'url de l'attestation sociale" do
+      expect(subject[:entreprise_attestation_sociale_url]).to eq("https://storage.entreprise.api.gouv.fr/siade/1569156881-f749d75e2bfd443316e2e02d59015f-attestation_vigilance_acoss.pdf")
+    end
+  end
+end

--- a/spec/lib/api_entreprise/attestation_sociale_adapter_spec.rb
+++ b/spec/lib/api_entreprise/attestation_sociale_adapter_spec.rb
@@ -1,12 +1,13 @@
 describe ApiEntreprise::AttestationSocialeAdapter do
   let(:siren) { '418166096' }
-  let(:procedure_id) { 22 }
-  let(:adapter) { described_class.new(siren, procedure_id) }
+  let(:procedure) { create(:procedure) }
+  let(:adapter) { described_class.new(siren, procedure.id) }
   subject { adapter.to_params }
 
   before do
     stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/attestations_sociales_acoss\/#{siren}?.*token=/)
       .to_return(body: body, status: status)
+    allow_any_instance_of(Procedure).to receive(:api_entreprise_roles).and_return(["attestations_sociales"])
   end
 
   context "when the SIREN is valid" do

--- a/spec/services/api_entreprise_service_spec.rb
+++ b/spec/services/api_entreprise_service_spec.rb
@@ -53,6 +53,10 @@ describe ApiEntrepriseService do
     let(:procedure) { create(:procedure, api_entreprise_token: 'un-jeton') }
     let(:result) { ApiEntrepriseService.get_etablissement_params_for_siret(siret, procedure.id) }
 
+    before do
+      allow_any_instance_of(Procedure).to receive(:api_entreprise_roles).and_return(["attestations_sociales"])
+    end
+
     context 'when service is up' do
       it 'should fetch etablissement params' do
         expect(result[:entreprise_siren]).to eq(siren)

--- a/spec/services/api_entreprise_service_spec.rb
+++ b/spec/services/api_entreprise_service_spec.rb
@@ -13,6 +13,8 @@ describe ApiEntrepriseService do
         .to_return(body: effectifs_mensuels_body, status: effectifs_mensuels_status)
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/effectifs_annuels_acoss_covid\/#{siren}?.*token=/)
         .to_return(body: effectifs_annuels_body, status: effectifs_annuels_status)
+      stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/attestations_sociales_acoss\/#{siren}?.*token=/)
+        .to_return(body: attestation_sociale_body, status: attestation_sociale_status)
     end
 
     before { Timecop.freeze(Time.zone.local(2020, 3, 14)) }
@@ -38,13 +40,17 @@ describe ApiEntrepriseService do
     let(:effectifs_annuels_body) { File.read('spec/fixtures/files/api_entreprise/effectifs_annuels.json') }
     let(:effectif_annuel) { 100.5 }
 
+    let(:attestation_sociale_status) { 200 }
+    let(:attestation_sociale_body) { File.read('spec/fixtures/files/api_entreprise/attestation_sociale.json') }
+    let(:attestation_sociale_url) { "https://storage.entreprise.api.gouv.fr/siade/1569156881-f749d75e2bfd443316e2e02d59015f-attestation_vigilance_acoss.pdf" }
+
     let(:exercices_status) { 200 }
     let(:exercices_body) { File.read('spec/fixtures/files/api_entreprise/exercices.json') }
 
     let(:associations_status) { 200 }
     let(:associations_body) { File.read('spec/fixtures/files/api_entreprise/associations.json') }
 
-    let(:procedure) { create(:procedure) }
+    let(:procedure) { create(:procedure, api_entreprise_token: 'un-jeton') }
     let(:result) { ApiEntrepriseService.get_etablissement_params_for_siret(siret, procedure.id) }
 
     context 'when service is up' do
@@ -55,6 +61,7 @@ describe ApiEntrepriseService do
         expect(result[:exercices_attributes]).to_not be_empty
         expect(result[:entreprise_effectif_mensuel]).to eq(effectif_mensuel)
         expect(result[:entreprise_effectif_annuel]).to eq(effectif_annuel)
+        expect(result[:entreprise_attestation_sociale_url]).to eq(attestation_sociale_url)
       end
     end
 


### PR DESCRIPTION
close #5086 

Lorsque un usager met à jour le SIRET, 
- si la procédure considérée a un jeton qui lui permet d'accéder aux attestations sociales, 
- récupère depuis api_entreprise l'attestation sociale
- la stocke
- la rend consultable à l'instructeur
 depuis la vue identité entreprise

![attestation](https://user-images.githubusercontent.com/1111966/80575672-3dd39480-8a04-11ea-83b7-83c6da311ccc.png)
