### PR TITLE
Nettoyage des chemins de chargement de Rails

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,8 +31,6 @@ module TPS
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
     config.i18n.available_locales = [:fr]
 
-    config.paths.add "#{config.root}/lib", eager_load: true
-
     config.assets.paths << Rails.root.join('app', 'assets', 'javascript')
     config.assets.paths << Rails.root.join('app', 'assets', 'fonts')
     config.assets.precompile += ['.woff']

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,6 @@ module TPS
     config.i18n.available_locales = [:fr]
 
     config.paths.add "#{config.root}/lib", eager_load: true
-    config.paths.add "#{config.root}/app/controllers/concerns", eager_load: true
 
     config.assets.paths << Rails.root.join('app', 'assets', 'javascript')
     config.assets.paths << Rails.root.join('app', 'assets', 'fonts')


### PR DESCRIPTION
Par défaut Rails pré-charge (et recharge automatiquement en cas de changements) [certains chemins](https://guides.rubyonrails.org/autoloading_and_reloading_constants_classic_mode.html#autoload-paths-and-eager-load-paths).

On a customisé ces chemins, mais ça serait bien qu'on se rapproche du setup Rails par défaut.

Or sur les deux chemins customisés:

- Un ne devrait pas être là
- L'autre est déjà inclus dans Rails par défaut

On doit donc pouvoir enlever les deux.