### PR TITLE
Rendre le nom d'application paramètrable

### DIFF
--- a/.haml-lint.yml
+++ b/.haml-lint.yml
@@ -1,4 +1,10 @@
+require:
+  - './lib/linters/application_name_linter.rb'
+
 linters:
+  ApplicationNameLinter:
+    enabled: true
+
   AlignmentTabs:
     enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 require:
   - rubocop/rspec/focused
   - ./lib/cops/unscoped.rb
+  - ./lib/cops/application_name.rb
 inherit_gem:
   rubocop-rails_config:
     - config/rails.yml
@@ -11,6 +12,17 @@ AllCops:
     - "db/migrate/20190730153555_recreate_structure.rb"
     - "bin/*"
     - "node_modules/**/*"
+
+DS/Unscoped:
+  Enabled: true
+
+DS/ApplicationName:
+  Enabled: true
+  Exclude:
+    - './config/application_name.rb'
+    - './lib/cops/application_name.rb'
+    - './lib/linters/application_name_linter.rb'
+    - "./spec/**/*"
 
 Bundler/DuplicatedGem:
   Enabled: true

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -19,7 +19,7 @@ class RootController < ApplicationController
   end
 
   def patron
-    description = 'Aller voir le super site : https://demarches-simplifiees.fr'
+    description = "Allez voir le super site : #{APPLICATION_BASE_URL}"
 
     all_champs = TypeDeChamp.type_champs
       .map { |name, _| TypeDeChamp.new(type_champ: name, private: false, libelle: name.humanize, description: description, mandatory: true) }

--- a/app/helpers/conservation_de_donnees_helper.rb
+++ b/app/helpers/conservation_de_donnees_helper.rb
@@ -7,7 +7,7 @@ module ConservationDeDonneesHelper
 
   def conservation_dans_ds(procedure)
     if procedure.duree_conservation_dossiers_dans_ds.present?
-      "Dans demarches-simplifiees.fr : #{procedure.duree_conservation_dossiers_dans_ds} mois"
+      "Dans #{APPLICATION_NAME} : #{procedure.duree_conservation_dossiers_dans_ds} mois"
     end
   end
 

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -118,7 +118,9 @@ module DossierHelper
   private
 
   def dinum_instance?
+    # rubocop:disable DS/ApplicationName
     ENV['APP_HOST']&.ends_with?('demarches-simplifiees.fr')
+    # rubocop:enable DS/ApplicationName
   end
 
   def dossiers_with_lost_attachments_ids

--- a/app/lib/api_entreprise/api.rb
+++ b/app/lib/api_entreprise/api.rb
@@ -93,6 +93,7 @@ class ApiEntreprise::API
   end
 
   def self.params(siret_or_siren, procedure_id, user_id)
+    # rubocop:disable DS/ApplicationName
     params = {
       context: "demarches-simplifiees.fr",
       recipient: siret_or_siren,
@@ -100,6 +101,7 @@ class ApiEntreprise::API
       non_diffusables: true,
       token: token_for_procedure(procedure_id)
     }
+    # rubocop:enable DS/ApplicationName
     params[:user_id] = user_id if user_id.present?
     params
   end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 class ApplicationMailer < ActionMailer::Base
   helper :application # gives access to all helpers defined within `application_helper`.
-  default from: "demarches-simplifiees.fr <#{CONTACT_EMAIL}>"
+  default from: "#{APPLICATION_NAME} <#{CONTACT_EMAIL}>"
   layout 'mailer'
 
   # Don’t retry to send a message if the server rejects the recipient address

--- a/app/mailers/instructeur_mailer.rb
+++ b/app/mailers/instructeur_mailer.rb
@@ -31,7 +31,7 @@ class InstructeurMailer < ApplicationMailer
   def send_login_token(instructeur, login_token)
     @instructeur_id = instructeur.id
     @login_token = login_token
-    subject = "Connexion sécurisée à demarches-simplifiees.fr"
+    subject = "Connexion sécurisée à #{APPLICATION_NAME}"
 
     mail(to: instructeur.email, subject: subject)
   end

--- a/app/mailers/new_attestation_mailer.rb
+++ b/app/mailers/new_attestation_mailer.rb
@@ -26,7 +26,7 @@ class NewAttestationMailer < ApplicationMailer
 
       Cordialement,
 
-      L’équipe demarches-simplifiees.fr
+      L’équipe #{APPLICATION_NAME}
     HEREDOC
   end
 end

--- a/app/mailers/preactivate_users_mailer.rb
+++ b/app/mailers/preactivate_users_mailer.rb
@@ -2,19 +2,19 @@ class PreactivateUsersMailer < ApplicationMailer
   layout 'mailers/layout'
 
   def reinvite(model, model_name)
-    subject = "Votre compte #{model_name} est activé sur demarches-simplifiees.fr"
+    subject = "Votre compte #{model_name} est activé sur #{APPLICATION_NAME}"
     signature_separator = "-- "
     body = <<~END_OF_MAIL
       Bonjour,
 
-      les activations de compte #{model_name} sur demarches-simplifiees.fr
+      les activations de compte #{model_name} sur #{APPLICATION_NAME}
       ont connu depuis deux semaines un fonctionnement erratique, et nous
-      pensons que votre inscription sur demarches-simplifiees.fr a pu s’en
+      pensons que votre inscription sur #{APPLICATION_NAME} a pu s’en
       trouver affectée.
 
       Nous avons maintenant rétabli un fonctionnement normal de l’activation
       des comptes. Vous pouvez désormais vous connecter sans encombres à votre
-      compte #{model_name} sur demarches-simplifiees.fr.
+      compte #{model_name} sur #{APPLICATION_NAME}.
       Si toutefois des difficultés devaient persister, n’hésitez pas à nous
       en faire part.
 
@@ -22,7 +22,7 @@ class PreactivateUsersMailer < ApplicationMailer
 
       Cordialement
       #{signature_separator}
-      L’équipe demarches-simplifees.fr
+      L’équipe #{APPLICATION_NAME}
     END_OF_MAIL
 
     mail(to: model.email,

--- a/app/mailers/resend_attestation_mailer.rb
+++ b/app/mailers/resend_attestation_mailer.rb
@@ -21,7 +21,7 @@ class ResendAttestationMailer < ApplicationMailer
 
       Cordialement,
 
-      L’équipe demarches-simplifiees.fr
+      L’équipe #{APPLICATION_NAME}
     HEREDOC
   end
 end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -259,10 +259,12 @@ class Dossier < ApplicationRecord
   scope :with_notifications, -> do
     # This scope is meant to be composed, typically with Instructeur.followed_dossiers, which means that the :follows table is already INNER JOINed;
     # it will fail otherwise
+    # rubocop:disable DS/ApplicationName
     joined_dossiers = joins('LEFT OUTER JOIN "champs" ON "champs" . "dossier_id" = "dossiers" . "id" AND "champs" . "parent_id" IS NULL AND "champs" . "private" = FALSE AND "champs"."updated_at" > "follows"."demande_seen_at"')
       .joins('LEFT OUTER JOIN "champs" "champs_privates_dossiers" ON "champs_privates_dossiers" . "dossier_id" = "dossiers" . "id" AND "champs_privates_dossiers" . "parent_id" IS NULL AND "champs_privates_dossiers" . "private" = TRUE AND "champs_privates_dossiers"."updated_at" > "follows"."annotations_privees_seen_at"')
       .joins('LEFT OUTER JOIN "avis" ON "avis" . "dossier_id" = "dossiers" . "id" AND avis.updated_at > follows.avis_seen_at')
       .joins('LEFT OUTER JOIN "commentaires" ON "commentaires" . "dossier_id" = "dossiers" . "id" and commentaires.updated_at > follows.messagerie_seen_at and "commentaires"."email" != \'contact@tps.apientreprise.fr\' AND "commentaires"."email" != \'contact@demarches-simplifiees.fr\'')
+    # rubocop:enable DS/ApplicationName
 
     updated_demandes = joined_dossiers
       .where('champs.updated_at > follows.demande_seen_at OR groupe_instructeur_updated_at > follows.demande_seen_at')

--- a/app/views/admin/procedures/_modal_publish.html.haml
+++ b/app/views/admin/procedures/_modal_publish.html.haml
@@ -30,7 +30,7 @@
                               style: 'width: 300px; display: inline;')
               = render 'publish_path_message', procedure: procedure, administrateur: administrateur
             .text-info
