### PR TITLE
5288 optim instructeur dashboard

### DIFF
--- a/app/controllers/concerns/create_avis_concern.rb
+++ b/app/controllers/concerns/create_avis_concern.rb
@@ -35,6 +35,7 @@ module CreateAvisConcern
     persisted, failed = create_results.partition(&:persisted?)
 
     if persisted.any?
+      dossier.update!(last_avis_updated_at: Time.zone.now)
       sent_emails_addresses = []
       persisted.each do |avis|
         avis.dossier.demander_un_avis!(avis)

--- a/app/controllers/instructeurs/avis_controller.rb
+++ b/app/controllers/instructeurs/avis_controller.rb
@@ -60,6 +60,7 @@ module Instructeurs
       @commentaire = CommentaireService.build(current_instructeur, avis.dossier, commentaire_params)
 
       if @commentaire.save
+        @commentaire.dossier.update!(last_commentaire_updated_at: Time.zone.now)
         flash.notice = "Message envoyé"
         redirect_to messagerie_instructeur_avis_path(avis.procedure, avis)
       else

--- a/app/controllers/instructeurs/avis_controller.rb
+++ b/app/controllers/instructeurs/avis_controller.rb
@@ -44,6 +44,7 @@ module Instructeurs
     def update
       if @avis.update(avis_params)
         flash.notice = 'Votre réponse est enregistrée.'
+        @avis.dossier.update!(last_avis_updated_at: Time.zone.now)
         redirect_to instruction_instructeur_avis_path(@avis.procedure, @avis)
       else
         flash.now.alert = @avis.errors.full_messages

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -192,7 +192,11 @@ module Instructeurs
 
     def update_annotations
       dossier = current_instructeur.dossiers.includes(champs_private: :type_de_champ).find(params[:dossier_id])
-      dossier.update(champs_private_params)
+      dossier.assign_attributes(champs_private_params)
+      if dossier.champs_private.any?(&:changed?)
+        dossier.last_champ_private_updated_at = Time.zone.now
+      end
+      dossier.save
       dossier.modifier_annotations!(current_instructeur)
       redirect_to annotations_privees_instructeur_dossier_path(procedure, dossier)
     end

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -169,6 +169,7 @@ module Instructeurs
       @commentaire = CommentaireService.build(current_instructeur, dossier, commentaire_params)
 
       if @commentaire.save
+        @commentaire.dossier.update!(last_commentaire_updated_at: Time.zone.now)
         current_instructeur.follow(dossier)
         flash.notice = "Message envoyé"
         redirect_to messagerie_instructeur_dossier_path(procedure, dossier)

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -197,7 +197,7 @@ module Instructeurs
         dossier.last_champ_private_updated_at = Time.zone.now
       end
       dossier.save
-      dossier.modifier_annotations!(current_instructeur)
+      dossier.log_modifier_annotations!(current_instructeur)
       redirect_to annotations_privees_instructeur_dossier_path(procedure, dossier)
     end
 

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -345,7 +345,11 @@ module Users
       errors = []
 
       if champs_params[:dossier]
-        if !@dossier.update(champs_params[:dossier])
+        @dossier.assign_attributes(champs_params[:dossier])
+        if @dossier.champs.any?(&:changed?)
+          @dossier.last_champ_updated_at = Time.zone.now
+        end
+        if !@dossier.save
           errors += @dossier.errors.full_messages
         elsif change_groupe_instructeur?
           groupe_instructeur = @dossier.procedure.groupe_instructeurs.find(params[:dossier][:groupe_instructeur_id])

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -198,6 +198,7 @@ module Users
       @commentaire = CommentaireService.build(current_user, dossier, commentaire_params)
 
       if @commentaire.save
+        @commentaire.dossier.update!(last_commentaire_updated_at: Time.zone.now)
         dossier.followers_instructeurs
           .with_instant_email_message_notifications
           .each do |instructeur|

