### PR TITLE
Afficher le nom du service en texte alternatif si possible au début d'une procédure

### DIFF
--- a/app/views/shared/_procedure_description.html.haml
+++ b/app/views/shared/_procedure_description.html.haml
@@ -1,5 +1,8 @@
 .procedure-logos
-  = image_tag procedure.logo_url, alt: "logo #{procedure.libelle}"
+  - procedure_logo_alt = ''
+  - if procedure.service.present?
+    - procedure_logo_alt = "#{procedure.service.nom} − #{procedure.service.organisme}"
+  = image_tag procedure.logo_url, alt: procedure_logo_alt
   - if procedure.euro_flag
     = image_tag("flag_of_europe.svg", id: 'euro_flag', class: (!procedure.euro_flag ? "hidden" : ""))
 %h1.procedure-title


### PR DESCRIPTION
Petite amélioration d'accessibilité pour **https://github.com/betagouv/demarches-simplifiees.fr/issues/5162 / P05 - Commencer**

Dans l'écran `/commencer`, sur un lecteur d'écran on a le nom de procédure dans le logo, puis le titre de la procédure, donc l'info apparait en double.

Avec le nom du service dans le logo on gagne en précision.