### PR TITLE
helpers: prevent some texts to be incorrectly detected as links

### DIFF
--- a/app/helpers/string_to_html_helper.rb
+++ b/app/helpers/string_to_html_helper.rb
@@ -1,7 +1,7 @@
 module StringToHtmlHelper
   def string_to_html(str, wrapper_tag = 'p')
     html_formatted = simple_format(str, {}, { wrapper_tag: wrapper_tag })
-    with_links = html_formatted.gsub(URI.regexp, '<a target="_blank" rel="noopener" href="\0">\0</a>')
+    with_links = Anchored::Linker.auto_link(html_formatted, target: '_blank', rel: 'noopener')
     sanitize(with_links, attributes: ['target', 'rel', 'href'])
   end
 end

--- a/spec/helpers/string_to_html_helper_spec.rb
+++ b/spec/helpers/string_to_html_helper_spec.rb
@@ -9,9 +9,20 @@ RSpec.describe StringToHtmlHelper, type: :helper do
     end
 
     context "with a link" do
-      let(:description) { "https://d-s.fr" }
+      context "using an authorized scheme" do
+        let(:description) { "Cliquez sur https://d-s.fr pour continuer." }
+        it { is_expected.to eq("<p>Cliquez sur <a href=\"https://d-s.fr\" target=\"_blank\" rel=\"noopener\">https://d-s.fr</a> pour continuer.</p>") }
+      end
 
-      it { is_expected.to eq("<p><a target=\"_blank\" rel=\"noopener\" href=\"https://d-s.fr\">https://d-s.fr</a></p>") }
+      context "using a non-authorized scheme" do
+        let(:description) { "Cliquez sur file://etc/password pour continuer." }
+        it { is_expected.to eq("<p>Cliquez sur file://etc/password pour continuer.</p>") }
+      end
+
+      context "not actually an URL" do
+        let(:description) { "Pour info: il ne devrait y avoir aucun lien." }
+        it { is_expected.to eq("<p>Pour info: il ne devrait y avoir aucun lien.</p>") }
+      end
     end
 
     context "with empty decription" do


### PR DESCRIPTION
Users were having issues with texts like:

> Pour info: penser à faire cette action.

where `info:` was detected as being an URI.

![image](https://user-images.githubusercontent.com/179923/83873404-0ad39d80-a734-11ea-98a9-8be29e218175.png)
