### PR TITLE
4897 display instructeur decision

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -689,6 +689,7 @@ Rails/CreateTableWithTimestamps:
     - db/migrate/2016*.rb
     - db/migrate/2017*.rb
     - db/migrate/2018*.rb
+    - db/migrate/20200630140356_create_traitements.rb
 
 Rails/Date:
   Enabled: false

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -249,9 +249,11 @@ class StatsController < ApplicationController
     min_date = 11.months.ago
     max_date = Time.zone.now.to_date
 
-    processed_dossiers = dossiers
+    processed_dossiers = Traitement.includes(:dossier)
+      .where(dossier_id: dossiers)
+      .where('dossiers.state' => Dossier::TERMINE)
       .where(:processed_at => min_date..max_date)
-      .pluck(:groupe_instructeur_id, :en_construction_at, :processed_at)
+      .pluck('dossiers.groupe_instructeur_id', 'dossiers.en_construction_at', :processed_at)
 
     # Group dossiers by month
     processed_dossiers_by_month = processed_dossiers
@@ -290,11 +292,13 @@ class StatsController < ApplicationController
     min_date = 11.months.ago
     max_date = Time.zone.now.to_date
 
-    processed_dossiers = dossiers
+    processed_dossiers = Traitement.includes(:dossier)
+      .where(dossier: dossiers)
+      .where('dossiers.state' => Dossier::TERMINE)
       .where(:processed_at => min_date..max_date)
       .pluck(
-        :groupe_instructeur_id,
-        Arel.sql('EXTRACT(EPOCH FROM (en_construction_at - created_at)) / 60 AS processing_time'),
+        'dossiers.groupe_instructeur_id',
+        Arel.sql('EXTRACT(EPOCH FROM (dossiers.en_construction_at - dossiers.created_at)) / 60 AS processing_time'),
         :processed_at
       )
 

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -149,7 +149,7 @@ module Users
       errors = update_dossier_and_compute_errors
 
       if passage_en_construction? && errors.blank?
-        @dossier.en_construction!
+        @dossier.passer_en_construction!
         NotificationMailer.send_initiated_notification(@dossier).deliver_later
         @dossier.groupe_instructeur.instructeurs.with_instant_email_dossier_notifications.each do |instructeur|
           DossierMailer.notify_new_dossier_depose_to_instructeur(@dossier, instructeur.email).deliver_later

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -199,10 +199,9 @@ class Dossier < ApplicationRecord
       .joins(:procedure)
       .where("dossiers.en_instruction_at + (duree_conservation_dossiers_dans_ds * INTERVAL '1 month') - INTERVAL :expires_in < :now", { now: Time.zone.now, expires_in: INTERVAL_BEFORE_EXPIRATION })
   end
-  scope :termine_close_to_expiration, -> do
-    state_termine
-      .joins(:procedure)
-      .where("dossiers.processed_at + (duree_conservation_dossiers_dans_ds * INTERVAL '1 month') - INTERVAL :expires_in < :now", { now: Time.zone.now, expires_in: INTERVAL_BEFORE_EXPIRATION })
+  def self.termine_close_to_expiration
+    dossier_ids = Traitement.termine_close_to_expiration.pluck(:dossier_id).uniq
+    Dossier.where(id: dossier_ids)
   end
 
   scope :brouillon_expired, -> do

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -548,7 +548,7 @@ class Dossier < ApplicationRecord
   end
 
   def after_accepter(instructeur, motivation, justificatif = nil)
-    self.traitements.build(state: Dossier.states.fetch(:accepte), instructeur: instructeur, motivation: motivation, processed_at: Time.zone.now)
+    self.traitements.build(state: Dossier.states.fetch(:accepte), instructeur_email: instructeur.email, motivation: motivation, processed_at: Time.zone.now)
 
     if justificatif
       self.justificatif_motivation.attach(justificatif)
@@ -564,7 +564,7 @@ class Dossier < ApplicationRecord
   end
 
   def after_accepter_automatiquement
-    self.traitements.build(state: Dossier.states.fetch(:accepte), instructeur: nil, motivation: nil, processed_at: Time.zone.now)
+    self.traitements.build(state: Dossier.states.fetch(:accepte), instructeur_email: nil, motivation: nil, processed_at: Time.zone.now)
     self.en_instruction_at ||= Time.zone.now
 
     if attestation.nil?
@@ -577,7 +577,7 @@ class Dossier < ApplicationRecord
   end
 
   def after_refuser(instructeur, motivation, justificatif = nil)
