### PR TITLE
remove useless dependent option

### DIFF
--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -1,8 +1,8 @@
 class GroupeInstructeur < ApplicationRecord
   DEFAULT_LABEL = 'défaut'
   belongs_to :procedure, -> { with_discarded }, inverse_of: :groupe_instructeurs
-  has_many :assign_tos
-  has_many :instructeurs, through: :assign_tos, dependent: :destroy
+  has_many :assign_tos, dependent: :destroy
+  has_many :instructeurs, through: :assign_tos
   has_many :dossiers
   has_and_belongs_to_many :exports
 


### PR DESCRIPTION
Un instructeur n'a pas besoin d'appartenir à un groupe instructeur