### PR TITLE
github: update rebase action

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,4 +1,4 @@
-on: 
+on:
   issue_comment:
     types: [created]
 name: Automatic Rebase

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,4 +1,4 @@
-on:
+on: 
   issue_comment:
     types: [created]
 name: Automatic Rebase
@@ -8,17 +8,11 @@ jobs:
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - name: Checkout the latest code
+      uses: actions/checkout@v2
       with:
         fetch-depth: 0
     - name: Automatic Rebase
-      uses: cirrus-actions/rebase@1.2
+      uses: cirrus-actions/rebase@1.3.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  # https://github.community/t5/GitHub-Actions/Workflow-is-failing-if-no-job-can-be-ran-due-to-condition/m-p/38186#M3250
-  always_job:
-    name: Always run job
-    runs-on: ubuntu-latest
-    steps:
-      - name: Always run
-        run: echo "This job is used to prevent the workflow to fail when all other jobs are skipped."


### PR DESCRIPTION
Update the Github rebase action from 1.2 to 1.3.1:

- Allows to rebase PRs on forks (as long as the submitter checked "allow edits from maintainers").
- Less workarounds.