### PR TITLE
define max_attempts for jobs

### DIFF
--- a/app/jobs/api_entreprise/association_job.rb
+++ b/app/jobs/api_entreprise/association_job.rb
@@ -1,4 +1,4 @@
-class ApiEntreprise::AssociationJob < ApplicationJob
+class ApiEntreprise::AssociationJob < ApiEntreprise::Job
   def perform(etablissement_id, procedure_id)
     etablissement = Etablissement.find(etablissement_id)
     etablissement_params = ApiEntreprise::RNAAdapter.new(etablissement.siret, procedure_id).to_params

--- a/app/jobs/api_entreprise/attestation_fiscale_job.rb
+++ b/app/jobs/api_entreprise/attestation_fiscale_job.rb
@@ -1,4 +1,4 @@
-class ApiEntreprise::AttestationFiscaleJob < ApplicationJob
+class ApiEntreprise::AttestationFiscaleJob < ApiEntreprise::Job
   def perform(etablissement_id, procedure_id, user_id)
     etablissement = Etablissement.find(etablissement_id)
     etablissement_params = ApiEntreprise::AttestationFiscaleAdapter.new(etablissement.siret, procedure_id, user_id).to_params

--- a/app/jobs/api_entreprise/attestation_sociale_job.rb
+++ b/app/jobs/api_entreprise/attestation_sociale_job.rb
@@ -1,4 +1,4 @@
-class ApiEntreprise::AttestationSocialeJob < ApplicationJob
+class ApiEntreprise::AttestationSocialeJob < ApiEntreprise::Job
   def perform(etablissement_id, procedure_id)
     etablissement = Etablissement.find(etablissement_id)
     etablissement_params = ApiEntreprise::AttestationSocialeAdapter.new(etablissement.siret, procedure_id).to_params

--- a/app/jobs/api_entreprise/bilans_bdf_job.rb
+++ b/app/jobs/api_entreprise/bilans_bdf_job.rb
@@ -1,4 +1,4 @@
-class ApiEntreprise::BilansBdfJob < ApplicationJob
+class ApiEntreprise::BilansBdfJob < ApiEntreprise::Job
   def perform(etablissement_id, procedure_id)
     etablissement = Etablissement.find(etablissement_id)
     etablissement_params = ApiEntreprise::BilansBdfAdapter.new(etablissement.siret, procedure_id).to_params

--- a/app/jobs/api_entreprise/effectifs_annuels_job.rb
+++ b/app/jobs/api_entreprise/effectifs_annuels_job.rb
@@ -1,4 +1,4 @@
-class ApiEntreprise::EffectifsAnnuelsJob < ApplicationJob
+class ApiEntreprise::EffectifsAnnuelsJob < ApiEntreprise::Job
   def perform(etablissement_id, procedure_id)
     etablissement = Etablissement.find(etablissement_id)
     etablissement_params = ApiEntreprise::EffectifsAnnuelsAdapter.new(etablissement.siret, procedure_id).to_params

--- a/app/jobs/api_entreprise/effectifs_job.rb
+++ b/app/jobs/api_entreprise/effectifs_job.rb
@@ -1,4 +1,4 @@
-class ApiEntreprise::EffectifsJob < ApplicationJob
+class ApiEntreprise::EffectifsJob < ApiEntreprise::Job
   def perform(etablissement_id, procedure_id)
     etablissement = Etablissement.find(etablissement_id)
     etablissement_params = ApiEntreprise::EffectifsAdapter.new(etablissement.siret, procedure_id, *get_current_valid_month_for_effectif).to_params

--- a/app/jobs/api_entreprise/entreprise_job.rb
+++ b/app/jobs/api_entreprise/entreprise_job.rb
@@ -1,4 +1,4 @@
-class ApiEntreprise::EntrepriseJob < ApplicationJob
+class ApiEntreprise::EntrepriseJob < ApiEntreprise::Job
   def perform(etablissement_id, procedure_id)
     etablissement = Etablissement.find(etablissement_id)
     etablissement_params = ApiEntreprise::EntrepriseAdapter.new(etablissement.siret, procedure_id).to_params

--- a/app/jobs/api_entreprise/exercices_job.rb
+++ b/app/jobs/api_entreprise/exercices_job.rb
@@ -1,4 +1,4 @@
-class ApiEntreprise::ExercicesJob < ApplicationJob
+class ApiEntreprise::ExercicesJob < ApiEntreprise::Job
   def perform(etablissement_id, procedure_id)
     etablissement = Etablissement.find(etablissement_id)
     etablissement_params = ApiEntreprise::ExercicesAdapter.new(etablissement.siret, procedure_id).to_params

--- a/app/jobs/api_entreprise/job.rb
+++ b/app/jobs/api_entreprise/job.rb
@@ -1,0 +1,6 @@
+class ApiEntreprise::Job < ApplicationJob
+  DEFAULT_MAX_ATTEMPTS_API_ENTREPRISE_JOBS = 5
+  def max_attempts
+    ENV[MAX_ATTEMPTS_API_ENTREPRISE_JOBS].to_i || DEFAULT_MAX_ATTEMPTS_API_ENTREPRISE_JOBS
+  end
+end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,4 +1,6 @@
 class ApplicationJob < ActiveJob::Base
+  DEFAULT_MAX_ATTEMPTS_JOBS = 25
+
   before_perform do |job|
     Rails.logger.info("#{job.class.name} started at #{Time.zone.now}")
   end
@@ -17,5 +19,9 @@ class ApplicationJob < ActiveJob::Base
 
   def error(job, exception)
     Raven.capture_exception(exception)
+  end
+
+  def max_attempts
+    ENV["MAX_ATTEMPTS_JOBS"].to_i || DEFAULT_MAX_ATTEMPTS_JOBS
   end
 end

--- a/config/env.example
+++ b/config/env.example
@@ -108,3 +108,7 @@ UNIVERSIGN_USERPWD=""
 # API Geo / Adresse
 API_ADRESSE_URL="https://api-adresse.data.gouv.fr"
 API_GEO_URL="https://geo.api.gouv.fr"
+
+# Modifier le nb de tentatives de relance de job si echec
+# MAX_ATTEMPTS_JOBS=25
+# MAX_ATTEMPTS_API_ENTREPRISE_JOBS=5


### PR DESCRIPTION
permet de définir le nb maximum de tentative de relance des jobs s'ils échouent
Les jobs api_entreprise peuvent avoir une valeur différente des jobs qui héritent de `ApplicationJob`

Pour ce faire, il s'agit de modifier les variables d'environnement suivantes :

```
MAX_ATTEMPTS_JOBS=25
MAX_ATTEMPTS_API_ENTREPRISE_JOBS=5
```

Les mailer jobs ne sont pas concernés par cette PR
