### PR TITLE
RFC: Ajout d'une tâche de validation W3C

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,21 @@ jobs:
       - run:
           name: Run linters
           command: bundle exec rake lint
+  accessibility:
+    <<: *defaults
+    steps:
+      - checkout
+      - *aptget_install
+      - *bundle_restore_cache
+      - *bundle_install
+      - *yarn_restore_cache
+      - *yarn_install
+      - run:
+          name: Start W3C validator docker container
+          command: bundle exec rake accessibility:local_w3c_validator:start
+      - run:
+          name: Run automated accessibility tests
+          command: bundle exec rake accessibility:lint
 
 workflows:
   version: 2

--- a/Gemfile
+++ b/Gemfile
@@ -120,4 +120,5 @@ group :development, :test do
   gem 'simple_xlsx_reader'
   gem 'spring' # Spring speeds up development by keeping your application running in the background
   gem 'spring-commands-rspec'
+  gem 'w3c_validators'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -339,6 +339,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.3.0)
     json-jwt (1.11.0)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -697,6 +698,9 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
+    w3c_validators (1.3.5)
+      json (>= 1.8)
+      nokogiri (~> 1.6)
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (3.7.0)
@@ -842,6 +846,7 @@ DEPENDENCIES
   timecop
   typhoeus
   vcr
+  w3c_validators
   warden
   web-console
   webdrivers (~> 4.0)

--- a/accessibility/usager_spec.rb
+++ b/accessibility/usager_spec.rb
@@ -1,4 +1,25 @@
-feature 'wcag rules for usager', js: true do
+require 'w3c_validators'
+
+include W3CValidators
+
+# Runs automated accessibility tests (WCAG validation, W3C validation)
+# on all the "usager" pages
+#  - all the unlogged pages (home, sign-in, sign-up, contact…)
+#  - after authentication:
+#    - identité
+#     - personne physique
+#     - personne morale
+#    - formulaire de dépot de dossier:
+#      - depot initial
+#      - modifier
+#      - merci
+#    - liste des dossiers
+#    - dossier déposé
+#      - résumé
+#      - demande
+#      - messagerie
+
+feature 'accessibility rules for usager', js: true do
   let(:procedure) { create(:procedure, :with_type_de_champ, :with_all_champs, :with_service, :for_individual, :published) }
   let(:password) { 'a very complicated password' }
   let(:litteraire_user) { create(:user, password: password) }
@@ -7,11 +28,13 @@ feature 'wcag rules for usager', js: true do
     scenario 'homepage' do
       visit root_path
       expect(page).to be_accessible.excluding ".footer-logo"
+      expect(page).to have_w3c_valid_html
     end
 
     scenario 'sign_up page' do
       visit new_user_registration_path
       expect(page).to be_accessible.excluding ".footer-logo"
+      expect(page).to have_w3c_valid_html
     end
 
     scenario 'account confirmation page' do
@@ -23,22 +46,26 @@ feature 'wcag rules for usager', js: true do
       perform_enqueued_jobs do
         click_button 'Créer un compte'
         expect(page).to be_accessible.skipping(:'page-has-heading-one', :'role-img-alt', :label)
+        expect(page).to have_w3c_valid_html
       end
     end
 
     scenario 'sign_in page' do
       visit new_user_session_path
       expect(page).to be_accessible.excluding ".footer-logo", '#user_email'
+      expect(page).not_to have_w3c_valid_html
     end
 
     scenario 'contact page' do
       visit contact_path
       expect(page).to be_accessible.excluding ".footer-logo"
+      expect(page).to have_w3c_valid_html
     end
 
     scenario 'commencer page' do
       visit commencer_path(path: procedure.reload.path)
       expect(page).to be_accessible
+      expect(page).to have_w3c_valid_html
     end
   end
 
