### PR TITLE
Améliore la vue identite_entreprise

### DIFF
--- a/app/assets/stylesheets/new_design/dossier_champs.scss
+++ b/app/assets/stylesheets/new_design/dossier_champs.scss
@@ -8,7 +8,7 @@
   }
 
   .libelle {
-    width: 300px;
+    width: 325px;
   }
 
   td.updated-at {

--- a/app/helpers/etablissement_helper.rb
+++ b/app/helpers/etablissement_helper.rb
@@ -40,6 +40,6 @@ module EtablissementHelper
   end
 
   def pretty_date_exercice(date)
-    date.sub(/(?<year>\d{4})(?<month>\d{2})/, '\k<month>/\k<year>') if date.present?
+    date.sub(/(?<year>\d{4})(?<month>\d{2})/, '\k<year>') if date.present?
   end
 end

--- a/app/helpers/etablissement_helper.rb
+++ b/app/helpers/etablissement_helper.rb
@@ -1,6 +1,11 @@
 module EtablissementHelper
-  def pretty_currency(capital_social)
-    number_to_currency(capital_social, locale: :fr)
+  def pretty_currency(capital_social, unit: '€')
+    number_to_currency(capital_social, locale: :fr, unit: unit)
+  end
+
+  def pretty_currency_unit(unit)
+    dict = { 'kEuros' => 'k€' }
+    dict[unit]
   end
 
   def raison_sociale_or_name(etablissement)

--- a/app/views/shared/dossiers/_identite_entreprise.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise.html.haml
@@ -32,13 +32,13 @@
           %th.libelle
             Effectif mensuel
             = try_format_mois_effectif(etablissement)
-            (URSSAF)
+            (URSSAF) :
           %td= etablissement.entreprise_effectif_mensuel
         %tr
           %th.libelle
             Effectif moyen annuel
             = etablissement.entreprise_effectif_annuel_annee
-            (URSSAF)
+            (URSSAF) :
           %td= etablissement.entreprise_effectif_annuel
       %tr
         %th.libelle Effectif de l'organisation (INSEE) :
@@ -73,27 +73,27 @@
           %tr
             %th.libelle
               Résultat exercice
-              = "(#{pretty_date_exercice(etablissement.entreprise_date_arret_exercice)})"
+              = "(#{pretty_date_exercice(etablissement.entreprise_date_arret_exercice)}) :"
             %td= pretty_currency(etablissement.entreprise_resultat_exercice, unit: pretty_currency_unit(etablissement.entreprise_bilans_bdf_monnaie))
           %tr
             %th
               Excédent brut d'exploitation
-              = "(#{pretty_date_exercice(etablissement.entreprise_date_arret_exercice)})"
+              = "(#{pretty_date_exercice(etablissement.entreprise_date_arret_exercice)}) :"
             %td= pretty_currency(etablissement.entreprise_excedent_brut_exploitation, unit: pretty_currency_unit(etablissement.entreprise_bilans_bdf_monnaie))
           %tr
             %th
               Fonds de roulement net global
-              = "(#{pretty_date_exercice(etablissement.entreprise_date_arret_exercice)})"
+              = "(#{pretty_date_exercice(etablissement.entreprise_date_arret_exercice)}) :"
             %td= pretty_currency(etablissement.entreprise_fdr_net_global, unit: pretty_currency_unit(etablissement.entreprise_bilans_bdf_monnaie))
           %tr
             %th
               Besoin en fonds de roulement
-              = "(#{pretty_date_exercice(etablissement.entreprise_date_arret_exercice)})"
+              = "(#{pretty_date_exercice(etablissement.entreprise_date_arret_exercice)}) :"
             %td= pretty_currency(etablissement.entreprise_besoin_fdr, unit: pretty_currency_unit(etablissement.entreprise_bilans_bdf_monnaie))
           %tr
             %th.libelle
               Chiffres financiers clés (Banque de France)
-              = "en #{pretty_currency_unit(etablissement.entreprise_bilans_bdf_monnaie)}"
+              = "en #{pretty_currency_unit(etablissement.entreprise_bilans_bdf_monnaie)} :"
 
             - if controller.is_a?(Instructeurs::AvisController)
               %td
@@ -114,11 +114,11 @@
         - else
           %tr
             %th.libelle
-              Bilans Banque de France
+              Bilans Banque de France :
             %td Les 3 derniers bilans connus de votre entreprise par la Banque de France ont été joints à votre dossier.
       - if etablissement.entreprise_attestation_sociale.attached?
         %tr
-          %th.libelle Attestation sociale
+          %th.libelle Attestation sociale :
           - if profile == 'instructeur'
             %td= link_to "Consulter l'attestation", url_for(etablissement.entreprise_attestation_sociale)
           - else
@@ -126,7 +126,7 @@
 
       - if etablissement.entreprise_attestation_fiscale.attached?
         %tr
-          %th.libelle Attestation fiscale
+          %th.libelle Attestation fiscale :
           - if profile == 'instructeur'
             %td= link_to "Consulter l'attestation", url_for(etablissement.entreprise_attestation_fiscale)
           - else

--- a/app/views/shared/dossiers/_identite_entreprise.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise.html.haml
@@ -67,6 +67,55 @@
           - elsif etablissement.exercices.present?
             = t('activemodel.models.exercices_summary', count: etablissement.exercices.count)
 
+
+      - if etablissement.entreprise_bilans_bdf.present?
+        - if profile == 'instructeur'
+          %tr
+            %th.libelle
+              Résultat exercice
+              = "(#{pretty_date_exercice(etablissement.entreprise_date_arret_exercice)})"
+            %td= pretty_currency(etablissement.entreprise_resultat_exercice, unit: pretty_currency_unit(etablissement.entreprise_bilans_bdf_monnaie))
+          %tr
+            %th
+              Excédent brut d'exploitation
+              = "(#{pretty_date_exercice(etablissement.entreprise_date_arret_exercice)})"
+            %td= pretty_currency(etablissement.entreprise_excedent_brut_exploitation, unit: pretty_currency_unit(etablissement.entreprise_bilans_bdf_monnaie))
+          %tr
+            %th
+              Fonds de roulement net global
+              = "(#{pretty_date_exercice(etablissement.entreprise_date_arret_exercice)})"
+            %td= pretty_currency(etablissement.entreprise_fdr_net_global, unit: pretty_currency_unit(etablissement.entreprise_bilans_bdf_monnaie))
+          %tr
+            %th
+              Besoin en fonds de roulement
+              = "(#{pretty_date_exercice(etablissement.entreprise_date_arret_exercice)})"
+            %td= pretty_currency(etablissement.entreprise_besoin_fdr, unit: pretty_currency_unit(etablissement.entreprise_bilans_bdf_monnaie))
+          %tr
+            %th.libelle
+              Chiffres financiers clés (Banque de France)
+              = "en #{pretty_currency_unit(etablissement.entreprise_bilans_bdf_monnaie)}"
+
+            - if controller.is_a?(Instructeurs::AvisController)
+              %td
+                Les consulter
+                = link_to "au format csv", bilans_bdf_instructeur_avis_path(@avis, format: 'csv')
+                ,
+                = link_to "au format xlsx", bilans_bdf_instructeur_avis_path(@avis, format: 'xlsx')
+                ou
+                = link_to "au format ods", bilans_bdf_instructeur_avis_path(@avis, format: 'ods')
+            - else
+              %td
+                Les consulter
+                = link_to "au format csv", bilans_bdf_instructeur_dossier_path(procedure_id: @dossier.procedure.id, dossier_id: @dossier.id, format: 'csv')
+                ,
+                = link_to "au format xlsx", bilans_bdf_instructeur_dossier_path(procedure_id: @dossier.procedure.id, dossier_id: @dossier.id, format: 'xlsx')
+                ou
+                = link_to "au format ods", bilans_bdf_instructeur_dossier_path(procedure_id: @dossier.procedure.id, dossier_id: @dossier.id, format: 'ods')
+        - else
+          %tr
+            %th.libelle
+              Bilans Banque de France
+            %td Les 3 derniers bilans connus de votre entreprise par la Banque de France ont été joints à votre dossier.
       - if etablissement.entreprise_attestation_sociale.attached?
         %tr
           %th.libelle Attestation sociale
@@ -82,49 +131,6 @@
             %td= link_to "Consulter l'attestation", url_for(etablissement.entreprise_attestation_fiscale)
           - else
             %td Une attestation fiscale délivrée par l'URSSAF a été jointe à votre dossier.
-
-      - if etablissement.entreprise_bilans_bdf.present?
-        %tr
-          %th.libelle
-            Bilans Banque de France
-            = "en #{etablissement.entreprise_bilans_bdf_monnaie}"
-          - if profile == 'instructeur'
-            - if controller.is_a?(Instructeurs::AvisController)
-              %td
-                Consulter les bilans
-                = link_to "au format csv", bilans_bdf_instructeur_avis_path(@avis, format: 'csv')
-                ,
-                = link_to "au format xlsx", bilans_bdf_instructeur_avis_path(@avis, format: 'xlsx')
-                ou
-                = link_to "au format ods", bilans_bdf_instructeur_avis_path(@avis, format: 'ods')
-            - else
-              %td
-                Consulter les bilans
-                = link_to "au format csv", bilans_bdf_instructeur_dossier_path(procedure_id: @dossier.procedure.id, dossier_id: @dossier.id, format: 'csv')
-                ,
-                = link_to "au format xlsx", bilans_bdf_instructeur_dossier_path(procedure_id: @dossier.procedure.id, dossier_id: @dossier.id, format: 'xlsx')
-                ou
-                = link_to "au format ods", bilans_bdf_instructeur_dossier_path(procedure_id: @dossier.procedure.id, dossier_id: @dossier.id, format: 'ods')
-            %tr
-              %th.libelle
-                Résultat exercice
-                = "(#{pretty_date_exercice(etablissement.entreprise_date_arret_exercice)})"
-              %td= etablissement.entreprise_resultat_exercice
-            %tr
-              %th
-                Excédent brut d'exploitation
-              %td= etablissement.entreprise_excedent_brut_exploitation
-            %tr
-              %th
-                Fonds de roulement net global
-              %td= etablissement.entreprise_fdr_net_global
-            %tr
-              %th
-                Besoin en fonds de roulement
-              %td= etablissement.entreprise_besoin_fdr
-
-          - else
-            %td Les 3 derniers bilans connus de votre entreprise par la Banque de France ont été joints à votre dossier.
 
       - if etablissement.association?
         %tr
@@ -147,6 +153,6 @@
           %td= try_format_date(etablissement.association_date_declaration)
 
 %p
-  = link_to '➡ Autres informations sur l’organisme sur « entreprise.data.gouv.fr »',
+  = link_to "➡ Autres informations sur l’organisme sur « entreprise.data.gouv.fr » (ex: fiche d'immatriculation RNCS)",
   "https://entreprise.data.gouv.fr/etablissement/#{etablissement.siret}",
   target: "_blank"

--- a/app/views/shared/dossiers/_identite_entreprise.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise.html.haml
@@ -57,39 +57,31 @@
         %th.libelle Capital social :
         %td= pretty_currency(etablissement.entreprise.capital_social)
       %tr
-        %th.libelle Exercices :
+        %th.libelle Chiffre d'affaires :
         %td
           - if profile == 'instructeur'
-            - etablissement.exercices.each_with_index do |exercice, index|
-              = "#{exercice.date_fin_exercice.year} : "
-              = pretty_currency(exercice.ca)
-              %br
+            %details
+              - etablissement.exercices.each_with_index do |exercice, index|
+                = "#{exercice.date_fin_exercice.year} : "
+                = pretty_currency(exercice.ca)
+                %br
           - elsif etablissement.exercices.present?
             = t('activemodel.models.exercices_summary', count: etablissement.exercices.count)
 
 
       - if etablissement.entreprise_bilans_bdf.present?
         - if profile == 'instructeur'
-          %tr
-            %th.libelle
-              Résultat exercice
-              = "(#{pretty_date_exercice(etablissement.entreprise_date_arret_exercice)}) :"
-            %td= pretty_currency(etablissement.entreprise_resultat_exercice, unit: pretty_currency_unit(etablissement.entreprise_bilans_bdf_monnaie))
-          %tr
-            %th
-              Excédent brut d'exploitation
-              = "(#{pretty_date_exercice(etablissement.entreprise_date_arret_exercice)}) :"
-            %td= pretty_currency(etablissement.entreprise_excedent_brut_exploitation, unit: pretty_currency_unit(etablissement.entreprise_bilans_bdf_monnaie))
-          %tr
-            %th
-              Fonds de roulement net global
-              = "(#{pretty_date_exercice(etablissement.entreprise_date_arret_exercice)}) :"
-            %td= pretty_currency(etablissement.entreprise_fdr_net_global, unit: pretty_currency_unit(etablissement.entreprise_bilans_bdf_monnaie))
-          %tr
-            %th
-              Besoin en fonds de roulement
-              = "(#{pretty_date_exercice(etablissement.entreprise_date_arret_exercice)}) :"
-            %td= pretty_currency(etablissement.entreprise_besoin_fdr, unit: pretty_currency_unit(etablissement.entreprise_bilans_bdf_monnaie))
+          = render partial: 'shared/dossiers/identite_entreprise_bilan_detail',
+            locals: { libelle: 'Résultat exercice', key: 'resultat_exercice', etablissement: etablissement }
+
+          = render partial: 'shared/dossiers/identite_entreprise_bilan_detail',
+            locals: { libelle: "Excédent brut d'exploitation", key: 'excedent_brut_exploitation', etablissement: etablissement }
+
+          = render partial: 'shared/dossiers/identite_entreprise_bilan_detail',
+            locals: { libelle: 'Fonds de roulement net global', key: 'fonds_roulement_net_global', etablissement: etablissement }
+
+          = render partial: 'shared/dossiers/identite_entreprise_bilan_detail',
+            locals: { libelle: 'Besoin en fonds de roulement', key: 'besoin_en_fonds_de_roulement', etablissement: etablissement }
           %tr
             %th.libelle
               Chiffres financiers clés (Banque de France)

--- a/app/views/shared/dossiers/_identite_entreprise_bilan_detail.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise_bilan_detail.html.haml
@@ -1,0 +1,10 @@
+%tr
+  %th.libelle
+    = "#{libelle} :"
+  %td
+    %details
+      - etablissement.entreprise_bilans_bdf.each do |bilan|
+        = "#{pretty_date_exercice(bilan["date_arret_exercice"])} : "
+        = pretty_currency(bilan[key], unit: pretty_currency_unit(etablissement.entreprise_bilans_bdf_monnaie))
+        %br
+

--- a/spec/helpers/etablissement_helper_spec.rb
+++ b/spec/helpers/etablissement_helper_spec.rb
@@ -59,6 +59,6 @@ RSpec.describe EtablissementHelper, type: :helper do
   end
   describe '#pretty_date_exercice' do
     subject { pretty_date_exercice("201908") }
-    it { is_expected.to eq("08/2019") }
+    it { is_expected.to eq("2019") }
   end
 end

--- a/spec/helpers/etablissement_helper_spec.rb
+++ b/spec/helpers/etablissement_helper_spec.rb
@@ -52,6 +52,11 @@ RSpec.describe EtablissementHelper, type: :helper do
     it { is_expected.to eq('123 000,00 €') }
   end
 
+  describe '#pretty_currency with special unit' do
+    subject { pretty_currency(12345, unit: 'k€') }
+
+    it { is_expected.to eq('12 345,00 k€') }
+  end
   describe '#pretty_date_exercice' do
     subject { pretty_date_exercice("201908") }
     it { is_expected.to eq("08/2019") }


### PR DESCRIPTION
Suite aux retours utilisateurs, nous améliorons la vue identité entreprise : 
- en affichant les chiffres clés des 3 derniers bilans
- en modifiant l'ordre des champs
- en homogénéisant l'affichage des valeurs monétaires
- en renommant _Exercices_ en _Chiffre d'affaires_

![bilans](https://user-images.githubusercontent.com/1111966/84171221-df75e900-aa7a-11ea-8748-29a498387d8c.png)