-    self.traitements.build(state: Dossier.states.fetch(:refuse), instructeur: instructeur, motivation: motivation, processed_at: Time.zone.now)
+    self.traitements.build(state: Dossier.states.fetch(:refuse), instructeur_email: instructeur.email, motivation: motivation, processed_at: Time.zone.now)
 
     if justificatif
       self.justificatif_motivation.attach(justificatif)
@@ -589,7 +589,7 @@ class Dossier < ApplicationRecord
   end
 
   def after_classer_sans_suite(instructeur, motivation, justificatif = nil)
-    self.traitements.build(state: Dossier.states.fetch(:sans_suite), instructeur: instructeur, motivation: motivation, processed_at: Time.zone.now)
+    self.traitements.build(state: Dossier.states.fetch(:sans_suite), instructeur_email: instructeur.email, motivation: motivation, processed_at: Time.zone.now)
 
     if justificatif
       self.justificatif_motivation.attach(justificatif)

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -129,6 +129,7 @@ class Dossier < ApplicationRecord
         :individual,
         :followers_instructeurs,
         :avis,
+        :traitements,
         etablissement: :champ,
         champs: {
           etablissement: :champ,
@@ -173,6 +174,7 @@ class Dossier < ApplicationRecord
       justificatif_motivation_attachment: :blob,
       attestation: [],
       avis: { piece_justificative_file_attachment: :blob },
+      traitements: [],
       etablissement: [],
       individual: [],
       user: [])
@@ -249,7 +251,7 @@ class Dossier < ApplicationRecord
   end
 
   scope :for_procedure, -> (procedure) { includes(:user, :groupe_instructeur).where(groupe_instructeurs: { procedure: procedure }) }
-  scope :for_api_v2, -> { includes(procedure: [:administrateurs], etablissement: [], individual: []) }
+  scope :for_api_v2, -> { includes(procedure: [:administrateurs], etablissement: [], individual: [], traitements: []) }
 
   scope :with_notifications, -> do
     # This scope is meant to be composed, typically with Instructeur.followed_dossiers, which means that the :follows table is already INNER JOINed;

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -161,7 +161,7 @@ class Instructeur < ApplicationRecord
       h = {
         nb_en_construction: groupe.dossiers.en_construction.count,
         nb_en_instruction: groupe.dossiers.en_instruction.count,
-        nb_accepted: groupe.dossiers.accepte.where(processed_at: Time.zone.yesterday.beginning_of_day..Time.zone.yesterday.end_of_day).count,
+        nb_accepted: Traitement.where(dossier: groupe.dossiers.accepte, processed_at: Time.zone.yesterday.beginning_of_day..Time.zone.yesterday.end_of_day).count,
         nb_notification: notifications_for_procedure(procedure, :not_archived).count
       }
 

--- a/app/models/traitement.rb
+++ b/app/models/traitement.rb
@@ -1,6 +1,5 @@
 class Traitement < ApplicationRecord
   belongs_to :dossier
-  belongs_to :instructeur
 
   scope :termine_close_to_expiration, -> do
     joins(dossier: :procedure)

--- a/app/models/traitement.rb
+++ b/app/models/traitement.rb
@@ -1,4 +1,11 @@
 class Traitement < ApplicationRecord
   belongs_to :dossier
   belongs_to :instructeur
+
+  scope :termine_close_to_expiration, -> do
+    joins(dossier: :procedure)
+      .where(state: Dossier::TERMINE)
+      .where('dossiers.state' => Dossier::TERMINE)
+      .where("traitements.processed_at + (procedures.duree_conservation_dossiers_dans_ds * INTERVAL '1 month') - INTERVAL :expires_in < :now", { now: Time.zone.now, expires_in: Dossier::INTERVAL_BEFORE_EXPIRATION })
+  end
 end

--- a/app/models/traitement.rb
+++ b/app/models/traitement.rb
@@ -1,0 +1,4 @@
+class Traitement < ApplicationRecord
+  belongs_to :dossier
+  belongs_to :instructeur
+end

--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -156,7 +156,7 @@ def add_etats_dossier(pdf, dossier)
   if dossier.en_instruction_at.present?
     format_in_2_columns(pdf, "En instruction le", try_format_date(dossier.en_instruction_at))
   end
-  if dossier.processed_at?.present?
+  if dossier.processed_at.present?
     format_in_2_columns(pdf, "Décision le", try_format_date(dossier.processed_at))
   end
 

