### PR TITLE
Annotation des modèles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,6 +96,7 @@ group :test do
 end
 
 group :development do
+  gem 'annotate'
   gem 'brakeman', require: false
   gem 'haml-lint'
   gem 'letter_opener_web'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,9 @@ GEM
     aes_key_wrap (1.1.0)
     after_party (1.11.2)
     anchored (1.1.0)
+    annotate (3.1.1)
+      activerecord (>= 3.2, < 7.0)
+      rake (>= 10.4, < 14.0)
     ast (2.4.1)
     attr_required (1.0.1)
     autoprefixer-rails (9.7.6)
@@ -752,6 +755,7 @@ DEPENDENCIES
   administrate
   after_party
   anchored
+  annotate
   axe-matchers
   bcrypt
   bootstrap-sass (>= 3.4.1)

--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: administrateurs
+#
+#  id              :integer          not null, primary key
+#  active          :boolean          default(FALSE)
+#  encrypted_token :string
+#  created_at      :datetime
+#  updated_at      :datetime
+#
 class Administrateur < ApplicationRecord
   include ActiveRecord::SecureToken
 

--- a/app/models/administrateurs_procedure.rb
+++ b/app/models/administrateurs_procedure.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: administrateurs_procedures
+#
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  administrateur_id :bigint           not null
+#  procedure_id      :bigint           not null
+#
 class AdministrateursProcedure < ApplicationRecord
   belongs_to :administrateur
   belongs_to :procedure

--- a/app/models/administration.rb
+++ b/app/models/administration.rb
@@ -1,3 +1,24 @@
+# == Schema Information
+#
+# Table name: administrations
+#
+#  id                     :integer          not null, primary key
+#  current_sign_in_at     :datetime
+#  current_sign_in_ip     :string
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  failed_attempts        :integer          default(0), not null
+#  last_sign_in_at        :datetime
+#  last_sign_in_ip        :string
+#  locked_at              :datetime
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  sign_in_count          :integer          default(0), not null
+#  unlock_token           :string
+#  created_at             :datetime
+#  updated_at             :datetime
+#
 class Administration < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable

--- a/app/models/assign_to.rb
+++ b/app/models/assign_to.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: assign_tos
+#
+#  id                                          :integer          not null, primary key
+#  daily_email_notifications_enabled           :boolean          default(FALSE), not null
+#  instant_email_dossier_notifications_enabled :boolean          default(FALSE), not null
+#  instant_email_message_notifications_enabled :boolean          default(FALSE), not null
+#  weekly_email_notifications_enabled          :boolean          default(TRUE), not null
+#  created_at                                  :datetime
+#  updated_at                                  :datetime
+#  groupe_instructeur_id                       :bigint
+#  instructeur_id                              :integer
+#  procedure_id                                :integer
+#
 class AssignTo < ApplicationRecord
   belongs_to :instructeur
   belongs_to :groupe_instructeur

--- a/app/models/attestation.rb
+++ b/app/models/attestation.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: attestations
+#
+#  id         :integer          not null, primary key
+#  title      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  dossier_id :integer          not null
+#
 class Attestation < ApplicationRecord
   self.ignored_columns = ['pdf', 'content_secure_token']
 

--- a/app/models/attestation_template.rb
+++ b/app/models/attestation_template.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: attestation_templates
+#
+#  id           :integer          not null, primary key
+#  activated    :boolean
+#  body         :text
+#  footer       :text
+#  title        :text
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  procedure_id :integer
+#
 class AttestationTemplate < ApplicationRecord
   self.ignored_columns = ['logo', 'signature', 'logo_secure_token', 'signature_secure_token']
 

--- a/app/models/avis.rb
+++ b/app/models/avis.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: avis
+#
+#  id             :integer          not null, primary key
+#  answer         :text
+#  confidentiel   :boolean          default(FALSE), not null
+#  email          :string
+#  introduction   :text
+#  revoked_at     :datetime
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  claimant_id    :integer          not null
+#  dossier_id     :integer
+#  instructeur_id :integer
+#
 class Avis < ApplicationRecord
   include EmailSanitizableConcern
 

