### PR TITLE
specs: use `fixture_file_upload` rather than `Rack::Test::UploadedFile`

### DIFF
--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -27,7 +27,7 @@ describe API::V2::GraphqlController do
     end.base64digest
   end
 
-  let(:file) { Rack::Test::UploadedFile.new("./spec/fixtures/files/logo_test_procedure.png", 'image/png') }
+  let(:file) { fixture_file_upload('spec/fixtures/files/logo_test_procedure.png', 'image/png') }
   let(:blob_info) do
     {
       filename: file.original_filename,

--- a/spec/controllers/champs/piece_justificative_controller_spec.rb
+++ b/spec/controllers/champs/piece_justificative_controller_spec.rb
@@ -17,7 +17,7 @@ describe Champs::PieceJustificativeController, type: :controller do
     end
 
     context 'when the file is valid' do
-      let(:file) { Rack::Test::UploadedFile.new('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
+      let(:file) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
 
       it 'attach the file' do
         subject
@@ -34,7 +34,7 @@ describe Champs::PieceJustificativeController, type: :controller do
     end
 
     context 'when the file is invalid' do
-      let(:file) { Rack::Test::UploadedFile.new('spec/fixtures/files/invalid_file_format.json', 'application/json') }
+      let(:file) { fixture_file_upload('spec/fixtures/files/invalid_file_format.json', 'application/json') }
 
       # TODO: for now there are no validators on the champ piece_justificative_file,
       # so we have to mock a failing validation.

--- a/spec/controllers/instructeurs/avis_controller_spec.rb
+++ b/spec/controllers/instructeurs/avis_controller_spec.rb
@@ -82,7 +82,7 @@ describe Instructeurs::AvisController, type: :controller do
 
       describe 'with attachment' do
         include ActiveJob::TestHelper
-        let(:file) { Rack::Test::UploadedFile.new("./spec/fixtures/files/piece_justificative_0.pdf", 'application/pdf') }
+        let(:file) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
 
         before do
           expect(ClamavService).to receive(:safe_file?).and_return(true)
@@ -119,7 +119,7 @@ describe Instructeurs::AvisController, type: :controller do
       end
 
       context "with a file" do
-        let(:file) { Rack::Test::UploadedFile.new("./spec/fixtures/files/piece_justificative_0.pdf", 'application/pdf') }
+        let(:file) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
 
         it do
           subject
@@ -139,7 +139,7 @@ describe Instructeurs::AvisController, type: :controller do
       let(:invite_linked_dossiers) { nil }
 
       before do
-        @introduction_file = Rack::Test::UploadedFile.new("./spec/fixtures/files/piece_justificative_0.pdf", 'application/pdf')
+        @introduction_file = fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf')
         post :create_avis, params: { id: previous_avis.id, procedure_id: procedure.id, avis: { emails: emails, introduction: intro, confidentiel: asked_confidentiel, invite_linked_dossiers: invite_linked_dossiers, introduction_file: @introduction_file } }
         created_avis.reload
       end

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -7,7 +7,7 @@ describe Instructeurs::DossiersController, type: :controller do
   let(:instructeurs) { [instructeur] }
   let(:procedure) { create(:procedure, :published, instructeurs: instructeurs) }
   let(:dossier) { create(:dossier, :en_construction, procedure: procedure) }
-  let(:fake_justificatif) { Rack::Test::UploadedFile.new("./spec/fixtures/files/piece_justificative_0.pdf", 'application/pdf') }
+  let(:fake_justificatif) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
 
   before { sign_in(instructeur.user) }
 
@@ -388,7 +388,7 @@ describe Instructeurs::DossiersController, type: :controller do
   describe "#create_commentaire" do
     let(:saved_commentaire) { dossier.commentaires.first }
     let(:body) { "avant\napres" }
-    let(:file) { Rack::Test::UploadedFile.new("./spec/fixtures/files/piece_justificative_0.pdf", 'application/pdf') }
+    let(:file) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
     let(:scan_result) { true }
 
     subject {

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -534,7 +534,7 @@ describe Users::DossiersController, type: :controller do
     let(:first_champ) { dossier.champs.first }
     let(:piece_justificative_champ) { dossier.champs.last }
     let(:value) { 'beautiful value' }
-    let(:file) { Rack::Test::UploadedFile.new("./spec/fixtures/files/piece_justificative_0.pdf", 'application/pdf') }
+    let(:file) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
     let(:now) { Time.zone.parse('01/01/2100') }
 
     let(:submit_payload) do
@@ -786,7 +786,7 @@ describe Users::DossiersController, type: :controller do
     let(:dossier) { create(:dossier, :en_construction, procedure: procedure, user: user) }
     let(:saved_commentaire) { dossier.commentaires.first }
     let(:body) { "avant\napres" }
-    let(:file) { Rack::Test::UploadedFile.new("./spec/fixtures/files/piece_justificative_0.pdf", 'application/pdf') }
+    let(:file) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
     let(:scan_result) { true }
 
     subject {

--- a/spec/factories/attestation.rb
+++ b/spec/factories/attestation.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
   end
 
   trait :with_pdf do
-    pdf { Rack::Test::UploadedFile.new("./spec/fixtures/files/dossierPDF.pdf", 'application/pdf') }
+    pdf { Rack::Test::UploadedFile.new('spec/fixtures/files/dossierPDF.pdf', 'application/pdf') }
   end
 end

--- a/spec/factories/attestation_template.rb
+++ b/spec/factories/attestation_template.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
   end
 
   trait :with_files do
-    logo { Rack::Test::UploadedFile.new("./spec/fixtures/files/logo_test_procedure.png", 'image/png') }
-    signature { Rack::Test::UploadedFile.new("./spec/fixtures/files/logo_test_procedure.png", 'image/png') }
+    logo { Rack::Test::UploadedFile.new('spec/fixtures/files/logo_test_procedure.png', 'image/png') }
+    signature { Rack::Test::UploadedFile.new('spec/fixtures/files/logo_test_procedure.png', 'image/png') }
   end
 end

--- a/spec/factories/bill_signature.rb
+++ b/spec/factories/bill_signature.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :bill_signature do
-    serialized { Rack::Test::UploadedFile.new("./spec/fixtures/files/bill_signature/serialized.json", 'application/json') }
-    signature { Rack::Test::UploadedFile.new("./spec/fixtures/files/bill_signature/signature.der", 'application/x-x509-ca-cert') }
+    serialized { Rack::Test::UploadedFile.new('spec/fixtures/files/bill_signature/serialized.json', 'application/json') }
+    signature { Rack::Test::UploadedFile.new('spec/fixtures/files/bill_signature/signature.der', 'application/x-x509-ca-cert') }
   end
 end

--- a/spec/factories/commentaire.rb
+++ b/spec/factories/commentaire.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     end
 
     trait :with_file do
-      piece_jointe { Rack::Test::UploadedFile.new("./spec/fixtures/files/logo_test_procedure.png", 'image/png') }
+      piece_jointe { Rack::Test::UploadedFile.new('spec/fixtures/files/logo_test_procedure.png', 'image/png') }
     end
   end
 end

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -55,7 +55,7 @@ FactoryBot.define do
     end
 
     trait :with_logo do
-      logo { Rack::Test::UploadedFile.new("./spec/fixtures/files/logo_test_procedure.png", 'image/png') }
+      logo { Rack::Test::UploadedFile.new('spec/fixtures/files/logo_test_procedure.png', 'image/png') }
     end
 
     trait :with_path do

--- a/spec/mailers/previews/dossier_mailer_preview.rb
+++ b/spec/mailers/previews/dossier_mailer_preview.rb
@@ -96,7 +96,7 @@ class DossierMailerPreview < ActionMailer::Preview
   end
 
   def procedure
-    Procedure.new(id: 1234, libelle: 'Dotation d’Équipement des Territoires Ruraux - Exercice 2019', service: service, logo: Rack::Test::UploadedFile.new("./spec/fixtures/files/logo_test_procedure.png", 'image/png'), auto_archive_on: Time.zone.today + Dossier::REMAINING_DAYS_BEFORE_CLOSING.days)
+    Procedure.new(id: 1234, libelle: 'Dotation d’Équipement des Territoires Ruraux - Exercice 2019', service: service, logo: Rack::Test::UploadedFile.new('spec/fixtures/files/logo_test_procedure.png', 'image/png'), auto_archive_on: Time.zone.today + Dossier::REMAINING_DAYS_BEFORE_CLOSING.days)
   end
 
   def service

--- a/spec/models/attestation_template_spec.rb
+++ b/spec/models/attestation_template_spec.rb
@@ -57,8 +57,8 @@ describe AttestationTemplate, type: :model do
 
   describe 'dup' do
     before do
-      @logo = Rack::Test::UploadedFile.new('spec/fixtures/files/white.png', 'image/png')
-      @signature = Rack::Test::UploadedFile.new('spec/fixtures/files/black.png', 'image/png')
+      @logo = fixture_file_upload('spec/fixtures/files/white.png', 'image/png')
+      @signature = fixture_file_upload('spec/fixtures/files/black.png', 'image/png')
     end
 
     after do
@@ -89,8 +89,8 @@ describe AttestationTemplate, type: :model do
 
   describe 'invalidate attestation if images attachments are not valid' do
     before do
-      @logo = Rack::Test::UploadedFile.new('spec/fixtures/files/french-flag.gif', 'image/gif')
-      @signature = Rack::Test::UploadedFile.new('spec/fixtures/files/beta-gouv.gif', 'image/gif')
+      @logo = fixture_file_upload('spec/fixtures/files/french-flag.gif', 'image/gif')
+      @signature = fixture_file_upload('spec/fixtures/files/beta-gouv.gif', 'image/gif')
     end
 
     after do

--- a/spec/models/concern/mail_template_concern_spec.rb
+++ b/spec/models/concern/mail_template_concern_spec.rb
@@ -3,7 +3,7 @@ describe MailTemplateConcern do
   let(:dossier) { create(:dossier, procedure: procedure) }
   let(:dossier2) { create(:dossier, procedure: procedure) }
   let(:initiated_mail) { create(:initiated_mail, procedure: procedure) }
-  let(:justificatif) { Rack::Test::UploadedFile.new("./spec/fixtures/files/piece_justificative_0.pdf", 'application/pdf') }
+  let(:justificatif) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
 
   shared_examples "can replace tokens in template" do
     describe 'with no token to replace' do

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -191,7 +191,7 @@ describe Procedure do
 
         context 'when the deliberation is uploaded ' do
           before do
-            procedure.deliberation = Rack::Test::UploadedFile.new('spec/fixtures/files/file.pdf', 'application/pdf')
+            procedure.deliberation = fixture_file_upload('spec/fixtures/files/file.pdf', 'application/pdf')
           end
 
           it { expect(procedure.valid?).to eq(true) }
@@ -199,7 +199,7 @@ describe Procedure do
 
         context 'when the deliberation is uploaded with an unauthorized format' do
           before do
-            procedure.deliberation = Rack::Test::UploadedFile.new('spec/fixtures/files/french-flag.gif', 'image/gif')
+            procedure.deliberation = fixture_file_upload('spec/fixtures/files/french-flag.gif', 'image/gif')
           end
 
           it { expect(procedure.valid?).to eq(false) }
@@ -952,7 +952,7 @@ describe Procedure do
       p.reload
       expect(p.juridique_required).to be_falsey
 
-      @deliberation = Rack::Test::UploadedFile.new('spec/fixtures/files/file.pdf', 'application/pdf')
+      @deliberation = fixture_file_upload('spec/fixtures/files/file.pdf', 'application/pdf')
       p.update(deliberation: @deliberation)
       p.reload
       expect(p.juridique_required).to be_truthy

--- a/spec/services/commentaire_service_spec.rb
+++ b/spec/services/commentaire_service_spec.rb
@@ -27,7 +27,7 @@ describe CommentaireService do
     end
 
     context 'when it has a file' do
-      let(:file) { Rack::Test::UploadedFile.new("./spec/fixtures/files/piece_justificative_0.pdf", 'application/pdf') }
+      let(:file) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
 
       before do
         expect(ClamavService).to receive(:safe_file?).and_return(true)

--- a/spec/views/new_administrateur/procedures/edit.html.haml_spec.rb
+++ b/spec/views/new_administrateur/procedures/edit.html.haml_spec.rb
@@ -1,5 +1,5 @@
 describe 'new_administrateur/procedures/edit.html.haml' do
-  let(:logo) { Rack::Test::UploadedFile.new("./spec/fixtures/files/logo_test_procedure.png", 'image/png') }
+  let(:logo) { fixture_file_upload('spec/fixtures/files/logo_test_procedure.png', 'image/png') }
   let(:procedure) { create(:procedure, logo: logo, lien_site_web: 'http://some.website') }
 
   before do


### PR DESCRIPTION
This is mostly for consistency (both styles were used before).

Note: we still have to use `Rack::Test::UploadedFile.new` in factories,
because of thoughtbot/factory_bot#385.