### PR TITLE
Expose repetitions and options on champ_descriptors

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -55,6 +55,11 @@ interface Champ {
 
 type ChampDescriptor {
   """
+  Description des champs d'un bloc répétable.
+  """
+  champDescriptors: [ChampDescriptor!]
+
+  """
   Description du champ.
   """
   description: String
@@ -64,6 +69,11 @@ type ChampDescriptor {
   Libellé du champ.
   """
   label: String!
+
+  """
+  List des options d'un champ avec selection.
+  """
+  options: [String!]
 
   """
   Est-ce que le champ est obligatoire ?

--- a/app/graphql/types/champ_descriptor_type.rb
+++ b/app/graphql/types/champ_descriptor_type.rb
@@ -13,5 +13,20 @@ module Types
     field :label, String, "Libellé du champ.", null: false, method: :libelle
     field :description, String, "Description du champ.", null: true
     field :required, Boolean, "Est-ce que le champ est obligatoire ?", null: false, method: :mandatory?
+
+    field :champ_descriptors, [Types::ChampDescriptorType], "Description des champs d'un bloc répétable.", null: true
+    field :options, [String], "List des options d'un champ avec selection.", null: true
+
+    def champ_descriptors
+      if object.repetition?
+        Loaders::Association.for(object.class, :types_de_champ).load(object)
+      end
+    end
+
+    def options
+      if object.drop_down_list?
+        object.drop_down_list_options.reject(&:empty?)
+      end
+    end
   end
 end

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -74,6 +74,11 @@ describe API::V2::GraphqlController do
           label
           description
           required
+          champDescriptors {
+            id
+            type
+          }
+          options
         }
         dossiers {
           nodes {
@@ -129,7 +134,9 @@ describe API::V2::GraphqlController do
               label: tdc.libelle,
               type: tdc.type_champ,
               description: tdc.description,
-              required: tdc.mandatory?
+              required: tdc.mandatory?,
+              champDescriptors: tdc.repetition? ? tdc.reload.types_de_champ.map { |tdc| { id: tdc.to_typed_id, type: tdc.type_champ } } : nil,
+              options: tdc.drop_down_list? ? tdc.drop_down_list_options.reject(&:empty?) : nil
             }
           end,
           dossiers: {


### PR DESCRIPTION
Actuellement dans le schéma exposé via l'api il manque l'information sur la structure des blocs repérables et les options des select