### PR TITLE
models: remove columns that have been deleted from db schema

### DIFF
--- a/app/models/attestation.rb
+++ b/app/models/attestation.rb
@@ -9,8 +9,6 @@
 #  dossier_id :integer          not null
 #
 class Attestation < ApplicationRecord
-  self.ignored_columns = ['pdf', 'content_secure_token']
-
   belongs_to :dossier
 
   has_one_attached :pdf

--- a/app/models/attestation_template.rb
+++ b/app/models/attestation_template.rb
@@ -12,8 +12,6 @@
 #  procedure_id :integer
 #
 class AttestationTemplate < ApplicationRecord
-  self.ignored_columns = ['logo', 'signature', 'logo_secure_token', 'signature_secure_token']
-
   include ActionView::Helpers::NumberHelper
   include TagsSubstitutionConcern
 

--- a/app/models/commentaire.rb
+++ b/app/models/commentaire.rb
@@ -12,8 +12,6 @@
 #  user_id        :bigint
 #
 class Commentaire < ApplicationRecord
-  self.ignored_columns = ['file', 'piece_justificative_id']
-
   belongs_to :dossier, inverse_of: :commentaires, touch: true
 
   belongs_to :user

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -29,7 +29,6 @@
 #  user_id                                            :integer
 #
 class Dossier < ApplicationRecord
-  self.ignored_columns = ['procedure_id']
   include DossierFilteringConcern
 
   include Discard::Model

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -15,7 +15,6 @@
 #  administrateur_id :bigint
 #
 class Service < ApplicationRecord
-  self.ignored_columns = ['siret']
   has_many :procedures
   belongs_to :administrateur
 


### PR DESCRIPTION
These columns are gone, so we can't stop ignoring them.