@@ -51,6 +78,7 @@ feature 'wcag rules for usager', js: true do
     scenario 'écran identité usager' do
       click_on 'Commencer la démarche'
       expect(page).to be_accessible
+      expect(page).not_to have_w3c_valid_html
     end
 
     # with no surprise, there's a lot of work on this one
@@ -63,6 +91,7 @@ feature 'wcag rules for usager', js: true do
       click_on 'Continuer'
 
       expect(page).to be_accessible.skipping :'aria-input-field-name', :'heading-order', :label
+      expect(page).not_to have_w3c_valid_html
     end
   end
 
@@ -77,6 +106,7 @@ feature 'wcag rules for usager', js: true do
     scenario "écran identification de l'entreprise" do
       click_on 'Commencer la démarche'
       expect(page).to be_accessible.skipping :label
+      expect(page).not_to have_w3c_valid_html
     end
   end
 
@@ -89,36 +119,43 @@ feature 'wcag rules for usager', js: true do
     scenario 'liste des dossiers' do
       visit dossiers_path
       expect(page).to be_accessible
+      expect(page).not_to have_w3c_valid_html
     end
 
     scenario 'dossier' do
       visit dossier_path(dossier)
       expect(page).to be_accessible.skipping :'heading-order', :label, :'aria-input-field-name'
+      expect(page).not_to have_w3c_valid_html
     end
 
     scenario 'merci' do
       visit merci_dossier_path(dossier)
       expect(page).to be_accessible
+      expect(page).not_to have_w3c_valid_html
     end
 
     scenario 'demande' do
       visit demande_dossier_path(dossier)
       expect(page).to be_accessible
+      expect(page).not_to have_w3c_valid_html
     end
 
     scenario 'messagerie' do
       visit messagerie_dossier_path(dossier)
       expect(page).to be_accessible
+      expect(page).not_to have_w3c_valid_html
     end
 
     scenario 'modifier' do
       visit modifier_dossier_path(dossier)
       expect(page).to be_accessible.skipping :'aria-input-field-name', :'heading-order', :label
+      expect(page).not_to have_w3c_valid_html
     end
 
     scenario 'brouillon' do
       visit brouillon_dossier_path(dossier)
       expect(page).to be_accessible.skipping :'aria-input-field-name', :'heading-order', :label
+      expect(page).not_to have_w3c_valid_html
     end
   end
 end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -6,3 +6,17 @@ task :lint do
   sh "yarn lint:ec"
   sh "yarn lint:js"
 end
+
+namespace :accessibility do
+  task :lint do
+    sh "bundle exec rspec accessibility"
+  end
+
+  # The main task `lint` expects you to run the W3C server application
+  # beforehand
+  namespace :local_w3c_validator do
+    task :start do
+      sh "docker run -it --rm -p 8888:8888 validator/validator:latest"
+    end
+  end
+end


### PR DESCRIPTION
C'est pas terminé, mais je commence à le montrer et ça (me) permet de détecter et corriger des problèmes.

Dans l'idée j'aimerais bien un linter qui passe sur un certain nombre de pages, y compris des pages après authentification pour faire certaines vérifs:
 - ici, tester la conformité html (ya 2-3 trucs à corriger, ça arrivera dans une PR dédiée)
 - demain, quelques indicateurs sur l'accessibilité (peut-être via [`lighthouse`](https://developers.google.com/web/tools/lighthouse/#cli) directement, ou le composant qu'il utilise en interne [`axe-core`](https://github.com/dequelabs/axe-core))

Cette implém utilise une instance locale du [validateur W3C](https://github.com/validator/validator) qui tourne dans un container docker (d'où une tâche rake `accessibility:local_w3c_validator:start`), ça pose sans doute problème pour une intégration en CI.

Je ne suis pas certain qu'on veuille avoir ça en CI au point que ça casse le build, par contre ça vaut le coup d'avoir un rapport sur la qualité des pages occasionnellement pour éviter les (trop grosses) régressions.
