### PR TITLE
mise à jour de doc pour se passer d'overmind

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-server: bin/rails server -p 3000
-jobs: bin/delayed_job run
+server: RAILS_QUEUE_ADAPTER=delayed_job bin/rails server -p 3000
+jobs: bin/rake jobs:work

--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@ Vous souhaitez y apporter des changements ou des améliorations ? Lisez notre [
 
 - rbenv : voir https://github.com/rbenv/rbenv-installer#rbenv-installer--doctor-scripts
 - Yarn : voir https://yarnpkg.com/en/docs/install
-- Overmind :
-  * Mac : `brew install overmind`
-  * Linux : voir https://github.com/DarthSim/overmind#installation
 
 #### Tests
 
@@ -60,9 +57,18 @@ Afin d'initialiser l'environnement de développement, exécutez la commande suiv
 
 ### Lancement de l'application
 
-    overmind start
+On lance le serveur d'application ainsi :
 
-L'application tourne à l'adresse `http://localhost:3000`.
+    bin/rails server
+
+L'application tourne alors à l'adresse `http://localhost:3000`, et utilise le mécanisme par défaut de rails pour les tâches asynchrones.
+C'est ce qu'on veut dans la plupart des cas. Une exception: ça ne joue pas les tâches cron.
+
+Pour être une peu plus proche du comportement de production, et jouer les tâches cron, on peut lancer la message queue
+dans un service dédié, et indiquer à rails d'utiliser delayed_job:
+    
+    bin/rake jobs:work
+    RAILS_QUEUE_ADAPTER=delayed_job bin/rails server
 
 ### Utilisateurs de test
 

--- a/README.md
+++ b/README.md
@@ -113,12 +113,6 @@ Pour exécuter les tests de l'application, plusieurs possibilités :
 
         rails generate after_party:task task_name
 
-### Debug
-
-Une fois `overmind` lancé, et un breakpoint `byebug` inséré dans le code, il faut se connecter au process `server` dans un nouveau terminal afin d'intéragir avec byebug :
-
-    overmind connect server
-
 ### Linting
 
 Le projet utilise plusieurs linters pour vérifier la lisibilité et la qualité du code.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ C'est ce qu'on veut dans la plupart des cas. Une exception: ça ne joue pas les 
 
 Pour être une peu plus proche du comportement de production, et jouer les tâches cron, on peut lancer la message queue
 dans un service dédié, et indiquer à rails d'utiliser delayed_job:
-    
+
     bin/rake jobs:work
     RAILS_QUEUE_ADAPTER=delayed_job bin/rails server
 

--- a/bin/setup
+++ b/bin/setup
@@ -34,5 +34,5 @@ chdir APP_ROOT do
   system! 'bin/rails log:clear tmp:clear'
 
   puts "\n== Done =="
-  puts "You can now start the application server with `overmind start`."
+  puts "You can now start the application server with `bin/rails server`."
 end

--- a/bin/setup
+++ b/bin/setup
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 require 'fileutils'
-include FileUtils
 
 # path to your application root.
 APP_ROOT = File.expand_path('..', __dir__)
@@ -9,13 +8,15 @@ def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
 end
 
-chdir APP_ROOT do
+FileUtils.chdir APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
 
   puts "\n== Installing dependencies =="
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
+
+  # Install JavaScript dependencies
   system! 'bin/yarn install'
 
   puts "\n== Updating webdrivers =="
@@ -23,7 +24,7 @@ chdir APP_ROOT do
 
   puts "\n== Copying sample files =="
   unless File.exist?('.env')
-    cp 'config/env.example', '.env'
+    FileUtils.cp 'config/env.example', '.env'
   end
 
   # Create the database, load the schema, and initialize it with the seed data

--- a/bin/update
+++ b/bin/update
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 require 'fileutils'
-include FileUtils
 
 # path to your application root.
 APP_ROOT = File.expand_path('..', __dir__)
@@ -9,7 +8,7 @@ def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
 end
 
-chdir APP_ROOT do
+FileUtils.chdir APP_ROOT do
   # This script is a way to update your development environment automatically.
   # Add necessary update steps to this file.
 

--- a/bin/update
+++ b/bin/update
@@ -31,5 +31,5 @@ chdir APP_ROOT do
   system! 'bin/rails log:clear'
 
   puts "\n== Done =="
-  puts "You can now start (or restart) the application server with `overmind start`."
+  puts "You can now start (or restart) the application server with `bin/rails server`."
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -83,10 +83,9 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  # This is useful to run rails in development with :async queue adapter
-  if ENV['RAILS_QUEUE_ADAPTER']
-    config.active_job.queue_adapter = ENV['RAILS_QUEUE_ADAPTER'].to_sym
-  end
+  # We use the async adapter by default, but delayed_job can be set using
+  # RAILS_QUEUE_ADAPTER=delayed_job bin/rails server
+  config.active_job.queue_adapter = ENV.fetch('RAILS_QUEUE_ADAPTER', 'async').to_sym
 
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end


### PR DESCRIPTION
Depuis le passage à Rails 6, je n'arrive pas à faire démarrer l'application avec overmind.
C'est probablement lié à [cette issue](https://github.com/collectiveidea/delayed_job/issues/1099), qui suggère de privilégier `rake jobs:work`

…mais il se trouve que plusieurs personnes n'utilisent pas overmind, et qu'on pourrait supprimer cette dépendance pour simplifier l'installation.

Si personne ne se sert d'overmind, j'ai l'impression qu'on peut aussi se passer de `Procfile`.