--- a/app/jobs/tmp_set_dossiers_last_updated_at_job.rb
+++ b/app/jobs/tmp_set_dossiers_last_updated_at_job.rb
@@ -1,0 +1,27 @@
+class TmpSetDossiersLastUpdatedAtJob < ApplicationJob
+  def perform(except)
+    dossiers = Dossier.where
+      .not(id: except)
+      .where(last_champ_updated_at: nil)
+      .includes(:champs, :avis, :commentaires)
+      .limit(100)
+
+    dossiers.find_each do |dossier|
+      last_commentaire_updated_at = dossier.commentaires.maximum(:updated_at)
+      last_avis_updated_at = dossier.avis.maximum(:updated_at)
+      last_champ_updated_at = dossier.champs.maximum(:updated_at)
+      last_champ_private_updated_at = dossier.champs_private.maximum(:updated_at)
+      dossier.update_columns(
+        last_commentaire_updated_at: last_commentaire_updated_at,
+        last_avis_updated_at: last_avis_updated_at,
+        last_champ_updated_at: last_champ_updated_at,
+        last_champ_private_updated_at: last_champ_private_updated_at
+      )
+      except << dossier.id
+    end
+
+    if dossiers.where.not(id: except).exists?
+      TmpSetDossiersLastUpdatedAtJob.perform_later(except)
+    end
+  end
+end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -615,7 +615,7 @@ class Dossier < ApplicationRecord
       end
   end
 
-  def modifier_annotations!(instructeur)
+  def log_modifier_annotations!(instructeur)
     champs_private.filter(&:value_previously_changed?).each do |champ|
       log_dossier_operation(instructeur, :modifier_annotation, champ)
     end

--- a/db/migrate/20200722135121_add_dossiers_latest_updates_to_dossiers.rb
+++ b/db/migrate/20200722135121_add_dossiers_latest_updates_to_dossiers.rb
@@ -1,0 +1,8 @@
+class AddDossiersLatestUpdatesToDossiers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :dossiers, :last_champ_updated_at, :datetime
+    add_column :dossiers, :last_champ_private_updated_at, :datetime
+    add_column :dossiers, :last_avis_updated_at, :datetime
+    add_column :dossiers, :last_commentaire_updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_15_143010) do
+ActiveRecord::Schema.define(version: 2020_07_22_135121) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -260,6 +260,10 @@ ActiveRecord::Schema.define(version: 2020_07_15_143010) do
     t.bigint "revision_id"
     t.index "to_tsvector('french'::regconfig, (search_terms || private_search_terms))", name: "index_dossiers_on_search_terms_private_search_terms", using: :gin
     t.index "to_tsvector('french'::regconfig, search_terms)", name: "index_dossiers_on_search_terms", using: :gin
+    t.datetime "last_champ_updated_at"
+    t.datetime "last_champ_private_updated_at"
+    t.datetime "last_avis_updated_at"
+    t.datetime "last_commentaire_updated_at"
     t.index ["archived"], name: "index_dossiers_on_archived"
     t.index ["groupe_instructeur_id"], name: "index_dossiers_on_groupe_instructeur_id"
     t.index ["hidden_at"], name: "index_dossiers_on_hidden_at"

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -584,9 +584,26 @@ describe Instructeurs::DossiersController, type: :controller do
       create(:dossier, :en_construction, procedure: procedure, champs_private: [champ_multiple_drop_down_list, champ_linked_drop_down_list, champ_datetime, champ_repetition])
     end
 
+    let(:now) { Time.zone.parse('01/01/2100') }
+
     before do
-      patch :update_annotations, params: {
-        procedure_id: procedure.id,
+      Timecop.freeze(now)
+      patch :update_annotations, params: params
+
+      champ_multiple_drop_down_list.reload
+      champ_linked_drop_down_list.reload
+      champ_datetime.reload
+      champ_repetition.reload
+    end
+
+    after do
+      Timecop.return
+    end
+
+    context "with new values for champs_private" do
+      let(:params) do
+        {
+          procedure_id: procedure.id,
         dossier_id: dossier.id,
         dossier: {
           champs_private_attributes: {
@@ -616,20 +633,36 @@ describe Instructeurs::DossiersController, type: :controller do
             }
           }
         }
-      }
-
-      champ_multiple_drop_down_list.reload
-      champ_linked_drop_down_list.reload
-      champ_datetime.reload
-      champ_repetition.reload
+        }
+      end
+      it { expect(champ_multiple_drop_down_list.value).to eq('["un", "deux"]') }
+      it { expect(champ_linked_drop_down_list.primary_value).to eq('primary') }
+      it { expect(champ_linked_drop_down_list.secondary_value).to eq('secondary') }
+      it { expect(champ_datetime.value).to eq('21/12/2019 13:17') }
+      it { expect(champ_repetition.champs.first.value).to eq('text') }
+      it { expect(dossier.reload.last_champ_private_updated_at).to eq(now) }
+      it { expect(response).to redirect_to(annotations_privees_instructeur_dossier_path(dossier.procedure, dossier)) }
     end
 
