### PR TITLE
#5456 - Fix(mailers/_signature): use APPLICATION_NAME

### DIFF
--- a/app/views/layouts/mailers/_signature.html.haml
+++ b/app/views/layouts/mailers/_signature.html.haml
@@ -4,5 +4,5 @@
   - if defined?(service) && service && service.nom.present?
     = service.nom
   - else
-    -# The WORD JOINER unicode entity prevents email clients from auto-linking the signature
-    L’équipe demarches-simplifiees&#8288;.fr
+    -# The WORD JOINER unicode entity (&#8288;) prevents email clients from auto-linking the signature
+    L’équipe #{APPLICATION_NAME.gsub(".","&#8288;.").html_safe}


### PR DESCRIPTION
Fixed #5456 _"Mail - La signature n'est pas personnalisée par APPLICATION_NAME"_ / @adullact

---------------

## Bug
Dans les mails, la signature n'est pas personnalisée par la variable d'environnement optionnelle `APPLICATION_NAME` à ajouter dans le fichier `.env`, alors que le champ `From` de l'email est bien personnalisé.

```html
From:    "ds-adullact.local" <contact(at)demarches-simplifiees.fr>

(...)
L’équipe demarches-simplifiees⁠.fr 
```


![Screenshot_2020-08-07 LetterOpenerWeb](https://user-images.githubusercontent.com/6709977/89609844-4c3e1180-d879-11ea-929c-ab81bab82e74.png)

#### Code source de l'email
Code source de l'email avec l'entité UTF-8 `&#8288; (WORD JOINER)`   avant le point :
```yaml
L=E2=80=99=C3=A9quipe demarches-simplifiees=E2=81=A0.fr
```
> |  UTF-8(hex.) | numerical HTML encoding | name                     |
> | ----------------- | ----------------------------------- | ------------------------ |
> | ⁠ `e2 81 a0`    | `&#8288;`                           | ⁠ `WORD JOINER` | 


## Reproduction

en attendant le correctif pour #5450, on modifie directement les valeurs par défauts dans le fichier [config/application_name.rb](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/config/application_name.rb), après redémarrage du serveur Puma,  ces modifications sont prises en compte : 
- la balise HTML  `title`  contient bien ce nouveau nom ;
- l'entête  de la page contient bien ce nouveau nom.

```diff
- APPLICATION_NAME = ENV.fetch("APPLICATION_NAME", "demarches-simplifiees.fr")
+ APPLICATION_NAME = ENV.fetch("APPLICATION_NAME", "ds-adullact.local")
```

Comment reproduire le problème :
1. Aller sur la page `/users/sign_in`
    - Cliquez sur "Mot de passe oublié ?"
    - Saisir l'adresse email d'un utilisateur
2. Aller sur `/letter_opener/`
   -  Cliquer sur l'email qui vient d'arriver 
   - la signature est toujours "L’équipe demarches-simplifiees⁠.fr " au lieu de "L’équipe ds-adullact.local"

## Comportement attendu
Dans les mails, la signature est personnalisée par la variable d'environnement optionnelle `APPLICATION_NAME` à ajouter dans le fichier `.env`.

```html
From:    "ds-adullact.local" <contact(at)demarches-simplifiees.fr>

(...)
L’équipe ds-adullact.local
```
![Screenshot_2020-08-07 LetterOpenerWeb(2)](https://user-images.githubusercontent.com/6709977/89610028-ce2e3a80-d879-11ea-9135-ca83ab0419df.png)

#### Code source de l'email
Code source de l'email avec l'entité UTF-8 `&#8288; (WORD JOINER)`   avant le point :
```yaml
L=E2=80=99=C3=A9quipe ds-adullact=E2=81=A0.local
```
> |  UTF-8(hex.) | numerical HTML encoding | name                     |
> | ----------------- | ----------------------------------- | ------------------------ |
> | ⁠ `e2 81 a0`    | `&#8288;`                           | ⁠ `WORD JOINER` | 


## Correctif proposé
Correctif proposé dans le fichier [app/views/layouts/mailers/_signature.html.haml](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/app/views/layouts/mailers/_signature.html.haml#L8)
```diff
 # The WORD JOINER unicode entity prevents email clients from auto-linking the signature
- L’équipe demarches-simplifiees&#8288;.fr
+ L’équipe #{APPLICATION_NAME.gsub(".","&#8288;.").html_safe}
```



