### PR TITLE
Pièces justificatives : amélioration des messages d'erreur

### DIFF
--- a/app/javascript/new_design/dossiers/auto-upload-controller.js
+++ b/app/javascript/new_design/dossiers/auto-upload-controller.js
@@ -1,6 +1,9 @@
 import Uploader from '../../shared/activestorage/uploader';
 import { show, hide, toggle } from '@utils';
-import { FAILURE_CONNECTIVITY } from '../../shared/activestorage/file-upload-error';
+import {
+  ERROR_CODE_READ,
+  FAILURE_CONNECTIVITY
+} from '../../shared/activestorage/file-upload-error';
 
 // Given a file input in a champ with a selected file, upload a file,
 // then attach it to the dossier.
@@ -67,6 +70,12 @@ export default class AutoUploadController {
         title: 'Le fichier n’a pas pu être envoyé.',
         description: 'Vérifiez votre connexion à Internet, puis ré-essayez.',
         retry: true
+      };
+    } else if (error.code == ERROR_CODE_READ) {
+      return {
+        title: 'Nous n’arrivons pas à lire ce fichier sur votre appareil.',
+        description: 'Essayez à nouveau, ou sélectionnez un autre fichier.',
+        retry: false
       };
     } else {
       return {


### PR DESCRIPTION
Cette PR affiche un meilleur message d'erreur en cas de "Reading error" au moment d'envoyer une PJ.

C'est toujours difficile de savoir à quoi correspondent ces "Reading error" : ça a l'air de surtout arriver sur mobile, mais de ne pas avoir de cause claire.

En tout les cas, un meilleur message d'erreur nous permet d'informer l'usager – et aussi d'arrêter de remonter les choses dans Sentry de notre côté.

Cf. #4432