### PR TITLE
Add revision migration and models

### DIFF
--- a/app/controllers/new_administrateur/procedures_controller.rb
+++ b/app/controllers/new_administrateur/procedures_controller.rb
@@ -33,6 +33,8 @@ module NewAdministrateur
       else
         flash.notice = 'Démarche enregistrée.'
         current_administrateur.instructeur.assign_to_procedure(@procedure)
+        # FIXUP: needed during transition to revisions
+        RevisionsMigration.add_revisions(@procedure)
 
         redirect_to champs_admin_procedure_path(@procedure)
       end

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -258,7 +258,10 @@ module Users
         return redirect_to url_for dossiers_path
       end
 
+      # FIXUP: needed during transition to revisions
+      RevisionsMigration.add_revisions(procedure)
       dossier = Dossier.new(
+        revision: procedure.active_revision,
         groupe_instructeur: procedure.defaut_groupe_instructeur,
         user: current_user,
         state: Dossier.states.fetch(:brouillon)

--- a/app/jobs/tmp_dossiers_migrate_revisions_job.rb
+++ b/app/jobs/tmp_dossiers_migrate_revisions_job.rb
@@ -1,0 +1,22 @@
+class TmpDossiersMigrateRevisionsJob < ApplicationJob
+  def perform(except)
+    dossiers = Dossier.with_discarded.where(revision_id: nil)
+
+    dossiers.where
+      .not(id: except)
+      .includes(procedure: [:draft_revision, :published_revision])
+      .limit(2000)
+      .find_each do |dossier|
+        if dossier.procedure.present?
+          dossier.revision = dossier.procedure.active_revision
+          dossier.save!(validate: false)
+        else
+          except << dossier.id
+        end
+      end
+
+    if dossiers.where.not(id: except).exists?
+      TmpDossiersMigrateRevisionsJob.perform_later(except)
+    end
+  end
+end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -48,6 +48,7 @@ class Dossier < ApplicationRecord
 
   belongs_to :groupe_instructeur
   has_one :procedure, through: :groupe_instructeur
+  belongs_to :revision, class_name: 'ProcedureRevision', optional: true
   belongs_to :user
 
   accepts_nested_attributes_for :champs

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -14,6 +14,9 @@ class Procedure < ApplicationRecord
 
   has_many :types_de_champ, -> { root.public_only.ordered }, inverse_of: :procedure, dependent: :destroy
   has_many :types_de_champ_private, -> { root.private_only.ordered }, class_name: 'TypeDeChamp', inverse_of: :procedure, dependent: :destroy
+  has_many :revisions, class_name: 'ProcedureRevision', inverse_of: :procedure, dependent: :destroy
+  belongs_to :draft_revision, class_name: 'ProcedureRevision', optional: true
+  belongs_to :published_revision, class_name: 'ProcedureRevision', optional: true
   has_many :deleted_dossiers, dependent: :destroy
 
   has_one :module_api_carto, dependent: :destroy
@@ -22,6 +25,10 @@ class Procedure < ApplicationRecord
   belongs_to :parent_procedure, class_name: 'Procedure'
   belongs_to :canonical_procedure, class_name: 'Procedure'
   belongs_to :service
+
+  def active_revision
+    brouillon? ? draft_revision : published_revision
+  end
 
   has_many :administrateurs_procedures
   has_many :administrateurs, through: :administrateurs_procedures, after_remove: -> (procedure, _admin) { procedure.validate! }

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -6,11 +6,102 @@ class ProcedureRevision < ApplicationRecord
   has_many :types_de_champ, through: :revision_types_de_champ, source: :type_de_champ
   has_many :types_de_champ_private, through: :revision_types_de_champ_private, source: :type_de_champ
 
+  def add_type_de_champ(params)
+    params[:procedure] = procedure
+    params[:revision] = self
+
+    if params[:parent_id]
+      find_or_clone_type_de_champ(params.delete(:parent_id))
+        .types_de_champ
+        .tap do |types_de_champ|
+          params[:order_place] = types_de_champ.size
+        end.create(params)
+    elsif params[:private]
+      types_de_champ_private.create(params)
+    else
+      types_de_champ.create(params)
+    end
+  end
+
+  def find_or_clone_type_de_champ(id)
+    type_de_champ = find_type_de_champ_by_id(id)
+
+    if type_de_champ.revision == self
+      type_de_champ
+    elsif type_de_champ.parent.present?
+      find_or_clone_type_de_champ(type_de_champ.parent.stable_id).types_de_champ.find_by!(stable_id: id)
+    else
+      type_de_champ.revise!
+    end
+  end
+
+  def move_type_de_champ(id, position)
+    type_de_champ = find_type_de_champ_by_id(id)
+
+    if type_de_champ.parent.present?
+      repetition_type_de_champ = find_or_clone_type_de_champ(id).parent
+
+      move_type_de_champ_hash(repetition_type_de_champ.types_de_champ.to_a, type_de_champ, position).each do |(id, position)|
+        repetition_type_de_champ.types_de_champ.find(id).update!(order_place: position)
+      end
+    elsif type_de_champ.private?
+      move_type_de_champ_hash(types_de_champ_private.to_a, type_de_champ, position).each do |(id, position)|
+        revision_types_de_champ_private.find_by!(type_de_champ_id: id).update!(position: position)
+      end
+    else
+      move_type_de_champ_hash(types_de_champ.to_a, type_de_champ, position).each do |(id, position)|
+        revision_types_de_champ.find_by!(type_de_champ_id: id).update!(position: position)
+      end
+    end
+  end
+
+  def remove_type_de_champ(id)
+    type_de_champ = find_type_de_champ_by_id(id)
+
+    if type_de_champ.revision == self
+      type_de_champ.destroy
+    elsif type_de_champ.parent.present?
+      find_or_clone_type_de_champ(id).destroy
+    elsif type_de_champ.private?
+      types_de_champ_private.delete(type_de_champ)
+    else
+      types_de_champ.delete(type_de_champ)
+    end
+  end
+
   def draft?
     procedure.draft_revision == self
   end
 
   def locked?
     !draft?
+  end
+
+  private
+
+  def find_type_de_champ_by_id(id)
+    types_de_champ.find_by(stable_id: id) ||
+      types_de_champ_private.find_by(stable_id: id) ||
+      types_de_champ_in_repetition.find_by!(stable_id: id)
+  end
+
+  def types_de_champ_in_repetition
+    parent_ids = types_de_champ.repetition.ids + types_de_champ_private.repetition.ids
+    TypeDeChamp.where(parent_id: parent_ids)
+  end
+
+  def move_type_de_champ_hash(types_de_champ, type_de_champ, new_index)
+    old_index = types_de_champ.index(type_de_champ)
+
+    if types_de_champ.delete_at(old_index)
+      types_de_champ.insert(new_index, type_de_champ)
+        .map.with_index do |type_de_champ, index|
+          # FIXUP: needed during transition to revisions
+          type_de_champ.update!(order_place: index)
+          [type_de_champ.id, index]
+        end
+    else
+      []
+    end
   end
 end

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -1,0 +1,16 @@
+class ProcedureRevision < ApplicationRecord
+  belongs_to :procedure, -> { with_discarded }, inverse_of: :revisions
+
+  has_many :revision_types_de_champ, -> { public_only.ordered }, class_name: 'ProcedureRevisionTypeDeChamp', foreign_key: :revision_id, dependent: :destroy, inverse_of: :revision
+  has_many :revision_types_de_champ_private, -> { private_only.ordered }, class_name: 'ProcedureRevisionTypeDeChamp', foreign_key: :revision_id, dependent: :destroy, inverse_of: :revision
+  has_many :types_de_champ, through: :revision_types_de_champ, source: :type_de_champ
+  has_many :types_de_champ_private, through: :revision_types_de_champ_private, source: :type_de_champ
+
+  def draft?
+    procedure.draft_revision == self
+  end
+
+  def locked?
+    !draft?
+  end
+end

--- a/app/models/procedure_revision_type_de_champ.rb
+++ b/app/models/procedure_revision_type_de_champ.rb
@@ -1,0 +1,24 @@
+class ProcedureRevisionTypeDeChamp < ApplicationRecord
+  belongs_to :revision, class_name: 'ProcedureRevision'
+  belongs_to :type_de_champ
+
+  scope :ordered, -> { order(:position) }
+  scope :public_only, -> { joins(:type_de_champ).where(types_de_champ: { private: false }) }
+  scope :private_only, -> { joins(:type_de_champ).where(types_de_champ: { private: true }) }
+
+  before_create :set_position
+
+  def private?
+    type_de_champ.private?
+  end
+
+  private
+
+  def set_position
+    self.position ||= if private?
+      revision.types_de_champ_private.size
+    else
+      revision.types_de_champ.size
+    end
+  end
+end

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -31,11 +31,14 @@ class TypeDeChamp < ApplicationRecord
   }
 
   belongs_to :procedure
