### PR TITLE
Amélioration de l'accessibilité d'activation de compte

### DIFF
--- a/app/assets/stylesheets/new_design/confirmations.scss
+++ b/app/assets/stylesheets/new_design/confirmations.scss
@@ -37,13 +37,18 @@
   }
 
   .confirmation-resend {
-    p {
+    p,
+    label {
       margin-bottom: $default-padding;
     }
 
     .form {
       display: flex;
       flex-wrap: wrap;
+
+      label {
+        flex-basis: 100%;
+      }
 
       input,
       button {
@@ -55,10 +60,6 @@
         flex-grow: 1;
         margin-right: $default-spacer;
       }
-    }
-
-    label {
-      display: none;
     }
   }
 }

--- a/app/views/users/confirmations/new.html.haml
+++ b/app/views/users/confirmations/new.html.haml
@@ -1,4 +1,4 @@
-- content_for(:title, 'Confirmer votre adresse email')
+- content_for(:title, 'Confirmez votre adresse email')
 
 - content_for :footer do
   = render partial: 'root/footer'
@@ -6,6 +6,7 @@
 .container.devise-container.devise-confirmations
   .one-column-centered
     = devise_error_messages!
+    %h1.center Confirmez votre adresse email
 
     %img.confirmation-icon{ src: image_url("user/confirmation-email.svg"), alt: "" }
 

--- a/app/views/users/confirmations/new.html.haml
+++ b/app/views/users/confirmations/new.html.haml
@@ -8,7 +8,7 @@
     = devise_error_messages!
     %h1.center Confirmez votre adresse email
 
-    %img.confirmation-icon{ src: image_url("user/confirmation-email.svg"), alt: "" }
+    %img.confirmation-icon{ src: image_url("user/confirmation-email.svg"), alt: "Email envoyé" }
 
     %p.confirmation-preamble
       = succeed '.' do

--- a/app/views/users/confirmations/new.html.haml
+++ b/app/views/users/confirmations/new.html.haml
@@ -27,7 +27,8 @@
       %p Si vous n’avez pas reçu notre message (avez-vous vérifié les indésirables ?), nous pouvons vous le renvoyer.
 
       = form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { class: 'form' }) do |f|
-        = f.label :email, 'Email'
+        = f.label :email, 'Votre email'
+        %br
         = f.email_field :email, placeholder: 'Email', class: 'small', autofocus: true
         = f.submit 'Renvoyer un email de confirmation', class: 'button'
 

--- a/spec/features/accessibilite/wcag_usager_spec.rb
+++ b/spec/features/accessibilite/wcag_usager_spec.rb
@@ -22,7 +22,7 @@ feature 'wcag rules for usager', js: true do
 
       perform_enqueued_jobs do
         click_button 'Créer un compte'
-        expect(page).to be_accessible.skipping(:'page-has-heading-one', :'role-img-alt', :label)
+        expect(page).to be_accessible.skipping(:'role-img-alt', :label)
       end
     end
 

--- a/spec/features/accessibilite/wcag_usager_spec.rb
+++ b/spec/features/accessibilite/wcag_usager_spec.rb
@@ -22,7 +22,7 @@ feature 'wcag rules for usager', js: true do
 
       perform_enqueued_jobs do
         click_button 'Créer un compte'
-        expect(page).to be_accessible.skipping(:'role-img-alt', :label)
+        expect(page).to be_accessible.skipping(:'role-img-alt')
       end
     end
 

--- a/spec/features/accessibilite/wcag_usager_spec.rb
+++ b/spec/features/accessibilite/wcag_usager_spec.rb
@@ -22,7 +22,7 @@ feature 'wcag rules for usager', js: true do
 
       perform_enqueued_jobs do
         click_button 'Créer un compte'
-        expect(page).to be_accessible.skipping(:'role-img-alt')
+        expect(page).to be_accessible
       end
     end
 


### PR DESCRIPTION
Correction de quelques détails d'accessibilité.

Cette PR contenait initialement d'autres fixes sur les token que je proposerais ailleurs.

```
des [précos pour l'écran d'activation de compte](https://design-system.service.gov.uk/patterns/confirm-an-email-address/#designing-the-activate-your-account-page), et corrige des détails. On était déjà pas mal (très bien, en fait). J'ai ajouté 2 écrans pour clarifier les possibilités:
 - votre compte est déja activé
 - votre jeton est obsolète, vous pouvez en générer un nouveau.

Ca va réduire également le support pour les demandes de renvoi de jeton.

![jeton-invalide](https://user-images.githubusercontent.com/1223316/86105940-3f7f0e80-bac0-11ea-85d2-d127220a4051.png)
![compte-deja-active](https://user-images.githubusercontent.com/1223316/86105945-4148d200-bac0-11ea-8b89-c21317ef2b8d.png)
```