### PR TITLE
fix active link menu for demarches

### DIFF
--- a/app/views/layouts/_new_header.haml
+++ b/app/views/layouts/_new_header.haml
@@ -29,10 +29,10 @@
         %ul.header-tabs
           - if current_instructeur.procedures.count > 0
             %li
-              = active_link_to "Démarches", instructeur_procedures_path, active: /^((?!avis).)*$/, class: 'tab-link'
+              = active_link_to "Démarches", instructeur_procedures_path, active: controller_name == 'dossiers', class: 'tab-link'
           - if current_instructeur.avis.count > 0
             %li
-              = active_link_to instructeur_all_avis_path, active: /avis/, class: 'tab-link' do
+              = active_link_to instructeur_all_avis_path, active: controller_name == 'avis', class: 'tab-link' do
                 Avis
                 - avis_counter = current_instructeur.avis.without_answer.count
                 - if avis_counter > 0


### PR DESCRIPTION
Cette PR corrige le bug suivant : lorsqu'un instructeur est sur l'onglet _Avis externe_ d'une démarche pour inviter un expert à donner un avis, le menu dans le header devrait indiquer qu'il est dans la section `Démarches` et non `Avis`

Sans la PR, voici ce qui est indiqué
![demarche-avis](https://user-images.githubusercontent.com/1111966/87922728-b0409780-ca7c-11ea-92e8-b8764bbeee60.png)

Une fois la PR appliquée, voici ce qui est affiché
![good-demarches-avis](https://user-images.githubusercontent.com/1111966/87922897-e54cea00-ca7c-11ea-8dae-6a555440b288.png)
