### PR TITLE
#5162 - Amélioration des libellés vers l'accueil

### DIFF
--- a/app/assets/stylesheets/new_design/new_header.scss
+++ b/app/assets/stylesheets/new_design/new_header.scss
@@ -26,6 +26,7 @@ $header-mobile-breakpoint: 550px;
 .header-logo {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
 
   img {
     margin-right: 10px;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -122,6 +122,19 @@ module ApplicationHelper
     end
   end
 
+  def root_path_info_for_profile(nav_bar_profile)
+    case nav_bar_profile
+    when :administrateur
+      [admin_procedures_path, "Aller au panneau d'administration"]
+    when :instructeur
+      [instructeur_procedures_path, 'Aller à la liste des démarches']
+    when :user
+      [dossiers_path, 'Aller à la liste des dossiers']
+    else
+      [root_path, "Aller à la page d'accueil"]
+    end
+  end
+
   def try_format_date(date)
     date.present? ? I18n.l(date) : ''
   end

--- a/app/views/layouts/_new_header.haml
+++ b/app/views/layouts/_new_header.haml
@@ -18,9 +18,10 @@
       - if params[:controller] == 'users/commencer'
         = link_to 'Revenir en arrière', url_for(:back), class: "button", title: "Revenir sur le site de mon administration"
       - else
-        = link_to root_path_for_profile(nav_bar_profile), class: 'header-logo justify-center', title: "Aller à la page d'accueil de demarches-simplifiees.fr" do
+        - root_profile_link, root_profile_libelle = root_path_info_for_profile(nav_bar_profile)
+        = link_to root_profile_link, class: 'header-logo justify-center', title: root_profile_libelle do
           = image_tag 'marianne.svg', alt: 'Liberté, égalité, fraternité', width: '65px'
-        = link_to root_path_for_profile(nav_bar_profile), class: 'header-logo justify-center', title: "Aller à la page d'accueil de demarches-simplifiees.fr" do
+        = link_to root_profile_link, class: 'header-logo justify-center', title: root_profile_libelle do
           %span.big.site-title> demarches-simplifiees.fr
           %span.small.site-title> d-s.fr
 

--- a/app/views/layouts/_new_header.haml
+++ b/app/views/layouts/_new_header.haml
@@ -21,7 +21,6 @@
         - root_profile_link, root_profile_libelle = root_path_info_for_profile(nav_bar_profile)
         = link_to root_profile_link, class: 'header-logo justify-center', title: root_profile_libelle do
           = image_tag 'marianne.svg', alt: 'Liberté, égalité, fraternité', width: '65px'
-        = link_to root_profile_link, class: 'header-logo justify-center', title: root_profile_libelle do
           %span.big.site-title> demarches-simplifiees.fr
           %span.small.site-title> d-s.fr
 


### PR DESCRIPTION
 - textes plus descriptifs en fonction des rôles
 - suppression du lien en doublon (préco [Wave](https://wave.webaim.org/))
![lien-redondants](https://user-images.githubusercontent.com/1223316/83643004-d46d1580-a5af-11ea-85f1-e943a01d9fe4.png)

_Ça a été remonté dans *P05: Commencer/déposer une démarche, mais ça concerne en fait tout le site*_