### PR TITLE
Don't retry Virus Scanner Jobs when the underlying blob file is missing

### DIFF
--- a/app/jobs/virus_scanner_job.rb
+++ b/app/jobs/virus_scanner_job.rb
@@ -1,4 +1,6 @@
 class VirusScannerJob < ApplicationJob
+  discard_on ActiveRecord::RecordNotFound
+
   def perform(blob)
     metadata = extract_metadata_via_virus_scanner(blob)
     blob.update!(metadata: blob.metadata.merge(metadata))

--- a/spec/jobs/virus_scanner_job_spec.rb
+++ b/spec/jobs/virus_scanner_job_spec.rb
@@ -1,11 +1,18 @@
 RSpec.describe VirusScannerJob, type: :job do
+  include ActiveJob::TestHelper
+
   let(:champ) do
     champ = create(:champ, :piece_justificative)
     champ.piece_justificative_file.attach(io: StringIO.new("toto"), filename: "toto.txt", content_type: "text/plain")
+    champ.save
     champ
   end
 
-  subject { VirusScannerJob.new.perform(champ.piece_justificative_file.blob) }
+  subject do
+    perform_enqueued_jobs do
+      VirusScannerJob.perform_later(champ.piece_justificative_file.blob)
+    end
+  end
 
   context "when no virus is found" do
     let(:virus_found?) { true }
@@ -15,7 +22,7 @@ RSpec.describe VirusScannerJob, type: :job do
       subject
     end
 
-    it { expect(champ.piece_justificative_file.virus_scanner.safe?).to be_truthy }
+    it { expect(champ.reload.piece_justificative_file.virus_scanner.safe?).to be_truthy }
   end
 
   context "when a virus is found" do
@@ -26,6 +33,6 @@ RSpec.describe VirusScannerJob, type: :job do
       subject
     end
 
-    it { expect(champ.piece_justificative_file.virus_scanner.infected?).to be_truthy }
+    it { expect(champ.reload.piece_justificative_file.virus_scanner.infected?).to be_truthy }
   end
 end

--- a/spec/jobs/virus_scanner_job_spec.rb
+++ b/spec/jobs/virus_scanner_job_spec.rb
@@ -35,4 +35,14 @@ RSpec.describe VirusScannerJob, type: :job do
 
     it { expect(champ.reload.piece_justificative_file.virus_scanner.infected?).to be_truthy }
   end
+
+  context "when the blob has been deleted" do
+    before do
+      Champ.find(champ.id).piece_justificative_file.purge
+    end
+
+    it "ignores the error" do
+      expect { subject }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
1. **specs: test de-serialization of job arguments**

When the job is invoked directly, the serialization and de-serialization of the job arguments is not actually tested.

Using `perform_later` inside a `perform_enqueued_jobs` allows to exercise the serialization.

2. **jobs: ignore missing blob during virus scan**

We currently have many failed VirusScannerJob enqueued, because the underlying blob is missing.

This PR fixes the issue by discarding the job in those cases (because if the blob is gone, the job is never going to succeed).

The implementation is based on a similar issue encoutered by the ActiveStorage::AnalyzeJob. See rails/rails@06f8baf