--- a/app/models/bill_signature.rb
+++ b/app/models/bill_signature.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: bill_signatures
+#
+#  id         :bigint           not null, primary key
+#  digest     :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class BillSignature < ApplicationRecord
   has_many :dossier_operation_logs
 

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champ < ApplicationRecord
   belongs_to :dossier, -> { with_discarded }, inverse_of: :champs, touch: true
   belongs_to :type_de_champ, inverse_of: :champ

--- a/app/models/champs/address_champ.rb
+++ b/app/models/champs/address_champ.rb
@@ -1,2 +1,18 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::AddressChamp < Champs::TextChamp
 end

--- a/app/models/champs/carte_champ.rb
+++ b/app/models/champs/carte_champ.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::CarteChamp < Champ
   # Default map location. Center of the World, ahm, France...
   DEFAULT_LON = 2.428462

--- a/app/models/champs/checkbox_champ.rb
+++ b/app/models/champs/checkbox_champ.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::CheckboxChamp < Champs::YesNoChamp
   def true?
     value == 'on'

--- a/app/models/champs/civilite_champ.rb
+++ b/app/models/champs/civilite_champ.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::CiviliteChamp < Champ
   def html_label?
     false

--- a/app/models/champs/commune_champ.rb
+++ b/app/models/champs/commune_champ.rb
@@ -1,2 +1,18 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::CommuneChamp < Champs::TextChamp
 end

--- a/app/models/champs/date_champ.rb
+++ b/app/models/champs/date_champ.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::DateChamp < Champ
   before_save :format_before_save
 

--- a/app/models/champs/datetime_champ.rb
+++ b/app/models/champs/datetime_champ.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::DatetimeChamp < Champ
   before_save :format_before_save
 

