### PR TITLE
Configuration Rails 5.1 par défaut

### DIFF
--- a/app/views/admin/instructeurs/index.html.haml
+++ b/app/views/admin/instructeurs/index.html.haml
@@ -18,7 +18,7 @@
   .col-xs-6
     %h3 Ajouter un instructeur
     #procedure_new.section.section-label
-      = form_with url: { controller: 'admin/instructeurs', action: :create } do
+      = form_with url: { controller: 'admin/instructeurs', action: :create }, local: true do
         .row
           .col-xs-5
             = render partial: 'admin/instructeurs/informations'

--- a/app/views/new_administrateur/procedures/jeton.html.haml
+++ b/app/views/new_administrateur/procedures/jeton.html.haml
@@ -9,7 +9,7 @@
 
 .container
   %h1
-  = form_with model: @procedure, url: url_for({ controller: 'new_administrateur/procedures', action: :update_jeton }), html: { class: 'form' } do |f|
+  = form_with model: @procedure, url: url_for({ controller: 'new_administrateur/procedures', action: :update_jeton }), local: true, html: { class: 'form' } do |f|
     %p.explication
       Démarches Simplifiées utilise
       = link_to 'API Entreprise', "https://entreprise.api.gouv.fr/"

--- a/app/views/new_administrateur/services/_form.html.haml
+++ b/app/views/new_administrateur/services/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with model: [ :admin, service] , html: { class: 'form' } do |f|
+= form_with model: [ :admin, service], local: true, html: { class: 'form' } do |f|
 
   = f.label :nom do
     Nom

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,8 @@ Dotenv::Railtie.load
 
 module TPS
   class Application < Rails::Application
-    config.load_defaults 5.0
+    config.load_defaults 5.1
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
Cette PR active les réglages par défaut de Rails 5.1.

Voir https://guides.rubyonrails.org/configuring.html#for-5-1-new-defaults-from-previous-versions-below-and