### PR TITLE
Création d'un toggle-switch

### DIFF
--- a/app/assets/stylesheets/new_design/toggle-switch.scss
+++ b/app/assets/stylesheets/new_design/toggle-switch.scss
@@ -1,0 +1,87 @@
+@import "colors";
+@import "constants";
+
+// Toggle-switch
+// The switch - the box around
+.form label.toggle-switch {
+  position: relative;
+  display: inline-block;
+  height: 24px;
+  margin: 0;
+  margin-right: 0.75rem;
+}
+
+// Hide default HTML checkbox
+.form label.toggle-switch input[type="checkbox"] {
+  opacity: 0;
+  width: 0;
+  height: 0;
+  margin: 0;
+}
+
+// The control
+.toggle-switch-control {
+  position: absolute;
+  width: 47px;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: $border-grey;
+  transition: 0.4s;
+}
+
+.toggle-switch-control::before {
+  position: absolute;
+  content: "";
+  height: 20px;
+  width: 20px;
+  left: 2px;
+  bottom: 2px;
+  background-color: $white;
+  transition: 0.4s;
+}
+
+input:checked + .toggle-switch-control {
+  background-color: $green;
+}
+
+input:focus + .toggle-switch-control {
+  box-shadow: 0 0 1px $green;
+}
+
+input:checked + .toggle-switch-control::before {
+  transform: translateX(23px);
+}
+
+.toggle-switch-label {
+  margin-left: 47px;
+  font-size: 1rem;
+  font-weight: normal;
+}
+
+.toggle-switch-label.on {
+  color: $green;
+}
+
+.toggle-switch-label.off {
+  color: $grey;
+}
+
+.toggle-switch-checkbox:checked ~ .toggle-switch-label.off {
+  display: none;
+}
+
+.toggle-switch-checkbox:not(:checked) ~ .toggle-switch-label.on {
+  display: none;
+}
+
+// Rounded control
+.toggle-switch-control.round {
+  border-radius: 24px;
+}
+
+.toggle-switch-control.round::before {
+  border-radius: 50%;
+}

--- a/app/assets/stylesheets/new_design/toggle-switch.scss
+++ b/app/assets/stylesheets/new_design/toggle-switch.scss
@@ -8,7 +8,7 @@
   display: inline-block;
   height: 24px;
   margin: 0;
-  margin-right: 0.75rem;
+  margin-right: 15px;
 }
 
 // Hide default HTML checkbox
@@ -30,6 +30,7 @@
   bottom: 0;
   background-color: $border-grey;
   transition: 0.4s;
+  border: 1px solid transparent;
 }
 
 .toggle-switch-control::before {
@@ -37,8 +38,8 @@
   content: "";
   height: 20px;
   width: 20px;
-  left: 2px;
-  bottom: 2px;
+  left: 1px;
+  bottom: 1px;
   background-color: $white;
   transition: 0.4s;
 }
@@ -48,7 +49,8 @@ input:checked + .toggle-switch-control {
 }
 
 input:focus + .toggle-switch-control {
-  box-shadow: 0 0 1px $green;
+  border-color: $blue;
+  box-shadow: 0px 0px 2px 1px $blue;
 }
 
 input:checked + .toggle-switch-control::before {
@@ -57,7 +59,7 @@ input:checked + .toggle-switch-control::before {
 
 .toggle-switch-label {
   margin-left: 47px;
-  font-size: 1rem;
+  font-size: 16px;
   font-weight: normal;
 }
 

--- a/app/views/root/patron.html.haml
+++ b/app/views/root/patron.html.haml
@@ -64,6 +64,13 @@
             Option B
             %p.notice Une autre option, pas mal non plus.
 
+        %h3.header-subsection Interrupteur
+        %label.toggle-switch{ tabindex: 0 }
+          = f.check_box :archived, class: 'toggle-switch-checkbox'
+          %span.toggle-switch-control.round
+          %span.toggle-switch-label.on Activé
+          %span.toggle-switch-label.off Désactivé
+
         .send-wrapper
           = f.submit 'Enregistrer un brouillon (formnovalidate)', formnovalidate: true, class: 'button send'
           = f.submit 'Envoyer', class: 'button send primary'

--- a/app/views/root/patron.html.haml
+++ b/app/views/root/patron.html.haml
@@ -65,7 +65,7 @@
             %p.notice Une autre option, pas mal non plus.
 
         %h3.header-subsection Interrupteur
-        %label.toggle-switch{ tabindex: 0 }
+        %label.toggle-switch
           = f.check_box :archived, class: 'toggle-switch-checkbox'
           %span.toggle-switch-control.round
           %span.toggle-switch-label.on Activé


### PR DESCRIPTION
Création d'une checkbox de type toggle-switch, utilisée dans le nouveau design et notamment dans attestation_template/edit.

Il y a également un texte qui s'affiche quand le toggle-switch est "off" et un autre quand il est "off".

Valeur par défaut:
<img width="291" alt="Capture d’écran 2020-07-23 à 11 25 09" src="https://user-images.githubusercontent.com/47247356/88271260-2f310c80-ccd7-11ea-9241-04bb3c4543d3.png">

Une fois coché:
<img width="277" alt="Capture d’écran 2020-07-23 à 11 25 51" src="https://user-images.githubusercontent.com/47247356/88271323-45d76380-ccd7-11ea-8575-4fb4db65279e.png">

Sélectionné:
<img width="214" alt="image" src="https://user-images.githubusercontent.com/47247356/88532763-73891900-d005-11ea-9259-0327db50d718.png">

