### PR TITLE
models: render attestations in a simpler way

### DIFF
--- a/app/models/attestation_template.rb
+++ b/app/models/attestation_template.rb
@@ -109,8 +109,11 @@ class AttestationTemplate < ApplicationRecord
 
   def build_pdf(dossier)
     attestation = render_attributes_for(dossier: dossier)
-    action_view = ActionView::Base.new(ActionController::Base.view_paths, attestation: attestation)
-    attestation_view = action_view.render(file: 'new_administrateur/attestation_templates/show', formats: [:pdf])
+    attestation_view = ApplicationController.render(
+      file: 'new_administrateur/attestation_templates/show',
+      formats: :pdf,
+      assigns: { attestation: attestation }
+    )
 
     StringIO.new(attestation_view)
   end

--- a/spec/models/attestation_template_spec.rb
+++ b/spec/models/attestation_template_spec.rb
@@ -122,12 +122,11 @@ describe AttestationTemplate, type: :model do
     end
 
     let(:view_args) do
-      original_new = ActionView::Base.method(:new)
       arguments = nil
 
-      allow(ActionView::Base).to receive(:new) do |paths, args|
-        arguments = args
-        original_new.call(paths, args)
+      allow(ApplicationController).to receive(:render).and_wrap_original do |m, *args|
+        arguments = args.first[:assigns]
+        m.call(*args)
       end
 
       attestation_template.attestation_for(dossier)
@@ -162,10 +161,14 @@ describe AttestationTemplate, type: :model do
               .update(value: 'libelle2')
           end
 
-          it do
+          it 'passes the correct parameters to the view' do
             expect(view_args[:attestation][:title]).to eq('title libelle1')
             expect(view_args[:attestation][:body]).to eq('body libelle2')
+          end
+
+          it 'generates an attestation' do
             expect(attestation.title).to eq('title libelle1')
+            expect(attestation.pdf).to be_attached
           end
         end
       end


### PR DESCRIPTION
The older method of instantiating an entire new rendering stack can be made simpler using Rails >= 5.0 methods.

It also seems more stable, and fixes intermittent ActionView crashes seen in production.

See https://api.rubyonrails.org/classes/ActionController/Renderer.html#method-i-render