--- a/app/views/instructeurs/dossiers/_decisions_rendues_block.html.haml
+++ b/app/views/instructeurs/dossiers/_decisions_rendues_block.html.haml
@@ -1,0 +1,19 @@
+.tab-title Décisions rendues
+- if traitements.any?
+  %ul.tab-list
+    - traitements.each do |traitement|
+      - if traitement.instructeur_email.present?
+        %li
+          = "Le #{l(traitement.processed_at, format: '%d %B %Y à %R')}, "
+          = traitement.instructeur_email
+          a
+          %strong= t(traitement.state, scope: 'activerecord.attributes.traitement.state').downcase
+          ce dossier
+      - else
+        %li
+          = "Le #{l(traitement.processed_at, format: '%d %B %Y à %R')}, "
+          ce dossier a été
+          %strong= t(traitement.state, scope: 'activerecord.attributes.traitement.state').downcase
+- else
+  %p.tab-paragraph Aucune décision n'a été rendue
+

--- a/app/views/instructeurs/dossiers/personnes_impliquees.html.haml
+++ b/app/views/instructeurs/dossiers/personnes_impliquees.html.haml
@@ -5,6 +5,9 @@
 .personnes-impliquees.container
   = render partial: 'instructeurs/dossiers/envoyer_dossier_block', locals: { dossier: @dossier, potential_recipients: @potential_recipients }
 
+  - @dossier.traitements.each do |traitement|
+    = render partial: 'instructeurs/dossiers/personnes_impliquees_block', locals: { emails_collection: [traitement.instructeur.email], title: "Instructeur qui a #{t(traitement.state, scope: 'activerecord.attributes.traitement.state').downcase} le dossier (#{l(traitement.processed_at)})" }
+
   = render partial: 'instructeurs/dossiers/personnes_impliquees_block', locals: { emails_collection: @following_instructeurs_emails, title: "Instructeurs qui suivent actuellement le dossier", blank: "Aucun instructeur ne suit ce dossier" }
 
   - if @previous_following_instructeurs_emails.present?

--- a/app/views/instructeurs/dossiers/personnes_impliquees.html.haml
+++ b/app/views/instructeurs/dossiers/personnes_impliquees.html.haml
@@ -6,7 +6,7 @@
   = render partial: 'instructeurs/dossiers/envoyer_dossier_block', locals: { dossier: @dossier, potential_recipients: @potential_recipients }
 
   - @dossier.traitements.each do |traitement|
-    = render partial: 'instructeurs/dossiers/personnes_impliquees_block', locals: { emails_collection: [traitement.instructeur.email], title: "Instructeur qui a #{t(traitement.state, scope: 'activerecord.attributes.traitement.state').downcase} le dossier (#{l(traitement.processed_at)})" }
+    = render partial: 'instructeurs/dossiers/personnes_impliquees_block', locals: { emails_collection: [traitement.instructeur_email], title: "Instructeur qui a #{t(traitement.state, scope: 'activerecord.attributes.traitement.state').downcase} le dossier (#{l(traitement.processed_at)})" }
 
   = render partial: 'instructeurs/dossiers/personnes_impliquees_block', locals: { emails_collection: @following_instructeurs_emails, title: "Instructeurs qui suivent actuellement le dossier", blank: "Aucun instructeur ne suit ce dossier" }
 

--- a/app/views/instructeurs/dossiers/personnes_impliquees.html.haml
+++ b/app/views/instructeurs/dossiers/personnes_impliquees.html.haml
@@ -5,10 +5,6 @@
 .personnes-impliquees.container
   = render partial: 'instructeurs/dossiers/envoyer_dossier_block', locals: { dossier: @dossier, potential_recipients: @potential_recipients }
 
-  - @dossier.traitements.each do |traitement|
-    - if traitement.instructeur_email.present?
-      = render partial: 'instructeurs/dossiers/personnes_impliquees_block', locals: { emails_collection: [traitement.instructeur_email], title: "Instructeur qui a #{t(traitement.state, scope: 'activerecord.attributes.traitement.state').downcase} le dossier (#{l(traitement.processed_at)})" }
-
   = render partial: 'instructeurs/dossiers/personnes_impliquees_block', locals: { emails_collection: @following_instructeurs_emails, title: "Instructeurs qui suivent actuellement le dossier", blank: "Aucun instructeur ne suit ce dossier" }
 
   - if @previous_following_instructeurs_emails.present?