-    it { expect(champ_multiple_drop_down_list.value).to eq('["un", "deux"]') }
-    it { expect(champ_linked_drop_down_list.primary_value).to eq('primary') }
-    it { expect(champ_linked_drop_down_list.secondary_value).to eq('secondary') }
-    it { expect(champ_datetime.value).to eq('21/12/2019 13:17') }
-    it { expect(champ_repetition.champs.first.value).to eq('text') }
-    it { expect(response).to redirect_to(annotations_privees_instructeur_dossier_path(dossier.procedure, dossier)) }
+    context "without new values for champs_private" do
+      let(:params) do
+        {
+          procedure_id: procedure.id,
+        dossier_id: dossier.id,
+        dossier: {
+          champs_private_attributes: {},
+          champs_attributes: {
+            '0': {
+              id: champ_multiple_drop_down_list.id,
+              value: ['', 'un', 'deux']
+            }
+          }
+        }
+        }
+      end
+      it { expect(dossier.reload.last_champ_private_updated_at).to eq(nil) }
+      it { expect(response).to redirect_to(annotations_privees_instructeur_dossier_path(dossier.procedure, dossier)) }
+    end
   end
 
   describe "#telecharger_pjs" do

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -464,6 +464,7 @@ describe Instructeurs::DossiersController, type: :controller do
       it { expect(response).to render_template :avis }
       it { expect(flash.alert).to eq(["emaila.com : Email n'est pas valide"]) }
       it { expect { subject }.not_to change(Avis, :count) }
+      it { expect(dossier.last_avis_updated_at).to eq(nil) }
     end
 
     context 'with multiple emails' do

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -390,6 +390,7 @@ describe Instructeurs::DossiersController, type: :controller do
     let(:body) { "avant\napres" }
     let(:file) { fixture_file_upload('spec/fixtures/files/piece_justificative_0.pdf', 'application/pdf') }
     let(:scan_result) { true }
+    let(:now) { Timecop.freeze("09/11/1989") }
 
     subject {
       post :create_commentaire, params: {
@@ -404,7 +405,10 @@ describe Instructeurs::DossiersController, type: :controller do
 
     before do
       allow(ClamavService).to receive(:safe_file?).and_return(scan_result)
+      Timecop.freeze(now)
     end
+
+    after { Timecop.return }
 
     it "creates a commentaire" do
       expect { subject }.to change(Commentaire, :count).by(1)
@@ -412,6 +416,7 @@ describe Instructeurs::DossiersController, type: :controller do
 
       expect(response).to redirect_to(messagerie_instructeur_dossier_path(dossier.procedure, dossier))
       expect(flash.notice).to be_present
+      expect(dossier.reload.last_commentaire_updated_at).to eq(now)
     end
 
     context "when the commentaire created with virus file" do

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -378,6 +378,22 @@ describe Users::DossiersController, type: :controller do
         expect(dossier.reload.state).to eq(Dossier.states.fetch(:en_construction))
       end
 
+      context 'without new values for champs' do
+        let(:submit_payload) do
+          {
+            id: dossier.id,
+            dossier: {
+              champs_attributes: {}
+            }
+          }
+        end
+
+        it "doesn't set last_champ_updated_at" do
+          subject
+          expect(dossier.reload.last_champ_updated_at).to eq(nil)
+        end
+      end
+
       context 'with instructeurs ok to be notified instantly' do
         let!(:instructeur_with_instant_email_dossier) { create(:instructeur) }
         let!(:instructeur_without_instant_email_dossier) { create(:instructeur) }
@@ -576,6 +592,7 @@ describe Users::DossiersController, type: :controller do
       it 'updates the champs' do
         subject
         expect(first_champ.reload.value).to eq('beautiful value')
+        expect(first_champ.dossier.reload.last_champ_updated_at).to eq(now)
         expect(piece_justificative_champ.reload.piece_justificative_file).to be_attached
       end
 


### PR DESCRIPTION
Première étape de  #5288 : ajoute un cache sur les dates de dernières mises à jour des champs, champs privés, commentaires et avis