### PR TITLE
#5089 - Fix test aléatoire pour DossierSearchService

### DIFF
--- a/spec/services/dossier_search_service_spec.rb
+++ b/spec/services/dossier_search_service_spec.rb
@@ -133,13 +133,13 @@ describe DossierSearchService do
       context 'when the user owns the dossier' do
         let(:terms) { dossier_0.id.to_s }
 
-        it { expect(subject.size).to eq(1) }
+        it { expect(subject.map(&:id)).to include(dossier_0.id) }
       end
 
       context 'when the user does not own the dossier' do
         let(:terms) { dossier_0b.id.to_s }
 
-        it { expect(subject.size).to eq(0) }
+        it { expect(subject.map(&:id)).not_to include(dossier_0b.id) }
       end
     end
 


### PR DESCRIPTION
Fix pour #5089

## Le problème

Lors d'une recherche par id de dossier, on matche sur plus de dossiers que prévu. C'est une feature: la recherche par id est assez laxiste. Par contre, tel que le test est écrit, ça fait parfois péter les tests.
C'est du au fait que:
 - on cherche dans plein de valeurs du dossier, pas juste sur l'id -_-
 - les données sont aléatoires
 - on fait la recherche en mode "je valide un match si la valeur commence par [terme recherché]" ce qui augmente les chances de collision

## Le fix

Écrire un test plus précis

## L'investigation

Je vous cache pas que je savais pas trop comment prendre ce problème et que j'ai un poil souffert, la principale difficulté à été de réduire le jeu de test pour mettre moins de 4mn entre chaque run, après il fallait comprendre ce qui se passait.

```bash
$ rspec './spec/services/dossier_search_service_spec.rb[1:2:1:1,1:2:2:2:1,1:2:3:1,1:2:4:1,1:2:5:1,1:2:6:1:1,1:2:6:2:1,1:2:10:1]' --seed 19
.......F.....
```

```ruby
context 'when the user does not own the dossier' do
  let(:terms) { dossier_0b.id.to_s }
  
  it {
    debugger
    expect(subject.size).to eq(0)
  }
end
```

```bash
(byebug) dossier_0b.id
44
(byebug) subject.map(&:id)
[45, 46, 47]
(byebug) subject.map(&:user).map(&:email)
["bidou@clap.fr", "bidou@clap.fr", "bidou@clap.fr"]
```

Eureka ! On tient quelque chose, on matche pas sur le dossier auquel on s'attend, mais ce sont bien des dossiers légitimes de l'utilisateur.
