### PR TITLE
#5379 - Allow status page URL to be configured in the .env file

### DIFF
--- a/config/env.example
+++ b/config/env.example
@@ -110,3 +110,6 @@ API_GEO_URL="https://geo.api.gouv.fr"
 # Modifier le nb de tentatives de relance de job si echec
 # MAX_ATTEMPTS_JOBS=25
 # MAX_ATTEMPTS_API_ENTREPRISE_JOBS=5
+
+# Personnalisation d'instance - Page externe "Disponibilité" (status page)
+# STATUS_PAGE_URL=""

--- a/config/env.example
+++ b/config/env.example
@@ -111,5 +111,3 @@ API_GEO_URL="https://geo.api.gouv.fr"
 # MAX_ATTEMPTS_JOBS=25
 # MAX_ATTEMPTS_API_ENTREPRISE_JOBS=5
 
-# Personnalisation d'instance - Page externe "Disponibilité" (status page)
-# STATUS_PAGE_URL=""

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -1,0 +1,3 @@
+
+# Variables d'environnement optionnelles
+

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -1,3 +1,5 @@
 
 # Variables d'environnement optionnelles
 
+# Personnalisation d'instance - Page externe "Disponibilité" (status page)
+# STATUS_PAGE_URL=""

--- a/config/initializers/urls.rb
+++ b/config/initializers/urls.rb
@@ -26,5 +26,5 @@ FAQ_URL = "https://faq.demarches-simplifiees.fr"
 FAQ_ADMIN_URL = [FAQ_URL, "collection", "1-administrateur-creation-dun-formulaire"].join("/")
 FAQ_AUTOSAVE_URL = [FAQ_URL, "article", "77-enregistrer-mon-formulaire-pour-le-reprendre-plus-tard?preview=5ec28ca1042863474d1aee00"].join("/")
 COMMENT_TROUVER_MA_DEMARCHE_URL = [FAQ_URL, "article", "59-comment-trouver-ma-demarche"].join("/")
-STATUS_PAGE_URL = "https://status.demarches-simplifiees.fr"
+STATUS_PAGE_URL = ENV.fetch("STATUS_PAGE_URL", "https://status.demarches-simplifiees.fr")
 MATOMO_IFRAME_URL = "https://stats.data.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=fr&&fontColor=333333&fontSize=16px&fontFamily=Muli"


### PR DESCRIPTION
- goal: allow **status page URL** to be configured in the `.env` file
- implementation: 
  - added a new optional variable in [`config/env.example`](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/config/env.example) file : `STATUS_PAGE_URL`
  - use `ENV.fetch()` method in [`config/initializers/urls.rb`](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/config/initializers/urls.rb#L29) file to use this new environment variable (if set) instead of the default URL.

-------------------------------

Fixed #5379 

