### PR TITLE
5347 validate api_entreprise_token

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -108,6 +108,8 @@ class Procedure < ApplicationRecord
   ], size: { less_than: 20.megabytes }
 
   validates :logo, content_type: ['image/png', 'image/jpg', 'image/jpeg'], size: { less_than: 5.megabytes }
+  validates :api_entreprise_token, jwt_token: true, allow_blank: true
+
   before_save :update_juridique_required
   after_initialize :ensure_path_exists
   before_save :ensure_path_exists

--- a/app/validators/jwt_token_validator.rb
+++ b/app/validators/jwt_token_validator.rb
@@ -1,0 +1,9 @@
+class JwtTokenValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    begin
+      JWT.decode value, nil, false
+    rescue
+      record.errors[attribute] << (options[:message] || "n'est pas un jeton valide")
+    end
+  end
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -77,7 +77,7 @@ test:
   secret_key_base: aa52abc3f3a629d04a61e9899a24c12f52b24c679cbf45f8ec0cdcc64ab9526d673adca84212882dff3911ac98e0c32ec4729ca7b3429ba18ef4dfd1bd18bc7a
   signing_key: aef3153a9829fa4ba10acb02927ac855df6b92795b1ad265d654443c4b14a017
   api_entreprise:
-    key: api_entreprise_test_key
+    key: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ik9oIHllYWgiLCJpYXQiOjE1MTYyMzkwMjJ9.f06sBo3q2Yxnw_TYPFUEs0CozBmcV-XniH_DeKNWzKE"
   pipedrive:
     key: pipedrive_test_key
   france_connect_particulier:

--- a/spec/controllers/new_administrateur/procedures_controller_spec.rb
+++ b/spec/controllers/new_administrateur/procedures_controller_spec.rb
@@ -312,10 +312,11 @@ describe NewAdministrateur::ProceduresController, type: :controller do
 
   describe 'PATCH #jeton' do
     let(:procedure) { create(:procedure, administrateur: admin) }
+    let(:valid_token) { "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c" }
 
     it "update api_entreprise_token" do
-      patch :update_jeton, params: { id: procedure.id, procedure: { api_entreprise_token: 'ceci-est-un-jeton' } }
-      expect(procedure.reload.api_entreprise_token).to eq('ceci-est-un-jeton')
+      patch :update_jeton, params: { id: procedure.id, procedure: { api_entreprise_token: valid_token } }
+      expect(procedure.reload.api_entreprise_token).to eq(valid_token)
     end
   end
 end

--- a/spec/lib/api_entreprise/api_spec.rb
+++ b/spec/lib/api_entreprise/api_spec.rb
@@ -62,13 +62,13 @@ describe ApiEntreprise::API do
       end
 
       context 'with specific token for procedure' do
-        let(:token) { 'token-for-demarche' }
+        let(:token) { "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c" }
         let(:procedure) { create(:procedure, api_entreprise_token: token) }
         let(:procedure_id) { procedure.id }
 
         it 'call api-entreprise with specfic token' do
           subject
-          expect(WebMock).to have_requested(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/entreprises\/#{siren}?.*token=token-for-demarche/)
+          expect(WebMock).to have_requested(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/entreprises\/#{siren}?.*token=#{token}/)
         end
       end
 

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -205,6 +205,13 @@ describe Procedure do
           it { expect(procedure.valid?).to eq(false) }
         end
       end
+
+      context 'api_entreprise_token' do
+        let(:valid_token) { "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c" }
+        let(:invalid_token) { 'plouf' }
+        it { is_expected.to allow_value(valid_token).for(:api_entreprise_token) }
+        it { is_expected.not_to allow_value(invalid_token).for(:api_entreprise_token) }
+      end
     end
 
     context 'when juridique_required is false' do
@@ -335,7 +342,7 @@ describe Procedure do
   end
 
   describe 'api_entreprise_token_expired?' do
-    let(:token) { "mon-token" }
+    let(:token) { "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c" }
     let(:procedure) { create(:procedure, api_entreprise_token: token) }
     let(:payload) {
       [

--- a/spec/services/api_entreprise_service_spec.rb
+++ b/spec/services/api_entreprise_service_spec.rb
@@ -8,7 +8,8 @@ describe ApiEntrepriseService do
     let(:siret) { '41816609600051' }
     let(:etablissements_status) { 200 }
     let(:etablissements_body) { File.read('spec/fixtures/files/api_entreprise/etablissements.json') }
-    let(:procedure) { create(:procedure, api_entreprise_token: 'un-jeton') }
+    let(:valid_token) { "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c" }
+    let(:procedure) { create(:procedure, api_entreprise_token: valid_token) }
     let(:dossier) { create(:dossier, procedure: procedure) }
     let(:subject) { ApiEntrepriseService.create_etablissement(dossier, siret, procedure.id) }
 


### PR DESCRIPTION
Cette PR s'assure que l'api_entreprise_token spécifique à une procédure fournie par l'administrateur est valide.

A noter que les clés de test sont des jetons jwt exemples, et n'ont aucun caractère confidentiel.