### PR TITLE
don't copy api_entreprise_token when cloning

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -306,6 +306,7 @@ class Procedure < ApplicationRecord
 
     if is_different_admin
       procedure.administrateurs = [admin]
+      procedure.api_entreprise_token = nil
     else
       procedure.administrateurs = administrateurs
     end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -461,6 +461,10 @@ describe Procedure do
         end
       end
 
+      it 'should discard specific api_entreprise_token' do
+        expect(subject.read_attribute(:api_entreprise_token)).to be_nil
+      end
+
       it 'should have one administrateur' do
         expect(subject.administrateurs).to eq([administrateur])
       end


### PR DESCRIPTION
except for an admin who owns the parent procedure