### PR TITLE
javascript: silence Crisp warning in Javascript console

### DIFF
--- a/app/javascript/shared/track/crisp.js
+++ b/app/javascript/shared/track/crisp.js
@@ -40,4 +40,7 @@ if (enabled) {
     'session:event',
     [[['PAGE_VIEW', { URL: window.location.pathname }]]]
   ]);
+
+  // Prevent Crisp to log warnings about Sentry overriding document.addEventListener
+  window.$crisp.push(['safe', true]);
 }


### PR DESCRIPTION
Fix this warning in the Javascript console:

> [WARNING] Crisp found shims of native JavaScript methods. This can alter the chatbox behavior and break things. Make sure not to override listed functions to ensure your chatbox works as expected. You may be looking for other JavaScript libraries in use on this page.
>
> You can disable this warning by adding: $crisp.push(["safe", true]) to your page JavaScript.
>
> Methods to check: 
>Array [ "document.addEventListener", "document.removeEventListener" ]

(Sentry overrides these methods, and I trust Sentry more than Crisp.)