@@ -17,3 +13,5 @@
   = render partial: 'instructeurs/dossiers/personnes_impliquees_block', locals: { emails_collection: @avis_emails, title: "Personnes à qui un avis a été demandé", blank: "Aucun avis n'a été demandé" }
 
   = render partial: 'instructeurs/dossiers/personnes_impliquees_block', locals: { emails_collection: @invites_emails, title: "Personnes invitées à consulter ce dossier", blank: "Aucune personne n'a été invitée à consulter ce dossier" }
+
+  = render partial: 'instructeurs/dossiers/decisions_rendues_block', locals: { traitements: @dossier.traitements }

--- a/app/views/instructeurs/dossiers/personnes_impliquees.html.haml
+++ b/app/views/instructeurs/dossiers/personnes_impliquees.html.haml
@@ -6,7 +6,8 @@
   = render partial: 'instructeurs/dossiers/envoyer_dossier_block', locals: { dossier: @dossier, potential_recipients: @potential_recipients }
 
   - @dossier.traitements.each do |traitement|
-    = render partial: 'instructeurs/dossiers/personnes_impliquees_block', locals: { emails_collection: [traitement.instructeur_email], title: "Instructeur qui a #{t(traitement.state, scope: 'activerecord.attributes.traitement.state').downcase} le dossier (#{l(traitement.processed_at)})" }
+    - if traitement.instructeur_email.present?
+      = render partial: 'instructeurs/dossiers/personnes_impliquees_block', locals: { emails_collection: [traitement.instructeur_email], title: "Instructeur qui a #{t(traitement.state, scope: 'activerecord.attributes.traitement.state').downcase} le dossier (#{l(traitement.processed_at)})" }
 
   = render partial: 'instructeurs/dossiers/personnes_impliquees_block', locals: { emails_collection: @following_instructeurs_emails, title: "Instructeurs qui suivent actuellement le dossier", blank: "Aucun instructeur ne suit ce dossier" }
 

--- a/config/locales/models/dossier/fr.yml
+++ b/config/locales/models/dossier/fr.yml
@@ -9,13 +9,13 @@ fr:
         montant_projet: 'Le montant du projet'
         montant_aide_demande: "Le montant d’aide demandée"
         date_previsionnelle: "La date de début prévisionnelle"
-        state:
+        state: &state
           brouillon: "Brouillon"
           en_construction: "En construction"
           en_instruction: "En instruction"
           accepte: "Accepté"
           refuse: "Refusé"
-          sans_suite: "Sans suite"
+          sans_suite: "Classé sans suite"
         autorisation_donnees: Acceptation des CGU
         state/brouillon: Brouillon
         state/en_construction: En construction
@@ -23,3 +23,6 @@ fr:
         state/accepte: Accepté
         state/refuse: Refusé
         state/sans_suite: Sans suite
+      traitement:
+        state:
+          <<: *state

--- a/db/migrate/20200630140356_create_traitements.rb
+++ b/db/migrate/20200630140356_create_traitements.rb
@@ -1,0 +1,11 @@
+class CreateTraitements < ActiveRecord::Migration[5.2]
+  def change
+    create_table :traitements do |t|
+      t.references :dossier, foreign_key: true
+      t.references :instructeur, foreign_key: true
+      t.string :motivation
+      t.string :state
+      t.timestamp :processed_at
+    end
+  end
+end

--- a/db/migrate/20200707082256_remove_instructeur_id_and_add_instructeur_email_to_traitements.rb
+++ b/db/migrate/20200707082256_remove_instructeur_id_and_add_instructeur_email_to_traitements.rb
@@ -1,0 +1,6 @@
+class RemoveInstructeurIdAndAddInstructeurEmailToTraitements < ActiveRecord::Migration[5.2]
+  def change
+    add_column :traitements, :instructeur_email, :string
+    remove_column :traitements, :instructeur_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_30_140356) do
+ActiveRecord::Schema.define(version: 2020_07_07_082256) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -562,12 +562,11 @@ ActiveRecord::Schema.define(version: 2020_06_30_140356) do
 
   create_table "traitements", force: :cascade do |t|
     t.bigint "dossier_id"
-    t.bigint "instructeur_id"
     t.string "motivation"
     t.string "state"
     t.datetime "processed_at"
+    t.string "instructeur_email"
     t.index ["dossier_id"], name: "index_traitements_on_dossier_id"
-    t.index ["instructeur_id"], name: "index_traitements_on_instructeur_id"
   end
 
   create_table "trusted_device_tokens", force: :cascade do |t|
