### PR TITLE
Amélioration du CSS des badges de synthèse des dossiers

### DIFF
--- a/app/assets/stylesheets/new_design/badges.scss
+++ b/app/assets/stylesheets/new_design/badges.scss
@@ -18,7 +18,10 @@
 
   &.procedure-synthese-badge {
     color: $white;
-    background-color: #6C757D;
-    margin-right: 3px;
+    background-color: $dark-grey;
+    margin-left: 3px;
+    padding-left: $default-spacer;
+    padding-right: $default-spacer;
+    vertical-align: baseline;
   }
 }


### PR DESCRIPTION
- Alignement vertical du texte
- Plus d'espacement et de marge dans les badges
- Utilisation des constantes CSS prédéfinies

## Avant

<img width="969" alt="Capture d’écran 2020-07-06 à 15 12 29" src="https://user-images.githubusercontent.com/179923/86596894-3d72ef00-bf9b-11ea-9d6f-a8a4a5d4094c.png">

## Après

<img width="975" alt="Capture d’écran 2020-07-06 à 15 11 13" src="https://user-images.githubusercontent.com/179923/86596884-3b109500-bf9b-11ea-948f-a7ac871aca04.png">

/cc @myriamzbyt 