### PR TITLE
Scope usual_traitement_time to the correct dossiers

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -440,17 +440,16 @@ class Procedure < ApplicationRecord
   end
 
   def usual_traitement_time
-    # times = Traitement.includes(:dossier)
-    #   .where(state: Dossier::TERMINE)
-    #   .where(processed_at: 1.month.ago..Time.zone.now)
-    #   .pluck('dossiers.en_construction_at', :processed_at)
-    #   .map { |(en_construction_at, processed_at)| processed_at - en_construction_at }
+    times = Traitement.includes(:dossier)
+      .where(dossier: self.dossiers)
+      .where.not('dossiers.en_construction_at' => nil, :processed_at => nil)
+      .where(processed_at: 1.month.ago..Time.zone.now)
+      .pluck('dossiers.en_construction_at', :processed_at)
+      .map { |(en_construction_at, processed_at)| processed_at - en_construction_at }
 
-    # if times.present?
-    #   times.percentile(90).ceil
-    # end
-
-    false
+    if times.present?
+      times.percentile(90).ceil
+    end
   end
 
   def populate_champ_stable_ids

--- a/spec/features/users/dossier_details_spec.rb
+++ b/spec/features/users/dossier_details_spec.rb
@@ -19,7 +19,7 @@ describe 'Dossier details:' do
   describe "the user can see the mean time they are expected to wait" do
     let(:other_dossier) { create(:dossier, :accepte, :with_individual, procedure: procedure, en_construction_at: 10.days.ago, en_instruction_at: 9.days.ago, processed_at: Time.zone.now) }
 
-    context "when the dossier is in construction", pending: true do
+    context "when the dossier is in construction" do
       it "displays the estimated wait duration" do
         other_dossier
         visit dossier_path(dossier)
@@ -27,7 +27,7 @@ describe 'Dossier details:' do
       end
     end
 
-    context "when the dossier is in instruction", pending: true do
+    context "when the dossier is in instruction" do
       let(:dossier) { create(:dossier, :en_instruction, :with_individual, :with_commentaires, user: user, procedure: procedure) }
 
       it "displays the estimated wait duration" do

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -981,7 +981,7 @@ describe Procedure do
     context 'when there are several processed dossiers' do
       let(:delays) { [1.day, 2.days, 2.days, 2.days, 2.days, 3.days, 3.days, 3.days, 3.days, 12.days] }
 
-      it 'returns a time representative of the dossier instruction delay', pending: true do
+      it 'returns a time representative of the dossier instruction delay' do
         expect(procedure.usual_traitement_time).to be_between(3.days, 4.days)
       end
     end
@@ -990,7 +990,7 @@ describe Procedure do
       let(:delays) { [2.days, 2.days] }
       let!(:old_dossier) { create_dossier(construction_date: 3.months.ago, instruction_date: 2.months.ago, processed_date: 2.months.ago) }
 
-      it 'ignores dossiers older than 1 month', pending: true do
+      it 'ignores dossiers older than 1 month' do
         expect(procedure.usual_traitement_time).to be_within(1.hour).of(2.days)
       end
     end
@@ -999,17 +999,17 @@ describe Procedure do
       let(:delays) { [2.days, 2.days] }
       let!(:bad_dossier) { create_dossier(construction_date: nil, instruction_date: nil, processed_date: 10.days.ago) }
 
-      it 'ignores bad dossiers', pending: true do
+      it 'ignores bad dossiers' do
         expect(procedure.usual_traitement_time).to be_within(1.hour).of(2.days)
       end
     end
 
-    context 'when there is only one processed dossier', pending: true do
+    context 'when there is only one processed dossier' do
       let(:delays) { [1.day] }
       it { expect(procedure.usual_traitement_time).to be_within(1.hour).of(1.day) }
     end
 
-    context 'where there is no processed dossier', pending: true do
+    context 'where there is no processed dossier' do
       let(:delays) { [] }
       it { expect(procedure.usual_traitement_time).to be_nil }
     end


### PR DESCRIPTION
L'introduction du modèle `Traitement` a introduit une régression dans le calcul de `usual_traitement_time`, qui ne prenait plus en compte les bons dossiers.

Cette PR corrige le problème, en se rapprochant de la [méthode antérieure](https://github.com/betagouv/demarches-simplifiees.fr/pull/5330/files#diff-9dc2b85a8d4cb2d900bdf624b6bc26f3) de calcul