### PR TITLE
Export tableur : ajout du nom de fichier aux pièces justificatives

### DIFF
--- a/app/models/champs/piece_justificative_champ.rb
+++ b/app/models/champs/piece_justificative_champ.rb
@@ -36,6 +36,10 @@ class Champs::PieceJustificativeChamp < Champ
     mandatory? && !piece_justificative_file.attached?
   end
 
+  def for_export
+    piece_justificative_file.filename.to_s if piece_justificative_file.attached?
+  end
+
   def for_api
     if piece_justificative_file.attached? && (piece_justificative_file.virus_scanner.safe? || piece_justificative_file.virus_scanner.pending?)
       piece_justificative_file.service_url

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -131,11 +131,19 @@ class Dossier < ApplicationRecord
         etablissement: :champ,
         champs: {
           etablissement: :champ,
-          type_de_champ: :drop_down_list
+          type_de_champ: :drop_down_list,
+          piece_justificative_file_attachment: :blob,
+          champs: [
+            piece_justificative_file_attachment: :blob
+          ]
         },
         champs_private: {
           etablissement: :champ,
-          type_de_champ: :drop_down_list
+          type_de_champ: :drop_down_list,
+          piece_justificative_file_attachment: :blob,
+          champs: [
+            piece_justificative_file_attachment: :blob
+          ]
         },
         procedure: :groupe_instructeurs
       ).order(en_construction_at: 'asc')

--- a/spec/models/champs/piece_justificative_champ_spec.rb
+++ b/spec/models/champs/piece_justificative_champ_spec.rb
@@ -14,6 +14,18 @@ describe Champs::PieceJustificativeChamp do
     it { is_expected.to validate_content_type_of(:piece_justificative_file).allowing(Champs::PieceJustificativeChamp::ACCEPTED_FORMATS) }
   end
 
+  describe "#for_export" do
+    let(:champ_pj) { create(:champ_piece_justificative) }
+    subject { champ_pj.for_export }
+
+    it { is_expected.to eq('toto.txt') }
+
+    context 'without attached file' do
+      before { champ_pj.piece_justificative_file.purge }
+      it { is_expected.to eq(nil) }
+    end
+  end
+
   describe '#for_api' do
     let(:champ_pj) { create(:champ_piece_justificative) }
     let(:metadata) { champ_pj.piece_justificative_file.blob.metadata }


### PR DESCRIPTION
Aujourd'hui, les champs "Pièce justificative" ont une colonne dans l'export, mais cette colonne est toujours vide.

Cette PR remplit à la place celle colonne avec le nom du fichier (si il est présent).

C'est une demande qui est déjà arrivé de temps en temps au support (la plus récente : `HS #39107`)