### PR TITLE
Revert "pdf dossier: better layout for etablissement fields"

### DIFF
--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -8,17 +8,11 @@ def format_in_2_lines(pdf, label, text)
   pdf.text "\n", size: 9
 end
 
-def render_box(pdf, text, x, width)
-  box = ::Prawn::Text::Box.new(text, { document: pdf, width: width, overflow: :expand, at: [x, pdf.cursor] })
-  box.render
-  box.height
-end
-
 def format_in_2_columns(pdf, label, text)
-  h1 = render_box(pdf, label, 0, 100)
-  h2 = render_box(pdf, ':', 100, 10)
-  h3 = render_box(pdf, text, 110, pdf.bounds.width - 110)
-  pdf.move_down 5 + [h1,h2,h3].max
+  pdf.text_box label, width: 200, height: 100, overflow: :expand, at: [0, pdf.cursor]
+      pdf.text_box ":", width: 10, height: 100, overflow: :expand, at: [100, pdf.cursor]
+  pdf.text_box text, width: 420, height: 100, overflow: :expand, at: [110, pdf.cursor]
+  pdf.text "\n"
 end
 
 def add_title(pdf, title)
@@ -53,32 +47,33 @@ def render_siret_info(pdf, etablissement)
 end
 
 def render_identite_etablissement(pdf, etablissement)
-  format_in_2_columns(pdf, "SIRET", etablissement.siret)
-  format_in_2_columns(pdf, "SIRET du siège social", etablissement.entreprise.siret_siege_social) if etablissement.entreprise.siret_siege_social.present?
-  format_in_2_columns(pdf, "Dénomination", raison_sociale_or_name(etablissement))
-  format_in_2_columns(pdf, "Forme juridique ", etablissement.entreprise_forme_juridique)
+  pdf.text " - SIRET : #{etablissement.siret}"
+  pdf.text " - SIRET du siège social: #{etablissement.entreprise.siret_siege_social}"
+  pdf.text " - Dénomination : #{raison_sociale_or_name(etablissement)}"
+  pdf.text " - Forme juridique : #{etablissement.entreprise_forme_juridique}"
   if etablissement.entreprise_capital_social.present?
-    format_in_2_columns(pdf, "Capital social ", pretty_currency(etablissement.entreprise_capital_social))
+    pdf.text " - Capital social : #{pretty_currency(etablissement.entreprise_capital_social)}"
   end
-  format_in_2_columns(pdf, "Libellé NAF ", etablissement.libelle_naf)
-  format_in_2_columns(pdf, "Code NAF ", etablissement.naf)
-  format_in_2_columns(pdf, "Date de création ", try_format_date(etablissement.entreprise.date_creation))
+  pdf.text " - Libellé NAF : #{etablissement.libelle_naf}"
+  pdf.text " - Code NAF : #{etablissement.naf}"
+  pdf.text " - Date de création : #{try_format_date(etablissement.entreprise.date_creation)}"
   if @include_infos_administration
-    format_in_2_columns(pdf, "Effectif mensuel #{try_format_mois_effectif(etablissement)} (URSSAF) ", etablissement.entreprise_effectif_mensuel)
-    format_in_2_columns(pdf, "Effectif moyen annuel #{etablissement.entreprise_effectif_annuel_annee} (URSSAF) ", etablissement.entreprise_effectif_annuel)
+    pdf.text " - Effectif mensuel #{try_format_mois_effectif(etablissement)} (URSSAF) : #{etablissement.entreprise_effectif_mensuel}"
+    pdf.text " - Effectif moyen annuel #{etablissement.entreprise_effectif_annuel_annee} (URSSAF) : #{etablissement.entreprise_effectif_annuel}"
   end
-  format_in_2_columns(pdf, "Effectif (ISPF) ", effectif(etablissement))
-  format_in_2_columns(pdf, "Code effectif ", etablissement.entreprise.code_effectif_entreprise)
-  format_in_2_columns(pdf, "Numéro de TVA intracommunautaire ", etablissement.entreprise.numero_tva_intracommunautaire) if etablissement.entreprise.numero_tva_intracommunautaire.present?
-  format_in_2_columns(pdf, "Adresse ", etablissement.adresse)
+  pdf.text " - Effectif de l'organisation (INSEE) : #{effectif(etablissement)}"
+  pdf.text " - Code effectif : #{etablissement.entreprise.code_effectif_entreprise}"
+  pdf.text " - Numéro de TVA intracommunautaire : #{etablissement.entreprise.numero_tva_intracommunautaire}"
+  pdf.text " - Adresse : #{etablissement.adresse}"
   if etablissement.association?
-    format_in_2_columns(pdf, "Numéro RNA ", etablissement.association_rna)
-    format_in_2_columns(pdf, "Titre ", etablissement.association_titre)
-    format_in_2_columns(pdf, "Objet ", etablissement.association_objet)
-    format_in_2_columns(pdf, "Date de création ", try_format_date(etablissement.association_date_creation))
-    format_in_2_columns(pdf, "Date de publication ", try_format_date(etablissement.association_date_publication))
-    format_in_2_columns(pdf, "Date de déclaration ", try_format_date(etablissement.association_date_declaration))
+    pdf.text " - Numéro RNA : #{etablissement.association_rna}"
+    pdf.text " - Titre : #{etablissement.association_titre}"
+    pdf.text " - Objet : #{etablissement.association_objet}"
+    pdf.text " - Date de création : #{try_format_date(etablissement.association_date_creation)}"
+    pdf.text " - Date de publication : #{try_format_date(etablissement.association_date_publication)}"
+    pdf.text " - Date de déclaration : #{try_format_date(etablissement.association_date_declaration)}"
   end
+  pdf.text "\n"
 end
 
 def render_single_champ(pdf, champ)


### PR DESCRIPTION
Reverts betagouv/demarches-simplifiees.fr#5319

Cette PR provoque des erreurs qui sont remontées dans Sentry :

```
  from app/views/dossiers/show.pdf.prawn:13:in `render_box'
  from app/views/dossiers/show.pdf.prawn:20:in `format_in_2_columns'
  from app/views/dossiers/show.pdf.prawn:67:in `render_identite_etablissement'
  from app/views/dossiers/show.pdf.prawn:104:in `render_single_champ'
  from app/views/dossiers/show.pdf.prawn:124:in `block in add_champs'
```

![Capture d’écran 2020-07-01 à 16 01 07](https://user-images.githubusercontent.com/179923/86252915-1a6bc800-bbb4-11ea-8cb5-ff77e370c442.png)

/cc @maatinito 