### PR TITLE
Style : rend l'onglet actif plus visible

### DIFF
--- a/app/assets/stylesheets/new_design/_tabs.scss
+++ b/app/assets/stylesheets/new_design/_tabs.scss
@@ -20,7 +20,7 @@
 
     &.active {
       background-color: #FFFFFF;
-      border-top: 1px solid $border-grey;
+      border-top: 2px solid $blue;
       border-left: 1px solid $border-grey;
       border-right: 1px solid $border-grey;
 


### PR DESCRIPTION
Les onglets sont notoirement difficiles à repérer dans une interface : l'œil a tendance à les ignorer, et du coup à louper des éléments d'information disponibles.

Cette PR rajoute un liseré pour rendre les onglets plus visible.

## Avant

<img width="1066" alt="Capture d’écran 2020-07-06 à 18 27 06" src="https://user-images.githubusercontent.com/179923/86616803-aae04900-bfb6-11ea-9351-039d07ad6eb1.png">


## Après

<img width="1086" alt="Capture d’écran 2020-07-06 à 18 26 41" src="https://user-images.githubusercontent.com/179923/86616807-ad42a300-bfb6-11ea-9296-4b895cc4e6f0.png">
