### PR TITLE
views: modernisation.gouv.fr -> numerique.gouv.fr

### DIFF
--- a/app/views/root/_footer.html.haml
+++ b/app/views/root/_footer.html.haml
@@ -6,12 +6,12 @@
         %ul.footer-logos
           %li.footer-text
             Un service fourni par la
-            = link_to "DINUM", "http://www.modernisation.gouv.fr/", title: "Direction Interministérielle au Numérique"
+            = link_to "DINUM", "https://numerique.gouv.fr/", title: "Direction Interministérielle au Numérique"
             %br
             et incubé par
             = link_to "beta.gouv.fr", "https://beta.gouv.fr", title: "le site de Beta.gouv.fr"
           %li
-            = link_to "http://www.modernisation.gouv.fr/", title: "DINUM" do
+            = link_to "https://numerique.gouv.fr/", title: "DINUM" do
               %span.footer-logo.footer-logo-dinum{ role: 'img', 'aria-label': 'DINUM' }
             = link_to "https://beta.gouv.fr", title: "le site de Beta.gouv.fr" do
               %span.footer-logo.footer-logo-beta-gouv-fr{ role: 'img', 'aria-label': 'beta.gouv.fr' }


### PR DESCRIPTION
Ça concerne ce footer :

<img width="1119" alt="Capture d’écran 2020-06-02 à 11 41 26" src="https://user-images.githubusercontent.com/179923/83505379-00ac6780-a4c6-11ea-8630-5a2c8a3e8a1b.png">


Fix #4161