### PR TITLE
Correction de liens vers la FAQ

### DIFF
--- a/app/views/users/dossiers/_autosave.html.haml
+++ b/app/views/users/dossiers/_autosave.html.haml
@@ -1,16 +1,14 @@
-- more_infos_url = 'https://faq.demarches-simplifiees.fr/article/73-enregistrer-mon-dossier?preview=5dcbf0bb2c7d3a7e9ae3e33f'
-
 .autosave.autosave-state-idle
   %p.autosave-explanation
     %span.autosave-explanation-text
       Votre brouillon est automatiquement enregistré.
-    = link_to 'En savoir plus', more_infos_url, target: '_blank', rel: 'noopener', class: 'autosave-more-infos'
+    = link_to 'En savoir plus', FAQ_AUTOSAVE_URL, target: '_blank', rel: 'noopener', class: 'autosave-more-infos'
 
   %p.autosave-status.succeeded
     %span.autosave-icon.icon.accept
     %span.autosave-label
       Brouillon enregistré
-    = link_to 'En savoir plus', more_infos_url, target: '_blank', rel: 'noopener', class: 'autosave-more-infos'
+    = link_to 'En savoir plus', FAQ_AUTOSAVE_URL, target: '_blank', rel: 'noopener', class: 'autosave-more-infos'
 
   %p.autosave-status.failed
     %span.autosave-icon ⚠️

--- a/config/initializers/urls.rb
+++ b/config/initializers/urls.rb
@@ -24,6 +24,7 @@ WEBHOOK_DOC_URL = [DOC_URL, "pour-aller-plus-loin", "webhook"].join("/")
 ARCHIVAGE_DOC_URL = [DOC_URL, "pour-aller-plus-loin", "archivage-longue-duree-des-demarches"].join("/")
 FAQ_URL = "https://faq.demarches-simplifiees.fr"
 FAQ_ADMIN_URL = [FAQ_URL, "collection", "1-administrateur-creation-dun-formulaire"].join("/")
+FAQ_AUTOSAVE_URL = [FAQ_URL, "article", "77-enregistrer-mon-formulaire-pour-le-reprendre-plus-tard?preview=5ec28ca1042863474d1aee00"].join("/")
 COMMENT_TROUVER_MA_DEMARCHE_URL = [FAQ_URL, "article", "59-comment-trouver-ma-demarche"].join("/")
 STATUS_PAGE_URL = "https://status.demarches-simplifiees.fr"
 MATOMO_IFRAME_URL = "https://stats.data.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=fr&&fontColor=333333&fontSize=16px&fontFamily=Muli"

--- a/config/initializers/urls.rb
+++ b/config/initializers/urls.rb
@@ -23,7 +23,7 @@ API_DOC_URL = [DOC_URL, "pour-aller-plus-loin", "api"].join("/")
 WEBHOOK_DOC_URL = [DOC_URL, "pour-aller-plus-loin", "webhook"].join("/")
 ARCHIVAGE_DOC_URL = [DOC_URL, "pour-aller-plus-loin", "archivage-longue-duree-des-demarches"].join("/")
 FAQ_URL = "https://faq.demarches-simplifiees.fr"
-FAQ_ADMIN_URL = "https://faq.demarches-simplifiees.fr/collection/1-administrateur"
+FAQ_ADMIN_URL = [FAQ_URL, "collection", "1-administrateur-creation-dun-formulaire"].join("/")
 COMMENT_TROUVER_MA_DEMARCHE_URL = [FAQ_URL, "article", "59-comment-trouver-ma-demarche"].join("/")
 STATUS_PAGE_URL = "https://status.demarches-simplifiees.fr"
 MATOMO_IFRAME_URL = "https://stats.data.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=fr&&fontColor=333333&fontSize=16px&fontFamily=Muli"


### PR DESCRIPTION
- La catégorie "Administrateurs" a changé d'URL
- L'article en brouillon "Enregistrement automatique" a été supprimé de HelpScout (!). Je l'ai donc ré-écrit, avec une nouvelle URL.