### PR TITLE
affiche attestation fiscale

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -104,7 +104,7 @@ module Users
 
       sanitized_siret = siret_model.siret
       begin
-        etablissement_attributes = ApiEntrepriseService.get_etablissement_params_for_siret(sanitized_siret, @dossier.procedure.id)
+        etablissement_attributes = ApiEntrepriseService.get_etablissement_params_for_siret(sanitized_siret, @dossier.procedure.id, current_user.id)
       rescue ApiEntreprise::API::RequestFailed
         return render_siret_error(t('errors.messages.siret_network_error'))
       end
@@ -113,8 +113,10 @@ module Users
       end
 
       attestation_sociale_url = etablissement_attributes.delete(:entreprise_attestation_sociale_url)
+      attestation_fiscale_url = etablissement_attributes.delete(:entreprise_attestation_fiscale_url)
       etablissement = @dossier.build_etablissement(etablissement_attributes)
       etablissement.upload_attestation_sociale(attestation_sociale_url) if attestation_sociale_url.present?
+      etablissement.upload_attestation_fiscale(attestation_fiscale_url) if attestation_fiscale_url.present?
       etablissement.save!
       current_user.update!(siret: sanitized_siret)
       @dossier.update!(autorisation_donnees: true)

--- a/app/lib/api_entreprise/attestation_fiscale_adapter.rb
+++ b/app/lib/api_entreprise/attestation_fiscale_adapter.rb
@@ -1,0 +1,23 @@
+class ApiEntreprise::AttestationFiscaleAdapter < ApiEntreprise::Adapter
+  def initialize(siren, procedure_id, user_id)
+    @siren = siren
+    @procedure_id = procedure_id
+    @user_id = user_id
+  end
+
+  private
+
+  def get_resource
+    ApiEntreprise::API.attestation_fiscale(@siren, @procedure_id, @user_id)
+  end
+
+  def process_params
+    if data_source[:url].present?
+      {
+        entreprise_attestation_fiscale_url: data_source[:url]
+      }
+    else
+      {}
+    end
+  end
+end

--- a/app/models/etablissement.rb
+++ b/app/models/etablissement.rb
@@ -5,6 +5,7 @@ class Etablissement < ApplicationRecord
   has_many :exercices, dependent: :destroy
 
   has_one_attached :entreprise_attestation_sociale
+  has_one_attached :entreprise_attestation_fiscale
 
   accepts_nested_attributes_for :exercices
 
@@ -116,17 +117,25 @@ class Etablissement < ApplicationRecord
     )
   end
 
-  def upload_attestation_sociale(url)
+  def upload_attestation(url, attestation)
     filename = File.basename(URI.parse(url).path)
     response = Typhoeus.get(url)
 
     if response.success?
