### PR TITLE
config: use actual 5.0 config defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,11 +42,11 @@ module TPS
     default_allowed_tags = ['strong', 'em', 'b', 'i', 'p', 'code', 'pre', 'tt', 'samp', 'kbd', 'var', 'sub', 'sup', 'dfn', 'cite', 'big', 'small', 'address', 'hr', 'br', 'div', 'span', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ul', 'ol', 'li', 'dl', 'dt', 'dd', 'abbr', 'acronym', 'a', 'img', 'blockquote', 'del', 'ins']
     config.action_view.sanitized_allowed_tags = default_allowed_tags + ['u']
 
-    config.action_controller.per_form_csrf_tokens = nil
-    config.action_controller.forgery_protection_origin_check = nil
-    ActiveSupport.to_time_preserves_timezone = false
+    # Since Rails 5.0, this option is enabled by default.
+    # However we keep it disabled for now, because many of our specs and fatories
+    # do not build the required associations properly.
+    # TODO: fix the specs, and enable this option.
     config.active_record.belongs_to_required_by_default = false
-    config.ssl_options = {}
 
     # Some mobile browsers have a behaviour where, although they will delete the session
     # cookie when the browser shutdowns, they will still serve a cached version


### PR DESCRIPTION
Avec cette PR, on utilise bien les valeurs par défaut de la config Rails 5.0 (au lieu de les re-déclarer nous-même).

Pour référence, les valeurs par défault en question : https://guides.rubyonrails.org/v6.0/configuring.html#for-5-0

