### PR TITLE
remove precision for currency

### DIFF
--- a/app/helpers/etablissement_helper.rb
+++ b/app/helpers/etablissement_helper.rb
@@ -1,6 +1,6 @@
 module EtablissementHelper
   def pretty_currency(capital_social, unit: '€')
-    number_to_currency(capital_social, locale: :fr, unit: unit)
+    number_to_currency(capital_social, locale: :fr, unit: unit, precision: 0)
   end
 
   def pretty_currency_unit(unit)

--- a/spec/helpers/etablissement_helper_spec.rb
+++ b/spec/helpers/etablissement_helper_spec.rb
@@ -49,13 +49,13 @@ RSpec.describe EtablissementHelper, type: :helper do
   describe '#pretty_currency' do
     subject { pretty_currency(etablissement.entreprise_capital_social) }
 
-    it { is_expected.to eq('123 000,00 €') }
+    it { is_expected.to eq('123 000 €') }
   end
 
   describe '#pretty_currency with special unit' do
     subject { pretty_currency(12345, unit: 'k€') }
 
-    it { is_expected.to eq('12 345,00 k€') }
+    it { is_expected.to eq('12 345 k€') }
   end
   describe '#pretty_date_exercice' do
     subject { pretty_date_exercice("201908") }


### PR DESCRIPTION
Il a été demandé par des utilisateurs de supprimer les _,00_ pour chacune des valeurs financières issues de la bdf ou le capital social afin d'améliorer la lisibilité (sachant que les données récupéres par les api n'ont jamais de précision après la virgule).
Cette PR affiche donc les valeurs financières de l'identité entreprise sans virgule.