### PR TITLE
Ajout de precisions pour les emails non reçus lors de la création de compte

### DIFF
--- a/app/views/users/confirmations/new.html.haml
+++ b/app/views/users/confirmations/new.html.haml
@@ -23,9 +23,14 @@
     %hr.confirmation-separator
 
     .confirmation-resend
-      %p Si vous n’avez pas reçu notre message, nous pouvons vous le renvoyer.
+      %p Si vous n’avez pas reçu notre message (avez-vous vérifié les indésirables ?), nous pouvons vous le renvoyer.
 
       = form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { class: 'form' }) do |f|
         = f.label :email, 'Email'
         = f.email_field :email, placeholder: 'Email', class: 'small', autofocus: true
         = f.submit 'Renvoyer un email de confirmation', class: 'button'
+
+      %p
+        Vous pouvez également consulter notre
+        = link_to('FAQ', "https://faq.demarches-simplifiees.fr/article/79-je-ne-recois-pas-demail", target: '_blank', rel: 'noopener')
+        \.


### PR DESCRIPTION
Tentative naive:
 - d'aider les nombreuses personnes qui contactent le support pour des comptes non créés/activés
 - d'endiguer le flux croissant de demandes de confirmation d'identité venant de mailinblack.
![email-non-reçus](https://user-images.githubusercontent.com/1223316/82792086-1dfe8780-9e6f-11ea-873a-6e762599b37c.png)