-      entreprise_attestation_sociale.attach(
+      attestation.attach(
         io: StringIO.new(response.body),
         filename: filename,
         metadata: { virus_scan_result: ActiveStorage::VirusScanner::SAFE }
       )
     end
+  end
+
+  def upload_attestation_sociale(url)
+    upload_attestation(url, entreprise_attestation_sociale)
+  end
+
+  def upload_attestation_fiscale(url)
+    upload_attestation(url, entreprise_attestation_fiscale)
   end
 
   private

--- a/app/services/api_entreprise_service.rb
+++ b/app/services/api_entreprise_service.rb
@@ -6,7 +6,7 @@ class ApiEntrepriseService
   #
   # Raises a ApiEntreprise::API::RequestFailed exception on transcient errors
   # (timeout, 5XX HTTP error code, etc.)
-  def self.get_etablissement_params_for_siret(siret, procedure_id)
+  def self.get_etablissement_params_for_siret(siret, procedure_id, user_id = nil)
     etablissement_params = ApiEntreprise::EtablissementAdapter.new(siret, procedure_id).to_params
     entreprise_params = ApiEntreprise::EntrepriseAdapter.new(siret, procedure_id).to_params
 
@@ -41,6 +41,11 @@ class ApiEntrepriseService
       rescue ApiEntreprise::API::RequestFailed
       end
 
+      begin
+        attestation_fiscale_params = ApiEntreprise::AttestationFiscaleAdapter.new(entreprise_params[:entreprise_siren], procedure_id, user_id).to_params
+        etablissement_params.merge!(attestation_fiscale_params)
+      rescue ApiEntreprise::API::RequestFailed
+      end
       etablissement_params.merge(entreprise_params)
     end
   end

--- a/app/views/shared/dossiers/_identite_entreprise.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise.html.haml
@@ -71,6 +71,12 @@
         %tr
           %th.libelle Attestation sociale
           %td= link_to "Consulter l'attestation", url_for(etablissement.entreprise_attestation_sociale)
+
+      - if etablissement.entreprise_attestation_fiscale.attached?
+        %tr
+          %th.libelle Attestation fiscale
+          %td= link_to "Consulter l'attestation", url_for(etablissement.entreprise_attestation_fiscale)
+
       - if etablissement.association?
         %tr
           %th.libelle Numéro RNA :

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -224,6 +224,9 @@ describe Users::DossiersController, type: :controller do
     let(:api_entreprise_attestation_sociale_status) { 200 }
     let(:api_entreprise_attestation_sociale_body) { File.read('spec/fixtures/files/api_entreprise/attestation_sociale.json') }
 
+    let(:api_entreprise_attestation_fiscale_status) { 200 }
+    let(:api_entreprise_attestation_fiscale_body) { File.read('spec/fixtures/files/api_entreprise/attestation_fiscale.json') }
+
     def stub_api_entreprise_requests
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/etablissements\/#{siret}?.*token=/)
         .to_return(status: api_etablissement_status, body: api_etablissement_body)
@@ -241,12 +244,16 @@ describe Users::DossiersController, type: :controller do
         .to_return(body: api_entreprise_attestation_sociale_body, status: api_entreprise_attestation_sociale_status)
       stub_request(:get, "https://storage.entreprise.api.gouv.fr/siade/1569156881-f749d75e2bfd443316e2e02d59015f-attestation_vigilance_acoss.pdf")
         .to_return(body: "body attestation", status: 200)
+      stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/attestations_fiscales_dgfip\/#{siren}?.*token=/)
+        .to_return(body: api_entreprise_attestation_fiscale_body, status: api_entreprise_attestation_fiscale_status)
+      stub_request(:get, "https://storage.entreprise.api.gouv.fr/siade/1569156756-f6b7779f99fa95cd60dc03c04fcb-attestation_fiscale_dgfip.pdf")
+        .to_return(body: "body attestation", status: 200)
     end
 
     before do
       sign_in(user)
       stub_api_entreprise_requests
-      allow_any_instance_of(Procedure).to receive(:api_entreprise_roles).and_return(["entreprises", "attestations_sociales"])
+      allow_any_instance_of(Procedure).to receive(:api_entreprise_roles).and_return(["attestations_fiscales", "attestations_sociales"])
     end
     before { Timecop.freeze(Time.zone.local(2020, 3, 14)) }
     after { Timecop.return }
@@ -343,6 +350,7 @@ describe Users::DossiersController, type: :controller do
           expect(dossier.etablissement.entreprise_effectif_mensuel).to be_present
           expect(dossier.etablissement.entreprise_effectif_annuel).to be_present
           expect(dossier.etablissement.entreprise_attestation_sociale).to be_attached
+          expect(dossier.etablissement.entreprise_attestation_fiscale).to be_attached
         end
       end
     end

--- a/spec/fixtures/files/api_entreprise/attestation_fiscale.json
+++ b/spec/fixtures/files/api_entreprise/attestation_fiscale.json
@@ -1,0 +1,4 @@
+{
+  "url":
+  "https://storage.entreprise.api.gouv.fr/siade/1569156756-f6b7779f99fa95cd60dc03c04fcb-attestation_fiscale_dgfip.pdf"
+}

--- a/spec/lib/api_entreprise/api_spec.rb
+++ b/spec/lib/api_entreprise/api_spec.rb
@@ -185,4 +185,32 @@ describe ApiEntreprise::API do
       it { expect(subject).to eq(JSON.parse(body, symbolize_names: true)) }
     end
   end
+
+  describe '.attestation_fiscale' do
+    let(:procedure) { create(:procedure, api_entreprise_token: token) }
+    let(:siren) { '418166096' }
+    let(:user_id) { 1 }
+    let(:status) { 200 }
+    let(:body) { File.read('spec/fixtures/files/api_entreprise/attestation_fiscale.json') }
+
+    before do
+      allow_any_instance_of(Procedure).to receive(:api_entreprise_roles).and_return(roles)
+      stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/attestations_fiscales_dgfip\/#{siren}?.*token=#{token}&user_id=#{user_id}/)
+        .to_return(body: body, status: status)
+    end
+
+    subject { described_class.attestation_fiscale(siren, procedure.id, user_id) }
+
+    context 'when token not authorized' do
+      let(:roles) { ["entreprises"] }
+
+      it { expect(subject).to eq(nil) }
+    end
+
+    context 'when token is authorized' do
+      let(:roles) { ["attestations_fiscales"] }
+
+      it { expect(subject).to eq(JSON.parse(body, symbolize_names: true)) }
+    end
+  end
 end

--- a/spec/lib/api_entreprise/attestation_fiscale_adapter_spec.rb
+++ b/spec/lib/api_entreprise/attestation_fiscale_adapter_spec.rb
@@ -1,0 +1,26 @@
+describe ApiEntreprise::AttestationFiscaleAdapter do
+  let(:siren) { '418166096' }
+  let(:procedure) { create(:procedure) }
+  let(:user_id) { 1 }
+  let(:adapter) { described_class.new(siren, procedure.id, user_id) }
+  subject { adapter.to_params }
+
+  before do
+    stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/attestations_fiscales_dgfip\/#{siren}?.*token=/)
+      .to_return(body: body, status: status)
+    allow_any_instance_of(Procedure).to receive(:api_entreprise_roles).and_return(["attestations_fiscales"])
+  end
+
+  context "when the SIREN is valid" do
+    let(:body) { File.read('spec/fixtures/files/api_entreprise/attestation_fiscale.json') }
+    let(:status) { 200 }
+
+    it '#to_params class est une Hash ?' do
+      expect(subject).to be_an_instance_of(Hash)
+    end
+
+    it "returns url of attestation_fiscale" do
+      expect(subject[:entreprise_attestation_fiscale_url]).to eq("https://storage.entreprise.api.gouv.fr/siade/1569156756-f6b7779f99fa95cd60dc03c04fcb-attestation_fiscale_dgfip.pdf")
+    end
+  end
+end

--- a/spec/services/api_entreprise_service_spec.rb
+++ b/spec/services/api_entreprise_service_spec.rb
@@ -15,6 +15,10 @@ describe ApiEntrepriseService do
         .to_return(body: effectifs_annuels_body, status: effectifs_annuels_status)
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/attestations_sociales_acoss\/#{siren}?.*token=/)
         .to_return(body: attestation_sociale_body, status: attestation_sociale_status)
+      stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/attestations_sociales_acoss\/#{siren}?.*token=/)
+        .to_return(body: attestation_sociale_body, status: attestation_sociale_status)
+      stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/attestations_fiscales_dgfip\/#{siren}?.*token=/)
+        .to_return(body: attestation_fiscale_body, status: attestation_fiscale_status)
     end
 
     before { Timecop.freeze(Time.zone.local(2020, 3, 14)) }
@@ -44,6 +48,10 @@ describe ApiEntrepriseService do
     let(:attestation_sociale_body) { File.read('spec/fixtures/files/api_entreprise/attestation_sociale.json') }
     let(:attestation_sociale_url) { "https://storage.entreprise.api.gouv.fr/siade/1569156881-f749d75e2bfd443316e2e02d59015f-attestation_vigilance_acoss.pdf" }
 
+    let(:attestation_fiscale_status) { 200 }
+    let(:attestation_fiscale_body) { File.read('spec/fixtures/files/api_entreprise/attestation_fiscale.json') }
+    let(:attestation_fiscale_url) { "https://storage.entreprise.api.gouv.fr/siade/1569156756-f6b7779f99fa95cd60dc03c04fcb-attestation_fiscale_dgfip.pdf" }
+
     let(:exercices_status) { 200 }
     let(:exercices_body) { File.read('spec/fixtures/files/api_entreprise/exercices.json') }
 
@@ -54,7 +62,7 @@ describe ApiEntrepriseService do
     let(:result) { ApiEntrepriseService.get_etablissement_params_for_siret(siret, procedure.id) }
 
     before do
-      allow_any_instance_of(Procedure).to receive(:api_entreprise_roles).and_return(["attestations_sociales"])
+      allow_any_instance_of(Procedure).to receive(:api_entreprise_roles).and_return(["attestations_sociales", "attestations_fiscales"])
     end
 
     context 'when service is up' do
@@ -66,6 +74,7 @@ describe ApiEntrepriseService do
         expect(result[:entreprise_effectif_mensuel]).to eq(effectif_mensuel)
         expect(result[:entreprise_effectif_annuel]).to eq(effectif_annuel)
         expect(result[:entreprise_attestation_sociale_url]).to eq(attestation_sociale_url)
+        expect(result[:entreprise_attestation_fiscale_url]).to eq(attestation_fiscale_url)
       end
     end
 


### PR DESCRIPTION
close #5087 

Lorsque un usager met à jour le SIRET, 
- si la procédure considérée a un jeton qui lui permet d'accéder aux attestations fiscales, 
- récupère depuis api_entreprise l'attestation fiscale
- la stocke
- la rend consultable à l'instructeur
 depuis la vue identité entreprise

