### PR TITLE
reorder bilans bdf csv

### DIFF
--- a/app/models/etablissement.rb
+++ b/app/models/etablissement.rb
@@ -140,7 +140,7 @@ class Etablissement < ApplicationRecord
   end
 
   def entreprise_bilans_bdf_to_csv
-    headers = entreprise_bilans_bdf.flat_map(&:keys).uniq
+    headers = bilans_headers.concat(bilans_new_keys)
     data = entreprise_bilans_bdf.map do |bilan|
       headers.map { |h| bilan[h] }
     end
@@ -148,6 +148,11 @@ class Etablissement < ApplicationRecord
   end
 
   private
+
+  def bilans_new_keys
+    keys = entreprise_bilans_bdf.flat_map(&:keys).uniq
+    keys - bilans_headers
+  end
 
   def dossier_id_for_export
     if dossier_id
@@ -159,5 +164,29 @@ class Etablissement < ApplicationRecord
 
   def libelle_for_export
     champ&.libelle || 'Dossier'
+  end
+
+  def bilans_headers
+    [
+      "date_arret_exercice", "duree_exercice", "chiffre_affaires_ht", "evolution_chiffre_affaires_ht",
+      "valeur_ajoutee_bdf", "evolution_valeur_ajoutee_bdf", "excedent_brut_exploitation",
+      "evolution_excedent_brut_exploitation", "resultat_exercice", "evolution_resultat_exercice",
+      "capacite_autofinancement", "evolution_capacite_autofinancement", "fonds_roulement_net_global",
+      "evolution_fonds_roulement_net_global", "besoin_en_fonds_de_roulement", "evolution_besoin_en_fonds_de_roulement",
+      "ratio_fonds_roulement_net_global_sur_besoin_en_fonds_de_roulement",
+      "evolution_ratio_fonds_roulement_net_global_sur_besoin_en_fonds_de_roulement", "disponibilites",
+      "evolution_disponibilites", "capital_social_inclus_dans_capitaux_propres_et_assimiles",
+      "evolution_capital_social_inclus_dans_capitaux_propres_et_assimiles", "capitaux_propres_et_assimiles",
+      "evolution_capitaux_propres_et_assimiles", "autres_fonds_propres", "evolution_autres_fonds_propres",
+      "total_provisions_pour_risques_et_charges", "evolution_total_provisions_pour_risques_et_charges",
+      "dettes1_emprunts_obligataires_et_convertibles", "evolution_dettes1_emprunts_obligataires_et_convertibles",
+      "dettes2_autres_emprunts_obligataires", "evolution_dettes2_autres_emprunts_obligataires",
+      "dettes3_emprunts_et_dettes_aupres_des_etablissements_de_credit",
+      "evolution_dettes3_emprunts_et_dettes_aupres_des_etablissements_de_credit",
+      "dettes4_maturite_a_un_an_au_plus", "evolution_dettes4_maturite_a_un_an_au_plus",
+      "emprunts_et_dettes_financieres_divers", "evolution_emprunts_et_dettes_financieres_divers",
+      "total_dettes_stables", "evolution_total_dettes_stables", "groupes_et_associes",
+      "evolution_groupes_et_associes", "total_passif", "evolution_total_passif"
+    ]
   end
 end

--- a/spec/models/etablissement_spec.rb
+++ b/spec/models/etablissement_spec.rb
@@ -38,14 +38,38 @@ describe Etablissement do
 
   describe '.entreprise_bilans_bdf_to_csv' do
     let(:etablissement) { build(:etablissement, entreprise_bilans_bdf: bilans) }
