### PR TITLE
show some info from bilans

### DIFF
--- a/app/helpers/etablissement_helper.rb
+++ b/app/helpers/etablissement_helper.rb
@@ -33,4 +33,8 @@ module EtablissementHelper
       '53' => '10 000 salariés et plus'
     }[etablissement.entreprise_code_effectif_entreprise]
   end
+
+  def pretty_date_exercice(date)
+    date.sub(/(?<year>\d{4})(?<month>\d{2})/, '\k<month>/\k<year>') if date.present?
+  end
 end

--- a/app/models/etablissement.rb
+++ b/app/models/etablissement.rb
@@ -139,6 +139,26 @@ class Etablissement < ApplicationRecord
     upload_attestation(url, entreprise_attestation_fiscale)
   end
 
+  def entreprise_date_arret_exercice
+    entreprise_last_bilan_info_cle("date_arret_exercice")
+  end
+
+  def entreprise_resultat_exercice
+    entreprise_last_bilan_info_cle("resultat_exercice")
+  end
+
+  def entreprise_excedent_brut_exploitation
+    entreprise_last_bilan_info_cle("excedent_brut_exploitation")
+  end
+
+  def entreprise_fdr_net_global
+    entreprise_last_bilan_info_cle("fonds_roulement_net_global")
+  end
+
+  def entreprise_besoin_fdr
+    entreprise_last_bilan_info_cle("besoin_en_fonds_de_roulement")
+  end
+
   def entreprise_bilans_bdf_to_csv
     headers = bilans_headers.concat(bilans_new_keys)
     data = entreprise_bilans_bdf.map do |bilan|
@@ -152,6 +172,10 @@ class Etablissement < ApplicationRecord
   def bilans_new_keys
     keys = entreprise_bilans_bdf.flat_map(&:keys).uniq
     keys - bilans_headers
+  end
+
+  def entreprise_last_bilan_info_cle(key)
+    entreprise_bilans_bdf.first[key]
   end
 
   def dossier_id_for_export

--- a/app/views/shared/dossiers/_identite_entreprise.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise.html.haml
@@ -93,6 +93,24 @@
               %td= link_to "Consulter les bilans", bilans_bdf_instructeur_avis_path(@avis.id)
             - else
               %td= link_to "Consulter les bilans", bilans_bdf_instructeur_dossier_path(procedure_id: @dossier.procedure.id, dossier_id: @dossier.id)
+            %tr
+              %th.libelle
+                Résultat exercice
+                = "(#{pretty_date_exercice(etablissement.entreprise_date_arret_exercice)})"
+              %td= etablissement.entreprise_resultat_exercice
+            %tr
+              %th
+                Excédent brut d'exploitation
+              %td= etablissement.entreprise_excedent_brut_exploitation
+            %tr
+              %th
+                Fonds de roulement net global
+              %td= etablissement.entreprise_fdr_net_global
+            %tr
+              %th
+                Besoin en fonds de roulement
+              %td= etablissement.entreprise_besoin_fdr
+
           - else
             %td Les 3 derniers bilans connus de votre entreprise par la Banque de France ont été joints à votre dossier.
 

--- a/spec/helpers/etablissement_helper_spec.rb
+++ b/spec/helpers/etablissement_helper_spec.rb
@@ -51,4 +51,9 @@ RSpec.describe EtablissementHelper, type: :helper do
 
     it { is_expected.to eq('123 000,00 €') }
   end
+
+  describe '#pretty_date_exercice' do
+    subject { pretty_date_exercice("201908") }
+    it { is_expected.to eq("08/2019") }
+  end
 end


### PR DESCRIPTION
close #5216 
Cette PR affiche dans l'identité du demandeur les informations suivantes issues du bilan bdf le plus récent

- Résultat exercice
- Excedent brut d'exploitation
- Fonds de roulement net global
- Besoin en fonds de roulement

![bilans_a](https://user-images.githubusercontent.com/1111966/83655950-3ed98200-a5bf-11ea-8bc1-69f326a634f1.png)

