### PR TITLE
mailers: ignore more SMTP errors

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -8,6 +8,12 @@ class ApplicationMailer < ActionMailer::Base
     message.perform_deliveries = false
   end
 
+  rescue_from Net::SMTPServerBusy do |error|
+    if error.message =~ /unexpected recipients/
+      message.perform_deliveries = false
+    end
+  end
+
   # Attach the procedure logo to the email (if any).
   # Returns the attachment url.
   def attach_logo(procedure)

--- a/app/mailers/devise_user_mailer.rb
+++ b/app/mailers/devise_user_mailer.rb
@@ -9,6 +9,12 @@ class DeviseUserMailer < Devise::Mailer
     message.perform_deliveries = false
   end
 
+  rescue_from Net::SMTPServerBusy do |error|
+    if error.message =~ /unexpected recipients/
+      message.perform_deliveries = false
+    end
+  end
+
   def template_paths
     ['devise_mailer']
   end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -7,10 +7,18 @@ RSpec.describe ApplicationMailer, type: :mailer do
       before do
         allow_any_instance_of(DossierMailer)
           .to receive(:notify_new_draft)
-          .and_raise(Net::SMTPSyntaxError)
+          .and_raise(smtp_error)
       end
 
-      it { expect(subject.message).to be_an_instance_of(ActionMailer::Base::NullMail) }
+      context 'when the server handles invalid emails with Net::SMTPSyntaxError' do
+        let(:smtp_error) { Net::SMTPSyntaxError.new }
+        it { expect(subject.message).to be_an_instance_of(ActionMailer::Base::NullMail) }
+      end
+
+      context 'when the server handles invalid emails with Net::SMTPServerBusy' do
+        let(:smtp_error) { Net::SMTPServerBusy.new('400 unexpected recipients: want atleast 1, got 0') }
+        it { expect(subject.message).to be_an_instance_of(ActionMailer::Base::NullMail) }
+      end
     end
 
     describe 'valid emails are sent' do


### PR DESCRIPTION
Although we already ignore "invalid recipient" errors, a new type of error recently popped: the mail service responds with :

> Net::SMTPServerBusy '400 unexpected recipients: want atleast 1, got 0'

(See https://sentry.io/organizations/demarches-simplifiees/issues/?project=1429550)

We want to also ignore this kind of errors.
