### PR TITLE
Remove admin creation notification email

### DIFF
--- a/app/mailers/administration_mailer.rb
+++ b/app/mailers/administration_mailer.rb
@@ -2,15 +2,6 @@
 class AdministrationMailer < ApplicationMailer
   layout 'mailers/layout'
 
-  def new_admin_email(admin, administration)
-    @admin = admin
-    @administration = administration
-    subject = "Création d'un compte admininistrateur"
-
-    mail(to: TECH_EMAIL,
-      subject: subject)
-  end
-
   def invite_admin(admin, reset_password_token, administration_id)
     @reset_password_token = reset_password_token
     @admin = admin

--- a/app/models/administration.rb
+++ b/app/models/administration.rb
@@ -11,7 +11,6 @@ class Administration < ApplicationRecord
     user = User.create_or_promote_to_administrateur(email, SecureRandom.hex)
 
     if user.valid?
-      AdministrationMailer.new_admin_email(user.administrateur, self).deliver_later
       user.invite_administrateur!(id)
     end
 

--- a/spec/controllers/manager/administrateurs_controller_spec.rb
+++ b/spec/controllers/manager/administrateurs_controller_spec.rb
@@ -36,8 +36,6 @@ describe Manager::AdministrateursController, type: :controller do
       end
 
       it 'alert new mail are send' do
-        expect(AdministrationMailer).to receive(:new_admin_email).and_return(AdministrationMailer)
-        expect(AdministrationMailer).to receive(:deliver_later)
         expect(AdministrationMailer).to receive(:invite_admin).and_return(AdministrationMailer)
         expect(AdministrationMailer).to receive(:deliver_later)
         subject

--- a/spec/mailers/administration_mailer_spec.rb
+++ b/spec/mailers/administration_mailer_spec.rb
@@ -1,13 +1,4 @@
 RSpec.describe AdministrationMailer, type: :mailer do
-  describe '#new_admin_email' do
-    let(:admin) { create(:administrateur) }
-    let(:administration) { create(:administration) }
-
-    subject { described_class.new_admin_email(admin, administration) }
-
-    it { expect(subject.subject).not_to be_empty }
-  end
-
   describe '#invite_admin' do
     let(:admin) { create(:administrateur) }
     let(:token) { "Toc toc toc" }

--- a/spec/mailers/previews/administration_mailer_preview.rb
+++ b/spec/mailers/previews/administration_mailer_preview.rb
@@ -19,11 +19,6 @@ class AdministrationMailerPreview < ActionMailer::Preview
     AdministrationMailer.refuse_admin('bad_admin@pipo.com')
   end
 
-  def new_admin
-    administration = Administration.new(email: 'superadmin@demarches-simplifiees.fr')
-    AdministrationMailer.new_admin_email(administrateur, administration)
-  end
-
   def dossier_expiration_summary
     expiring_dossiers = [Dossier.new(id: 100, procedure: procedure_1)]
     expired_dossiers = [Dossier.new(id: 100, procedure: procedure_2)]


### PR DESCRIPTION
Ce mail est envoyé à l'équipe tech. Je ne vois pas l'utilité. Mais n'hésitez pas à dire si vous vous en servez.