+  belongs_to :revision, class_name: 'ProcedureRevision'
 
   belongs_to :parent, class_name: 'TypeDeChamp'
   has_many :types_de_champ, -> { ordered }, foreign_key: :parent_id, class_name: 'TypeDeChamp', inverse_of: :parent, dependent: :destroy
 
   store_accessor :options, :cadastres, :quartiers_prioritaires, :parcelles_agricoles, :old_pj, :drop_down_options, :skip_pj_validation
+  has_many :revision_types_de_champ, class_name: 'ProcedureRevisionTypeDeChamp', dependent: :destroy, inverse_of: :type_de_champ
+
   delegate :tags_for_template, to: :dynamic_type
 
   class WithIndifferentAccess

--- a/app/services/revisions_migration.rb
+++ b/app/services/revisions_migration.rb
@@ -1,0 +1,39 @@
+class RevisionsMigration
+  def self.add_revisions(procedure)
+    if procedure.draft_revision.present?
+      return false
+    end
+
+    procedure.draft_revision = procedure.revisions.create
+    procedure.save!(validate: false)
+
+    add_types_de_champs_to_revision(procedure, :types_de_champ)
+    add_types_de_champs_to_revision(procedure, :types_de_champ_private)
+
+    if procedure.publiee?
+      published_revision = procedure.draft_revision
+
+      procedure.draft_revision = procedure.create_new_revision
+      procedure.published_revision = published_revision
+      procedure.save!(validate: false)
+    elsif procedure.close? || procedure.depubliee?
+      procedure.draft_revision = procedure.create_new_revision
+      procedure.save!(validate: false)
+    end
+
+    true
+  end
+
+  def self.add_types_de_champs_to_revision(procedure, types_de_champ_scope)
+    types_de_champ = procedure.send(types_de_champ_scope)
+    types_de_champ.where(revision_id: nil).update_all(revision_id: procedure.draft_revision.id)
+
+    types_de_champ.each.with_index do |type_de_champ, index|
+      type_de_champ.types_de_champ.where(revision_id: nil).update_all(revision_id: procedure.draft_revision.id)
+      procedure.draft_revision.send(:"revision_#{types_de_champ_scope}").create!(
+        type_de_champ: type_de_champ,
+        position: index
+      )
+    end
+  end
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -12,6 +12,9 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym 'RNA'
   inflect.irregular 'type_de_champ', 'types_de_champ'
   inflect.irregular 'type_de_champ_private', 'types_de_champ_private'