@@ -671,7 +670,6 @@ ActiveRecord::Schema.define(version: 2020_06_30_140356) do
   add_foreign_key "refused_mails", "procedures"
   add_foreign_key "services", "administrateurs"
   add_foreign_key "traitements", "dossiers"
-  add_foreign_key "traitements", "instructeurs"
   add_foreign_key "trusted_device_tokens", "instructeurs"
   add_foreign_key "types_de_champ", "types_de_champ", column: "parent_id"
   add_foreign_key "users", "administrateurs"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_11_122406) do
+ActiveRecord::Schema.define(version: 2020_06_30_140356) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -560,6 +560,16 @@ ActiveRecord::Schema.define(version: 2020_06_11_122406) do
     t.string "version", null: false
   end
 
+  create_table "traitements", force: :cascade do |t|
+    t.bigint "dossier_id"
+    t.bigint "instructeur_id"
+    t.string "motivation"
+    t.string "state"
+    t.datetime "processed_at"
+    t.index ["dossier_id"], name: "index_traitements_on_dossier_id"
+    t.index ["instructeur_id"], name: "index_traitements_on_instructeur_id"
+  end
+
   create_table "trusted_device_tokens", force: :cascade do |t|
     t.string "token", null: false
     t.bigint "instructeur_id"
@@ -660,6 +670,8 @@ ActiveRecord::Schema.define(version: 2020_06_11_122406) do
   add_foreign_key "received_mails", "procedures"
   add_foreign_key "refused_mails", "procedures"
   add_foreign_key "services", "administrateurs"
+  add_foreign_key "traitements", "dossiers"
+  add_foreign_key "traitements", "instructeurs"
   add_foreign_key "trusted_device_tokens", "instructeurs"
   add_foreign_key "types_de_champ", "types_de_champ", column: "parent_id"
   add_foreign_key "users", "administrateurs"

--- a/lib/tasks/deployment/20200630154829_add_traitements_from_dossiers.rake
+++ b/lib/tasks/deployment/20200630154829_add_traitements_from_dossiers.rake
@@ -1,0 +1,18 @@
+namespace :after_party do
+  desc 'Deployment task: add_traitements_from_dossiers'
+  task add_traitements_from_dossiers: :environment do
+    puts "Running deploy task 'add_traitements_from_dossiers'"
+
+    dossiers_termines = Dossier.state_termine
+    progress = ProgressReport.new(dossiers_termines.count)
+    dossiers_termines.find_each do |dossier|
+      dossier.traitements.create!(state: dossier.state, motivation: dossier.motivation, processed_at: dossier.processed_at)
+      progress.inc
+    end
+    progress.finish
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord.create version: '20200630154829'
+  end
+end

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -596,7 +596,7 @@ describe API::V2::GraphqlController do
           it "should fail" do
             expect(gql_errors).to eq(nil)
             expect(gql_data).to eq(dossierRefuser: {
-              errors: [{ message: "Le dossier est déjà sans suite" }],
+              errors: [{ message: "Le dossier est déjà classé sans suite" }],
               dossier: nil
             })
           end

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -194,7 +194,7 @@ describe Instructeurs::DossiersController, type: :controller do
   describe '#terminer' do
     context "with refuser" do
       before do
-        dossier.en_instruction!
+        dossier.passer_en_instruction!(instructeur)
         sign_in(instructeur.user)
       end
 
@@ -235,7 +235,7 @@ describe Instructeurs::DossiersController, type: :controller do
 
     context "with classer_sans_suite" do
       before do
-        dossier.en_instruction!
+        dossier.passer_en_instruction!(instructeur)
         sign_in(instructeur.user)
       end
       context 'without attachment' do
@@ -277,7 +277,7 @@ describe Instructeurs::DossiersController, type: :controller do
 
     context "with accepter" do
       before do
-        dossier.en_instruction!
+        dossier.passer_en_instruction!(instructeur)
         sign_in(instructeur.user)
 
         expect(NotificationMailer).to receive(:send_closed_notification)

--- a/spec/controllers/stats_controller_spec.rb
+++ b/spec/controllers/stats_controller_spec.rb
@@ -106,25 +106,22 @@ describe StatsController, type: :controller do
     before do
       procedure_1 = FactoryBot.create(:procedure)
       procedure_2 = FactoryBot.create(:procedure)
