### PR TITLE
Zip with identical files

### DIFF
--- a/app/lib/active_storage/downloadable_file.rb
+++ b/app/lib/active_storage/downloadable_file.rb
@@ -15,7 +15,7 @@ class ActiveStorage::DownloadableFile
     pjs = PiecesJustificativesService.liste_pieces_justificatives(dossier)
     pjs.map do |piece_justificative|
       [
-        ActiveStorage::DownloadableFile.new(piece_justificative),
+        piece_justificative,
         piece_justificative.filename.to_s
       ]
     end

--- a/app/lib/active_storage/downloadable_file.rb
+++ b/app/lib/active_storage/downloadable_file.rb
@@ -16,12 +16,20 @@ class ActiveStorage::DownloadableFile
     pjs.map do |piece_justificative|
       [
         piece_justificative,
-        piece_justificative.filename.to_s
+        self.timestamped_filename(piece_justificative)
       ]
     end
   end
 
   private
+
+  def self.timestamped_filename(piece_justificative)
+    extension = File.extname(piece_justificative.filename.to_s)
+    basename = File.basename(piece_justificative.filename.to_s, extension)
+    timestamp = piece_justificative.created_at.strftime("%d-%m-%Y-%H-%S")
+
+    "#{basename}-#{timestamp}#{extension}"
+  end
 
   def using_local_backend?
     [:local, :local_test, :test].include?(Rails.application.config.active_storage.service)


### PR DESCRIPTION
Corrige la génération des zip:
 - Lorsqu'ils contiennent des fichiers ayant le même nom de fichier : tous les fichiers sont toujours présents, j'ajoute un timestamp pour différencier les différentes versions
 - En général en local, qui a du être pétée avec le passage à rails 6.