### PR TITLE
5333 no sentry reporting for api-entreprise

### DIFF
--- a/app/jobs/api_entreprise/job.rb
+++ b/app/jobs/api_entreprise/job.rb
@@ -9,6 +9,10 @@ class ApiEntreprise::Job < ApplicationJob
     error(self, exception)
   end
 
+  def error(job, exception)
+    # override ApplicationJob#error to avoid reporting to sentry
+  end
+
   def max_attempts
     ENV.fetch("MAX_ATTEMPTS_API_ENTREPRISE_JOBS", DEFAULT_MAX_ATTEMPTS_API_ENTREPRISE_JOBS).to_i
   end


### PR DESCRIPTION
close #5333 

Cette PR ne remonte plus aucune exception api-entreprise dans sentry