### PR TITLE
stylesheets: fix with of large select elements

### DIFF
--- a/app/assets/stylesheets/new_design/forms.scss
+++ b/app/assets/stylesheets/new_design/forms.scss
@@ -266,6 +266,7 @@
     background-size: 14px;
     background-position: right 10px center;
     padding-right: 4 * $default-spacer;
+    max-width: 100%;
 
     &.small {
       padding-right: 3 * $default-spacer;


### PR DESCRIPTION
Select elements with very long options would overflow the form width, and create a disgraceful scroller bar on the bottom of the screen.

<img width="1077" alt="Capture d’écran 2020-07-02 à 11 46 01" src="https://user-images.githubusercontent.com/179923/86343722-a1bf4700-bc59-11ea-8fdf-fda8422a0400.png">