+  inflect.irregular 'procedure_revision_type_de_champ', 'procedure_revision_types_de_champ'
+  inflect.irregular 'revision_type_de_champ', 'revision_types_de_champ'
+  inflect.irregular 'revision_type_de_champ_private', 'revision_types_de_champ_private'
   inflect.irregular 'assign_to', 'assign_tos'
   inflect.uncountable(['avis', 'pays'])
 end

--- a/db/migrate/20200707082260_create_procedure_revisions.rb
+++ b/db/migrate/20200707082260_create_procedure_revisions.rb
@@ -1,0 +1,24 @@
+class CreateProcedureRevisions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :procedure_revisions do |t|
+      t.references :procedure, foreign_key: true, null: false, index: true
+
+      t.timestamps
+    end
+
+    add_column :dossiers, :revision_id, :bigint
+    add_column :types_de_champ, :revision_id, :bigint
+    add_column :procedures, :draft_revision_id, :bigint
+    add_column :procedures, :published_revision_id, :bigint
+
+    add_foreign_key :dossiers, :procedure_revisions, column: :revision_id
+    add_foreign_key :types_de_champ, :procedure_revisions, column: :revision_id
+    add_foreign_key :procedures, :procedure_revisions, column: :draft_revision_id
+    add_foreign_key :procedures, :procedure_revisions, column: :published_revision_id
+
+    add_index :dossiers, :revision_id
+    add_index :types_de_champ, :revision_id
+    add_index :procedures, :draft_revision_id
+    add_index :procedures, :published_revision_id
+  end
+end

