### PR TITLE
#5453 - Fix syntax for using APPLICATION_NAME in mailers/layout

### DIFF
--- a/app/views/layouts/mailers/layout.html.erb
+++ b/app/views/layouts/mailers/layout.html.erb
@@ -50,7 +50,7 @@
                       <tr>
                         <td style="word-wrap:break-word;font-size:0px;padding:0;padding-top:0px;padding-bottom:0px;" align="left">
                           <div class="" style="cursor:auto;color:#55575d;font-family:Helvetica, Arial, sans-serif;font-size:11px;text-align:left;">
-                            <img align="middle" alt="Logo #{APPLICATION_NAME}" src="<%= image_url('mailer/instructeur_mailer/logo.png') %>" style="max-width=600px; padding=30px 0; display=inline !important; vertical-align=bottom; border=0; height=auto; outline=none; text-decoration=none; -ms-interpolation-mode=bicubic;" />
+                            <img align="middle" alt="Logo <%= "#{APPLICATION_NAME}" %>" src="<%= image_url('mailer/instructeur_mailer/logo.png') %>" style="max-width=600px; padding=30px 0; display=inline !important; vertical-align=bottom; border=0; height=auto; outline=none; text-decoration=none; -ms-interpolation-mode=bicubic;" />
                           </div>
                         </td>
                       </tr>


### PR DESCRIPTION
Fixed #5453 _"Mail - Erreur de syntax pour le texte alternatif au logo "_ / @adullact

---------------

## Bug
Dans les mails, le logo en haut contient un texte alternatif qui n'est pas correct :
![Screenshot_2020-08-06 LetterOpenerWeb](https://user-images.githubusercontent.com/6709977/89521150-47c51a80-d7df-11ea-8532-444d21de82a5.png)
```html
<img align="middle" alt="Logo #{APPLICATION_NAME}"  (...)
```

## Reproduction
Comment reproduire le problème :
1. Aller sur la page `/users/sign_in`
    - Cliquez sur "Mot de passe oublié ?"
    - Saisir l'adresse email d'un utilisateur
2. Aller sur `/letter_opener/`
   -  Cliquer sur l'email qui vient d'arriver 
   - Cliquer sur "View plain text version"

## Comportement attendu
![Screenshot_2020-08-06 LetterOpenerWeb(1)](https://user-images.githubusercontent.com/6709977/89521326-94a8f100-d7df-11ea-90a3-fe63e4828430.png)
```html
<img align="middle" alt="Logo demarches-simplifiees.fr"  (...)
```



## Correctif proposé
Correctif  proposé dans le fichier [app/views/layouts/mailers/layout.html.erb](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/app/views/layouts/mailers/layout.html.erb#L53)
```diff
- <img align="middle" alt="Logo #{APPLICATION_NAME}" ...
+ <img align="middle" alt="Logo <%= "#{APPLICATION_NAME}" %>" ...
```

