### PR TITLE
Ajout d'un bouton d'export des mails des demandeurs

### DIFF
--- a/app/controllers/manager/procedures_controller.rb
+++ b/app/controllers/manager/procedures_controller.rb
@@ -39,6 +39,13 @@ module Manager
       redirect_to manager_procedure_path(procedure)
     end
 
+    def export_mail_brouillons
+      dossiers = procedure.dossiers.state_brouillon
+      emails = dossiers.map { |d| d.user.email }.sort
+      date = Time.zone.now.strftime('%d-%m-%Y')
+      send_data(emails.join("\n"), :filename => "brouillons-#{procedure.id}-au-#{date}.csv")
+    end
+
     def add_administrateur
       administrateur = Administrateur.by_email(params[:email])
       if administrateur

--- a/app/controllers/manager/procedures_controller.rb
+++ b/app/controllers/manager/procedures_controller.rb
@@ -40,8 +40,8 @@ module Manager
     end
 
     def export_mail_brouillons
-      dossiers = procedure.dossiers.state_brouillon
-      emails = dossiers.map { |d| d.user.email }.sort
+      dossiers = procedure.dossiers.state_brouillon.includes(:user)
+      emails = dossiers.map { |d| d.user.email }.sort.uniq
       date = Time.zone.now.strftime('%d-%m-%Y')
       send_data(emails.join("\n"), :filename => "brouillons-#{procedure.id}-au-#{date}.csv")
     end

--- a/app/views/manager/procedures/show.html.erb
+++ b/app/views/manager/procedures/show.html.erb
@@ -71,5 +71,8 @@ as well as a link to its edit page.
         <% end %>
       </dd>
     <% end %>
+    <dd class="attribute-data">
+      <a class="button" href="<%= export_mail_brouillons_manager_procedure_url(procedure) %>">Télécharger un export CSV contenant les emails des demandeurs ayant effectué une demandes en brouillon</a>
+    </dd>
   </dl>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
       post 'restore', on: :member
       post 'add_administrateur', on: :member
       post 'change_piece_justificative_template', on: :member
+      get 'export_mail_brouillons', on: :member
     end
 
     resources :dossiers, only: [:index, :show] do


### PR DESCRIPTION
Ajoute ce bouton dans le manager, sur l'écran `Démarches`:

![image](https://user-images.githubusercontent.com/1223316/82195511-aec9e600-98f8-11ea-89e5-687762e3f067.png)

On doit fournir dans certains cas l'info et faire cet export à la main à chaque fois est chronophage.

Je n'aime pas cette fonctionnalité, mais l'avoir dans le manager me parait un moindre mal.
