### PR TITLE
Add rbtrace memory monitoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem 'rack-mini-profiler'
 gem 'rails', '= 5.2.4.2'
 gem 'rails-i18n' # Locales par défaut
 gem 'rake-progressbar', require: false
+gem 'rbtrace', require: false
 gem 'react-rails'
 gem 'rgeo-geojson'
 gem 'sanitize-url'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -383,6 +383,7 @@ GEM
     minitest (5.14.1)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
+    msgpack (1.3.1)
     multi_json (1.14.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
@@ -424,6 +425,7 @@ GEM
       validate_email
       validate_url
       webfinger (>= 1.0.1)
+    optimist (3.0.1)
     orm_adapter (0.5.0)
     parallel (1.19.1)
     parser (2.7.0.4)
@@ -516,6 +518,10 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rbtrace (0.4.13)
+      ffi (>= 1.0.6)
+      msgpack (>= 0.4.3)
+      optimist (>= 3.0.0)
     react-rails (2.4.7)
       babel-transpiler (>= 0.7.0)
       connection_pool
@@ -799,6 +805,7 @@ DEPENDENCIES
   rails-controller-testing
   rails-i18n
   rake-progressbar
+  rbtrace
   react-rails
   rgeo-geojson
   rspec-rails (~> 4.0.0.beta)

--- a/config/initializers/rbtrace.rb
+++ b/config/initializers/rbtrace.rb
@@ -1,0 +1,5 @@
+if ENV.fetch('RBTRACE_ENABLED', 'false') == 'true'
+  require 'rbtrace'
+  require 'objspace'
+  ObjectSpace.trace_object_allocations_start
+end


### PR DESCRIPTION
Le plan: ajout de rbtrace en prod pour comprendre d'où viennent les grosses allocations mémoire qui sont apparues récemment.

Même pas peur ! Enfin si, un peu, parait que ca a un impact sur les perfs (cpu et mémoire) non négligable.
Du coup le plan ce serait:
 - de l'activer juste sur un serveur, via une variable d'env:
```
# en local, on peut tester
RBTRACE_ENABLED=true overmind start
```
 - d'attendre patiemment que ce serveur se mettent à faire des allocations en scrutant grafana tel un aigle 
 - de logguer à partir de ce moment là les allocations

```bash
# Faudra trouver le pid du process racine, sans doute avec pidof -s puma
$ bundle exec rbtrace --pid $PID -e 'Thread.new{GC.start;require "objspace";io=File.open("/tmp/ruby-heap.dump", "w"); ObjectSpace.dump_all(output: io); io.close}'
```
 - d'analyser ces dumps. Cf [Analyzing the heap dump](https://samsaffron.com/archive/2015/03/31/debugging-memory-leaks-in-ruby)
 - désactivation de rbtrace, reboot de puma
 - un fois la source détectée, on corrige (c'est sans doute pas simple)
 - suppression de l'utilisation de cette gem et de ses références… on disparait [sans laisser de traces](https://media.giphy.com/media/R7m04yMaGWVeE/giphy.gif)