### PR TITLE
Tasks : ajout d'une tâche pour déclencher un rollback

### DIFF
--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -32,3 +32,13 @@ task :post_deploy do
 
   sh "mina post_deploy domain=#{domains.first} branch=#{branch}"
 end
+
+task :rollback do
+  domains = domains_for_stage(ENV.fetch('STAGE'))
+  branch = ENV.fetch('BRANCH')
+
+  domains.each do |domain|
+    sh "mina rollback domain=#{domain} branch=#{branch}"
+    sh "mina service:restart_puma domain=#{domain} branch=#{branch}"
+  end
+end


### PR DESCRIPTION
Avec cette PR, `bin/rake rollback STAGE=prod BRANCH=master` demande à Mina de faire un rollback de la version en prod vers l'avant-dernière version déployée.

Ça prend environ 3s par serveur (effectivement Mina change juste un symlink), c'est magique.

## Intégration avec Gitlab-CI

Le but n'est pas de lancer la tâche de rollback à la main en local, mais de laisser Gitlab-CI le faire.

Pour cela, une p'tite modification au fichier `gitlab-ci.yml` permettra d'avoir un bouton "Rollback" dans l'interface de Gitlab.

<img width="920" alt="Capture d’écran 2020-05-14 à 17 12 46" src="https://user-images.githubusercontent.com/179923/81952287-990da580-9606-11ea-822c-a85ae45ac53d.png">

## Intégration avec ds-cli

Pour l'instant j'ai la flemme d'intégrer le rollback dans ds-cli. Ça nécessite de :

- Aller chercher l'ID du dernier pipeline sur gitlab
- Aller chercher l'ID de l'action 'rollback' de ce pipeline
- Déclencher l'action
- Demander à Gitlab un stream du log de rollback

Je pense que le bouton "Rollback" dans l'UI sera suffisant pour l'instant. Si un jour on veut l'intégrer à ds-cli, ça sera toujours possible.