### PR TITLE
fix demandes adapter when no demandes

### DIFF
--- a/app/lib/pipedrive/person_adapter.rb
+++ b/app/lib/pipedrive/person_adapter.rb
@@ -6,17 +6,23 @@ class Pipedrive::PersonAdapter
   PIPEDRIVE_ROBOT_ID = '11381160'
 
   def self.get_demandes_from_persons_owned_by_robot
-    Pipedrive::API.get_persons_owned_by_user(PIPEDRIVE_ROBOT_ID).map do |datum|
-      {
-        person_id: datum['id'],
-        nom: datum['name'],
-        poste: datum[PIPEDRIVE_POSTE_ATTRIBUTE_ID],
-        email: datum.dig('email', 0, 'value'),
-        tel: datum.dig('phone', 0, 'value'),
-        organisation: datum['org_name'],
-        nb_dossiers: datum[PIPEDRIVE_NB_DOSSIERS_ATTRIBUTE_ID],
-        deadline: datum[PIPEDRIVE_DEADLINE_ATTRIBUTE_ID]
-      }
+    demandes = Pipedrive::API.get_persons_owned_by_user(PIPEDRIVE_ROBOT_ID)
+
+    if demandes.present?
+      demandes.map do |datum|
+        {
+          person_id: datum['id'],
+          nom: datum['name'],
+          poste: datum[PIPEDRIVE_POSTE_ATTRIBUTE_ID],
+          email: datum.dig('email', 0, 'value'),
+          tel: datum.dig('phone', 0, 'value'),
+          organisation: datum['org_name'],
+          nb_dossiers: datum[PIPEDRIVE_NB_DOSSIERS_ATTRIBUTE_ID],
+          deadline: datum[PIPEDRIVE_DEADLINE_ATTRIBUTE_ID]
+        }
+      end
+    else
+      []
     end
   end
 


### PR DESCRIPTION
L'écran `demandes` du manager fait une 500 aujourd'hui quand la liste des demandes est vide, c'est corrigé.