-              Attention, diffusez toujours le <strong>lien complet</strong> affiché ci-dessus, et non pas un lien générique vers demarches-simplifiees.fr. Ne dites pas non plus aux usagers de se rendre sur le site générique demarches-simplifiees.fr, donnez-leur toujours le lien complet.
+              Attention, diffusez toujours le <strong>lien complet</strong> affiché ci-dessus, et non pas un lien générique vers #{APPLICATION_NAME}. Ne dites pas non plus aux usagers de se rendre sur le site générique #{APPLICATION_NAME}, donnez-leur toujours le lien complet.
           .form-group
             %h4 Diffusion de la démarche
             %p Où les utilisateurs trouveront-ils le lien de la démarche ? Typiquement, il s’agit d’une page de votre site web.

--- a/app/views/admin/procedures/new_from_existing.html.haml
+++ b/app/views/admin/procedures/new_from_existing.html.haml
@@ -17,13 +17,13 @@
       %br
       > Vous pouvez lire notre
       = link_to "documentation en ligne",
-        "https://doc.demarches-simplifiees.fr/tutoriels/tutoriel-administrateur",
+        ADMINISTRATEUR_TUTORIAL_URL,
         target: "_blank"
 
       %br
       > Vous pouvez enfin
       = link_to "prendre un rendez-vous téléphonique avec nous",
-        "https://calendly.com/demarches-simplifiees/accompagnement-administrateur-demarches-simplifiees-fr",
+        CALENDLY_URL,
         target: "_blank"
 
       :javascript

--- a/app/views/admin/procedures/show.html.haml
+++ b/app/views/admin/procedures/show.html.haml
@@ -57,7 +57,7 @@
           = link_to @procedure_lien, sanitize_url(@procedure_lien), target: :blank, rel: :noopener
           %br
           %br
-          Attention, diffusez toujours le <strong>lien complet</strong> affiché ci-dessus, et non pas un lien générique vers demarches-simplifiees.fr. Ne dites pas non plus aux usagers de se rendre sur le site générique demarches-simplifiees.fr, donnez-leur toujours le lien complet.
+          Attention, diffusez toujours le <strong>lien complet</strong> affiché ci-dessus, et non pas un lien générique vers #{APPLICATION_NAME}. Ne dites pas non plus aux usagers de se rendre sur le site générique #{APPLICATION_NAME}, donnez-leur toujours le lien complet.
         - elsif @procedure.brouillon?
           - if @procedure.missing_steps.empty?
             %p

--- a/app/views/administrateur_mailer/activate_before_expiration.haml
+++ b/app/views/administrateur_mailer/activate_before_expiration.haml
@@ -4,7 +4,7 @@
   Bonjour,
 
 %p
-  Vous avez fait la demande d’un compte administrateur sur demarches-simplifiees.fr.
+  Vous avez fait la demande d’un compte administrateur sur #{APPLICATION_NAME}.
   Votre compte a été créé mais reste inactif, il arrivera à expiration le #{try_format_date(@expiration_date)}
 
 %p

--- a/app/views/administration_mailer/new_admin_email.html.haml
+++ b/app/views/administration_mailer/new_admin_email.html.haml
@@ -1,5 +1,5 @@
 %p
-  Un nouvel administrateur a été créé sur demarches-simplifiees.fr.
+  Un nouvel administrateur a été créé sur #{APPLICATION_NAME}.
 
 %ul
   %li

--- a/app/views/administration_mailer/refuse_admin.html.haml
+++ b/app/views/administration_mailer/refuse_admin.html.haml
@@ -8,10 +8,10 @@
 
 
 %p
-  Pour les usagers ou les administrations publiques (collectivités, etc.) qui souhaitent remplir une démarche ou un déposer un dossier en ligne, l’entrée dans demarches-simplifiees.fr se fait via un lien fourni par l’administration responsable, sur son propre site web. Ce lien vous permettra de créer un compte et de remplir le formulaire dans la foulée.
+  Pour les usagers ou les administrations publiques (collectivités, etc.) qui souhaitent remplir une démarche ou un déposer un dossier en ligne, l’entrée dans #{APPLICATION_NAME} se fait via un lien fourni par l’administration responsable, sur son propre site web. Ce lien vous permettra de créer un compte et de remplir le formulaire dans la foulée.
 
 %p
-  Si par contre vous rencontrez des problèmes lors de l'utilisation de demarches-simplifiees.fr en tant qu'usager, merci d'expliciter le problème rencontré sur notre
+  Si par contre vous rencontrez des problèmes lors de l'utilisation de #{APPLICATION_NAME} en tant qu'usager, merci d'expliciter le problème rencontré sur notre
   = link_to("formulaire de contact", contact_url)
   \.
 

--- a/app/views/avis_mailer/avis_invitation.html.haml
+++ b/app/views/avis_mailer/avis_invitation.html.haml
@@ -3,7 +3,7 @@
 
 - content_for(:footer) do
   Merci de ne pas répondre à cet email. Donnez votre avis
-  = link_to("sur demarches-simplifiees.fr", avis_link)
+  = link_to("sur #{APPLICATION_NAME}", avis_link)
   ou
   = succeed '.' do
     = mail_to(@avis.claimant.email, "contactez la personne qui vous a invité")

--- a/app/views/commencer/show.html.haml
+++ b/app/views/commencer/show.html.haml
@@ -6,7 +6,7 @@
     = link_to commencer_sign_up_path(path: @procedure.path), class: ['button large expand primary'] do
       Créer un compte
       %span.optional-on-small-screens
-        demarches-simplifiees.fr
+        #{APPLICATION_NAME}
     = link_to 'J’ai déjà un compte', commencer_sign_in_path(path: @procedure.path), class: ['button large expand']
     = render partial: 'shared/france_connect_login', locals: { url: commencer_france_connect_path(path: @procedure.path) }
 

--- a/app/views/demandes/new.html.haml
+++ b/app/views/demandes/new.html.haml
@@ -22,14 +22,14 @@
     %p
       Cliquez plutôt sur le
       %strong lien direct
-      vers votre démarche que doit vous communiquer l'administration – par exemple <strong>https://www.demarches-simplifiees.fr/commencer/NOM_DE_LA_DEMARCHE</strong>.
+      vers votre démarche que doit vous communiquer l'administration – par exemple <strong>#{APPLICATION_BASE_URL}/commencer/NOM_DE_LA_DEMARCHE</strong>.
     %p
       Vous pouvez aussi consulter la
       = succeed '.' do
-        = link_to "liste des démarches disponibles", "https://doc.demarches-simplifiees.fr/listes-des-demarches"
+        = link_to "liste des démarches disponibles", LISTE_DES_DEMARCHES_URL
 
