### PR TITLE
Dossiers accessibility

### DIFF
--- a/app/assets/stylesheets/new_design/accessibilite.scss
+++ b/app/assets/stylesheets/new_design/accessibilite.scss
@@ -16,3 +16,17 @@ $new-p-margin-bottom: 3 * $default-space;
 .new-p {
   margin-bottom: $new-p-margin-bottom;
 }
+
+// A class to make elements only accessible to screen-readers
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: none;
+}

--- a/app/assets/stylesheets/new_design/dossiers_table.scss
+++ b/app/assets/stylesheets/new_design/dossiers_table.scss
@@ -67,6 +67,7 @@
     .label {
       width: 110px;
       text-align: center;
+      margin: 0 4px;
     }
   }
 
@@ -83,4 +84,17 @@
   .follow-col {
     width: 200px;
   }
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: none;
 }

--- a/app/assets/stylesheets/new_design/dossiers_table.scss
+++ b/app/assets/stylesheets/new_design/dossiers_table.scss
@@ -85,16 +85,3 @@
     width: 200px;
   }
 }
-
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  opacity: 0;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: none;
-}

--- a/app/views/users/dossiers/index.html.haml
+++ b/app/views/users/dossiers/index.html.haml
@@ -29,36 +29,31 @@
     %table.table.dossiers-table.hoverable
       %thead
         %tr
-          %th.notification-col
           %th.number-col Nº dossier
           %th Démarche
           - if @dossiers.count > 1
             %th Demandeur
           %th.status-col Statut
           %th.updated-at-col Mis à jour
-          %th
+          %th.sr-only Actions
       %tbody
         - @dossiers.each do |dossier|
           %tr{ data: { 'dossier-id': dossier.id } }
-            %td.folder-col
-              = link_to(url_for_dossier(dossier), class: 'cell-link') do
-                %span.icon.folder
             %td.number-col
-              = link_to(url_for_dossier(dossier), class: 'cell-link') do
+              = link_to(url_for_dossier(dossier), class: 'cell-link', tabindex: -1) do
+                %span.icon.folder
                 = dossier.id
             %td
               = link_to(url_for_dossier(dossier), class: 'cell-link') do
                 = procedure_libelle(dossier.procedure)
             - if @dossiers.count > 1
-              %td.number-col
+              %td.cell-link
                 = demandeur_dossier(dossier)
             %td.status-col
-              = link_to(url_for_dossier(dossier), class: 'cell-link') do
-                = status_badge(dossier.state)
-            %td.updated-at-col
-              = link_to(url_for_dossier(dossier), class: 'cell-link') do
-                = try_format_date(dossier.updated_at)
-            %td.action-col.action-col
+              = status_badge(dossier.state)
+            %td.updated-at-col.cell-link
+              = try_format_date(dossier.updated_at)
+            %td.action-col
               = render partial: 'dossier_actions', locals: { dossier: dossier }
     = paginate(@dossiers)
 


### PR DESCRIPTION
Variation on #4558.
Issue #5162 

Les problèmes d'accessibilité posés par la page "Mes dossiers" sont:
- titres manquants sur les colonnes "Dossier" et "Actions"
- chaque case du tableau est un lien: _difficulté de navigation au clavier (il faut parcourir les 6 cases pour passer à la ligne suivante) et avalanche d'informations redondantes avec les lecteurs d'écran_

Page "Mes dossiers" actuelle:
<img width="1141" alt="page Dossiers actuelle" src="https://user-images.githubusercontent.com/47247356/85688209-d66b5580-b6d1-11ea-926c-087d1858f626.png">

Ce travail a été commencé dans la PR #4558, voici une proposition avec:
- fusion des colonnes "Dossier" et "N° de dossier"
- ajout d'un titre (accessible uniquement aux lecteurs d'écran via la classe CSS sr-only) à la colonne "Actions"
- diminution du nombre de liens, que l'on ne retrouve plus que dans les colonnes:
_pour les utilisateurs de la souris et de lecteurs d'écran:_ N° de dossier, Démarche et Actions
_pour les utilisateurs du clavier:_ Démarche et Actions

_**A noter:**_ lorsqu'on a un lien, les lecteurs d'écran en informent l'utilisateur en ajoutant beaucoup d'informations.
Celà est lourd pour l'usager et peut mener à confusion (*) il convient d'éviter la redondance des liens. Dans notre cas, on continue d'avoir deux cases qui se suivent (N° de dossier et Démarche) qui contiennent le même lien.
Il est important d'améliorer ce point (peut-être en refondant totalement la présentation, comme proposé [ici](https://github.com/betagouv/demarches-simplifiees.fr/pull/4558#issuecomment-558985615) ), mais le choix a été fait pour le moment de maintenir le lien sur la première colonne car cela semble être un comportement attendu par les utilisateurs.

Page "Mes dossiers" proposée:
<img width="1200" alt="page Dossiers proposée" src="https://user-images.githubusercontent.com/47247356/85686670-74f6b700-b6d0-11ea-8deb-876b78cb88ab.png">

*: un utilisateur peut penser que deux liens côté-à-côte mènent vers deux pages différentes. Dans le cas d'un utilisateur qui utilise un lecteur d'écran, iele aura potentiellement besoin de faire lire les deux pages par le lecteur pour réaliser que ce sont les mêmes, entraînant agacement et perte de temps.