### PR TITLE
doesn't update dossier etablissement for siret controller

### DIFF
--- a/app/controllers/champs/siret_controller.rb
+++ b/app/controllers/champs/siret_controller.rb
@@ -50,7 +50,7 @@ class Champs::SiretController < ApplicationController
   end
 
   def find_etablissement_with_siret
-    ApiEntrepriseService.create_etablissement(@champ.dossier, @siret, current_user.id)
+    ApiEntrepriseService.create_etablissement(@champ, @siret, current_user.id)
   end
 
   def clear_siret_and_etablissement

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -11,7 +11,7 @@ class Champ < ApplicationRecord
   belongs_to :etablissement, dependent: :destroy
   has_many :champs, -> { ordered }, foreign_key: :parent_id, inverse_of: :parent, dependent: :destroy
 
-  delegate :libelle, :type_champ, :order_place, :mandatory?, :description, :drop_down_list, :exclude_from_export?, :exclude_from_view?, :repetition?, :dossier_link?, to: :type_de_champ
+  delegate :libelle, :type_champ, :procedure, :order_place, :mandatory?, :description, :drop_down_list, :exclude_from_export?, :exclude_from_view?, :repetition?, :dossier_link?, to: :type_de_champ
 
   scope :updated_since?, -> (date) { where('champs.updated_at > ?', date) }
   scope :public_only, -> { where(private: false) }

--- a/app/services/api_entreprise_service.rb
+++ b/app/services/api_entreprise_service.rb
@@ -7,11 +7,11 @@ class ApiEntrepriseService
   #
   # Raises a ApiEntreprise::API::RequestFailed exception on transient errors
   # (timeout, 5XX HTTP error code, etc.)
-  def self.create_etablissement(dossier, siret, user_id = nil)
-    etablissement_params = ApiEntreprise::EtablissementAdapter.new(siret, dossier.procedure.id).to_params
+  def self.create_etablissement(dossier_or_champ, siret, user_id = nil)
+    etablissement_params = ApiEntreprise::EtablissementAdapter.new(siret, dossier_or_champ.procedure.id).to_params
     return nil if etablissement_params.empty?
 
-    etablissement = dossier.build_etablissement(etablissement_params)
+    etablissement = dossier_or_champ.build_etablissement(etablissement_params)
     etablissement.save
 
     [
@@ -19,9 +19,9 @@ class ApiEntrepriseService
       ApiEntreprise::EffectifsJob, ApiEntreprise::EffectifsAnnuelsJob, ApiEntreprise::AttestationSocialeJob,
       ApiEntreprise::BilansBdfJob
     ].each do |job|
-      job.perform_later(etablissement.id, dossier.procedure.id)
+      job.perform_later(etablissement.id, dossier_or_champ.procedure.id)
     end
-    ApiEntreprise::AttestationFiscaleJob.perform_later(etablissement.id, dossier.procedure.id, user_id)
+    ApiEntreprise::AttestationFiscaleJob.perform_later(etablissement.id, dossier_or_champ.procedure.id, user_id)
 
     etablissement
   end

--- a/spec/controllers/champs/siret_controller_spec.rb
+++ b/spec/controllers/champs/siret_controller_spec.rb
@@ -4,7 +4,11 @@ describe Champs::SiretController, type: :controller do
 
   describe '#show' do
     let(:dossier) { create(:dossier, user: user, procedure: procedure) }
-    let(:champ) { create(:champ_siret, dossier: dossier, value: nil, etablissement: nil) }
+    let(:champ) do
+      d = dossier
+      type_de_champ = create(:type_de_champ_siret, procedure: procedure)
+      type_de_champ.champ.create(dossier: d, value: nil, etablissement: nil)
+    end
     let(:params) do
       {
         champ_id: champ.id,
@@ -109,6 +113,7 @@ describe Champs::SiretController, type: :controller do
           expect(champ.value).to eq(siret)
           expect(champ.etablissement.siret).to eq(siret)
           expect(champ.reload.etablissement.naf).to eq("6202A")
+          expect(dossier.reload.etablissement).to eq(nil)
         end
       end
     end


### PR DESCRIPTION
Le passage en asynchrone des appels à api_entreprise a eu comme effet de bord la mise à jour de l'établissement du dossier lors de la modification d'un champ SIRET. C'est un bug et pas du tout le comportement attendu.

Cette PR permet de ne plus modifier l'établissement du dossier.