### PR TITLE
app: remove tooltips on the old design

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,18 +16,3 @@
 //= require smart_listing
 //= require bootstrap-wysihtml5
 //= require bootstrap-wysihtml5/locales/fr-FR
-
-/* globals $ */
-
-$(document).on('turbolinks:load', application_init);
-
-function application_init() {
-  tooltip_init();
-}
-
-function tooltip_init() {
-  $('.action_button[data-toggle="tooltip"]').tooltip({
-    delay: { show: 100, hide: 100 }
-  });
-  $('[data-toggle="tooltip"]').tooltip({ delay: { show: 800, hide: 100 } });
-}

--- a/app/views/admin/attestation_templates/edit.html.haml
+++ b/app/views/admin/attestation_templates/edit.html.haml
@@ -85,6 +85,6 @@
       - if @attestation_template.new_record? || !@attestation_template.activated
         %button.btn.btn-success Activer l'attestation
       - else
-        - save_data = @procedure.locked? ? { toggle: :tooltip, confirm: "Attention: les modifications n'affecteront pas les attestations déjà délivrées." } : nil
+        - save_data = @procedure.locked? ? { confirm: "Attention: les modifications n'affecteront pas les attestations déjà délivrées." } : nil
         %button.btn.btn-success{ data: save_data } Enregistrer
 

--- a/app/views/admin/procedures/show.html.haml
+++ b/app/views/admin/procedures/show.html.haml
@@ -12,7 +12,7 @@
         - if @procedure.service.nil?
           - missing_elements << 'un service'
         - message = "Affectez #{missing_elements.join(' et ')} à votre démarche."
-        %button.action_button.btn.btn-success#disabled-publish-procedure{ data: { toggle: :tooltip, placement: :bottom }, style: 'float: right; margin-top: 10px;', disabled: true, title: message }
+        %button.action_button.btn.btn-success#disabled-publish-procedure{ style: 'float: right; margin-top: 10px;', disabled: true, title: message }
           %i.fa.fa-eraser
           Publier
       - else


### PR DESCRIPTION
- Tooltips are no longer used anywhere
- They cause an error on app initialisation

Fixes "TypeError: dataAttributes.hasOwnProperty is not a function" errors that we've been seeing recently on Sentry.