### PR TITLE
Export tableur : suppression de la colonne "Date de naissance"

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -626,9 +626,11 @@ class Dossier < ApplicationRecord
       columns += [
         ['Civilité', individual&.gender],
         ['Nom', individual&.nom],
-        ['Prénom', individual&.prenom],
-        ['Date de naissance', individual&.birthdate]
+        ['Prénom', individual&.prenom]
       ]
+      if procedure.ask_birthday
+        columns += [['Date de naissance', individual&.birthdate]]
+      end
     elsif with_etablissement
       columns += [
         ['Établissement SIRET', etablissement&.siret],

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -25,13 +25,13 @@ describe ProcedureExportService do
       procedure.reload
     end
 
-    context 'dossiers' do
-      it 'should have sheets' do
+    describe 'sheets' do
+      it 'should have a sheet for each record type' do
         expect(subject.sheets.map(&:name)).to eq(['Dossiers', 'Etablissements', 'Avis'])
       end
     end
 
-    context 'with dossier' do
+    describe 'Dossiers sheet' do
       let!(:dossier) { create(:dossier, :en_instruction, :with_all_champs, :with_individual, procedure: procedure) }
 
       let(:nominal_headers) do
@@ -97,14 +97,14 @@ describe ProcedureExportService do
       context 'with a procedure routee' do
         before { procedure.groupe_instructeurs.create(label: '2') }
 
-        let(:routee_header) { nominal_headers.insert(nominal_headers.index('textarea'), 'Groupe instructeur') }
+        let(:routee_headers) { nominal_headers.insert(nominal_headers.index('textarea'), 'Groupe instructeur') }
 
-        it { expect(dossiers_sheet.headers).to match(routee_header) }
+        it { expect(dossiers_sheet.headers).to match(routee_headers) }
         it { expect(dossiers_sheet.data[0][dossiers_sheet.headers.index('Groupe instructeur')]).to eq('défaut') }
       end
     end
 
-    context 'with etablissement' do
+    describe 'Etablissement sheet' do
       let(:procedure) { create(:procedure, :published, :with_all_champs) }
       let!(:dossier) { create(:dossier, :en_instruction, :with_all_champs, :with_entreprise, procedure: procedure) }
 
@@ -284,7 +284,7 @@ describe ProcedureExportService do
       end
     end
 
-    context 'with avis' do
+    describe 'Avis sheet' do
       let!(:dossier) { create(:dossier, :en_instruction, :with_all_champs, :with_individual, procedure: procedure) }
       let!(:avis) { create(:avis, :with_answer, dossier: dossier) }
 
@@ -305,7 +305,7 @@ describe ProcedureExportService do
       end
     end
 
-    context 'with repetitions' do
+    describe 'Repetitions sheet' do
       let!(:dossiers) do
         [
           create(:dossier, :en_instruction, :with_all_champs, :with_individual, procedure: procedure),

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -41,7 +41,6 @@ describe ProcedureExportService do
           "Civilité",
           "Nom",
           "Prénom",
-          "Date de naissance",
           "Archivé",
           "État du dossier",
           "Dernière mise à jour le",
@@ -88,10 +87,19 @@ describe ProcedureExportService do
 
         # SimpleXlsxReader is transforming datetimes in utc... It is only used in test so we just hack around.
         offset = dossier.en_construction_at.utc_offset
-        en_construction_at = Time.zone.at(dossiers_sheet.data[0][9] - offset.seconds)
-        en_instruction_at = Time.zone.at(dossiers_sheet.data[0][10] - offset.seconds)
+        en_construction_at = Time.zone.at(dossiers_sheet.data[0][8] - offset.seconds)
+        en_instruction_at = Time.zone.at(dossiers_sheet.data[0][9] - offset.seconds)
         expect(en_construction_at).to eq(dossier.en_construction_at.round)
         expect(en_instruction_at).to eq(dossier.en_instruction_at.round)
+      end
+
+      context 'with a birthdate' do
+        before { procedure.update(ask_birthday: true) }
+
+        let(:birthdate_headers) { nominal_headers.insert(nominal_headers.index('Archivé'), 'Date de naissance') }
+
+        it { expect(dossiers_sheet.headers).to match(birthdate_headers) }
+        it { expect(dossiers_sheet.data[0][dossiers_sheet.headers.index('Date de naissance')]).to be_a(Date) }
       end
 
       context 'with a procedure routee' do


### PR DESCRIPTION
La date de naissance est dépréciée, n'est quasiment plus utilisée sur les démarches. Cette PR n'affiche la colonne "Date de naissance" que si c'est une démarche legacy qui le demande.

_Note :_ techniquement ça va modifier l'ordre des colonnes dans les exports tableur. Est-ce qu'on veut vraiment ça ? Est-ce qu'on notifie les utilisateurs de l'export avant ?