### PR TITLE
#5162 - Meilleurs titres HTML pour écrans sign in/sign up

### DIFF
--- a/app/assets/stylesheets/new_design/procedure_context.scss
+++ b/app/assets/stylesheets/new_design/procedure_context.scss
@@ -16,7 +16,8 @@ $procedure-description-line-height: 22px;
     }
   }
 
-  h3 {
+  .simple {
+    font-size: 24px;
     color: $blue;
     font-weight: bold;
   }

--- a/app/views/layouts/commencer/_no_procedure.html.haml
+++ b/app/views/layouts/commencer/_no_procedure.html.haml
@@ -1,8 +1,9 @@
 .no-procedure
   = image_tag "landing/hero/dematerialiser.svg", class: "paperless-logo", alt: "moins de papier"
   .baseline.center
-    %h3 Un outil simple
     %p
+      %span.simple Un outil simple
+      %br
       pour gérer les formulaires
       %br
       administratifs dématérialisés.

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -3,7 +3,7 @@
 .auth-form.sign-in-form
 
   = form_for User.new, url: user_session_path, html: { class: "form" } do |f|
-    %h2.huge-title Connectez-vous
+    %h1.huge-title Connectez-vous
 
     = f.label :email, "Email (nom@site.com)"
     = f.text_field :email, type: :email, autocomplete: 'username', autofocus: true


### PR DESCRIPTION

 - Sur l'[écran de connection](https://www.demarches-simplifiees.fr/users/sign_in), la structure HTML actuelle est incorrecte :

   - h3 (discutable) avant h2
   - pas de h1

 - Sur la page de [sign_up](https://www.demarches-simplifiees.fr/users/sign_up), on a bien un h1 mais le h3 «un outil simple» se trouve avant

## avant

![sign_in-before](https://user-images.githubusercontent.com/1223316/83647942-c4f0cb00-a5b5-11ea-9a38-9ca4c8e621cd.png)

## après

![sign_in-headers-after](https://user-images.githubusercontent.com/1223316/83647944-c621f800-a5b5-11ea-9f3f-3273835baeff.png)

