### PR TITLE
#5440 - Allow to disable France-Connect

### DIFF
--- a/app/controllers/france_connect/particulier_controller.rb
+++ b/app/controllers/france_connect/particulier_controller.rb
@@ -2,7 +2,11 @@ class FranceConnect::ParticulierController < ApplicationController
   before_action :redirect_to_login_if_fc_aborted, only: [:callback]
 
   def login
-    redirect_to FranceConnectService.authorization_uri
+    if FranceConnectService.enabled?
+      redirect_to FranceConnectService.authorization_uri
+    else
+      redirect_to new_user_session_path
+    end
   end
 
   def callback

--- a/app/services/france_connect_service.rb
+++ b/app/services/france_connect_service.rb
@@ -1,4 +1,8 @@
 class FranceConnectService
+  def self.enabled?
+    ENV.fetch("FRANCE_CONNECT_ENABLED", "enabled") == "enabled"
+  end
+
   def self.authorization_uri
     client = FranceConnectParticulierClient.new
 

--- a/app/views/shared/_france_connect_login.html.haml
+++ b/app/views/shared/_france_connect_login.html.haml
@@ -1,11 +1,14 @@
-.france-connect-login
-  %h2
-    = t('views.shared.france_connect_login.title')
-  %p
-    = t('views.shared.france_connect_login.description')
-  .france-connect-login-buttons
-    = link_to t('views.shared.france_connect_login.login_button'), url, class: "france-connect-login-button"
-  .france-connect-help-link
-    = link_to t('views.shared.france_connect_login.help_link'), "https://franceconnect.gouv.fr/", target: "_blank", rel: "noopener", class: "link"
-  .france-connect-login-separator
-    = t('views.shared.france_connect_login.separator')
+- if FranceConnectService.enabled?
+  .france-connect-login
+    %h2
+      = t('views.shared.france_connect_login.title')
+    %p
+      = t('views.shared.france_connect_login.description')
+    .france-connect-login-buttons
+      = link_to t('views.shared.france_connect_login.login_button'), url, class: "france-connect-login-button"
+    .france-connect-help-link
+      = link_to t('views.shared.france_connect_login.help_link'), "https://franceconnect.gouv.fr/", target: "_blank", rel: "noopener", class: "link"
+    .france-connect-login-separator
+      = t('views.shared.france_connect_login.separator')
+- else
+  <!-- FranceConnect is not configured -->

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -6,6 +6,9 @@ APPLICATION_NAME="demarches-simplifiees.fr"
 APPLICATION_SHORTNAME="d-s.fr"
 APPLICATION_BASE_URL="https://www.demarches-simplifiees.fr"
 
+# Utilisation de France Connect
+# FRANCE_CONNECT_ENABLED="disabled" # "enabled" par défaut
+
 # Personnalisation d'instance - Adresses Email de l'application et téléphone
 # CONTACT_EMAIL=""
 # EQUIPE_EMAIL=""


### PR DESCRIPTION
##  Actuellement

Lorsqu'on installe sa propre instance DS (par exemple celle de l'_Adullact_) et si on ne configure pas les variables d'environnements relatives à  **FranceConnect**, alors :
- les boutons **FranceConnect** sont visibles 
  - sur la page `/users/sign_in` 
  - sur les pages `/commencer/une-demarche-exemple` quand l'utilisateur n'est pas connecté
- l'URL de ces boutons provoque une erreur 500 "Internal Server Error" :
  - `/france_connect/particulier` à partir de la page `/users/sign_in` 
  - `/commencer/une-demarche-exemple/france_connect` à partir de la page `/commencer/une-demarche-exemple`


```ruby
Started GET "/france_connect/particulier" 
Processing by FranceConnect::ParticulierController#login as HTML
Completed 500 Internal Server Error in 2ms (ActiveRecord: 0.0ms | Allocations: 3840)

    'identifier' required. excluded from capture: DSN not set
    AttrRequired::AttrMissing ('identifier' required.):
  
    app/models/france_connect_particulier_client.rb:3:in `initialize'
    app/services/france_connect_service.rb:3:in `new'
    app/services/france_connect_service.rb:3:in `authorization_uri'
    app/controllers/france_connect/particulier_controller.rb:6:in `login'
```

## Comportement attendu

Si on ne configure pas les variables d'environnements relatives à  **FranceConnect** ou si une variable d'environnement complémentaire pour désactiver **FranceConnect** est utilisée alors :
- les boutons **FranceConnect** ne sont plus visibles 
- l'URL `/france_connect/particulier`  redirige vers la page `/users/sign_in` 


## Implémentation

Ajout d'une variable d'environnement optionnelle dans le fichier  [config/env.example.optional](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/config/env.example.optional) : 
`FRANCE_CONNECT_ENABLED` pour désactiver **FranceConnect**.


### Détails du comportement attendu

- les boutons **FranceConnect** s'affichent et se comportent normalement :
  -  si le fichier `.env` ne contient pas la variable `FRANCE_CONNECT_ENABLED`
  -  si le fichier `.env` contient `FRANCE_CONNECT_ENABLED="enabled"`
- les boutons **FranceConnect** ne s'affichent pas et l'URL `/france_connect/particulier`  redirige vers la page `/users/sign_in`  :
  -  si le fichier `.env` contient `FRANCE_CONNECT_ENABLED="disabled"`
  -  si le fichier `.env` contient `FRANCE_CONNECT_ENABLED="nimportequoi"`

-------------
Fixed #5440