### PR TITLE
more verbose exception when RequestFailed for apientreprise occurs

### DIFF
--- a/app/lib/api_entreprise/api.rb
+++ b/app/lib/api_entreprise/api.rb
@@ -78,7 +78,7 @@ class ApiEntreprise::API
     elsif response.code == 400
       raise BadFormatRequest, "url:  #{url}"
     else
-      raise RequestFailed, "HTTP Error Code: #{response.code} for #{url}"
+      raise RequestFailed, "HTTP Error Code: #{response.code} for #{url}\nheaders: #{response.headers}\nbody: #{response.body}"
     end
   end
 


### PR DESCRIPTION
Afin de comprendre pourquoi on a parfois des `response.code` qui valent 0 d'après Typhoeus