+    let(:ordered_headers) {
+      [
+        "date_arret_exercice", "duree_exercice", "chiffre_affaires_ht", "evolution_chiffre_affaires_ht",
+        "valeur_ajoutee_bdf", "evolution_valeur_ajoutee_bdf", "excedent_brut_exploitation",
+        "evolution_excedent_brut_exploitation", "resultat_exercice", "evolution_resultat_exercice",
+        "capacite_autofinancement", "evolution_capacite_autofinancement", "fonds_roulement_net_global",
+        "evolution_fonds_roulement_net_global", "besoin_en_fonds_de_roulement", "evolution_besoin_en_fonds_de_roulement",
+        "ratio_fonds_roulement_net_global_sur_besoin_en_fonds_de_roulement",
+        "evolution_ratio_fonds_roulement_net_global_sur_besoin_en_fonds_de_roulement", "disponibilites",
+        "evolution_disponibilites", "capital_social_inclus_dans_capitaux_propres_et_assimiles",
+        "evolution_capital_social_inclus_dans_capitaux_propres_et_assimiles", "capitaux_propres_et_assimiles",
+        "evolution_capitaux_propres_et_assimiles", "autres_fonds_propres", "evolution_autres_fonds_propres",
+        "total_provisions_pour_risques_et_charges", "evolution_total_provisions_pour_risques_et_charges",
+        "dettes1_emprunts_obligataires_et_convertibles", "evolution_dettes1_emprunts_obligataires_et_convertibles",
+        "dettes2_autres_emprunts_obligataires", "evolution_dettes2_autres_emprunts_obligataires",
+        "dettes3_emprunts_et_dettes_aupres_des_etablissements_de_credit",
+        "evolution_dettes3_emprunts_et_dettes_aupres_des_etablissements_de_credit",
+        "dettes4_maturite_a_un_an_au_plus", "evolution_dettes4_maturite_a_un_an_au_plus",
+        "emprunts_et_dettes_financieres_divers", "evolution_emprunts_et_dettes_financieres_divers",
+        "total_dettes_stables", "evolution_total_dettes_stables", "groupes_et_associes",
+        "evolution_groupes_et_associes", "total_passif", "evolution_total_passif"
+      ]
+    }
     let(:bilans) do
       [
         {
           "total_passif": "1200",
-          "chiffres_affaires_ht": "40000"
+          "chiffre_affaires_ht": "40000"
         },
         {
           "total_passif": "0",
+          "new_key": "50",
           "evolution_total_dettes_stables": "30"
         }
       ]
@@ -53,10 +77,32 @@ describe Etablissement do
 
     subject { etablissement.entreprise_bilans_bdf_to_csv.split("\n") }
 
-    it "build a csv with all keys" do
-      expect(subject[0].split(',').sort).to eq(["total_passif", "chiffres_affaires_ht", "evolution_total_dettes_stables"].sort)
-      expect(subject[1].split(',')).to eq(["1200", "40000"])
-      expect(subject[2].split(',')).to eq(["0", "", "30"])
+    it "build a csv with keys in right order" do
+      headers = subject[0].split(',')
+      expect(headers).to eq(ordered_headers.concat(["new_key"]))
     end
+
+    it "build a csv with good values" do
+      bilans_h = csv_to_array_of_hash(subject)
+      expect(bilans_h[0]["total_passif"]).to eq("1200")
+      expect(bilans_h[0]["chiffre_affaires_ht"]).to eq("40000")
+      expect(bilans_h[1]["evolution_total_dettes_stables"]).to eq("30")
+      expect(bilans_h[1]["new_key"]).to eq("50")
+    end
+  end
+
+  private
+
+  def csv_to_array_of_hash(lines)
+    headers = lines.shift.split(',')
+    lines.map { |line| line_to_hash(line, headers) }
+  end
+
+  def line_to_hash(line, headers)
+    bilan = {}
+    line.split(',').each_with_index do |value, index|
+      bilan[headers[index]] = value
+    end
+    bilan
   end
 end


### PR DESCRIPTION
close #5213 

Afin de faciliter la compréhension à l'instructeur, cette PR réordonne dans un ordre plus logique les colonnes du fichier csv bilans bdf.
Si l'api renvoie une clé inconnue à ce jour, la colonne associée dans le csv sera placée en dernier.