### PR TITLE
#4926 - Préparation des validator

### DIFF
--- a/app/models/champs/piece_justificative_champ.rb
+++ b/app/models/champs/piece_justificative_champ.rb
@@ -49,6 +49,6 @@ class Champs::PieceJustificativeChamp < Champ
   end
 
   def update_skip_pj_validation
-    type_de_champ.update(options: type_de_champ.options&.merge({ :skip_pj_validation => true }) || { :skip_pj_validation => true })
+    type_de_champ.update(skip_pj_validation: true)
   end
 end

--- a/app/models/champs/piece_justificative_champ.rb
+++ b/app/models/champs/piece_justificative_champ.rb
@@ -24,6 +24,8 @@ class Champs::PieceJustificativeChamp < Champ
   #   content_type: ACCEPTED_FORMATS,
   #   size: { less_than: MAX_SIZE }
 
+  before_save :update_skip_pj_validation
+
   def main_value_name
     :piece_justificative_file
   end
@@ -44,5 +46,9 @@ class Champs::PieceJustificativeChamp < Champ
     if piece_justificative_file.attached? && (piece_justificative_file.virus_scanner.safe? || piece_justificative_file.virus_scanner.pending?)
       piece_justificative_file.service_url
     end
+  end
+
+  def update_skip_pj_validation
+    type_de_champ.update(options: type_de_champ.options&.merge({ :skip_pj_validation => true }) || { :skip_pj_validation => true })
   end
 end

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -35,7 +35,7 @@ class TypeDeChamp < ApplicationRecord
   belongs_to :parent, class_name: 'TypeDeChamp'
   has_many :types_de_champ, -> { ordered }, foreign_key: :parent_id, class_name: 'TypeDeChamp', inverse_of: :parent, dependent: :destroy
 
-  store_accessor :options, :cadastres, :quartiers_prioritaires, :parcelles_agricoles, :old_pj, :drop_down_options
+  store_accessor :options, :cadastres, :quartiers_prioritaires, :parcelles_agricoles, :old_pj, :drop_down_options, :skip_pj_validation
   delegate :tags_for_template, to: :dynamic_type
 
   class WithIndifferentAccess

--- a/lib/tasks/deployment/20200708101123_add_default_skip_validation_to_piece_justificative.rake
+++ b/lib/tasks/deployment/20200708101123_add_default_skip_validation_to_piece_justificative.rake
@@ -6,7 +6,7 @@ namespace :after_party do
     tdcs = TypeDeChamp.where(type_champ: TypeDeChamp.type_champs.fetch(:piece_justificative))
     progress = ProgressReport.new(tdcs.count)
     tdcs.find_each do |tdc|
-      tdc.update(options: tdc.options&.merge({ :skip_pj_validation => true }) || { :skip_pj_validation => true })
+      tdc.update(skip_pj_validation: true)
       progress.inc
     end
     progress.finish

--- a/lib/tasks/deployment/20200708101123_add_default_skip_validation_to_piece_justificative.rake
+++ b/lib/tasks/deployment/20200708101123_add_default_skip_validation_to_piece_justificative.rake
@@ -1,0 +1,18 @@
+namespace :after_party do
+  desc 'Deployment task: add_default_skip_validation_to_piece_justificative'
+  task add_default_skip_validation_to_piece_justificative: :environment do
+    puts "Running deploy task 'add_default_skip_validation_to_piece_justificative'"
+
+    tdcs = TypeDeChamp.where(type_champ: TypeDeChamp.type_champs.fetch(:piece_justificative))
+    progress = ProgressReport.new(tdcs.count)
+    tdcs.find_each do |tdc|
+      tdc.update(options: tdc.options&.merge({ :skip_pj_validation => true }) || { :skip_pj_validation => true })
+      progress.inc
+    end
+    progress.finish
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord.create version: '20200708101123'
+  end
+end

--- a/spec/lib/tasks/deployment/20200708101123_add_default_skip_validation_to_piece_justificative.rake_spec.rb
+++ b/spec/lib/tasks/deployment/20200708101123_add_default_skip_validation_to_piece_justificative.rake_spec.rb
@@ -1,0 +1,25 @@
+describe '20200708101123_add_default_skip_validation_to_piece_justificative.rake' do
+  let(:rake_task) { Rake::Task['after_party:add_default_skip_validation_to_piece_justificative'] }
+  let!(:pj_type_de_champ) { create(:type_de_champ_piece_justificative) }
+  let!(:text_type_de_champ) { create(:type_de_champ_text) }
+
+  before do
+    rake_task.invoke
+    text_type_de_champ.reload
+    pj_type_de_champ.reload
+  end
+
+  after { rake_task.reenable }
+
+  context 'on a piece_justificative type de champ' do
+    it 'sets the skip_pj_validation option' do
+      expect(pj_type_de_champ.skip_pj_validation).to be_truthy
+    end
+  end
+
+  context 'on a non piece_justificative type de champ' do
+    it 'does not set the skip_pj_validation option' do
+      expect(text_type_de_champ.skip_pj_validation).to be_blank
+    end
+  end
+end

--- a/spec/models/champs/piece_justificative_champ_spec.rb
+++ b/spec/models/champs/piece_justificative_champ_spec.rb
@@ -3,6 +3,19 @@ require 'active_storage_validations/matchers'
 describe Champs::PieceJustificativeChamp do
   include ActiveStorageValidations::Matchers
 
+  describe "update_skip_validation" do
+    subject { champ_pj.type_de_champ.skip_pj_validation }
+
+    context 'before_save' do
+      let(:champ_pj) { build (:champ_piece_justificative) }
+      it { is_expected.to be_falsy }
+    end
+    context 'after_save' do
+      let(:champ_pj) { create (:champ_piece_justificative) }
+      it { is_expected.to be_truthy }
+    end
+  end
+
   # TODO: once we're running on Rails 6, re-enable the PieceJustificativeChamp validator,
   # and re-enable this spec.
   #


### PR DESCRIPTION
Ajout d'une option pour sauter la validation sur les pj antérieures à la mise en place de la validation, ce qui doit donc passer avant https://github.com/betagouv/demarches-simplifiees.fr/pull/5357

Le `find_each/update` c'est pas hyyyyyper performant (10mn pour 96k types de champs), mais je n'ai pas trouvé comment faire un `update_all` sur un champ jsonb. De ce que je comprends de [la doc rails et postgres](https://guides.rubyonrails.org/active_record_postgresql.html#json-and-jsonb), il n'y a pas grand chose pour les update.