### PR TITLE
#5140 - Anonymisation de l'instructeur dans la messagerie

### DIFF
--- a/app/models/commentaire.rb
+++ b/app/models/commentaire.rb
@@ -34,7 +34,11 @@ class Commentaire < ApplicationRecord
 
   def redacted_email
     if instructeur.present?
-      instructeur.email.split('@').first
+      if Flipper.enabled?(:hide_instructeur_email, dossier.procedure)
+        "Instructeur n° #{instructeur.id}"
+      else
+        instructeur.email.split('@').first
+      end
     else
       email
     end

--- a/spec/models/commentaire_spec.rb
+++ b/spec/models/commentaire_spec.rb
@@ -44,11 +44,22 @@ describe Commentaire do
   describe "#redacted_email" do
     subject { commentaire.redacted_email }
 
+    let(:procedure) { create(:procedure) }
+    let(:dossier) { create(:dossier, procedure: procedure) }
+
     context 'with a commentaire created by a instructeur' do
-      let(:commentaire) { build :commentaire, instructeur: instructeur }
+      let(:commentaire) { build :commentaire, instructeur: instructeur, dossier: dossier }
       let(:instructeur) { build :instructeur, email: 'some_user@exemple.fr' }
 
-      it { is_expected.to eq 'some_user' }
+      context 'when the procedure shows instructeurs email' do
+        before { Flipper.disable(:hide_instructeur_email, procedure) }
+        it { is_expected.to eq 'some_user' }
+      end
+
+      context 'when the procedure hides instructeurs email' do
+        before { Flipper.enable(:hide_instructeur_email, procedure) }
+        it { is_expected.to eq "Instructeur n° #{instructeur.id}" }
+      end
     end
 
     context 'with a commentaire created by a user' do

--- a/spec/views/shared/dossiers/messages/message.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/messages/message.html.haml_spec.rb
@@ -20,4 +20,31 @@ describe 'shared/dossiers/messages/message.html.haml', type: :view do
 
     it { is_expected.to have_css(".highlighted") }
   end
+
+  context 'with an instructeur message' do
+    let(:instructeur) { create(:instructeur) }
+    let(:procedure) { create(:procedure) }
+    let(:commentaire) { create(:commentaire, instructeur: instructeur, body: 'Second message') }
+    let(:dossier) { create(:dossier, :en_construction, commentaires: [commentaire], procedure: procedure) }
+
+    context 'on a procedure with anonymous instructeurs' do
+      before { Flipper.enable_actor(:hide_instructeur_email, procedure) }
+
+      context 'redacts the instructeur email' do
+        it { is_expected.to have_text(commentaire.body) }
+        it { is_expected.to have_text("Instructeur n° #{instructeur.id}") }
+        it { is_expected.not_to have_text(instructeur.email) }
+      end
+    end
+
+    context 'on a procedure where instructeurs names are not redacted' do
+      before { Flipper.disable_actor(:hide_instructeur_email, procedure) }
+
+      context 'redacts the instructeur email but keeps the name' do
+        it { is_expected.to have_text(commentaire.body) }
+        it { is_expected.to have_text(instructeur.email.split('@').first) }
+        it { is_expected.not_to have_text(instructeur.email) }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Pour #5140. Si le feature flag `hide_instructeur_email` est activé sur une procédure, on masque le nom au profit d'un identifiant.

J'ai l'impression qu'avec ça on est bon ; on affiche l'email instructeur uniquement dans la messagerie pour les usagers.
Dans le mail de notification usager (`DossierMailer#notify_new_answer`), on affiche rien sur l'instructeur. Du tour que j'ai fait dans les mails, j'ai l'impression que c'est le seul susceptible de contenir cette info.

J'ai un test qui parait doublon:
 - `spec/views/shared/dossiers/messages/message.html.haml_spec.rb`
 - `spec/views/users/dossiers/show.html.haml_spec.rb`

Je me dis que ça permet de se blinder en cas de régression, mais c'est sans doute un poil overkill. Si vous trouvez que c'est trop peut supprimer les ajouts dans `spec/views/users/dossiers/show.html.haml_spec.rb`, cette vue inclue une vue partagée