### PR TITLE
Fix broken bill dashboard page

### DIFF
--- a/app/dashboards/bill_signature_dashboard.rb
+++ b/app/dashboards/bill_signature_dashboard.rb
@@ -19,4 +19,8 @@ class BillSignatureDashboard < Administrate::BaseDashboard
     :serialized,
     :signature
   ].freeze
+
+  # The show page is disabled, but administrate requires the constant
+  # to be defined
+  SHOW_PAGE_ATTRIBUTES = [].freeze
 end


### PR DESCRIPTION
Permet à nouveau l'accès à l'écran `/manager/bill_signatures`