--- a/db/migrate/20200707082261_create_procedure_revision_types_de_champ.rb
+++ b/db/migrate/20200707082261_create_procedure_revision_types_de_champ.rb
@@ -1,0 +1,14 @@
+class CreateProcedureRevisionTypesDeChamp < ActiveRecord::Migration[5.2]
+  def change
+    create_table :procedure_revision_types_de_champ do |t|
+      t.references :revision, null: false, index: true
+      t.references :type_de_champ, foreign_key: true, null: false, index: true
+
+      t.integer :position, null: false
+
+      t.timestamps
+    end
+
+    add_foreign_key :procedure_revision_types_de_champ, :procedure_revisions, column: :revision_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_15_143010) do
+ActiveRecord::Schema.define(version: 2020_07_16_143010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -259,9 +259,11 @@ ActiveRecord::Schema.define(version: 2020_07_15_143010) do
     t.datetime "termine_close_to_expiration_notice_sent_at"
     t.index "to_tsvector('french'::regconfig, (search_terms || private_search_terms))", name: "index_dossiers_on_search_terms_private_search_terms", using: :gin
     t.index "to_tsvector('french'::regconfig, search_terms)", name: "index_dossiers_on_search_terms", using: :gin
+    t.bigint "revision_id"
     t.index ["archived"], name: "index_dossiers_on_archived"
     t.index ["groupe_instructeur_id"], name: "index_dossiers_on_groupe_instructeur_id"
     t.index ["hidden_at"], name: "index_dossiers_on_hidden_at"
+    t.index ["revision_id"], name: "index_dossiers_on_revision_id"
     t.index ["state"], name: "index_dossiers_on_state"
     t.index ["user_id"], name: "index_dossiers_on_user_id"
   end
@@ -476,6 +478,23 @@ ActiveRecord::Schema.define(version: 2020_07_15_143010) do
     t.index ["assign_to_id"], name: "index_procedure_presentations_on_assign_to_id", unique: true
   end
 
+  create_table "procedure_revision_types_de_champ", force: :cascade do |t|
+    t.bigint "revision_id", null: false
+    t.bigint "type_de_champ_id", null: false
+    t.integer "position", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["revision_id"], name: "index_procedure_revision_types_de_champ_on_revision_id"
+    t.index ["type_de_champ_id"], name: "index_procedure_revision_types_de_champ_on_type_de_champ_id"
+  end
+
+  create_table "procedure_revisions", force: :cascade do |t|
+    t.bigint "procedure_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["procedure_id"], name: "index_procedure_revisions_on_procedure_id"
+  end
+
   create_table "procedures", id: :serial, force: :cascade do |t|
     t.string "libelle"
     t.string "description"
@@ -517,10 +536,14 @@ ActiveRecord::Schema.define(version: 2020_07_15_143010) do
     t.datetime "unpublished_at"
     t.bigint "canonical_procedure_id"
     t.string "api_entreprise_token"
+    t.bigint "draft_revision_id"
+    t.bigint "published_revision_id"
     t.index ["declarative_with_state"], name: "index_procedures_on_declarative_with_state"
+    t.index ["draft_revision_id"], name: "index_procedures_on_draft_revision_id"
     t.index ["hidden_at"], name: "index_procedures_on_hidden_at"
     t.index ["parent_procedure_id"], name: "index_procedures_on_parent_procedure_id"
     t.index ["path", "closed_at", "hidden_at"], name: "index_procedures_on_path_and_closed_at_and_hidden_at", unique: true
+    t.index ["published_revision_id"], name: "index_procedures_on_published_revision_id"
     t.index ["service_id"], name: "index_procedures_on_service_id"
   end
 
@@ -592,9 +615,11 @@ ActiveRecord::Schema.define(version: 2020_07_15_143010) do
     t.jsonb "options"
     t.bigint "stable_id"
     t.bigint "parent_id"
+    t.bigint "revision_id"
     t.index ["parent_id"], name: "index_types_de_champ_on_parent_id"
     t.index ["private"], name: "index_types_de_champ_on_private"
     t.index ["procedure_id"], name: "index_types_de_champ_on_procedure_id"
+    t.index ["revision_id"], name: "index_types_de_champ_on_revision_id"
     t.index ["stable_id"], name: "index_types_de_champ_on_stable_id"
   end
 
@@ -660,18 +685,25 @@ ActiveRecord::Schema.define(version: 2020_07_15_143010) do
   add_foreign_key "dossier_operation_logs", "dossiers"
   add_foreign_key "dossier_operation_logs", "instructeurs"
   add_foreign_key "dossiers", "groupe_instructeurs"
+  add_foreign_key "dossiers", "procedure_revisions", column: "revision_id"
   add_foreign_key "dossiers", "users"
   add_foreign_key "feedbacks", "users"
   add_foreign_key "geo_areas", "champs"
   add_foreign_key "groupe_instructeurs", "procedures"
   add_foreign_key "initiated_mails", "procedures"
   add_foreign_key "procedure_presentations", "assign_tos"
+  add_foreign_key "procedure_revision_types_de_champ", "procedure_revisions", column: "revision_id"
+  add_foreign_key "procedure_revision_types_de_champ", "types_de_champ"
+  add_foreign_key "procedure_revisions", "procedures"
+  add_foreign_key "procedures", "procedure_revisions", column: "draft_revision_id"
+  add_foreign_key "procedures", "procedure_revisions", column: "published_revision_id"
   add_foreign_key "procedures", "services"
   add_foreign_key "received_mails", "procedures"
   add_foreign_key "refused_mails", "procedures"
   add_foreign_key "services", "administrateurs"
   add_foreign_key "traitements", "dossiers"
   add_foreign_key "trusted_device_tokens", "instructeurs"
+  add_foreign_key "types_de_champ", "procedure_revisions", column: "revision_id"
   add_foreign_key "types_de_champ", "types_de_champ", column: "parent_id"
   add_foreign_key "users", "administrateurs"
   add_foreign_key "users", "instructeurs"

--- a/lib/tasks/deployment/20200625113026_migrate_revisions.rake
+++ b/lib/tasks/deployment/20200625113026_migrate_revisions.rake
@@ -1,0 +1,22 @@
+namespace :after_party do
+  desc 'Deployment task: migrate_revisions'
+  task migrate_revisions: :environment do
+    puts "Running deploy task 'migrate_revisions'"
+
+    procedures = Procedure.with_discarded.where(draft_revision_id: nil)
+    progress = ProgressReport.new(procedures.count)
+
+    puts "Processing procedures"
+    procedures.find_each do |procedure|
+      RevisionsMigration.add_revisions(procedure)
+      progress.inc
+    end
+    progress.finish
+
+    TmpDossiersMigrateRevisionsJob.perform_later([])
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord.create version: '20200625113026'
+  end
+end

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -130,4 +130,30 @@ describe ProcedureRevision do
       expect(procedure.types_de_champ.size).to eq(2)
     end
   end
+
+  describe '#create_new_revision' do
+    let(:new_revision) { procedure.create_new_revision }
+
+    before { new_revision.save }
+
+    it 'should be part of procedure' do
+      expect(new_revision.procedure).to eq(revision.procedure)
+      expect(procedure.revisions.count).to eq(2)
+      expect(procedure.revisions).to eq([revision, new_revision])
+    end
+
+    it 'should have types_de_champ' do
+      expect(new_revision.types_de_champ.count).to eq(2)
+      expect(new_revision.types_de_champ_private.count).to eq(1)
+      expect(new_revision.types_de_champ).to eq(revision.types_de_champ)
+      expect(new_revision.types_de_champ_private).to eq(revision.types_de_champ_private)
+
+      expect(new_revision.revision_types_de_champ.count).to eq(2)
+      expect(new_revision.revision_types_de_champ_private.count).to eq(1)
+      expect(new_revision.revision_types_de_champ.count).to eq(revision.revision_types_de_champ.count)
+      expect(new_revision.revision_types_de_champ_private.count).to eq(revision.revision_types_de_champ_private.count)
+      expect(new_revision.revision_types_de_champ).not_to eq(revision.revision_types_de_champ)
+      expect(new_revision.revision_types_de_champ_private).not_to eq(revision.revision_types_de_champ_private)
+    end
+  end
 end

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -1,0 +1,133 @@
+describe ProcedureRevision do
+  let(:procedure) { create(:procedure, :with_type_de_champ, :with_type_de_champ_private, :with_repetition) }
+  let(:revision) { procedure.active_revision }
+  let(:type_de_champ) { revision.types_de_champ.first }
+  let(:type_de_champ_private) { revision.types_de_champ_private.first }
+  let(:type_de_champ_repetition) do
+    type_de_champ = revision.types_de_champ.repetition.first
+    type_de_champ.update(stable_id: 3333)
+    type_de_champ
+  end
+
+  before do
+    RevisionsMigration.add_revisions(procedure)
+  end
+
+  describe '#add_type_de_champ' do
+    it 'type_de_champ' do
+      expect(revision.types_de_champ.size).to eq(2)
+      revision.add_type_de_champ({
+        type_champ: TypeDeChamp.type_champs.fetch(:text),
+        libelle: "Un champ text"
+      })
+      procedure.reload
+      expect(revision.types_de_champ.size).to eq(3)
+      expect(procedure.types_de_champ.size).to eq(3)
+    end
+
+    it 'type_de_champ_private' do
+      expect(revision.types_de_champ_private.size).to eq(1)
+      revision.add_type_de_champ({
+        type_champ: TypeDeChamp.type_champs.fetch(:text),
+        libelle: "Un champ text",
+        private: true
+      })
+      procedure.reload
+      expect(revision.types_de_champ_private.size).to eq(2)
+      expect(procedure.types_de_champ_private.size).to eq(2)
+    end
+
+    it 'type_de_champ_repetition' do
+      expect(type_de_champ_repetition.types_de_champ.size).to eq(1)
+      revision.add_type_de_champ({
+        type_champ: TypeDeChamp.type_champs.fetch(:text),
+        libelle: "Un champ text",
+        parent_id: type_de_champ_repetition.stable_id
+      })
+      type_de_champ_repetition.reload
+      expect(type_de_champ_repetition.types_de_champ.size).to eq(2)
+    end
+  end
+
+  describe '#move_type_de_champ' do
+    let(:procedure) { create(:procedure, :with_type_de_champ, types_de_champ_count: 4) }
+    let(:last_type_de_champ) { revision.types_de_champ.last }
+
+    it 'move down' do
+      expect(revision.types_de_champ.index(type_de_champ)).to eq(0)
+      revision.move_type_de_champ(type_de_champ.stable_id, 2)
+      revision.reload
+      expect(revision.types_de_champ.index(type_de_champ)).to eq(2)
+    end
+
+    it 'move up' do
+      expect(revision.types_de_champ.index(last_type_de_champ)).to eq(3)
+      revision.move_type_de_champ(last_type_de_champ.stable_id, 0)
+      revision.reload
+      expect(revision.types_de_champ.index(last_type_de_champ)).to eq(0)
+    end
+
+    context 'repetition' do
+      let(:procedure) { create(:procedure, :with_repetition) }
+      let(:type_de_champ) { type_de_champ_repetition.types_de_champ.first }
+      let(:last_type_de_champ) { type_de_champ_repetition.types_de_champ.last }
+
+      before do
+        revision.add_type_de_champ({
+          type_champ: TypeDeChamp.type_champs.fetch(:text),
+          libelle: "Un champ text",
+          parent_id: type_de_champ_repetition.stable_id
+        })
+        revision.add_type_de_champ({
+          type_champ: TypeDeChamp.type_champs.fetch(:text),
+          libelle: "Un champ text",
+          parent_id: type_de_champ_repetition.stable_id
+        })
+        type_de_champ_repetition.reload
+      end
+
+      it 'move down' do
+        expect(type_de_champ_repetition.types_de_champ.index(type_de_champ)).to eq(0)
+        revision.move_type_de_champ(type_de_champ.stable_id, 2)
+        type_de_champ_repetition.reload
+        expect(type_de_champ_repetition.types_de_champ.index(type_de_champ)).to eq(2)
+      end
+
+      it 'move up' do
+        expect(type_de_champ_repetition.types_de_champ.index(last_type_de_champ)).to eq(2)
+        revision.move_type_de_champ(last_type_de_champ.stable_id, 0)
+        type_de_champ_repetition.reload
+        expect(type_de_champ_repetition.types_de_champ.index(last_type_de_champ)).to eq(0)
+      end
+    end
+  end
+
+  describe '#remove_type_de_champ' do
+    it 'type_de_champ' do
+      expect(revision.types_de_champ.size).to eq(2)
+      revision.remove_type_de_champ(type_de_champ.stable_id)
+      procedure.reload
+      expect(revision.types_de_champ.size).to eq(1)
+      expect(procedure.types_de_champ.size).to eq(1)
+    end
+
+    it 'type_de_champ_private' do
+      expect(revision.types_de_champ_private.size).to eq(1)
+      revision.remove_type_de_champ(type_de_champ_private.stable_id)
+      procedure.reload
+      expect(revision.types_de_champ_private.size).to eq(0)
+      expect(procedure.types_de_champ_private.size).to eq(0)
+    end
+
+    it 'type_de_champ_repetition' do
+      expect(type_de_champ_repetition.types_de_champ.size).to eq(1)
+      expect(revision.types_de_champ.size).to eq(2)
+      revision.remove_type_de_champ(type_de_champ_repetition.types_de_champ.first.stable_id)
+      procedure.reload
+      type_de_champ_repetition.reload
+      expect(type_de_champ_repetition.types_de_champ.size).to eq(0)
+      expect(revision.types_de_champ.size).to eq(2)
+      expect(procedure.types_de_champ.size).to eq(2)
+    end
+  end
+end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -417,13 +417,21 @@ describe Procedure do
       expect(subject.types_de_champ_private.size).to eq procedure.types_de_champ_private.size
       expect(subject.types_de_champ.map(&:drop_down_options).compact.size).to eq procedure.types_de_champ.map(&:drop_down_options).compact.size
       expect(subject.types_de_champ_private.map(&:drop_down_options).compact.size).to eq procedure.types_de_champ_private.map(&:drop_down_options).compact.size
+      expect(subject.draft_revision.types_de_champ.size).to eq(procedure.draft_revision.types_de_champ.size)
+      expect(subject.draft_revision.types_de_champ_private.size).to eq(procedure.draft_revision.types_de_champ_private.size)
 
       procedure.types_de_champ.zip(subject.types_de_champ).each do |ptc, stc|
         expect(stc).to have_same_attributes_as(ptc)
       end
+      procedure.types_de_champ.zip(procedure.draft_revision.types_de_champ).each do |ptc, rtc|
+        expect(ptc).to eq(rtc)
+      end
 
       subject.types_de_champ_private.zip(procedure.types_de_champ_private).each do |stc, ptc|
         expect(stc).to have_same_attributes_as(ptc)
+      end
+      procedure.types_de_champ_private.zip(procedure.draft_revision.types_de_champ_private).each do |ptc, rtc|
+        expect(ptc).to eq(rtc)
       end
 
       expect(subject.attestation_template.title).to eq(procedure.attestation_template.title)
@@ -432,7 +440,7 @@ describe Procedure do
 
       cloned_procedure = subject
       cloned_procedure.parent_procedure_id = nil
-      expect(cloned_procedure).to have_same_attributes_as(procedure, except: ["path"])
+      expect(cloned_procedure).to have_same_attributes_as(procedure, except: ["path", "draft_revision_id"])
     end
 
     context 'when the procedure is cloned from the library' do

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -288,40 +288,6 @@ describe Procedure do
     it { expect(subject.last).to eq(type_de_champ_0) }
   end
 
-  describe '#switch_types_de_champ' do
-    let(:procedure) { create(:procedure) }
-    let(:index) { 0 }
-    subject { procedure.switch_types_de_champ(index) }
-
-    context 'when procedure has no types_de_champ' do
-      it { expect(subject).to eq(false) }
-    end
-    context 'when procedure has 3 types de champ' do
-      let!(:type_de_champ_0) { create(:type_de_champ, procedure: procedure, order_place: 0) }
-      let!(:type_de_champ_1) { create(:type_de_champ, procedure: procedure, order_place: 1) }
-      let!(:type_de_champ_2) { create(:type_de_champ, procedure: procedure, order_place: 2) }
-      context 'when index is not the last element' do
-        it { expect(subject).to eq(true) }
-        it 'switches the position of the champ N and N+1' do
-          subject
-          expect(procedure.types_de_champ[0]).to eq(type_de_champ_1)
-          expect(procedure.types_de_champ[0].order_place).to eq(0)
-          expect(procedure.types_de_champ[1]).to eq(type_de_champ_0)
-          expect(procedure.types_de_champ[1].order_place).to eq(1)
-        end
-        it 'doesn’t move other types de champ' do
-          subject
-          expect(procedure.types_de_champ[2]).to eq(type_de_champ_2)
-          expect(procedure.types_de_champ[2].order_place).to eq(2)
-        end
-      end
-      context 'when index is the last element' do
-        let(:index) { 2 }
-        it { expect(subject).to eq(false) }
-      end
-    end
-  end
-
   describe 'active' do
     let(:procedure) { create(:procedure) }
     subject { Procedure.active(procedure.id) }
@@ -1020,82 +986,6 @@ describe Procedure do
     context 'where there is no processed dossier' do
       let(:delays) { [] }
       it { expect(procedure.usual_traitement_time).to be_nil }
-    end
-  end
-
-  describe '#move_type_de_champ' do
-    let(:procedure) { create(:procedure) }
-
-    context 'type_de_champ' do
-      let(:type_de_champ) { create(:type_de_champ_text, order_place: 0, procedure: procedure) }
-      let!(:type_de_champ1) { create(:type_de_champ_text, order_place: 1, procedure: procedure) }
-      let!(:type_de_champ2) { create(:type_de_champ_text, order_place: 2, procedure: procedure) }
-
-      it 'move down' do
-        procedure.move_type_de_champ(type_de_champ, 2)
-
-        type_de_champ.reload
-        procedure.reload
-
-        expect(procedure.types_de_champ.index(type_de_champ)).to eq(2)
-        expect(type_de_champ.order_place).to eq(2)
-      end
-
-      context 'repetition' do
-        let!(:type_de_champ_repetition) do
-          create(:type_de_champ_repetition, types_de_champ: [
-            type_de_champ,
-            type_de_champ1,
-            type_de_champ2
-          ], procedure: procedure)
-        end
-
-        it 'move down' do
-          procedure.move_type_de_champ(type_de_champ, 2)
-
-          type_de_champ.reload
-          procedure.reload
-
-          expect(type_de_champ.parent.types_de_champ.index(type_de_champ)).to eq(2)
-          expect(type_de_champ.order_place).to eq(2)
-        end
-
-        context 'private' do
-          let!(:type_de_champ_repetition) do
-            create(:type_de_champ_repetition, types_de_champ: [
-              type_de_champ,
-              type_de_champ1,
-              type_de_champ2
-            ], private: true, procedure: procedure)
-          end
-
-          it 'move down' do
-            procedure.move_type_de_champ(type_de_champ, 2)
-
-            type_de_champ.reload
-            procedure.reload
-
-            expect(type_de_champ.parent.types_de_champ.index(type_de_champ)).to eq(2)
-            expect(type_de_champ.order_place).to eq(2)
-          end
-        end
-      end
-    end
-
-    context 'private' do
-      let(:type_de_champ) { create(:type_de_champ_text, order_place: 0, private: true, procedure: procedure) }
-      let!(:type_de_champ1) { create(:type_de_champ_text, order_place: 1, private: true, procedure: procedure) }
-      let!(:type_de_champ2) { create(:type_de_champ_text, order_place: 2, private: true, procedure: procedure) }
-
-      it 'move down' do
-        procedure.move_type_de_champ(type_de_champ, 2)
-
-        type_de_champ.reload
-        procedure.reload
-
-        expect(procedure.types_de_champ_private.index(type_de_champ)).to eq(2)
-        expect(type_de_champ.order_place).to eq(2)
-      end
     end
   end
 

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -572,6 +572,13 @@ describe Procedure do
         expect(Procedure.find_by(path: "example-path")).to eq(procedure)
         expect(Procedure.find_by(path: "example-path").administrateurs).to eq(procedure.administrateurs)
       end
+
+      it 'creates a new draft revision' do
+        expect(procedure.published_revision).not_to be_nil
+        expect(procedure.draft_revision).not_to be_nil
+        expect(procedure.revisions.count).to eq(2)
+        expect(procedure.revisions).to eq([procedure.published_revision, procedure.draft_revision])
+      end
     end
 
     context 'when publishing over a previous canonical procedure' do
@@ -622,6 +629,13 @@ describe Procedure do
       it 'unpublishes the canonical procedure' do
         expect(canonical_procedure.unpublished_at).to eq(now)
       end
+
+      it 'creates a new draft revision' do
+        expect(procedure.published_revision).not_to be_nil
+        expect(procedure.draft_revision).not_to be_nil
+        expect(procedure.revisions.count).to eq(2)
+        expect(procedure.revisions).to eq([procedure.published_revision, procedure.draft_revision])
+      end
     end
 
     context 'when publishing over a previous procedure with canonical procedure' do
@@ -668,6 +682,13 @@ describe Procedure do
       expect(procedure.published_at).not_to be_nil
       expect(procedure.unpublished_at).to eq(now)
     }
+
+    it 'sets published revision' do
+      expect(procedure.published_revision).not_to be_nil
+      expect(procedure.draft_revision).not_to be_nil
+      expect(procedure.revisions.count).to eq(2)
+      expect(procedure.revisions.last).to eq(procedure.draft_revision)
+    end
   end
 
   describe "#brouillon?" do
@@ -742,6 +763,13 @@ describe Procedure do
 
     it { expect(procedure.close?).to be_truthy }
     it { expect(procedure.closed_at).to eq(now) }
+
+    it 'sets published revision' do
+      expect(procedure.published_revision).not_to be_nil
+      expect(procedure.draft_revision).not_to be_nil
+      expect(procedure.revisions.count).to eq(2)
+      expect(procedure.revisions.last).to eq(procedure.draft_revision)
+    end
   end
 
   describe 'path_customized?' do


### PR DESCRIPTION
j'ai extrait de la grosse PR une première étape:

À la suite de cette étape, les procédures, les dossiers et les types_de_champ devraient être associés aux révisions. L'éditeur de types de champ fonctionne en "double write" – il écrit les nouvelles et les anciennes relations.

- [x] test procedure_revision
- [x] test clone
- [x] test procedure#create_new_revision