### PR TITLE
fix bilans bdf link

### DIFF
--- a/app/controllers/instructeurs/avis_controller.rb
+++ b/app/controllers/instructeurs/avis_controller.rb
@@ -72,6 +72,14 @@ module Instructeurs
       end
     end
 
+    def bilans_bdf
+      if avis.dossier.etablissement&.entreprise_bilans_bdf_to_csv.present?
+        render csv: avis.dossier.etablissement.entreprise_bilans_bdf_to_csv
+      else
+        redirect_to instructeur_avis_path(avis)
+      end
+    end
+
     def sign_up
       @email = params[:email]
       @dossier = Avis.includes(:dossier).find(params[:id]).dossier

--- a/app/views/shared/dossiers/_identite_entreprise.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise.html.haml
@@ -83,7 +83,7 @@
             %th.libelle
               Bilans Banque de France
               = "en #{etablissement.entreprise_bilans_bdf_monnaie}"
-            %td= link_to "Consulter les bilans", bilans_bdf_instructeur_dossier_path
+            %td= link_to "Consulter les bilans", bilans_bdf_instructeur_dossier_path(procedure_id: @dossier.procedure.id, dossier_id: @dossier.id)
 
       - if etablissement.association?
         %tr

--- a/app/views/shared/dossiers/_identite_entreprise.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise.html.haml
@@ -83,7 +83,10 @@
             %th.libelle
               Bilans Banque de France
               = "en #{etablissement.entreprise_bilans_bdf_monnaie}"
-            %td= link_to "Consulter les bilans", bilans_bdf_instructeur_dossier_path(procedure_id: @dossier.procedure.id, dossier_id: @dossier.id)
+            - if controller.is_a?(Instructeurs::AvisController)
+              %td= link_to "Consulter les bilans", bilans_bdf_instructeur_avis_path(@avis.id)
+            - else
+              %td= link_to "Consulter les bilans", bilans_bdf_instructeur_dossier_path(procedure_id: @dossier.procedure.id, dossier_id: @dossier.id)
 
       - if etablissement.association?
         %tr

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -354,6 +354,7 @@ Rails.application.routes.draw do
         get 'messagerie'
         post 'commentaire' => 'avis#create_commentaire'
         post 'avis' => 'avis#create_avis'
+        get 'bilans_bdf'
 
         get 'sign_up/email/:email' => 'avis#sign_up', constraints: { email: /.*/ }, as: 'sign_up'
         post 'sign_up/email/:email' => 'avis#create_instructeur', constraints: { email: /.*/ }

--- a/spec/controllers/instructeurs/avis_controller_spec.rb
+++ b/spec/controllers/instructeurs/avis_controller_spec.rb
@@ -50,6 +50,12 @@ describe Instructeurs::AvisController, type: :controller do
       it { expect(assigns(:dossier)).to eq(dossier) }
     end
 
+    describe '#bilans_bdf' do
+      before { get :bilans_bdf, params: { id: avis_without_answer.id } }
+
+      it { expect(response).to redirect_to(instructeur_avis_path(avis_without_answer)) }
+    end
+
     describe '#update' do
       describe 'without attachment' do
         before do


### PR DESCRIPTION
close #5125 

Le lien pour les bilans bdf était mal généré dans le cas de la consultation d'une demande par un expert suite à une demande d'avis.

Cette PR génère un lien correct.
