### PR TITLE
#5207 - Add overide for fog openstack v3

### DIFF
--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -40,3 +40,26 @@ module Fog::OpenStack::Auth::Catalog
     end
   end
 end
+
+require 'fog/openstack/auth/catalog/v3'
+module Fog::OpenStack::Auth::Catalog
+  class V3
+    def endpoint_url(endpoint, interface)
+      url = endpoint["#{interface}URL"]
+
+      if interface == 'public'
+        publicize(url)
+      else
+        url
+      end
+    end
+
+    private
+
+    def publicize(url)
+      search = %r{^https://[^/]+/}
+      replace = "#{ENV['DS_PROXY_URL']}/"
+      url.gsub(search, replace)
+    end
+  end
+end


### PR DESCRIPTION
We are almost good for #5207 : our components can already deal with the new protocol, it seems we only need to perform a version bump.

A few notes on vocabulary by the way:
 - [KeyStone](https://en.wikipedia.org/wiki/OpenStack#Identity_(Keystone)) is the name for OpenStack's identity protocol.
 - We use [`activestorage-openstack`](https://github.com/chaadow/activestorage-openstack) which, internally, uses [`fog-openstack`](https://github.com/fog/fog-openstack/) for authentification.

```ruby
# Gemfile.lock
    activestorage-openstack (1.4.1)
      fog-openstack (~> 1.0)
```

We configure `activestorage-openstack` in `config/storage.rb`, and we override fog's authentication URL in `config/initializers/active_storage.rb`.

So this update need to be done in 3 steps in order to avoid a downtime of the uploads:
 - first, this PR, where we add our override for `Fog::OpenStack::Auth::Catalog::V3`
 - then, we update the setting to `FOG_OPENSTACK_IDENTITY_API_VERSION: "v3.0"`
 - finally another PR to remove the then obsolete `Fog::OpenStack::Auth::Catalog::V2`
