### PR TITLE
WHEN IE11 DEPRECATED : added the scroll-padding property for pages with sticky-bottoms

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -132,7 +132,8 @@ linters:
 
   PropertySpelling:
     enabled: true
-    extra_properties: []
+    extra_properties:
+      - scroll-padding
     disabled_properties: []
 
   # To enable later

--- a/app/assets/stylesheets/new_design/layouts.scss
+++ b/app/assets/stylesheets/new_design/layouts.scss
@@ -69,3 +69,6 @@
   bottom: 0;
 }
 
+html.scroll-margins-for-sticky-footer {
+  scroll-padding: 0 0 100px 0;
+}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,5 +1,5 @@
 !!! 5
-%html{ lang: "fr" }
+%html{ lang: "fr", class: yield(:root_class) }
   %head
     %meta{ "http-equiv": "Content-Type", content: "text/html; charset=UTF-8" }
     %meta{ "http-equiv": "X-UA-Compatible", content: "IE=edge" }

--- a/app/views/new_administrateur/attestation_templates/edit.html.haml
+++ b/app/views/new_administrateur/attestation_templates/edit.html.haml
@@ -1,0 +1,56 @@
+- content_for(:root_class, 'scroll-margins-for-sticky-footer')
+
+= render partial: 'new_administrateur/breadcrumbs',
+  locals: { steps: [link_to('Démarches', admin_procedures_path),
+                    link_to(@procedure.libelle, admin_procedure_path(@procedure)),
+                    'Attestation'] }
+
+.procedure-form#attestation-template-edit
+  .procedure-form__columns.container
+    = form_for @attestation_template,
+      url: url_for({ controller: 'new_administrateur/attestation_templates', action: :update, id: @procedure.id }),
+      multipart: true,
+      html: { class: 'form procedure-form__column--form' } do |f|
+
+      %h1.page-title
+        Délivrance d‘attestation
+        - if @attestation_template.activated?
+          %span.text-active activée
+        - else
+          %span.text-inactive désactivée
+
+      - if @attestation_template.activated && @procedure.locked?
+        .card.warning
+          %p L’attestation ne peut plus être désactivée car la démarche est publiée.
+
+      %p.notice
+        L’attestation, si elle est activée, est émise au moment où un dossier est accepté.
+        %br
+        L’email d’accusé d’acceptation envoyé à l’usager comporte alors un lien vers l’attestation ;
+        celle-ci est également disponible au téléchargement depuis l’espace personnel de l’usager.
+
+      = render partial: 'new_administrateur/attestation_templates/informations', locals: { f: f }
+
+      .procedure-form__actions.sticky--bottom
+        .actions-left
+          -# Admins cannot disactivate the Attestation if it is activated and the procedure is published
+          - if !(@attestation_template.activated && @procedure.locked?)
+            %label.toggle-switch
+              = f.check_box :activated, class: 'toggle-switch-checkbox'
+              %span.toggle-switch-control.round
+              %span.toggle-switch-label.on Attestation activée
+              %span.toggle-switch-label.off Attestation désactivée
+
+        .actions-right
+          = link_to 'Annuler', edit_admin_procedure_attestation_template_path(id: @procedure), class: 'button', data: { confirm: 'Êtes-vous sûr de vouloir annuler les modifications effectuées ?'}
+          = f.button 'Enregistrer', class: 'button primary send'
+
+    .procedure-form__column--preview
+      .procedure-form__preview.sticky--top
+        %h3
+          .procedure-form__preview-title
+            Aperçu
+            .notice
+              Cet aperçu est mis à jour après chaque sauvegarde.
+        .procedure-preview
+          = render partial: 'new_administrateur/attestation_templates/apercu', locals: { procedure: @procedure }

--- a/app/views/new_administrateur/procedures/edit.html.haml
+++ b/app/views/new_administrateur/procedures/edit.html.haml
@@ -1,3 +1,5 @@
+- content_for(:root_class, 'scroll-margins-for-sticky-footer')
+
 = render partial: 'new_administrateur/breadcrumbs',
   locals: { steps: [link_to('Démarches', admin_procedures_path),
                     link_to(@procedure.libelle, admin_procedure_path(@procedure)),

--- a/app/views/new_administrateur/procedures/new.html.haml
+++ b/app/views/new_administrateur/procedures/new.html.haml
@@ -1,3 +1,5 @@
+- content_for(:root_class, 'scroll-margins-for-sticky-footer')
+
 = render partial: 'new_administrateur/breadcrumbs',
   locals: { steps: [link_to('Démarches', admin_procedures_path),
                     'Nouvelle'] }

--- a/app/views/users/dossiers/brouillon.html.haml
+++ b/app/views/users/dossiers/brouillon.html.haml
@@ -1,3 +1,4 @@
+- content_for(:root_class, 'scroll-margins-for-sticky-footer')
 - content_for(:title, "Modification du brouillon nº #{@dossier.id} (#{@dossier.procedure.libelle})")
 
 - content_for :footer do


### PR DESCRIPTION
Ajout d'une propriété 'scroll-padding' qui permet, quand on a un sticky-bottom, de remonter la page plus haut afin que les champs séléctionnés au clavier soient situés au-dessus du sticky-bottom, et non cachés par lui, comme actuellement.