### PR TITLE
no sentry report when error 400 for exercices

### DIFF
--- a/app/jobs/api_entreprise/exercices_job.rb
+++ b/app/jobs/api_entreprise/exercices_job.rb
@@ -1,4 +1,7 @@
 class ApiEntreprise::ExercicesJob < ApiEntreprise::Job
+  rescue_from(ApiEntreprise::API::BadFormatRequest) do |exception|
+  end
+
   def perform(etablissement_id, procedure_id)
     etablissement = Etablissement.find(etablissement_id)
     etablissement_params = ApiEntreprise::ExercicesAdapter.new(etablissement.siret, procedure_id).to_params

--- a/app/jobs/api_entreprise/job.rb
+++ b/app/jobs/api_entreprise/job.rb
@@ -1,5 +1,14 @@
 class ApiEntreprise::Job < ApplicationJob
   DEFAULT_MAX_ATTEMPTS_API_ENTREPRISE_JOBS = 5
+
+  rescue_from(ApiEntreprise::API::ResourceNotFound) do |exception|
+    error(self, exception)
+  end
+
+  rescue_from(ApiEntreprise::API::BadFormatRequest) do |exception|
+    error(self, exception)
+  end
+
   def max_attempts
     ENV[MAX_ATTEMPTS_API_ENTREPRISE_JOBS].to_i || DEFAULT_MAX_ATTEMPTS_API_ENTREPRISE_JOBS
   end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -13,10 +13,6 @@ class ApplicationJob < ActiveJob::Base
     error(self, exception)
   end
 
-  rescue_from(ApiEntreprise::API::BadFormatRequest) do |exception|
-    error(self, exception)
-  end
-
   def error(job, exception)
     Raven.capture_exception(exception)
   end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -9,10 +9,6 @@ class ApplicationJob < ActiveJob::Base
     Rails.logger.info("#{job.class.name} ended at #{Time.zone.now}")
   end
 
-  rescue_from(ApiEntreprise::API::ResourceNotFound) do |exception|
-    error(self, exception)
-  end
-
   def error(job, exception)
     Raven.capture_exception(exception)
   end


### PR DESCRIPTION
L'api entreprise renvoie 400 comme status code lorsqu'on appelle le endpoint exercices et que l'information demandée n'est pas connue. Comme nous ne savons pas à l'avance si cette info est disponible ou pas, nous faisons l'appel et parfois avons un retour 400. Il est inutile de remonter l'exception à Sentry dans le cas d'un appel à l'endpoint exercices.