### PR TITLE
config: enable debug assets in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  config.assets.debug = false
+  config.assets.debug = true
 
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.


### PR DESCRIPTION
Historically, debug assets were disabled because they made reloading pages very slow. This seems fixed by Rails 6. So we can now enjoy readable stylesheets in development.