### PR TITLE
Ajoute les PJs des annotations privées à l'export

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,7 @@ class ApplicationController < ActionController::Base
   before_action :setup_tracking
 
   helper_method :multiple_devise_profile_connect?, :instructeur_signed_in?, :current_instructeur,
-    :administrateur_signed_in?, :current_administrateur
+    :administrateur_signed_in?, :current_administrateur, :current_account
 
   def staging_authenticate
     if StagingAuthService.enabled? && !authenticate_with_http_basic { |username, password| StagingAuthService.authenticate(username, password) }
@@ -49,14 +49,6 @@ class ApplicationController < ActionController::Base
         user_signed_in? && administrateur_signed_in?
   end
 
-  def pundit_user
-    {
-      administrateur: current_administrateur,
-      instructeur: current_instructeur,
-      user: current_user
-    }.compact
-  end
-
   def current_instructeur
     current_user&.instructeur
   end
@@ -72,6 +64,16 @@ class ApplicationController < ActionController::Base
   def administrateur_signed_in?
     current_administrateur.present?
   end
+
+  def current_account
+    {
+      administrateur: current_administrateur,
+      instructeur: current_instructeur,
+      user: current_user
+    }.compact
+  end
+
+  alias_method :pundit_user, :current_account
 
   protected
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -701,7 +701,8 @@ class Dossier < ApplicationRecord
   end
 
   def attachments_downloadable?
-    !PiecesJustificativesService.liste_pieces_justificatives(self).empty? && PiecesJustificativesService.pieces_justificatives_total_size(self) < Dossier::TAILLE_MAX_ZIP
+    PiecesJustificativesService.liste_pieces_justificatives(self).present? \
+      && PiecesJustificativesService.pieces_justificatives_total_size(self) < Dossier::TAILLE_MAX_ZIP
   end
 
   def linked_dossiers_for(instructeur)

--- a/app/policies/champ_policy.rb
+++ b/app/policies/champ_policy.rb
@@ -1,4 +1,8 @@
 class ChampPolicy < ApplicationPolicy
+  # Scope for WRITING to a champ.
+  #
+  # (If the need for a scope to READ a champ emerges, we can implement another scope
+  # in this file, following this example: https://github.com/varvet/pundit/issues/368#issuecomment-196111115)
   class Scope < ApplicationScope
     def resolve
       if user.blank?

--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -43,7 +43,7 @@ class PiecesJustificativesService
   private
 
   def self.pjs_for_champs(dossier)
-    allowed_champs = dossier.champs
+    allowed_champs = dossier.champs + dossier.champs_private
 
     allowed_child_champs = allowed_champs
       .filter { |c| c.type_champ == TypeDeChamp.type_champs.fetch(:repetition) }

--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -1,16 +1,10 @@
 class PiecesJustificativesService
   def self.liste_pieces_justificatives(dossier)
-    pjs_commentaires = dossier.commentaires
-      .map(&:piece_jointe)
+    pjs_champs = pjs_for_champs(dossier)
+    pjs_commentaires = pjs_for_commentaires(dossier)
+
+    (pjs_champs + pjs_commentaires)
       .filter(&:attached?)
-
-    champs_blocs_repetables = dossier.champs
-      .filter { |c| c.type_champ == TypeDeChamp.type_champs.fetch(:repetition) }
-      .flat_map(&:champs)
-
-    pjs_commentaires + champs_pieces_justificatives_with_attachments(
-      champs_blocs_repetables + dossier.champs
-    )
   end
 
   def self.pieces_justificatives_total_size(dossier)
@@ -48,10 +42,21 @@ class PiecesJustificativesService
 
   private
 
-  def self.champs_pieces_justificatives_with_attachments(champs)
-    champs
+  def self.pjs_for_champs(dossier)
+    allowed_champs = dossier.champs
+
+    allowed_child_champs = allowed_champs
+      .filter { |c| c.type_champ == TypeDeChamp.type_champs.fetch(:repetition) }
+      .flat_map(&:champs)
+
+    (allowed_champs + allowed_child_champs)
       .filter { |c| c.type_champ == TypeDeChamp.type_champs.fetch(:piece_justificative) }
-      .filter { |pj| pj.piece_justificative_file.attached? }
       .map(&:piece_justificative_file)
+  end
+
+  def self.pjs_for_commentaires(dossier)
+    dossier
+      .commentaires
+      .map(&:piece_jointe)
   end
 end

--- a/app/views/instructeurs/dossiers/_header_actions.html.haml
+++ b/app/views/instructeurs/dossiers/_header_actions.html.haml
@@ -12,7 +12,7 @@
       %li
         = link_to "Export GeoJSON", geo_data_instructeur_dossier_path(dossier.procedure, dossier), target: "_blank", rel: "noopener", class: "menu-item menu-link"
 
-- if !PiecesJustificativesService.liste_pieces_justificatives(dossier).empty?
+- if PiecesJustificativesService.liste_pieces_justificatives(dossier).present?
   %span.dropdown.print-menu-opener
     %button.button.dropdown-button.icon-only
       %span.icon.attached

--- a/spec/lib/active_storage/downloadable_file_spec.rb
+++ b/spec/lib/active_storage/downloadable_file_spec.rb
@@ -16,6 +16,14 @@ describe ActiveStorage::DownloadableFile do
       it { expect(list.length).to eq 1 }
     end
 
+    context 'when there is a private piece_justificative' do
+      before do
+        dossier.champs_private << create(:champ, :piece_justificative, :with_piece_justificative_file, private: true)
+      end
+
+      it { expect(list.length).to eq 1 }
+    end
+
     context 'when there is a repetition bloc' do
       let(:champ) { build(:champ_repetition_with_piece_jointe) }
       let(:dossier) { create(:dossier, :en_construction, champs: [champ]) }

--- a/spec/lib/active_storage/downloadable_file_spec.rb
+++ b/spec/lib/active_storage/downloadable_file_spec.rb
@@ -13,7 +13,7 @@ describe ActiveStorage::DownloadableFile do
         dossier.champs << create(:champ, :piece_justificative, :with_piece_justificative_file)
       end
 
-      it { expect(list.length).to be 1 }
+      it { expect(list.length).to eq 1 }
     end
 
     context 'when there is a repetition bloc' do
@@ -21,7 +21,7 @@ describe ActiveStorage::DownloadableFile do
       let(:dossier) { create(:dossier, :en_construction, champs: [champ]) }
 
       it 'should have 4 piece_justificatives' do
-        expect(list.size).to eq(4)
+        expect(list.size).to eq 4
       end
     end
 
@@ -29,14 +29,14 @@ describe ActiveStorage::DownloadableFile do
       let(:commentaire) { create(:commentaire) }
       let(:dossier) { commentaire.dossier }
 
-      it { expect(list.length).to be 0 }
+      it { expect(list.length).to eq 0 }
     end
 
     context 'when there is a message with an attachment' do
       let(:commentaire) { create(:commentaire, :with_file) }
       let(:dossier) { commentaire.dossier }
 
-      it { expect(list.length).to be 1 }
+      it { expect(list.length).to eq 1 }
     end
   end
 end


### PR DESCRIPTION
Si l'usager qui fait la demande d'export des pièces jointes a le droit d'accéder aux annotations privées, on ajoute ces PJs à l'export.

Fix #5297