### PR TITLE
fix identite entreprise view

### DIFF
--- a/app/views/shared/dossiers/_identite_entreprise.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise.html.haml
@@ -78,7 +78,7 @@
             %th.libelle Attestation fiscale
             %td= link_to "Consulter l'attestation", url_for(etablissement.entreprise_attestation_fiscale)
 
-        - if etablissement.entreprise_bilans_bdf_to_csv.present?
+        - if etablissement.entreprise_bilans_bdf.present?
           %tr
             %th.libelle
               Bilans Banque de France


### PR DESCRIPTION
Une erreur 500 survient si l'etablissement n'a pas de bilans bdf.
Cette PR corrige ce bug.