--- a/app/models/champs/decimal_number_champ.rb
+++ b/app/models/champs/decimal_number_champ.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::DecimalNumberChamp < Champ
   validates :value, numericality: {
     allow_nil: true,

--- a/app/models/champs/departement_champ.rb
+++ b/app/models/champs/departement_champ.rb
@@ -1,2 +1,18 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::DepartementChamp < Champs::TextChamp
 end

--- a/app/models/champs/dossier_link_champ.rb
+++ b/app/models/champs/dossier_link_champ.rb
@@ -1,2 +1,18 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::DossierLinkChamp < Champ
 end

--- a/app/models/champs/drop_down_list_champ.rb
+++ b/app/models/champs/drop_down_list_champ.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::DropDownListChamp < Champ
   THRESHOLD_NB_OPTIONS_AS_RADIO = 5
 

--- a/app/models/champs/email_champ.rb
+++ b/app/models/champs/email_champ.rb
@@ -1,2 +1,18 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::EmailChamp < Champs::TextChamp
 end

--- a/app/models/champs/engagement_champ.rb
+++ b/app/models/champs/engagement_champ.rb
@@ -1,2 +1,18 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::EngagementChamp < Champs::CheckboxChamp
 end

--- a/app/models/champs/explication_champ.rb
+++ b/app/models/champs/explication_champ.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::ExplicationChamp < Champs::TextChamp
   def search_terms
     # The user cannot enter any information here so it doesn’t make much sense to search

--- a/app/models/champs/header_section_champ.rb
+++ b/app/models/champs/header_section_champ.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::HeaderSectionChamp < Champ
   def search_terms
     # The user cannot enter any information here so it doesn’t make much sense to search

--- a/app/models/champs/integer_number_champ.rb
+++ b/app/models/champs/integer_number_champ.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::IntegerNumberChamp < Champ
   validates :value, numericality: {
     only_integer: true,

--- a/app/models/champs/linked_drop_down_list_champ.rb
+++ b/app/models/champs/linked_drop_down_list_champ.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::LinkedDropDownListChamp < Champ
   delegate :primary_options, :secondary_options, to: 'type_de_champ.dynamic_type'
 

--- a/app/models/champs/multiple_drop_down_list_champ.rb
+++ b/app/models/champs/multiple_drop_down_list_champ.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::MultipleDropDownListChamp < Champ
   before_save :format_before_save
 

--- a/app/models/champs/number_champ.rb
+++ b/app/models/champs/number_champ.rb
@@ -1,2 +1,18 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::NumberChamp < Champ
 end

--- a/app/models/champs/pays_champ.rb
+++ b/app/models/champs/pays_champ.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::PaysChamp < Champs::TextChamp
   PAYS = JSON.parse(Rails.root.join('app', 'lib', 'api_geo', 'pays.json').read, symbolize_names: true)
 

--- a/app/models/champs/phone_champ.rb
+++ b/app/models/champs/phone_champ.rb
@@ -1,2 +1,18 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::PhoneChamp < Champs::TextChamp
 end

--- a/app/models/champs/piece_justificative_champ.rb
+++ b/app/models/champs/piece_justificative_champ.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::PieceJustificativeChamp < Champ
   MAX_SIZE = 200.megabytes
 

--- a/app/models/champs/region_champ.rb
+++ b/app/models/champs/region_champ.rb
@@ -1,2 +1,18 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::RegionChamp < Champs::TextChamp
 end

--- a/app/models/champs/repetition_champ.rb
+++ b/app/models/champs/repetition_champ.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::RepetitionChamp < Champ
   accepts_nested_attributes_for :champs, allow_destroy: true
 

--- a/app/models/champs/siret_champ.rb
+++ b/app/models/champs/siret_champ.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::SiretChamp < Champ
   def search_terms
     etablissement.present? ? etablissement.search_terms : [value]

--- a/app/models/champs/text_champ.rb
+++ b/app/models/champs/text_champ.rb
@@ -1,2 +1,18 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::TextChamp < Champ
 end

--- a/app/models/champs/textarea_champ.rb
+++ b/app/models/champs/textarea_champ.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::TextareaChamp < Champs::TextChamp
   def for_export
     value.present? ? ActionView::Base.full_sanitizer.sanitize(value) : nil

--- a/app/models/champs/yes_no_champ.rb
+++ b/app/models/champs/yes_no_champ.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id               :integer          not null, primary key
+#  private          :boolean          default(FALSE), not null
+#  row              :integer
+#  type             :string
+#  value            :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  dossier_id       :integer
+#  etablissement_id :integer
+#  parent_id        :bigint
+#  type_de_champ_id :integer
+#
 class Champs::YesNoChamp < Champ
   def search_terms
     if true?

--- a/app/models/commentaire.rb
+++ b/app/models/commentaire.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: commentaires
+#
+#  id             :integer          not null, primary key
+#  body           :string
+#  email          :string
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  dossier_id     :integer
+#  instructeur_id :bigint
+#  user_id        :bigint
+#
 class Commentaire < ApplicationRecord
   self.ignored_columns = ['file', 'piece_justificative_id']
 

--- a/app/models/deleted_dossier.rb
+++ b/app/models/deleted_dossier.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: deleted_dossiers
+#
+#  id           :bigint           not null, primary key
+#  deleted_at   :datetime
+#  reason       :string
+#  state        :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  dossier_id   :bigint
+#  procedure_id :bigint
+#
 class DeletedDossier < ApplicationRecord
   belongs_to :procedure, -> { with_discarded }, inverse_of: :deleted_dossiers
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1,3 +1,33 @@
+# == Schema Information
+#
+# Table name: dossiers
+#
+#  id                                                 :integer          not null, primary key
+#  archived                                           :boolean          default(FALSE)
+#  autorisation_donnees                               :boolean
+#  brouillon_close_to_expiration_notice_sent_at       :datetime
+#  en_construction_at                                 :datetime
+#  en_construction_close_to_expiration_notice_sent_at :datetime
+#  en_construction_conservation_extension             :interval         default(0 seconds)
+#  en_instruction_at                                  :datetime
+#  groupe_instructeur_updated_at                      :datetime
+#  hidden_at                                          :datetime
+#  last_avis_updated_at                               :datetime
+#  last_champ_private_updated_at                      :datetime
+#  last_champ_updated_at                              :datetime
+#  last_commentaire_updated_at                        :datetime
+#  motivation                                         :text
+#  private_search_terms                               :text
+#  processed_at                                       :datetime
+#  search_terms                                       :text
+#  state                                              :string
+#  termine_close_to_expiration_notice_sent_at         :datetime
+#  created_at                                         :datetime
+#  updated_at                                         :datetime
+#  groupe_instructeur_id                              :bigint
+#  revision_id                                        :bigint
+#  user_id                                            :integer
+#
 class Dossier < ApplicationRecord
   self.ignored_columns = ['procedure_id']
   include DossierFilteringConcern

--- a/app/models/dossier_operation_log.rb
+++ b/app/models/dossier_operation_log.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: dossier_operation_logs
+#
+#  id                  :bigint           not null, primary key
+#  automatic_operation :boolean          default(FALSE), not null
+#  digest              :text
+#  executed_at         :datetime
+#  keep_until          :datetime
+#  operation           :string           not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  bill_signature_id   :bigint
+#  dossier_id          :bigint
+#  instructeur_id      :bigint
+#
 class DossierOperationLog < ApplicationRecord
   enum operation: {
     changer_groupe_instructeur: 'changer_groupe_instructeur',

--- a/app/models/etablissement.rb
+++ b/app/models/etablissement.rb
@@ -1,3 +1,51 @@
+# == Schema Information
+#
+# Table name: etablissements
+#
+#  id                                       :integer          not null, primary key
+#  adresse                                  :string
+#  association_date_creation                :date
+#  association_date_declaration             :date
+#  association_date_publication             :date
+#  association_objet                        :text
+#  association_rna                          :string
+#  association_titre                        :string
+#  code_insee_localite                      :string
+#  code_postal                              :string
+#  complement_adresse                       :string
+#  diffusable_commercialement               :boolean
+#  entreprise_bilans_bdf                    :jsonb
+#  entreprise_bilans_bdf_monnaie            :string
+#  entreprise_capital_social                :bigint
+#  entreprise_code_effectif_entreprise      :string
+#  entreprise_date_creation                 :date
+#  entreprise_effectif_annee                :string
+#  entreprise_effectif_annuel               :decimal(, )
+#  entreprise_effectif_annuel_annee         :string
+#  entreprise_effectif_mensuel              :decimal(, )
+#  entreprise_effectif_mois                 :string
+#  entreprise_forme_juridique               :string
+#  entreprise_forme_juridique_code          :string
+#  entreprise_nom                           :string
+#  entreprise_nom_commercial                :string
+#  entreprise_numero_tva_intracommunautaire :string
+#  entreprise_prenom                        :string
+#  entreprise_raison_sociale                :string
+#  entreprise_siren                         :string
+#  entreprise_siret_siege_social            :string
+#  libelle_naf                              :string
+#  localite                                 :string
+#  naf                                      :string
+#  nom_voie                                 :string
+#  numero_voie                              :string
+#  siege_social                             :boolean
+#  siret                                    :string
+#  type_voie                                :string
+#  created_at                               :datetime
+#  updated_at                               :datetime
+#  dossier_id                               :integer
+#  entreprise_id                            :integer
+#
 class Etablissement < ApplicationRecord
   belongs_to :dossier
 

--- a/app/models/exercice.rb
+++ b/app/models/exercice.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: exercices
+#
+#  id                          :integer          not null, primary key
+#  ca                          :string
+#  dateFinExercice             :datetime
+#  date_fin_exercice           :datetime
+#  date_fin_exercice_timestamp :integer
+#  created_at                  :datetime
+#  updated_at                  :datetime
+#  etablissement_id            :integer
+#
 class Exercice < ApplicationRecord
   belongs_to :etablissement
 

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: exports
+#
+#  id         :bigint           not null, primary key
+#  format     :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class Export < ApplicationRecord
   MAX_DUREE_CONSERVATION_EXPORT = 15.minutes
 

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: feedbacks
+#
+#  id         :bigint           not null, primary key
+#  rating     :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint
+#
 class Feedback < ApplicationRecord
   belongs_to :user
 

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: follows
+#
+#  id                          :integer          not null, primary key
+#  annotations_privees_seen_at :datetime         not null
+#  avis_seen_at                :datetime         not null
+#  demande_seen_at             :datetime         not null
+#  messagerie_seen_at          :datetime         not null
+#  unfollowed_at               :datetime
+#  created_at                  :datetime
+#  updated_at                  :datetime
+#  dossier_id                  :integer          not null
+#  instructeur_id              :integer          not null
+#
 class Follow < ApplicationRecord
   belongs_to :instructeur
   belongs_to :dossier

--- a/app/models/france_connect_information.rb
+++ b/app/models/france_connect_information.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: france_connect_informations
+#
+#  id                            :integer          not null, primary key
+#  birthdate                     :date
+#  birthplace                    :string
+#  email_france_connect          :string
+#  family_name                   :string
+#  gender                        :string
+#  given_name                    :string
+#  created_at                    :datetime
+#  updated_at                    :datetime
+#  france_connect_particulier_id :string
+#  user_id                       :integer
+#
 class FranceConnectInformation < ApplicationRecord
   belongs_to :user
 

--- a/app/models/geo_area.rb
+++ b/app/models/geo_area.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: geo_areas
+#
+#  id               :bigint           not null, primary key
+#  geometry         :jsonb
+#  properties       :jsonb
+#  source           :string
+#  created_at       :datetime
+#  updated_at       :datetime
+#  champ_id         :bigint
+#  geo_reference_id :string
+#
 class GeoArea < ApplicationRecord
   belongs_to :champ
 

--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: groupe_instructeurs
+#
+#  id           :bigint           not null, primary key
+#  label        :text             not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  procedure_id :bigint           not null
+#
 class GroupeInstructeur < ApplicationRecord
   DEFAULT_LABEL = 'défaut'
   belongs_to :procedure, -> { with_discarded }, inverse_of: :groupe_instructeurs

--- a/app/models/individual.rb
+++ b/app/models/individual.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: individuals
+#
+#  id         :integer          not null, primary key
+#  birthdate  :date
+#  gender     :string
+#  nom        :string
+#  prenom     :string
+#  created_at :datetime
+#  updated_at :datetime
+#  dossier_id :integer
+#
 class Individual < ApplicationRecord
   belongs_to :dossier
 

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: instructeurs
+#
+#  id                     :integer          not null, primary key
+#  encrypted_login_token  :text
+#  login_token_created_at :datetime
+#  created_at             :datetime
+#  updated_at             :datetime
+#
 class Instructeur < ApplicationRecord
   has_and_belongs_to_many :administrateurs
 

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: invites
+#
+#  id           :integer          not null, primary key
+#  email        :string
+#  email_sender :string
+#  message      :text
+#  created_at   :datetime
+#  updated_at   :datetime
+#  dossier_id   :integer
+#  user_id      :integer
+#
 class Invite < ApplicationRecord
   include EmailSanitizableConcern
 

--- a/app/models/mails/closed_mail.rb
+++ b/app/models/mails/closed_mail.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: closed_mails
+#
+#  id           :integer          not null, primary key
+#  body         :text
+#  subject      :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  procedure_id :integer
+#
 module Mails
   class ClosedMail < ApplicationRecord
     include MailTemplateConcern

--- a/app/models/mails/initiated_mail.rb
+++ b/app/models/mails/initiated_mail.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: initiated_mails
+#
+#  id           :integer          not null, primary key
+#  body         :text
+#  subject      :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  procedure_id :integer
+#
 module Mails
   class InitiatedMail < ApplicationRecord
     include MailTemplateConcern

--- a/app/models/mails/received_mail.rb
+++ b/app/models/mails/received_mail.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: received_mails
+#
+#  id           :integer          not null, primary key
+#  body         :text
+#  subject      :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  procedure_id :integer
+#
 module Mails
   class ReceivedMail < ApplicationRecord
     include MailTemplateConcern

--- a/app/models/mails/refused_mail.rb
+++ b/app/models/mails/refused_mail.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: refused_mails
+#
+#  id           :integer          not null, primary key
+#  body         :text
+#  subject      :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  procedure_id :integer
+#
 module Mails
   class RefusedMail < ApplicationRecord
     include MailTemplateConcern

--- a/app/models/mails/without_continuation_mail.rb
+++ b/app/models/mails/without_continuation_mail.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: without_continuation_mails
+#
+#  id           :integer          not null, primary key
+#  body         :text
+#  subject      :string
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  procedure_id :integer
+#
 module Mails
   class WithoutContinuationMail < ApplicationRecord
     include MailTemplateConcern

--- a/app/models/module_api_carto.rb
+++ b/app/models/module_api_carto.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: module_api_cartos
+#
+#  id                     :integer          not null, primary key
+#  cadastre               :boolean          default(FALSE)
+#  migrated               :boolean
+#  quartiers_prioritaires :boolean          default(FALSE)
+#  use_api_carto          :boolean          default(FALSE)
+#  created_at             :datetime
+#  updated_at             :datetime
+#  procedure_id           :integer
+#
 class ModuleAPICarto < ApplicationRecord
   belongs_to :procedure
 end

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -1,3 +1,47 @@
+# == Schema Information
+#
+# Table name: procedures
+#
+#  id                                  :integer          not null, primary key
+#  aasm_state                          :string           default("brouillon")
+#  api_entreprise_token                :string
+#  ask_birthday                        :boolean          default(FALSE), not null
+#  auto_archive_on                     :date
+#  cadre_juridique                     :string
+#  cerfa_flag                          :boolean          default(FALSE)
+#  cloned_from_library                 :boolean          default(FALSE)
+#  closed_at                           :datetime
+#  declarative_with_state              :string
+#  description                         :string
+#  direction                           :string
+#  duree_conservation_dossiers_dans_ds :integer
+#  duree_conservation_dossiers_hors_ds :integer
+#  durees_conservation_required        :boolean          default(TRUE)
+#  euro_flag                           :boolean          default(FALSE)
+#  for_individual                      :boolean          default(FALSE)
+#  hidden_at                           :datetime
+#  juridique_required                  :boolean          default(TRUE)
+#  libelle                             :string
+#  lien_demarche                       :string
+#  lien_notice                         :string
+#  lien_site_web                       :string
+#  monavis_embed                       :text
+#  organisation                        :string
+#  path                                :string           not null
+#  published_at                        :datetime
+#  routing_criteria_name               :text             default("Votre ville")
+#  test_started_at                     :datetime
+#  unpublished_at                      :datetime
+#  web_hook_url                        :string
+#  whitelisted_at                      :datetime
+#  created_at                          :datetime         not null
+#  updated_at                          :datetime         not null
+#  canonical_procedure_id              :bigint
+#  draft_revision_id                   :bigint
+#  parent_procedure_id                 :bigint
+#  published_revision_id               :bigint
+#  service_id                          :bigint
+#
 require Rails.root.join('lib', 'percentile')
 
 class Procedure < ApplicationRecord

--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: procedure_presentations
+#
+#  id               :integer          not null, primary key
+#  displayed_fields :jsonb            not null
+#  filters          :jsonb            not null
+#  sort             :jsonb            not null
+#  created_at       :datetime
+#  updated_at       :datetime
+#  assign_to_id     :integer
+#
 class ProcedurePresentation < ApplicationRecord
   EXTRA_SORT_COLUMNS = {
     'notifications' => ['notifications'],

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: procedure_revisions
+#
+#  id           :bigint           not null, primary key
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  procedure_id :bigint           not null
+#
 class ProcedureRevision < ApplicationRecord
   self.implicit_order_column = :created_at
   belongs_to :procedure, -> { with_discarded }, inverse_of: :revisions

--- a/app/models/procedure_revision_type_de_champ.rb
+++ b/app/models/procedure_revision_type_de_champ.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: procedure_revision_types_de_champ
+#
+#  id               :bigint           not null, primary key
+#  position         :integer          not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  revision_id      :bigint           not null
+#  type_de_champ_id :bigint           not null
+#
 class ProcedureRevisionTypeDeChamp < ApplicationRecord
   belongs_to :revision, class_name: 'ProcedureRevision'
   belongs_to :type_de_champ

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: services
+#
+#  id                :bigint           not null, primary key
+#  adresse           :text
+#  email             :string
+#  horaires          :text
+#  nom               :string           not null
+#  organisme         :string
+#  telephone         :string
+#  type_organisme    :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  administrateur_id :bigint
+#
 class Service < ApplicationRecord
   self.ignored_columns = ['siret']
   has_many :procedures

--- a/app/models/traitement.rb
+++ b/app/models/traitement.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: traitements
+#
+#  id                :bigint           not null, primary key
+#  instructeur_email :string
+#  motivation        :string
+#  processed_at      :datetime
+#  state             :string
+#  dossier_id        :bigint
+#
 class Traitement < ApplicationRecord
   belongs_to :dossier
 

--- a/app/models/trusted_device_token.rb
+++ b/app/models/trusted_device_token.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: trusted_device_tokens
+#
+#  id             :bigint           not null, primary key
+#  token          :string           not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  instructeur_id :bigint
+#
 class TrustedDeviceToken < ApplicationRecord
   LOGIN_TOKEN_VALIDITY = 1.week
   LOGIN_TOKEN_YOUTH = 15.minutes

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: types_de_champ
+#
+#  id           :integer          not null, primary key
+#  description  :text
+#  libelle      :string
+#  mandatory    :boolean          default(FALSE)
+#  options      :jsonb
+#  order_place  :integer
+#  private      :boolean          default(FALSE), not null
+#  type_champ   :string
+#  created_at   :datetime
+#  updated_at   :datetime
+#  parent_id    :bigint
+#  procedure_id :integer
+#  revision_id  :bigint
+#  stable_id    :bigint
+#
 class TypeDeChamp < ApplicationRecord
   enum type_champs: {
     text: 'text',

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,32 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                           :integer          not null, primary key
+#  confirmation_sent_at         :datetime
+#  confirmation_token           :string
+#  confirmed_at                 :datetime
+#  current_sign_in_at           :datetime
+#  current_sign_in_ip           :string
+#  email                        :string           default(""), not null
+#  encrypted_password           :string           default(""), not null
+#  failed_attempts              :integer          default(0), not null
+#  last_sign_in_at              :datetime
+#  last_sign_in_ip              :string
+#  locked_at                    :datetime
+#  loged_in_with_france_connect :string           default(NULL)
+#  remember_created_at          :datetime
+#  reset_password_sent_at       :datetime
+#  reset_password_token         :string
+#  sign_in_count                :integer          default(0), not null
+#  siret                        :string
+#  unconfirmed_email            :text
+#  unlock_token                 :string
+#  created_at                   :datetime
+#  updated_at                   :datetime
+#  administrateur_id            :bigint
+#  instructeur_id               :bigint
+#
 class User < ApplicationRecord
   include EmailSanitizableConcern
 

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'active_admin'                => 'false',
+      'additional_file_patterns'    => [],
+      'routes'                      => 'false',
+      'models'                      => 'true',
+      'position_in_routes'          => 'before',
+      'position_in_class'           => 'before',
+      'position_in_test'            => 'before',
+      'position_in_fixture'         => 'before',
+      'position_in_factory'         => 'before',
+      'position_in_serializer'      => 'before',
+      'show_foreign_keys'           => 'false',
+      'show_complete_foreign_keys'  => 'false',
+      'show_indexes'                => 'false',
+      'simple_indexes'              => 'false',
+      'model_dir'                   => 'app/models',
+      'root_dir'                    => '',
+      'include_version'             => 'false',
+      'require'                     => '',
+      'exclude_tests'               => 'true',
+      'exclude_fixtures'            => 'true',
+      'exclude_factories'           => 'true',
+      'exclude_serializers'         => 'true',
+      'exclude_scaffolds'           => 'true',
+      'exclude_controllers'         => 'true',
+      'exclude_helpers'             => 'true',
+      'exclude_sti_subclasses'      => 'false',
+      'ignore_model_sub_dir'        => 'false',
+      'ignore_columns'              => nil,
+      'ignore_routes'               => nil,
+      'ignore_unknown_models'       => 'true',
+      'hide_limit_column_types'     => 'integer,bigint,boolean',
+      'hide_default_column_types'   => 'json,jsonb,hstore',
+      'skip_on_db_migrate'          => 'false',
+      'format_bare'                 => 'true',
+      'format_rdoc'                 => 'false',
+      'format_yard'                 => 'false',
+      'format_markdown'             => 'false',
+      'sort'                        => 'false',
+      'force'                       => 'false',
+      'frozen'                      => 'false',
+      'classified_sort'             => 'true',
+      'trace'                       => 'false',
+      'wrapper_open'                => nil,
+      'wrapper_close'               => nil,
+      'with_comment'                => 'true'
+    )
+  end
+
+  Annotate.load_tasks
+end


### PR DESCRIPTION
Je trouve ça assez relou de ne pas pouvoir savoir quels attributs sont disponibles sur un modèle juste en regardant le fichier `models/*.rb`. Faut aller regarder le schéma juste pour savoir quels attributs sont disponibles sur la classe, c'est pénible.

La solution standard pour ça est `annotate`, une gem qui rajoute en commentaire les infos du schéma.

Ces annotations sont automatiquement maintenues à jour (à chaque `db:migrate` lancé en développement). Elles sont également triées, pour ne pas être dépendantes de l'ordre dans lequel les migrations sont jouées.

Vous en pensez quoi ?