### PR TITLE
ask effectifs only for 2020/02

### DIFF
--- a/app/jobs/api_entreprise/effectifs_job.rb
+++ b/app/jobs/api_entreprise/effectifs_job.rb
@@ -1,7 +1,8 @@
 class ApiEntreprise::EffectifsJob < ApiEntreprise::Job
   def perform(etablissement_id, procedure_id)
     etablissement = Etablissement.find(etablissement_id)
-    etablissement_params = ApiEntreprise::EffectifsAdapter.new(etablissement.siret, procedure_id, *get_current_valid_month_for_effectif).to_params
+    # effectifs endpoint currently only works when asking for february 2020 month
+    etablissement_params = ApiEntreprise::EffectifsAdapter.new(etablissement.siret, procedure_id, "2020", "02").to_params
     etablissement.update!(etablissement_params)
   end
 


### PR DESCRIPTION
close #5224 

Actuellement, l'endpoint effectifs mensuels d'api entreprise ne fonctionne que pour le mois de février 2020. Tout autre mois provoque une erreur 502. En attendant que ce soit réparé, cette PR interroge uniquement les effectifs de février 2020, quelque soit le mois courant.