### PR TITLE
change link from to contact to FAQ on home

### DIFF
--- a/app/views/root/landing.html.haml
+++ b/app/views/root/landing.html.haml
@@ -68,13 +68,20 @@
       .cta-panel-wrapper
         %div
           %h2.cta-panel-title Une question, un problème ?
-          %p.cta-panel-explanation Notre équipe est disponible pour vous renseigner et vous aider
+          %p.cta-panel-explanation La réponse est dans l’aide en ligne
         %div
-          = contact_link "Contactez-nous",
-            tags: 'landing',
+          = link_to "Accéder à l’aide en ligne", FAQ_URL,
             class: "cta-panel-button-white",
             target: "_blank",
             rel: "noopener noreferrer"
+        -#   We temporarily disable the link to the contact page on the homepage
+        -#   %p.cta-panel-explanation Notre équipe est disponible pour vous renseigner et vous aider
+        -# %div
+        -#   = contact_link "Contactez-nous",
+        -#     tags: 'landing',
+        -#     class: "cta-panel-button-white",
+        -#     target: "_blank",
+        -#     rel: "noopener noreferrer"
 
   .landing-panel
     .container


### PR DESCRIPTION
# Avant
![image](https://user-images.githubusercontent.com/1223316/86899446-4b934d80-c10a-11ea-899f-2c23c07a36d0.png)

# Après
![image](https://user-images.githubusercontent.com/1223316/86899354-31596f80-c10a-11ea-8d91-36e63269de8f.png)

Fix #5348