### PR TITLE
fix geoareas of carte field not updated

### DIFF
--- a/app/views/champs/carte/index.js.erb
+++ b/app/views/champs/carte/index.js.erb
@@ -1,6 +1,6 @@
 <%= render_flash(timeout: 5000, fixed: true) %>
 
-<%= render_to_element("#{@selector} + .geo-areas",
+<%= render_to_element("#{@selector} ~ .geo-areas",
   partial: 'shared/champs/carte/geo_areas',
   locals: { champ: @champ, error: @error }) %>
 

--- a/app/views/champs/carte/show.js.erb
+++ b/app/views/champs/carte/show.js.erb
@@ -1,6 +1,6 @@
 <%= render_flash(timeout: 5000, fixed: true) %>
 
-<%= render_to_element("#{@selector} + .geo-areas",
+<%= render_to_element("#{@selector} ~ .geo-areas",
   partial: 'shared/champs/carte/geo_areas',
   locals: { champ: @champ, error: @error }) %>
 


### PR DESCRIPTION
Dans un champ carte, la partie geoareas (qui indique les zones selectionnées) n'est pas mise a jour en temps reel chez moi. 
Le javascript déclenche une erreur 
```
Uncaught TypeError: Cannot set property 'innerHTML' of null
```
Sur le selecteur CSS '.carte-1 + .geoareas'
```
<%= render_to_element("#{@selector} + .geo-areas",
  partial: 'shared/champs/carte/geo_areas',
  locals: { champ: @champ, error: @error }) %>
```
Cela ne fonctionne pas car le + demande à ce que geoareas soit immédiatement apres carte 1. Hors il y a entre les deux un <input caché
![image](https://user-images.githubusercontent.com/15379878/82844969-4c379380-9e7e-11ea-88ec-2c266de309cf.png)
Une solution possible: utiliser le ~ au lieu du + 

Note: je ne maitrise pas trop cette partie de code et elle ne sert pas en Polynésie donc n'hésitez pas à contrôler ou rejeter si pb. 