### PR TITLE
#5450 - Fix for using APPLICATION_NAME in .env file

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,13 +1,13 @@
 require File.expand_path('boot', __dir__)
 
 require 'rails/all'
-require_relative 'application_name'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
 Dotenv::Railtie.load
+require_relative 'application_name'
 
 module TPS
   class Application < Rails::Application


### PR DESCRIPTION
##  Actuellement

Depuis la PR #5405  _"Rendre le nom d'application paramétrable"_, il est possible de configurer le nom de l'application via  une variable d'environnement optionnelle APPLICATION_NAME à rajouter dans le fichier `.env`.

### Variables dans le fichier `.env` 
En ce basant sur le fichier [config/env.example.optional](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/config/env.example.optional), nous avons rajouté dans notre fichier `.env` les 3 lignes suivantes :

```bash
# Les paramètres pour l'affichage du nom l'application, et pour la génération des liens
APPLICATION_NAME="ds-adullact.local"
APPLICATION_SHORTNAME="d-a.lo"
APPLICATION_BASE_URL="https://ds-adullact.local"
```

Après redémarrage du serveur Puma,  ces modifications ne sont pas prises en compte : 
- la balise HTML  `title` ne contient pas ce nouveau nom, mais celui par défaut ;
- l'entête  de la page ne contient pas ce nouveau nom, mais celui par défaut.

### Modification des valeurs par défauts

Si on modifie directement les valeurs par défauts dans le fichier [config/application_name.rb](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/config/application_name.rb), après redémarrage du serveur Puma,  ces modifications sont prises en compte : 
- la balise HTML  `title`  contient bien ce nouveau nom ;
- l'entête  de la page contient bien ce nouveau nom.

```diff
- APPLICATION_NAME = ENV.fetch("APPLICATION_NAME", "demarches-simplifiees.fr")
- APPLICATION_SHORTNAME = ENV.fetch("APPLICATION_SHORTNAME", "d-s.fr")
- APPLICATION_BASE_URL = ENV.fetch("APPLICATION_BASE_URL", "https://www.demarches-simplifiees.fr")
+ APPLICATION_NAME = ENV.fetch("APPLICATION_NAME", "ds-poc.local")
+ APPLICATION_SHORTNAME = ENV.fetch("APPLICATION_SHORTNAME", "d-p.lo")
+ APPLICATION_BASE_URL = ENV.fetch("APPLICATION_BASE_URL", "https://ds-poc.local")
```


## Comportement attendu

En ce basant sur le fichier [config/env.example.optional](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/config/env.example.optional), l'ajout dans le fichier `.env` des 3 lignes suivantes est pris en compte après redémarrage du serveur Puma :
- la balise HTML  `title`  contient bien ce nouveau nom ;
- l'entête  de la page contient bien ce nouveau nom.
- ...

```bash
# Les paramètres pour l'affichage du nom l'application, et pour la génération des liens
APPLICATION_NAME="ds-adullact.local"
APPLICATION_SHORTNAME="d-a.lo"
APPLICATION_BASE_URL="https://ds-adullact.local"
```

## Analyse du problème

Dans le fichier [`config/application.rb`](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/config/application.rb#L4), la ligne (n°4) suivante n'a pas encore accès aux variables d'environnements du fichier `.env` :

```ruby
require_relative 'application_name'
```

En revanche, les variables d'environnements du fichier `.env`  sont disponibles juste après la [ligne 10 du fichier `config/application.rb`](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/config/application.rb#L10) :

```ruby
Dotenv::Railtie.load
```

Le message de commit 3340a2b091318f0cdedd4a15a3cc25265099808e de @Keirua  donnent quelques informations complémentaires :

>  ajout du nom d'application tot au demarrage
> 
> The application name is used in the views, but also in the initializers and in the config/ directory
> 
> According to rails doc (https://guides.rubyonrails.org/v6.0/configuring.html#locations-for-initialization-code),
> if we want to do some things before the initializers and the environment, the only place to do so is in config/application.rb


## Correctif proposé

```diff
 require File.expand_path('boot', __dir__)
 
 require 'rails/all'
-require_relative 'application_name'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
 Dotenv::Railtie.load
+require_relative 'application_name'
 
 module TPS
   class Application < Rails::Application
```
- Les 3 constantes définies dans  [config/application_name.rb](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/config/application_name.rb) sont utilisées dans le dossier `config/` uniquement dans le dossier `config/initializers/`.
- Cette modification proposée est bien prise en compte dans les `initializers`.


---------------------
Fixed #5450