### PR TITLE
dossier: fix PDF rendering of effectif_mensuel

### DIFF
--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -9,7 +9,7 @@ def format_in_2_lines(pdf, label, text)
 end
 
 def render_box(pdf, text, x, width)
-  box = ::Prawn::Text::Box.new(text || '', { document: pdf, width: width, overflow: :expand, at: [x, pdf.cursor] })
+  box = ::Prawn::Text::Box.new(text.to_s, { document: pdf, width: width, overflow: :expand, at: [x, pdf.cursor] })
   box.render
   box.height
 end

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -526,16 +526,19 @@ describe Instructeurs::DossiersController, type: :controller do
   describe "#show" do
     context "when the dossier is exported as PDF" do
       let(:instructeur) { create(:instructeur) }
-      let(:dossier) {
-  create(:dossier,
-    :accepte,
-    :with_all_champs,
-    :with_all_annotations,
-    :with_motivation,
-    :with_commentaires, procedure: procedure)
-}
-      let!(:avis) { create(:avis, dossier: dossier, instructeur: instructeur) }
+      let(:dossier) do
+        create(:dossier,
+          :accepte,
+          :with_all_champs,
+          :with_all_annotations,
+          :with_motivation,
+          :with_entreprise,
+          :with_commentaires, procedure: procedure)
+      end
+      let(:avis) { create(:avis, dossier: dossier, instructeur: instructeur) }
+
       subject do
+        avis
         get :show, params: {
           procedure_id: procedure.id,
           dossier_id: dossier.id,
@@ -543,9 +546,8 @@ describe Instructeurs::DossiersController, type: :controller do
         }
       end
 
-      before do
-        subject
-      end
+      before { subject }
+
       it { expect(assigns(:include_infos_administration)).to eq(true) }
       it { expect(response).to render_template 'dossiers/show' }
     end

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -28,7 +28,7 @@ FactoryBot.define do
         if dossier.procedure.for_individual?
           raise 'Inconsistent factory: attempting to create a dossier :with_entreprise on a procedure that is `for_individual?`'
         end
-        etablissement = create(:etablissement)
+        etablissement = create(:etablissement, :with_exercices, :with_effectif_mensuel)
         dossier.etablissement = etablissement
       end
     end

--- a/spec/factories/etablissement.rb
+++ b/spec/factories/etablissement.rb
@@ -30,6 +30,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_effectif_mensuel do
+      entreprise_effectif_mensuel { 100.5 }
+      entreprise_effectif_mois { '03' }
+      entreprise_effectif_annee { '2020' }
+    end
+
     trait :non_diffusable do
       diffusable_commercialement { false }
     end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -223,7 +223,6 @@ describe Dossier do
 
   describe '#reset!' do
     let!(:dossier) { create :dossier, :with_entreprise, autorisation_donnees: true }
-    let!(:exercice) { create :exercice, etablissement: dossier.etablissement }
 
     subject { dossier.reset! }
 


### PR DESCRIPTION
The effectif_mensuel was a number, it needs to be converted explicitely into a string.

As a bonus, `nil.to_s` is `""`, so we can remove the special case for nil.

Fix https://sentry.io/organizations/demarches-simplifiees/issues/1708582264