-      dossier_p1_a = FactoryBot.create(:dossier,
+      dossier_p1_a = FactoryBot.create(:dossier, :accepte,
         :procedure          => procedure_1,
         :en_construction_at => 2.months.ago.beginning_of_month,
         :processed_at       => 2.months.ago.beginning_of_month + 3.days)
-      dossier_p1_b = FactoryBot.create(:dossier,
+      dossier_p1_b = FactoryBot.create(:dossier, :accepte,
         :procedure          => procedure_1,
         :en_construction_at => 2.months.ago.beginning_of_month,
         :processed_at       => 2.months.ago.beginning_of_month + 1.day)
-      dossier_p1_c = FactoryBot.create(:dossier,
+      dossier_p1_c = FactoryBot.create(:dossier, :accepte,
         :procedure          => procedure_1,
         :en_construction_at => 1.month.ago.beginning_of_month,
         :processed_at       => 1.month.ago.beginning_of_month + 5.days)
-      dossier_p2_a = FactoryBot.create(:dossier,
+      dossier_p2_a = FactoryBot.create(:dossier, :accepte,
         :procedure          => procedure_2,
         :en_construction_at => 2.months.ago.beginning_of_month,
         :processed_at       => 2.months.ago.beginning_of_month + 4.days)
-
-      # Write directly in the DB to avoid the before_validation hook
-      Dossier.update_all(state: Dossier.states.fetch(:accepte))
 
       @expected_hash = {
         (2.months.ago.beginning_of_month).to_s => 3.0,
@@ -154,29 +151,26 @@ describe StatsController, type: :controller do
     before do
       procedure_1 = FactoryBot.create(:procedure, :with_type_de_champ, :types_de_champ_count => 24)
       procedure_2 = FactoryBot.create(:procedure, :with_type_de_champ, :types_de_champ_count => 48)
-      dossier_p1_a = FactoryBot.create(:dossier,
+      dossier_p1_a = FactoryBot.create(:dossier, :accepte,
         :procedure    => procedure_1,
         :created_at   => 2.months.ago.beginning_of_month,
         :en_construction_at => 2.months.ago.beginning_of_month + 30.minutes,
         :processed_at => 2.months.ago.beginning_of_month + 1.day)
-      dossier_p1_b = FactoryBot.create(:dossier,
+      dossier_p1_b = FactoryBot.create(:dossier, :accepte,
         :procedure    => procedure_1,
         :created_at   => 2.months.ago.beginning_of_month,
         :en_construction_at => 2.months.ago.beginning_of_month + 10.minutes,
         :processed_at => 2.months.ago.beginning_of_month + 1.day)
-      dossier_p1_c = FactoryBot.create(:dossier,
+      dossier_p1_c = FactoryBot.create(:dossier, :accepte,
         :procedure    => procedure_1,
         :created_at   => 1.month.ago.beginning_of_month,
         :en_construction_at => 1.month.ago.beginning_of_month + 50.minutes,
         :processed_at => 1.month.ago.beginning_of_month + 1.day)
-      dossier_p2_a = FactoryBot.create(:dossier,
+      dossier_p2_a = FactoryBot.create(:dossier, :accepte,
         :procedure    => procedure_2,
         :created_at   => 2.months.ago.beginning_of_month,
         :en_construction_at => 2.months.ago.beginning_of_month + 80.minutes,
         :processed_at => 2.months.ago.beginning_of_month + 1.day)
-
-      # Write directly in the DB to avoid the before_validation hook
-      Dossier.update_all(state: Dossier.states.fetch(:accepte))
 
       @expected_hash = {
         (2.months.ago.beginning_of_month).to_s => 30.0,

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -657,7 +657,7 @@ describe Users::DossiersController, type: :controller do
       let!(:invite) { create(:invite, dossier: dossier, user: user) }
 
       before do
-        dossier.en_construction!
+        dossier.passer_en_construction!
         subject
       end
 

--- a/spec/helpers/dossier_helper_spec.rb
+++ b/spec/helpers/dossier_helper_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe DossierHelper, type: :helper do
 
     it 'sans_suite is traité' do
       dossier.sans_suite!
-      expect(subject).to eq('Sans suite')
+      expect(subject).to eq('Classé sans suite')
     end
 
     it 'refuse is traité' do

--- a/spec/models/concern/tags_substitution_concern_spec.rb
+++ b/spec/models/concern/tags_substitution_concern_spec.rb
@@ -35,6 +35,7 @@ describe TagsSubstitutionConcern, type: :model do
     let(:individual) { nil }
     let(:etablissement) { create(:etablissement) }
     let!(:dossier) { create(:dossier, procedure: procedure, individual: individual, etablissement: etablissement) }
+    let(:instructeur) { create(:instructeur) }
 
     before { Timecop.freeze(Time.zone.now) }
 
@@ -242,7 +243,7 @@ describe TagsSubstitutionConcern, type: :model do
     end
 
     context 'when the dossier has a motivation' do
-      let(:dossier) { create(:dossier, motivation: 'motivation') }
+      let(:dossier) { create(:dossier, :accepte, motivation: 'motivation') }
 
       context 'and the template has some dossier tags' do
         let(:template) { '--motivation-- --numéro du dossier--' }
@@ -318,9 +319,13 @@ describe TagsSubstitutionConcern, type: :model do
 
     context "when using a date tag" do
       before do
-        dossier.en_construction_at = Time.zone.local(2001, 2, 3)
-        dossier.en_instruction_at = Time.zone.local(2004, 5, 6)
-        dossier.processed_at = Time.zone.local(2007, 8, 9)
+        Timecop.freeze(Time.zone.local(2001, 2, 3))
+        dossier.passer_en_construction!
+        Timecop.freeze(Time.zone.local(2004, 5, 6))
+        dossier.passer_en_instruction!(instructeur)
+        Timecop.freeze(Time.zone.local(2007, 8, 9))
+        dossier.accepter!(instructeur, nil, nil)
+        Timecop.return
       end
 
       context "with date de dépôt" do

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -915,7 +915,7 @@ describe Dossier do
 
     it { expect(dossier.traitements.last.motivation).to eq('motivation') }
     it { expect(dossier.motivation).to eq('motivation') }
-    it { expect(dossier.traitements.last.instructeur).to eq(instructeur) }
+    it { expect(dossier.traitements.last.instructeur_email).to eq(instructeur.email) }
     it { expect(dossier.en_instruction_at).to eq(dossier.en_instruction_at) }
     it { expect(dossier.traitements.last.processed_at).to eq(now) }
     it { expect(dossier.processed_at).to eq(now) }

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -346,13 +346,14 @@ describe Dossier do
     let(:state) { Dossier.states.fetch(:brouillon) }
     let(:dossier) { create(:dossier, state: state) }
     let(:beginning_of_day) { Time.zone.now.beginning_of_day }
+    let(:instructeur) { create(:instructeur) }
 
     before { Timecop.freeze(beginning_of_day) }
     after { Timecop.return }
 
     context 'when dossier is en_construction' do
       before do
-        dossier.en_construction!
+        dossier.passer_en_construction!
         dossier.reload
       end
 
@@ -361,8 +362,8 @@ describe Dossier do
 
       it 'should keep first en_construction_at date' do
         Timecop.return
-        dossier.en_instruction!
-        dossier.en_construction!
+        dossier.passer_en_instruction!(instructeur)
+        dossier.repasser_en_construction!(instructeur)
 
         expect(dossier.en_construction_at).to eq(beginning_of_day)
       end
@@ -370,9 +371,10 @@ describe Dossier do
 
     context 'when dossier is en_instruction' do
       let(:state) { Dossier.states.fetch(:en_construction) }
+      let(:instructeur) { create(:instructeur) }
 
       before do
-        dossier.en_instruction!
+        dossier.passer_en_instruction!(instructeur)
         dossier.reload
       end
 
@@ -381,39 +383,48 @@ describe Dossier do
 
       it 'should keep first en_instruction_at date if dossier is set to en_construction again' do
         Timecop.return
-        dossier.en_construction!
-        dossier.en_instruction!
+        dossier.repasser_en_construction!(instructeur)
+        dossier.passer_en_instruction!(instructeur)
 
         expect(dossier.en_instruction_at).to eq(beginning_of_day)
       end
     end
 
-    shared_examples 'dossier is processed' do |new_state|
-      before do
-        dossier.update(state: new_state)
-        dossier.reload
-      end
-
-      it { expect(dossier.state).to eq(new_state) }
-      it { expect(dossier.processed_at).to eq(beginning_of_day) }
-    end
-
     context 'when dossier is accepte' do
       let(:state) { Dossier.states.fetch(:en_instruction) }
 
-      it_behaves_like 'dossier is processed', Dossier.states.fetch(:accepte)
+      before do
+        dossier.accepter!(instructeur, nil, nil)
+        dossier.reload
+      end
+
+      it { expect(dossier.state).to eq(Dossier.states.fetch(:accepte)) }
+      it { expect(dossier.processed_at).to eq(beginning_of_day) }
+
     end
 
     context 'when dossier is refuse' do
       let(:state) { Dossier.states.fetch(:en_instruction) }
 
-      it_behaves_like 'dossier is processed', Dossier.states.fetch(:refuse)
+      before do
+        dossier.refuser!(instructeur, nil, nil)
+        dossier.reload
+      end
+
+      it { expect(dossier.state).to eq(Dossier.states.fetch(:refuse)) }
+      it { expect(dossier.processed_at).to eq(beginning_of_day) }
     end
 
     context 'when dossier is sans_suite' do
       let(:state) { Dossier.states.fetch(:en_instruction) }
 
-      it_behaves_like 'dossier is processed', Dossier.states.fetch(:sans_suite)
+      before do
+        dossier.classer_sans_suite!(instructeur, nil, nil)
+        dossier.reload
+      end
+
+      it { expect(dossier.state).to eq(Dossier.states.fetch(:sans_suite)) }
+      it { expect(dossier.processed_at).to eq(beginning_of_day) }
     end
   end
 
@@ -478,13 +489,14 @@ describe Dossier do
   describe "#send_dossier_received" do
     let(:procedure) { create(:procedure) }
     let(:dossier) { create(:dossier, procedure: procedure, state: Dossier.states.fetch(:en_construction)) }
+    let(:instructeur) { create(:instructeur) }
 
     before do
       allow(NotificationMailer).to receive(:send_dossier_received).and_return(double(deliver_later: nil))
     end
 
     it "sends an email when the dossier becomes en_instruction" do
-      dossier.en_instruction!
+      dossier.passer_en_instruction!(instructeur)
       expect(NotificationMailer).to have_received(:send_dossier_received).with(dossier)
     end
 
@@ -777,6 +789,7 @@ describe Dossier do
 
   describe 'webhook' do
     let(:dossier) { create(:dossier) }
+    let(:instructeur) { create(:instructeur) }
 
     it 'should not call webhook' do
       expect {
@@ -792,7 +805,7 @@ describe Dossier do
       }.to_not have_enqueued_job(WebHookJob)
 
       expect {
-        dossier.en_construction!
+        dossier.passer_en_construction!
       }.to have_enqueued_job(WebHookJob)
 
       expect {
@@ -800,7 +813,7 @@ describe Dossier do
       }.to_not have_enqueued_job(WebHookJob)
 
       expect {
-        dossier.en_instruction!
+        dossier.passer_en_instruction!(instructeur)
       }.to have_enqueued_job(WebHookJob)
     end
   end

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -478,7 +478,7 @@ describe Instructeur, type: :model do
       before do
         procedure_to_assign.update(declarative_with_state: "accepte")
         DeclarativeProceduresJob.new.perform
-        dossier.update(processed_at: Time.zone.yesterday.beginning_of_day)
+        dossier.traitements.last.update(processed_at: Time.zone.yesterday.beginning_of_day)
         dossier.reload
       end
 

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -958,8 +958,7 @@ describe Procedure do
     let(:procedure) { create(:procedure) }
 
     def create_dossier(construction_date:, instruction_date:, processed_date:)
-      dossier = create(:dossier, :accepte, procedure: procedure)
-      dossier.update!(en_construction_at: construction_date, en_instruction_at: instruction_date, processed_at: processed_date)
+      dossier = create(:dossier, :accepte, procedure: procedure, en_construction_at: construction_date, en_instruction_at: instruction_date, processed_at: processed_date)
     end
 
     before do

--- a/spec/models/traitement_spec.rb
+++ b/spec/models/traitement_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Traitement, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/traitement_spec.rb
+++ b/spec/models/traitement_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Traitement, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -66,7 +66,7 @@ describe NotificationService do
         before do
           procedure.update(declarative_with_state: "accepte")
           DeclarativeProceduresJob.new.perform
-          dossier.update(processed_at: Time.zone.yesterday.beginning_of_day)
+          dossier.traitements.last.update!(processed_at: Time.zone.yesterday.beginning_of_day)
           dossier.reload
         end
 


### PR DESCRIPTION
close #4897 

Cette PR affiche pour l'instructeur qui a pris la décision d'accepter, refuser ou classer sans suite un dossier. Si plusieurs décisions ont été prises, elles sont toutes affichées par ordre chronologique.

C'est lel model `traitement` qui stocke l'information (etat, instructeur, à quelle date).

![traitements](https://user-images.githubusercontent.com/1111966/86568698-8dd35800-bf6d-11ea-9d26-7c4b7d375d92.png)
