### PR TITLE
javascript: ignore most common upload errors also in standard uploads

### DIFF
--- a/app/javascript/shared/activestorage/ujs.js
+++ b/app/javascript/shared/activestorage/ujs.js
@@ -1,7 +1,8 @@
 import ProgressBar from './progress-bar';
 import {
   errorFromDirectUploadMessage,
-  FAILURE_CONNECTIVITY
+  ERROR_CODE_READ,
+  FAILURE_CLIENT
 } from './file-upload-error';
 import { fire } from '@utils';
 
@@ -58,8 +59,10 @@ addUploadEventListener(ERROR_EVENT, (event) => {
 
   ProgressBar.error(id, errorMsg);
 
+  // Report unexpected client errors to Sentry.
+  // (But ignore usual client errors, or errors we can monitor better on the server side.)
   let error = errorFromDirectUploadMessage(errorMsg);
-  if (error.failureReason != FAILURE_CONNECTIVITY) {
+  if (error.failureReason == FAILURE_CLIENT && error.code != ERROR_CODE_READ) {
     fire(document, 'sentry:capture-exception', error);
   }
 });


### PR DESCRIPTION
In #5149, we ignored most common upload errors, but only for auto-uploads.

This PR also ignores those errors for standard uploads.