-  %p.intro Attention, la création de compte administrateur est réservée <b>uniquement aux organismes publics</b>. Elle ne concerne ni les particuliers, ni les entreprises, ni les associations (sauf celles reconnues d'utilité publique), ni les personnes souhaitant remplir un dossier ou faire une démarche en ligne. Ce compte vous permettra de créer des démarches sur demarches-simplifiees.fr, vous pourrez ensuite les diffuser en ligne auprès de vos usagers.
-  %p.intro Pour obtenir un compte administrateur sur demarches-simplifiees.fr, veuillez remplir le formulaire ci-dessous et un membre de notre équipe vous contactera dès que possible.
+  %p.intro Attention, la création de compte administrateur est réservée <b>uniquement aux organismes publics</b>. Elle ne concerne ni les particuliers, ni les entreprises, ni les associations (sauf celles reconnues d'utilité publique), ni les personnes souhaitant remplir un dossier ou faire une démarche en ligne. Ce compte vous permettra de créer des démarches sur #{APPLICATION_NAME}, vous pourrez ensuite les diffuser en ligne auprès de vos usagers.
+  %p.intro Pour obtenir un compte administrateur sur #{APPLICATION_NAME}, veuillez remplir le formulaire ci-dessous et un membre de notre équipe vous contactera dès que possible.
   %p.intro Tous les champs sont obligatoires.
   %p.intro <b>Si vous souhaitez seulement compléter une démarche sur notre site, vous n'avez pas besoin de compte administrateur!</b>
 
@@ -69,7 +69,7 @@
     = text_field_tag :phone, nil, required: true
 
     = label_tag :source do
-      Comment avez-vous entendu parler de demarches-simplifiees.fr ?
+      Comment avez-vous entendu parler de #{APPLICATION_NAME} ?
       %span.mandatory *
     = text_field_tag :source, nil, required: true
 

--- a/app/views/devise_mailer/confirmation_instructions.html.haml
+++ b/app/views/devise_mailer/confirmation_instructions.html.haml
@@ -6,7 +6,7 @@
     Bonjour,
 
   %p
-    Pour activer votre compte sur demarches-simplifiees.fr, veuillez cliquer sur le lien suivant :
+    Pour activer votre compte sur #{APPLICATION_NAME}, veuillez cliquer sur le lien suivant :
     - link = confirmation_url(@user, confirmation_token: @token, procedure_id: @procedure&.id)
     = link_to(link, link)
 

--- a/app/views/devise_mailer/email_changed.html.haml
+++ b/app/views/devise_mailer/email_changed.html.haml
@@ -7,13 +7,13 @@
 - if unconfirmed_email.present?
   %p
     Nous avons reçu une demande de changement d’adresse email pour votre
-    compte #{@email} sur demarches-simplifiees.fr.
+    compte #{@email} sur #{APPLICATION_NAME}.
     Une fois la demande prise en compte, la nouvelle adresse email de
     votre compte sera #{unconfirmed_email}.
 - else
   %p
     Le changement d’adresse email de votre compte #{@email} sur
-    demarches-simplifiees.fr a bien été pris en compte.
+    #{APPLICATION_NAME} a bien été pris en compte.
     Vous pouvez désormais vous connecter avec l’adresse #{@resource.email}.
 
 = render partial: "layouts/mailers/signature"

--- a/app/views/devise_mailer/password_change.html.haml
+++ b/app/views/devise_mailer/password_change.html.haml
@@ -5,6 +5,6 @@
 
 %p
   La demande de changement de mot de passe pour votre compte #{@resource.email} sur
-  demarches-simplifiees.fr a bien été prise en compte.
+  #{APPLICATION_NAME} a bien été prise en compte.
 
 = render partial: "layouts/mailers/signature"

--- a/app/views/devise_mailer/reset_password_instructions.html.haml
+++ b/app/views/devise_mailer/reset_password_instructions.html.haml
@@ -2,7 +2,7 @@
   Bonjour,
 
 %p
-  Vous avez demandé à regénérer votre mot de passe sur demarches-simplifiees.fr. Pour ceci, merci de suivre le lien suivant :
+  Vous avez demandé à regénérer votre mot de passe sur #{APPLICATION_BASE_URL}. Pour ceci, merci de suivre le lien suivant :
   %br
   = link_to edit_password_url(@resource, reset_password_token: @token), edit_password_url(@resource, reset_password_token: @token)
 

--- a/app/views/devise_mailer/unlock_instructions.html.haml
+++ b/app/views/devise_mailer/unlock_instructions.html.haml
@@ -5,7 +5,7 @@
 
 %p
   Quelqu’un a tenté de se connecter un grand nombre de fois sans succès à votre
-  compte #{@resource.email} sur demarches-simplifiees.fr. Par mesure de précaution,
+  compte #{@resource.email} sur #{APPLICATION_NAME}. Par mesure de précaution,
   nous avons temporairement désactivé l’accès à votre compte.
 
 %p

--- a/app/views/instructeur_mailer/send_login_token.html.haml
+++ b/app/views/instructeur_mailer/send_login_token.html.haml
@@ -2,7 +2,7 @@
   Bonjour,
 
 %p
-  Veuillez cliquer sur le lien suivant pour vous connecter sur le site demarches-simplifiees.fr : 
+  Veuillez cliquer sur le lien suivant pour vous connecter sur le site #{APPLICATION_NAME} : 
   = link_to(sign_in_by_link_url(@instructeur_id, jeton: @login_token), sign_in_by_link_url(@instructeur_id, jeton: @login_token))
 
 %p

--- a/app/views/instructeur_mailer/send_notifications.html.haml
+++ b/app/views/instructeur_mailer/send_notifications.html.haml
@@ -4,7 +4,7 @@
   Bonjour,
 
 %p
-  Vous avez du nouveau sur demarches-simplifiees.fr.
+  Vous avez du nouveau sur #{APPLICATION_NAME}.
 
 %ul
   - @data.each do |datum|

--- a/app/views/instructeur_mailer/user_to_instructeur.html.haml
+++ b/app/views/instructeur_mailer/user_to_instructeur.html.haml
@@ -2,7 +2,7 @@
   Bonjour,
 
 %p
-  Vous venez d'être nommé instructeur sur demarches-simplifiees.fr.
+  Vous venez d'être nommé instructeur sur #{APPLICATION_NAME}.
   = "Votre compte (#{@email}) vous donnera désormais aussi accès à l’espace instructeur."
 
 = render partial: "layouts/mailers/signature"

--- a/app/views/invite_mailer/invite_guest.html.haml
+++ b/app/views/invite_mailer/invite_guest.html.haml
@@ -6,7 +6,7 @@
   = @invite.email_sender
   souhaite que vous participiez à l'élaboration d'un dossier pour la démarche
   %strong= @invite.dossier.procedure.libelle
-  sur demarches-simplifiees.fr.
+  sur #{APPLICATION_NAME}.
 
 - if @invite.message.present?
   %blockquote

--- a/app/views/invite_mailer/invite_user.html.haml
+++ b/app/views/invite_mailer/invite_user.html.haml
@@ -4,7 +4,7 @@
 %p
   L'utilisateur
   = @invite.email_sender
-  souhaite que vous participiez à l'élaboration d'un dossier sur demarches-simplifiees.fr.
+  souhaite que vous participiez à l'élaboration d'un dossier sur #{APPLICATION_NAME}.
 
 - if @invite.message.present?
   %blockquote

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -3,7 +3,7 @@
     = link_to 'DINUM', 'https://www.numerique.gouv.fr/dinum/'
     = Time.zone.now.year
     \-
-    = link_to 'Nouveautés', 'https://doc.demarches-simplifiees.fr/nouveautes', target: '_blank'
+    = link_to 'Nouveautés', DOC_NOUVEAUTES_URL, target: '_blank'
     \-
     = link_to 'Statistiques', stats_path
     \-

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -4,14 +4,14 @@
       .col-lg-6.no-padding
         = image_tag('marianne.svg', class: 'logo')
       .col-lg-6.no-padding#tps-title
-        demarches-simplifiees.fr
+        = APPLICATION_NAME
 
 .col-xs-10.no-padding
   #navbar-body
     .row
       %div{ style: "max-width: 50%; position: absolute; display: flex; flex-direction: column; justify-content: center; height: 60px; line-height: 20px; z-index: 2;" }
         %span
-          👉 Besoin d’aide ? Consultez <a target="_blank" rel="noopener" href="https://doc.demarches-simplifiees.fr/">la documentation</a> et <a target="_blank" rel="noopener" href="https://faq.demarches-simplifiees.fr/">l’aide</a>, contactez-nous par <a style="cursor:hand" onclick="$crisp.push(['do', 'chat:open'])">chat</a> ou <a href="#{contact_admin_path}" target="_blank" rel="noopener">email</a>, ou <a target="_blank" rel="noopener" href="https://calendly.com/demarches-simplifiees/accompagnement-administrateur-demarches-simplifiees-fr">prenez RDV</a>.
+          👉 Besoin d’aide ? Consultez <a target="_blank" rel="noopener" href="#{DOC_URL}">la documentation</a> et <a target="_blank" rel="noopener" href="#{FAQ_URL}">l’aide</a>, contactez-nous par <a style="cursor:hand" onclick="$crisp.push(['do', 'chat:open'])">chat</a> ou <a href="#{contact_admin_path}" target="_blank" rel="noopener">email</a>, ou <a target="_blank" rel="noopener" href="#{CALENDLY_URL}">prenez RDV</a>.
       -# BEST WTF EVER
       -# this begin rescue hides potentials bugs by displaying another navbar
       - begin

--- a/app/views/layouts/_new_header.haml
+++ b/app/views/layouts/_new_header.haml
@@ -21,8 +21,10 @@
         - root_profile_link, root_profile_libelle = root_path_info_for_profile(nav_bar_profile)
         = link_to root_profile_link, class: 'header-logo justify-center', title: root_profile_libelle do
           = image_tag 'marianne.svg', alt: 'Liberté, égalité, fraternité', width: '65'
-          %span.big.site-title> demarches-simplifiees.fr
-          %span.small.site-title> d-s.fr
+          %span.big.site-title>
+            = APPLICATION_NAME
+          %span.small.site-title>
+            = APPLICATION_SHORTNAME
 
       - if nav_bar_profile == :instructeur && instructeur_signed_in?
         - current_url = request.path_info

--- a/app/views/layouts/_outdated_browser_banner.html.haml
+++ b/app/views/layouts/_outdated_browser_banner.html.haml
@@ -12,7 +12,7 @@
       - else
         .site-banner-text
           %strong
-            #{browser.name} #{browser.version} est trop ancien pour utiliser demarches-simplifiees.fr.
+            #{browser.name} #{browser.version} est trop ancien pour utiliser #{APPLICATION_NAME}.
           %br
           Certaines parties du site ne fonctionneront pas correctement.
       .site-banner-actions

--- a/app/views/layouts/_pre_maintenance.html.haml
+++ b/app/views/layouts/_pre_maintenance.html.haml
@@ -4,6 +4,6 @@
       .site-banner-icon 🕚
       .site-banner-text
         %strong
-          Une opération de maintenance est prévue sur demarches-simplifiees.fr à 23 h 00.
+          Une opération de maintenance est prévue sur #{APPLICATION_NAME} à 23 h 00.
         %br
         La plateforme sera inaccessible pendant une vingtaine de minutes.

--- a/app/views/layouts/_strike_banner.html.haml
+++ b/app/views/layouts/_strike_banner.html.haml
@@ -3,6 +3,6 @@
     .site-banner-icon ⚠️
     .site-banner-text
       %strong
-        En raison d’une grève nationale interprofessionnelle, une partie du personnel de demarches-simplifiees.fr ne travaille pas.
+        En raison d’une grève nationale interprofessionnelle, une partie du personnel de #{APPLICATION_NAME} ne travaille pas.
       %br
       Les délais de réponse aux questions techniques pourront être perturbés pendant les prochains jours.

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,7 +7,7 @@
     = csrf_meta_tags
 
     %title
-      = content_for?(:title) ? "#{yield(:title)} · demarches-simplifiees.fr" : "demarches-simplifiees.fr"
+      = content_for?(:title) ? "#{yield(:title)} · #{APPLICATION_NAME}" : APPLICATION_NAME
 
     = favicon_link_tag(image_url("favicons/16x16.png"), type: "image/png", sizes: "16x16")
     = favicon_link_tag(image_url("favicons/32x32.png"), type: "image/png", sizes: "32x32")

--- a/app/views/layouts/mailers/_bizdev_signature.html.haml
+++ b/app/views/layouts/mailers/_bizdev_signature.html.haml
@@ -4,7 +4,7 @@ Cordialement,
 = author_name
 %br
 %br
-Équipe demarches-simplifiees.fr
+Équipe #{APPLICATION_NAME}
 %br
 Téléphone (standard) :
 = CONTACT_PHONE

--- a/app/views/layouts/mailers/layout.html.erb
+++ b/app/views/layouts/mailers/layout.html.erb
@@ -50,7 +50,7 @@
                       <tr>
                         <td style="word-wrap:break-word;font-size:0px;padding:0;padding-top:0px;padding-bottom:0px;" align="left">
                           <div class="" style="cursor:auto;color:#55575d;font-family:Helvetica, Arial, sans-serif;font-size:11px;text-align:left;">
-                            <img align="middle" alt="Logo demarches-simplifiees.fr" src="<%= image_url('mailer/instructeur_mailer/logo.png') %>" style="max-width=600px; padding=30px 0; display=inline !important; vertical-align=bottom; border=0; height=auto; outline=none; text-decoration=none; -ms-interpolation-mode=bicubic;" />
+                            <img align="middle" alt="Logo #{APPLICATION_NAME}" src="<%= image_url('mailer/instructeur_mailer/logo.png') %>" style="max-width=600px; padding=30px 0; display=inline !important; vertical-align=bottom; border=0; height=auto; outline=none; text-decoration=none; -ms-interpolation-mode=bicubic;" />
                           </div>
                         </td>
                       </tr>

--- a/app/views/layouts/mailers/notifications_layout.html.erb
+++ b/app/views/layouts/mailers/notifications_layout.html.erb
@@ -145,7 +145,7 @@
                       <tr>
                         <td style="word-wrap:break-word;font-size:0px;padding:0px 20px 0px 20px;padding-top:0px;padding-bottom:0px;" align="center">
                           <div class="" style="cursor:auto;color:#55575d;font-family:Helvetica, Arial, sans-serif;font-size:11px;line-height:22px;text-align:center;">
-                            demarches-simplifiees.fr est un service fourni par la DINUM et incubé par beta.gouv.fr
+                            #{APPLICATION_NAME} est un service fourni par la DINUM et incubé par beta.gouv.fr
                           </div>
                         </td>
                       </tr>

--- a/app/views/new_administrateur/procedure_administrateurs/_add_admin_form.html.haml
+++ b/app/views/new_administrateur/procedure_administrateurs/_add_admin_form.html.haml
@@ -4,6 +4,6 @@
   remote: true do |f|
   = f.label :email do
     Ajouter un administrateur
-  %p.notice Renseignez l’email d’un administrateur déjà enregistré sur demarches-simplifiees.fr pour lui permettre de modifier « #{procedure.libelle} ».
+  %p.notice Renseignez l’email d’un administrateur déjà enregistré sur #{APPLICATION_NAME} pour lui permettre de modifier « #{procedure.libelle} ».
   = f.email_field :email, placeholder: 'marie.dupont@exemple.fr', required: true
   = f.submit 'Ajouter comme administrateur', class: 'button primary send'

--- a/app/views/new_administrateur/procedures/_informations.html.haml
+++ b/app/views/new_administrateur/procedures/_informations.html.haml
@@ -23,13 +23,13 @@
 - if !@procedure.locked?
   %h3.header-subsection Conservation des données
   = f.label :duree_conservation_dossiers_dans_ds do
-    Sur demarches-simplifiees.fr
+    Sur #{APPLICATION_NAME}
     %span.mandatory *
   %p.notice (durée en mois après le début de l’instruction)
   = f.number_field :duree_conservation_dossiers_dans_ds, class: 'form-control', placeholder: '6', required: true
 
   = f.label :duree_conservation_dossiers_hors_ds do
-    Hors demarches-simplifiees.fr
+    Hors #{APPLICATION_NAME}
     %span.mandatory *
   %p.notice (durée en mois après la fin de l'instruction)
   = f.number_field :duree_conservation_dossiers_hors_ds, class: 'form-control', placeholder: '6', required: true
@@ -103,7 +103,7 @@
     = f.label :web_hook_url do
       Lien de rappel HTTP (webhook)
     %p.notice
-      Vous pouvez définir un lien de rappel HTTP (aussi appelé webhook) pour notifier un service tiers du changement de l'état d’un dossier de cette démarche sur demarches-simplifiees.fr.
+      Vous pouvez définir un lien de rappel HTTP (aussi appelé webhook) pour notifier un service tiers du changement de l'état d’un dossier de cette démarche sur #{APPLICATION_NAME}.
       = link_to("Consulter la documentation du webhook", WEBHOOK_DOC_URL, target: "_blank", rel: "noopener")
     = f.text_field :web_hook_url, class: 'form-control', placeholder: 'https://callback.exemple.fr/'
 

--- a/app/views/new_administrateur/procedures/_monavis.html.haml
+++ b/app/views/new_administrateur/procedures/_monavis.html.haml
@@ -5,8 +5,8 @@
   %br
   %br
   Vous pouvez
-  %a{ :href => "https://doc.demarches-simplifiees.fr/tutoriels/integration-du-bouton-mon-avis" } consulter notre tutoriel complet
-  pour intégrer le bouton « MonAvis » sur demarches-simplifiees.fr.
+  %a{ :href => DOC_INTEGRATION_MONAVIS_URL } consulter notre tutoriel complet
+  pour intégrer le bouton « MonAvis » sur #{APPLICATION_NAME}.
   %br
   %br
   Une fois en possession du code généré sur le site MonAvis, vous pouvez le coller dans le champ ci-dessous :

--- a/app/views/root/_footer.html.haml
+++ b/app/views/root/_footer.html.haml
@@ -22,7 +22,9 @@
           %li.footer-link
             = link_to "Newsletter", "https://my.sendinblue.com/users/subscribe/js_id/3s2q1/id/1", :title => "Notre newsletter", :class => "footer-link", :target => "_blank", rel: "noopener"
           %li.footer-link
+            -# haml-lint:disable ApplicationNameLinter
             = link_to "Nouveautés", "https://github.com/betagouv/demarches-simplifiees.fr/releases", :class => "footer-link", :title => "Nos nouveautés"
+            -# haml-lint:enable ApplicationNameLinter
           %li.footer-link
             = link_to "Statistiques", stats_path, :class => "footer-link"
           %li.footer-link

--- a/app/views/root/administration.html.haml
+++ b/app/views/root/administration.html.haml
@@ -137,7 +137,7 @@
   - cache "numbers-panel", :expires_in => 3.hours do
     .landing-panel.numbers-panel
       .container
-        %h2.landing-panel-title demarches-simplifiees.fr en chiffres
+        %h2.landing-panel-title #{APPLICATION_NAME} en chiffres
         %ul.numbers
           %li.number
             .number-value
@@ -163,7 +163,7 @@
 
   .landing-panel.users-panel
     .container
-      %h2.landing-panel-title Ils utilisent déjà demarches-simplifiees.fr
+      %h2.landing-panel-title Ils utilisent déjà #{APPLICATION_NAME}
 
       %ul.users
         %li.user
@@ -211,10 +211,12 @@
       .half
         %h1.cta-panel-title Vous voulez en savoir plus ?
         %p.cta-panel-explanation Participez à notre prochain Webinaire
+        -# haml-lint:disable ApplicationNameLinter
         = link_to "Inscription à notre webinaire",
           "https://app.livestorm.co/demarches-simplifiees/presentation-general-de-demarches-simplifieesfr",
           target: "_blank",
           class: "cta-panel-button-blue"
+        -# haml-lint:enable ApplicationNameLinter
 
       .clearfix
 

--- a/app/views/root/landing.html.haml
+++ b/app/views/root/landing.html.haml
@@ -39,7 +39,7 @@
   - cache "numbers-panel", :expires_in => 3.hours do
     .landing-panel
       .container
-        %h2.landing-panel-title demarches-simplifiees.fr en chiffres
+        %h2.landing-panel-title #{APPLICATION_NAME} en chiffres
         %ul.numbers
           %li.number
             .number-value

--- a/app/views/shared/champs/siret/_etablissement.html.haml
+++ b/app/views/shared/champs/siret/_etablissement.html.haml
@@ -4,7 +4,7 @@
 
 - when :not_found
   Nous n’avons pas trouvé d’établissement correspondant à ce numéro de SIRET.
-  = link_to('Plus d’informations', "https://faq.demarches-simplifiees.fr/article/4-erreur-siret", target: '_blank', rel: 'noopener')
+  = link_to('Plus d’informations', FAQ_ERREUR_SIRET_URL, target: '_blank', rel: 'noopener')
 
 - when :network_error
   = t('errors.messages.siret_network_error')

--- a/app/views/shared/dossiers/_lost_attachments.html.haml
+++ b/app/views/shared/dossiers/_lost_attachments.html.haml
@@ -1,4 +1,6 @@
+-# haml-lint:disable ApplicationNameLinter
 - post_mortem_url = 'https://demarches-simplifiees.gitbook.io/articles-demarches-simplifiees-fr/2020/incident-de-production-du-21-janvier-2020'
+-# haml-lint:enable ApplicationNameLinter
 - if profile == 'usager'
   /# Message for Usager
   .card.warning
@@ -6,7 +8,7 @@
     %p
       Suite à un
       = link_to 'incident', post_mortem_url, target: '_blank'
-      survenu le 21 janvier, demarches-simplifiees.fr a perdu par erreur une partie des pièces jointes de votre dossier. L’administration en charge de votre dossier a été prévenue.
+      survenu le 21 janvier, #{APPLICATION_NAME} a perdu par erreur une partie des pièces jointes de votre dossier. L’administration en charge de votre dossier a été prévenue.
 
     - if dossier.read_only?
       %p
@@ -30,7 +32,7 @@
     %p
       Suite à un
       = link_to 'incident', post_mortem_url, target: '_blank'
-      survenu le 21 janvier, demarches-simplifiees.fr a perdu par erreur une partie des pièces jointes de ce dossier.
+      survenu le 21 janvier, #{APPLICATION_NAME} a perdu par erreur une partie des pièces jointes de ce dossier.
 
     - if dossier.read_only?
       %p

--- a/app/views/shared/dossiers/messages/_messagerie_disabled.html.haml
+++ b/app/views/shared/dossiers/messages/_messagerie_disabled.html.haml
@@ -14,7 +14,7 @@
     %p
       = mail_to service.email,
         service.email,
-        subject: "[demarches-simplifiees.fr] Question sur le dossier Nº #{dossier.id} de la démarche Nº #{dossier.procedure.id}",
+        subject: "[#{APPLICATION_NAME}] Question sur le dossier Nº #{dossier.id} de la démarche Nº #{dossier.procedure.id}",
         rel: "noopener noreferrer",
         target: '_blank'
 

--- a/app/views/support/index.html.haml
+++ b/app/views/support/index.html.haml
@@ -41,26 +41,26 @@
             ) sont bien remplis ?
           %p Si vous avez des questions sur les informations à saisir, contactez les services en charge de la démarche.
           %p
-            %a{ href: 'https://faq.demarches-simplifiees.fr/article/12-contacter-le-service-en-charge-de-ma-demarche' }
+            %a{ href: FAQ_CONTACTER_SERVICE_EN_CHARGE_URL }
               En savoir plus
 
       .support.card.featured.hidden{ data: { 'contact-type-only': Helpscout::FormAdapter::TYPE_PERDU } }
         .card-title
           👉 Notre réponse
         .card-content
-          %p Nous vous invitons à contacter l’administration en charge de votre démarche pour qu’elle vous indique le lien à suivre. Celui-ci devrait ressembler à cela : https://www.demarches-simplifiees.fr/commencer/NOM_DE_LA_DEMARCHE .
+          %p Nous vous invitons à contacter l’administration en charge de votre démarche pour qu’elle vous indique le lien à suivre. Celui-ci devrait ressembler à cela : #{APPLICATION_BASE_URL}/commencer/NOM_DE_LA_DEMARCHE .
           %br
           %p Vous pouvez aussi consulter ici la liste de nos démarches les plus frequentes (permis, detr etc) :
           %p
-            %a{ href: 'https://doc.demarches-simplifiees.fr/listes-des-demarches' }
-              https://doc.demarches-simplifiees.fr/listes-des-demarches
+            %a{ href: LISTE_DES_DEMARCHES_URL }
+              = LISTE_DES_DEMARCHES_URL
 
       .support.card.featured.hidden{ data: { 'contact-type-only': Helpscout::FormAdapter::TYPE_INSTRUCTION } }
         .card-title
           👉 Notre réponse
         %p Si vous avez des questions sur l’instruction de votre dossier (par exemple sur les délais), nous vous invitons à contacter directement les services qui instruisent votre dossier par votre messagerie.
         %p
-          %a{ href: 'https://faq.demarches-simplifiees.fr/article/11-je-veux-savoir-ou-en-est-linstruction-de-ma-demarche' }
+          %a{ href: FAQ_OU_EN_EST_MON_DOSSIER_URL }
             En savoir plus
         %br
         %p Si vous souhaitez poser une question pour un problème technique sur le site, utilisez le formulaire ci-dessous. Nous ne pourrons pas vous renseigner sur l'instruction de votre dossier.
@@ -80,7 +80,7 @@
 
         %p
           %strong
-            %a{ href: 'https://demarches-simplifiees.featureupvote.com' }
+            %a{ href: FEATURE_UPVOTE_URL }
               ➡ Accéder au tableau des améliorations
 
       .contact-champ

--- a/app/views/user_mailer/invite_instructeur.html.haml
+++ b/app/views/user_mailer/invite_instructeur.html.haml
@@ -4,7 +4,7 @@
   Bonjour,
 
 %p
-  Vous venez d'être nommé instructeur sur demarches-simplifiees.fr.
+  Vous venez d'être nommé instructeur sur #{APPLICATION_NAME}.
 
 %p
   Votre compte a été créé pour l'adresse email #{@user.email}. Pour l’activer, je vous invite à cliquer sur le lien suivant : 

--- a/app/views/user_mailer/new_account_warning.html.haml
+++ b/app/views/user_mailer/new_account_warning.html.haml
@@ -4,7 +4,7 @@
   Bonjour,
 
 %p
-  Une demande de création de compte a été réalisée sur le site demarches-simplifiees.fr pour l'email #{@user.email}.
+  Une demande de création de compte a été réalisée sur le site #{APPLICATION_NAME} pour l'email #{@user.email}.
 
 %p
   %strong Votre compte existe déjà.

--- a/app/views/users/confirmations/new.html.haml
+++ b/app/views/users/confirmations/new.html.haml
@@ -32,5 +32,5 @@
 
       %p
         Vous pouvez également consulter notre
-        = link_to('FAQ', "https://faq.demarches-simplifiees.fr/article/79-je-ne-recois-pas-demail", target: '_blank', rel: 'noopener')
+        = link_to('FAQ', FAQ_EMAIL_NON_RECU_URL, target: '_blank', rel: 'noopener')
         \.

--- a/app/views/users/dossiers/index.html.haml
+++ b/app/views/users/dossiers/index.html.haml
@@ -74,4 +74,4 @@
       %p.empty-text-details
         Pour remplir une démarche, contactez votre administration en lui demandant le lien de la démarche.
         %br
-        Celui ci doit ressembler à https://www.demarches-simplifiees.fr/commencer/xxx.
+        Celui ci doit ressembler à #{APPLICATION_BASE_URL}/commencer/xxx.

--- a/app/views/users/profil/show.html.haml
+++ b/app/views/users/profil/show.html.haml
@@ -26,7 +26,7 @@
   - if current_administrateur.present?
     .card
       .card-title Jeton d’identification de l’API (token)
-      %p Ce jeton est nécessaire pour effectuer des appels vers l’API de demarches-simplifiees.fr.
+      %p Ce jeton est nécessaire pour effectuer des appels vers l’API de #{APPLICATION_NAME}.
 
       - if defined?(@token)
         %p Jeton : <b>#{@token}</b>

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -3,7 +3,7 @@
 .auth-form
   = devise_error_messages!
   = form_for resource, url: user_registration_path, html: { class: "form" } do |f|
-    %h1 Créez-vous un compte demarches-simplifiees.fr
+    %h1 Créez-vous un compte #{APPLICATION_NAME}
 
     = f.label :email, "Email (nom@site.com)", id: :user_email_label
     = f.text_field :email, type: :email, autocomplete: 'email', autofocus: true, placeholder: "Votre adresse email", 'aria-describedby': :user_email_label

--- a/app/views/users/sessions/link_sent.html.haml
+++ b/app/views/users/sessions/link_sent.html.haml
@@ -8,13 +8,13 @@
   %h1 Encore une petite étape :)
 
   %p.mail
-    Ouvrez votre boite email <b>#{@email}</b> puis cliquez sur le lien d'activation du message <b>Connexion sécurisée à demarches-simplifiees.fr</b>.
+    Ouvrez votre boite email <b>#{@email}</b> puis cliquez sur le lien d'activation du message <b>Connexion sécurisée à #{APPLICATION_NAME}</b>.
     %br
     %br
     <b>Attention</b>, ce message peut mettre jusqu'à <b>15 minutes</b> pour arriver.
 
   %p.help
-    Si vous voyez cette page trop souvent, consultez notre aide : #{link_to 'https://faq.demarches-simplifiees.fr/article/34-je-dois-confirmer-mon-compte-a-chaque-connexion', 'https://faq.demarches-simplifiees.fr/article/34-je-dois-confirmer-mon-compte-a-chaque-connexion', target: '_blank', rel: 'noopener' }
+    Si vous voyez cette page trop souvent, consultez notre aide : #{link_to FAQ_CONFIRMER_COMPTE_CHAQUE_CONNEXION_URL, FAQ_CONFIRMER_COMPTE_CHAQUE_CONNEXION_URL, target: '_blank', rel: 'noopener' }
     %br
     %br
     En cas de difficultés, nous restons joignables

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -28,4 +28,4 @@
     %span Vous êtes nouveau sur demarches&#8209;simplifiees.fr ?
     %br
     %br
-    = link_to "Trouvez votre démarche", "https://faq.demarches-simplifiees.fr/article/59-comment-trouver-ma-demarche", target: "_blank", class: "button expend secondary"
+    = link_to "Trouvez votre démarche", COMMENT_TROUVER_MA_DEMARCHE_URL, target: "_blank", class: "button expend secondary"

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require File.expand_path('boot', __dir__)
 
 require 'rails/all'
+require_relative 'application_name'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/application_name.rb
+++ b/config/application_name.rb
@@ -1,0 +1,3 @@
+APPLICATION_NAME = ENV.fetch("APPLICATION_NAME", "demarches-simplifiees.fr")
+APPLICATION_SHORTNAME = ENV.fetch("APPLICATION_SHORTNAME", "d-s.fr")
+APPLICATION_BASE_URL = ENV.fetch("APPLICATION_BASE_URL", "https://www.demarches-simplifiees.fr")

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -26,7 +26,9 @@ shared_dirs = [
 
 set :domain, ENV.fetch('domain')
 set :deploy_to, deploy_to
+# rubocop:disable DS/ApplicationName
 set :repository, 'https://github.com/betagouv/demarches-simplifiees.fr.git'
+# rubocop:enable DS/ApplicationName
 set :branch, ENV.fetch('branch')
 set :forward_agent, true
 set :user, 'ds'

--- a/config/env.example
+++ b/config/env.example
@@ -10,6 +10,11 @@ APP_NAME="tps_local"
 #   * pour de la prod: www.demarches-simplifiees.fr
 APP_HOST="localhost:3000"
 
+# Les paramètres pour l'affichage du nom l'application, et pour la génération des liens
+APPLICATION_NAME="demarches-simplifiees.fr"
+APPLICATION_SHORTNAME="d-s.fr"
+APPLICATION_BASE_URL="https://www.demarches-simplifiees.fr"
+
 # Utilisé pour les logs LogRage
 SOURCE="tps_local"
 

--- a/config/env.example
+++ b/config/env.example
@@ -10,11 +10,6 @@ APP_NAME="tps_local"
 #   * pour de la prod: www.demarches-simplifiees.fr
 APP_HOST="localhost:3000"
 
-# Les paramètres pour l'affichage du nom l'application, et pour la génération des liens
-APPLICATION_NAME="demarches-simplifiees.fr"
-APPLICATION_SHORTNAME="d-s.fr"
-APPLICATION_BASE_URL="https://www.demarches-simplifiees.fr"
-
 # Utilisé pour les logs LogRage
 SOURCE="tps_local"
 

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -1,5 +1,10 @@
 
 # Variables d'environnement optionnelles
 
+# Les paramètres pour l'affichage du nom l'application, et pour la génération des liens
+APPLICATION_NAME="demarches-simplifiees.fr"
+APPLICATION_SHORTNAME="d-s.fr"
+APPLICATION_BASE_URL="https://www.demarches-simplifiees.fr"
+
 # Personnalisation d'instance - Page externe "Disponibilité" (status page)
 # STATUS_PAGE_URL=""

--- a/config/initializers/contacts.rb
+++ b/config/initializers/contacts.rb
@@ -1,3 +1,5 @@
+# rubocop:disable DS/ApplicationName
+# todo: will be externally configurable
 if !defined?(CONTACT_EMAIL)
   CONTACT_EMAIL = "contact@demarches-simplifiees.fr"
   EQUIPE_EMAIL = "equipe@demarches-simplifiees.fr"
@@ -7,3 +9,4 @@ if !defined?(CONTACT_EMAIL)
 
   OLD_CONTACT_EMAIL = "contact@tps.apientreprise.fr"
 end
+# rubocop:enable DS/ApplicationName

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,3 +1,4 @@
+# rubocop:disable DS/ApplicationName
 Rails.application.config.content_security_policy do |policy|
   # Whitelist image
   policy.img_src :self, "*.openstreetmap.org", "static.demarches-simplifiees.fr", "*.cloud.ovh.net", "stats.data.gouv.fr", "*", :data, :blob
@@ -20,3 +21,4 @@ Rails.application.config.content_security_policy do |policy|
     policy.connect_src(*policy.connect_src, "ws://localhost:3035", "http://localhost:3035")
   end
 end
+# rubocop:enable DS/ApplicationName

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -13,7 +13,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "demarches-simplifiees.fr <#{CONTACT_EMAIL}>"
+  config.mailer_sender = "#{APPLICATION_NAME} <#{CONTACT_EMAIL}>"
 
   # Configure the class responsible to send e-mails.
   config.mailer = 'DeviseUserMailer'

--- a/config/initializers/graphql.rb
+++ b/config/initializers/graphql.rb
@@ -5,7 +5,7 @@ GraphQL::RailsLogger.configure do |config|
 end
 
 GraphqlPlayground::Rails.configure do |config|
-  config.title = "demarches-simplifiees.fr"
+  config.title = APPLICATION_NAME
   config.settings = {
     "schema.polling.enable": false
   }

--- a/config/initializers/typhoeus.rb
+++ b/config/initializers/typhoeus.rb
@@ -1,1 +1,1 @@
-Typhoeus::Config.user_agent = "demarches-simplifiees.fr"
+Typhoeus::Config.user_agent = APPLICATION_NAME

--- a/config/initializers/urls.rb
+++ b/config/initializers/urls.rb
@@ -6,25 +6,37 @@ PIPEDRIVE_API_URL = ENV.fetch("PIPEDRIVE_API_URL", "https://api.pipedrive.com/v1
 SENDINBLUE_API_URL = ENV.fetch("SENDINBLUE_API_URL", "https://in-automate.sendinblue.com/api/v2")
 SENDINBLUE_API_V3_URL = ENV.fetch("SENDINBLUE_API_V3_URL", "https://api.sendinblue.com/v3")
 UNIVERSIGN_API_URL = ENV.fetch("UNIVERSIGN_API_URL", "https://ws.universign.eu/tsa/post/")
+FEATURE_UPVOTE_URL = ENV.fetch("FEATURE_UPVOTE_URL", "https://demarches-simplifiees.featureupvote.com")
 
 # Internal URLs
 FOG_BASE_URL = "https://static.demarches-simplifiees.fr"
 
 # External services URLs
+WEBINAIRE_URL = "https://app.livestorm.co/demarches-simplifiees"
+CALENDLY_URL = "https://calendly.com/demarches-simplifiees/accompagnement-administrateur-demarches-simplifiees-fr"
+
 DOC_URL = "https://doc.demarches-simplifiees.fr"
+DOC_NOUVEAUTES_URL = [DOC_URL, "nouveautes"].join("/")
 ADMINISTRATEUR_TUTORIAL_URL = [DOC_URL, "tutoriels", "tutoriel-administrateur"].join("/")
 INSTRUCTEUR_TUTORIAL_URL = [DOC_URL, "tutoriels", "tutoriel-accompagnateur"].join("/")
 CADRE_JURIDIQUE_URL = [DOC_URL, "tutoriels/video-le-cadre-juridique"].join("/")
-WEBINAIRE_URL = "https://app.livestorm.co/demarches-simplifiees"
 LISTE_DES_DEMARCHES_URL = [DOC_URL, "listes-des-demarches"].join("/")
 CGU_URL = [DOC_URL, "cgu"].join("/")
 MENTIONS_LEGALES_URL = [DOC_URL, "mentions-legales"].join("/")
 API_DOC_URL = [DOC_URL, "pour-aller-plus-loin", "api"].join("/")
 WEBHOOK_DOC_URL = [DOC_URL, "pour-aller-plus-loin", "webhook"].join("/")
 ARCHIVAGE_DOC_URL = [DOC_URL, "pour-aller-plus-loin", "archivage-longue-duree-des-demarches"].join("/")
+DOC_INTEGRATION_MONAVIS_URL = [DOC_URL, "tutoriels", "integration-du-bouton-mon-avis"].join("/")
+
 FAQ_URL = "https://faq.demarches-simplifiees.fr"
 FAQ_ADMIN_URL = [FAQ_URL, "collection", "1-administrateur-creation-dun-formulaire"].join("/")
 FAQ_AUTOSAVE_URL = [FAQ_URL, "article", "77-enregistrer-mon-formulaire-pour-le-reprendre-plus-tard?preview=5ec28ca1042863474d1aee00"].join("/")
 COMMENT_TROUVER_MA_DEMARCHE_URL = [FAQ_URL, "article", "59-comment-trouver-ma-demarche"].join("/")
+FAQ_CONFIRMER_COMPTE_CHAQUE_CONNEXION_URL = [FAQ_URL, "article", "34-je-dois-confirmer-mon-compte-a-chaque-connexion"].join("/")
+FAQ_EMAIL_NON_RECU_URL = [FAQ_URL, "article", "79-je-ne-recois-pas-demail"].join("/")
+FAQ_CONTACTER_SERVICE_EN_CHARGE_URL = [FAQ_URL, "article", "12-contacter-le-service-en-charge-de-ma-demarche"].join("/")
+FAQ_OU_EN_EST_MON_DOSSIER_URL = [FAQ_URL, "article", "11-je-veux-savoir-ou-en-est-linstruction-de-ma-demarche"].join("/")
+FAQ_ERREUR_SIRET_URL = [FAQ_URL, "article", "4-erreur-siret"].join("/")
+
 STATUS_PAGE_URL = ENV.fetch("STATUS_PAGE_URL", "https://status.demarches-simplifiees.fr")
 MATOMO_IFRAME_URL = "https://stats.data.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=fr&&fontColor=333333&fontSize=16px&fontFamily=Muli"

--- a/config/initializers/urls.rb
+++ b/config/initializers/urls.rb
@@ -1,3 +1,4 @@
+# rubocop:disable DS/ApplicationName
 # API URLs
 API_CARTO_URL = ENV.fetch("API_CARTO_URL", "https://sandbox.geo.api.gouv.fr/apicarto")
 API_ENTREPRISE_URL = ENV.fetch("API_ENTREPRISE_URL", "https://entreprise.api.gouv.fr/v2")
@@ -40,3 +41,5 @@ FAQ_ERREUR_SIRET_URL = [FAQ_URL, "article", "4-erreur-siret"].join("/")
 
 STATUS_PAGE_URL = ENV.fetch("STATUS_PAGE_URL", "https://status.demarches-simplifiees.fr")
 MATOMO_IFRAME_URL = "https://stats.data.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=fr&&fontColor=333333&fontSize=16px&fontFamily=Muli"
+
+# rubocop:enable DS/ApplicationName

--- a/lib/cops/application_name.rb
+++ b/lib/cops/application_name.rb
@@ -1,0 +1,17 @@
+if defined?(RuboCop)
+  module RuboCop
+    module Cop
+      module DS
+        class ApplicationName < Cop
+          MSG = "Avoid hardcoding `demarches-simplifiees.fr`. Instead use a dedicated environnement variable."
+
+          def on_str(node)
+            return unless node.source.include?('demarches-simplifiees.fr')
+
+            add_offense(node)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/linters/application_name_linter.rb
+++ b/lib/linters/application_name_linter.rb
@@ -1,0 +1,46 @@
+module HamlLint
+  class Linter::ApplicationNameLinter < Linter
+    include LinterRegistry
+
+    FORBIDDEN = 'demarches-simplifiees.fr'
+    REPLACEMENT = "APPLICATION_NAME"
+    MSG = 'Hardcoding %s is forbidden, use %s instead'
+
+    def visit_tag(node)
+      check(node)
+    end
+
+    def visit_script(node)
+      check(node)
+    end
+
+    def visit_silent_script(node)
+      check(node)
+    end
+
+    def visit_plain(node)
+      check(node)
+    end
+
+    def visit_comment(node)
+      check(node)
+    end
+
+    def visit_haml_comment(node)
+      check(node)
+    end
+
+    def check(node)
+      line = line_text_for_node(node)
+      if line.downcase.include?(FORBIDDEN)
+        record_lint(node, format(MSG, FORBIDDEN, REPLACEMENT))
+      end
+    end
+
+    private
+
+    def line_text_for_node(node)
+      document.source_lines[node.line - 1]
+    end
+  end
+end

--- a/lib/mailers/attestation_closed_mail_discrepancy_mailer.rb
+++ b/lib/mailers/attestation_closed_mail_discrepancy_mailer.rb
@@ -15,7 +15,7 @@ module Mailers
       else
         procedure_ids = 'vos démarches nº ' + procedures.map(&:id).join(', ')
       end
-      "demarches-simplifiees.fr – mise à jour nécessaire de l’accusé d’acceptation de #{procedure_ids}"
+      "#{APPLICATION_NAME} – mise à jour nécessaire de l’accusé d’acceptation de #{procedure_ids}"
     end
 
     def body(procedures)
@@ -24,11 +24,11 @@ module Mailers
 
         Pour des raisons de confidentialité, le mode de transmission des attestations aux usagers évolue.
 
-        À compter du 30 avril, les mails d’accusé d’acceptation émis par demarches-simplifiees.fr ne
+        À compter du 30 avril, les mails d’accusé d’acceptation émis par #{APPLICATION_NAME} ne
         comporteront plus d’attestation en pièce jointe comme c’est le cas aujourd’hui.
 
         À la place, le mail contiendra un lien permettant à l’usager de télécharger son
-        attestation dirctement dans son espace sécurisé sur demarches-simplifiees.fr.
+        attestation dirctement dans son espace sécurisé sur #{APPLICATION_NAME}.
 
         Ce lien de téléchargement est généré par la balise --lien attestation--.
 
@@ -36,7 +36,7 @@ module Mailers
 
         Pour toute question vous pouvez nous joindre par téléphone au #{CONTACT_PHONE}
         ou sur l’adresse email #{CONTACT_EMAIL}.
-        -- \nL’équipe demarches-simplifiees.fr
+        -- \nL’équipe #{APPLICATION_NAME}
       HEREDOC
     end
 

--- a/spec/controllers/instructeurs/avis_controller_spec.rb
+++ b/spec/controllers/instructeurs/avis_controller_spec.rb
@@ -372,7 +372,7 @@ describe Instructeurs::AvisController, type: :controller do
       let(:procedure) { dossier.procedure }
       let!(:avis) { create(:avis, email: invited_email, dossier: dossier) }
       let(:avis_id) { avis.id }
-      let(:password) { 'démarches-simplifiées-pwd' }
+      let(:password) { 'my-s3cure-p4ssword' }
       let(:created_instructeur) { Instructeur.by_email(invited_email) }
       let(:invitations_email) { true }
 

--- a/spec/controllers/manager/administrateurs_controller_spec.rb
+++ b/spec/controllers/manager/administrateurs_controller_spec.rb
@@ -26,7 +26,7 @@ describe Manager::AdministrateursController, type: :controller do
 
   describe 'POST #create' do
     let(:email) { 'plop@plop.com' }
-    let(:password) { 'démarches-simplifiées-pwd' }
+    let(:password) { 'my-s3cure-p4ssword' }
 
     subject { post :create, params: { administrateur: { email: email } } }
 

--- a/spec/controllers/users/registrations_controller_spec.rb
+++ b/spec/controllers/users/registrations_controller_spec.rb
@@ -1,6 +1,6 @@
 describe Users::RegistrationsController, type: :controller do
   let(:email) { 'test@octo.com' }
-  let(:password) { 'démarches-simplifiées-pwd' }
+  let(:password) { 'my-s3cure-p4ssword' }
 
   let(:user) { { email: email, password: password } }
 

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -1,6 +1,6 @@
 describe Users::SessionsController, type: :controller do
   let(:email) { 'unique@plop.com' }
-  let(:password) { 'démarches-simplifiées-pwd' }
+  let(:password) { 'my-s3cure-p4ssword' }
   let(:loged_in_with_france_connect) { User.loged_in_with_france_connects.fetch(:particulier) }
   let!(:user) { create(:user, email: email, password: password, loged_in_with_france_connect: loged_in_with_france_connect) }
 

--- a/spec/factories/administration.rb
+++ b/spec/factories/administration.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   sequence(:administration_email) { |n| "plop#{n}@plop.com" }
   factory :administration do
     email { generate(:administration_email) }
-    password { 'démarches-simplifiées-pwd' }
+    password { 'my-s3cure-p4ssword' }
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   sequence(:user_email) { |n| "user#{n}@user.com" }
   factory :user do
     email { generate(:user_email) }
-    password { 'démarches-simplifiées-pwd' }
+    password { 'my-s3cure-p4ssword' }
     confirmed_at { Time.zone.now }
 
     trait :unconfirmed do

--- a/spec/features/admin/admin_creation_spec.rb
+++ b/spec/features/admin/admin_creation_spec.rb
@@ -16,7 +16,7 @@ feature 'As an administrateur', js: true do
     token_params = confirmation_email.body.match(/token=[^"]+/)
 
     visit "admin/activate?#{token_params}"
-    fill_in :administrateur_password, with: 'démarches-simplifiées-pwd'
+    fill_in :administrateur_password, with: 'my-s3cure-p4ssword'
 
     click_button 'Continuer'
 

--- a/spec/features/instructeurs/expert_spec.rb
+++ b/spec/features/instructeurs/expert_spec.rb
@@ -2,7 +2,7 @@ feature 'Inviting an expert:' do
   include ActiveJob::TestHelper
   include ActionView::Helpers
 
-  let(:instructeur) { create(:instructeur, password: 'démarches-simplifiées-pwd') }
+  let(:instructeur) { create(:instructeur, password: 'my-s3cure-p4ssword') }
   let(:expert) { create(:instructeur, password: expert_password) }
   let(:expert_password) { 'mot de passe d’expert' }
   let(:procedure) { create(:procedure, :published, instructeurs: [instructeur]) }

--- a/spec/features/instructeurs/instructeur_creation_spec.rb
+++ b/spec/features/instructeurs/instructeur_creation_spec.rb
@@ -19,7 +19,7 @@ feature 'As an instructeur', js: true do
     token_params = confirmation_email.body.match(/token=[^"]+/)
 
     visit "users/activate?#{token_params}"
-    fill_in :user_password, with: 'démarches-simplifiées-pwd'
+    fill_in :user_password, with: 'my-s3cure-p4ssword'
 
     click_button 'Définir le mot de passe'
 

--- a/spec/features/instructeurs/instruction_spec.rb
+++ b/spec/features/instructeurs/instruction_spec.rb
@@ -1,7 +1,7 @@
 feature 'Instructing a dossier:' do
   include ActiveJob::TestHelper
 
-  let(:password) { 'démarches-simplifiées-pwd' }
+  let(:password) { 'my-s3cure-p4ssword' }
   let!(:instructeur) { create(:instructeur, password: password) }
 
   let!(:procedure) { create(:procedure, :published, instructeurs: [instructeur]) }

--- a/spec/features/sessions/sign_in_spec.rb
+++ b/spec/features/sessions/sign_in_spec.rb
@@ -1,6 +1,6 @@
 feature 'Signin in:' do
   let!(:user) { create(:user, password: password) }
-  let(:password) { 'démarches-simplifiées-pwd' }
+  let(:password) { 'my-s3cure-p4ssword' }
 
   scenario 'an existing user can sign-in' do
     visit root_path

--- a/spec/features/users/brouillon_spec.rb
+++ b/spec/features/users/brouillon_spec.rb
@@ -1,5 +1,5 @@
 feature 'The user' do
-  let(:password) { 'démarches-simplifiées-pwd' }
+  let(:password) { 'my-s3cure-p4ssword' }
   let!(:user) { create(:user, password: password) }
 
   let!(:procedure) { create(:procedure, :published, :for_individual, :with_all_champs_mandatory) }

--- a/spec/features/users/invite_spec.rb
+++ b/spec/features/users/invite_spec.rb
@@ -26,7 +26,7 @@ feature 'Invitations' do
 
     context 'when inviting someone without an existing account' do
       let(:invite) { create(:invite, dossier: dossier, user: nil) }
-      let(:user_password) { 'démarches-simplifiées-pwd' }
+      let(:user_password) { 'my-s3cure-p4ssword' }
 
       scenario 'an invited user can register using the registration link sent in the invitation email' do
         # Click the invitation link

--- a/spec/features/users/linked_dropdown_spec.rb
+++ b/spec/features/users/linked_dropdown_spec.rb
@@ -1,5 +1,5 @@
 feature 'linked dropdown lists' do
-  let(:password) { 'démarches-simplifiées-pwd' }
+  let(:password) { 'my-s3cure-p4ssword' }
   let!(:user) { create(:user, password: password) }
 
   let(:list_items) do

--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -1,6 +1,6 @@
 feature 'Signing up:' do
   let(:user_email) { generate :user_email }
-  let(:user_password) { 'démarches-simplifiées-pwd' }
+  let(:user_password) { 'my-s3cure-p4ssword' }
   let(:procedure) { create :simple_procedure, :with_service }
 
   scenario 'a new user can sign-up from scratch' do

--- a/spec/models/administrateur_spec.rb
+++ b/spec/models/administrateur_spec.rb
@@ -78,7 +78,7 @@ describe Administrateur, type: :model do
 
   # describe '#password_complexity' do
   #   let(:email) { 'mail@beta.gouv.fr' }
-  #   let(:passwords) { ['pass', '12pass23', 'démarches ', 'démarches-simple', 'démarches-simplifiées-pwd'] }
+  #   let(:passwords) { ['pass', '12pass23', 'démarches ', 'démarches-simple', 'my-s3cure-p4ssword'] }
   #   let(:administrateur) { build(:administrateur, email: email, password: password) }
   #   let(:min_complexity) { PASSWORD_COMPLEXITY_FOR_ADMIN }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,7 +6,7 @@ describe User, type: :model do
     let(:user) do
       create(:user,
         email: email,
-        password: 'démarches-simplifiées-pwd',
+        password: 'my-s3cure-p4ssword',
         confirmation_token: '123',
         confirmed_at: nil)
     end
@@ -125,11 +125,11 @@ describe User, type: :model do
     end
 
     context 'with an existing user' do
-      before { create(:user, email: email, password: 'démarches-simplifiées-pwd') }
+      before { create(:user, email: email, password: 'my-s3cure-p4ssword') }
 
       it 'keeps the previous password' do
         user = subject
-        expect(user.valid_password?('démarches-simplifiées-pwd')).to be true
+        expect(user.valid_password?('my-s3cure-p4ssword')).to be true
         expect(user.instructeur).to be_present
       end
 

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -39,7 +39,7 @@ module FeatureHelpers
     end
   end
 
-  def sign_up_with(email, password = 'démarches-simplifiées-pwd')
+  def sign_up_with(email, password = 'my-s3cure-p4ssword')
     fill_in :user_email, with: email
     fill_in :user_password, with: password
 


### PR DESCRIPTION
Petit nettoyage de l'été ! Il y a des `demarches-simplifiees.fr` en dur un peu partout, et c'est pas fou fou. J'ai fait une passe sur les vues.

À la relecture, on peut sans doute remplacer `APPLICATION_BASE_URL` par `APP_HOST`. 