### PR TITLE
corrige mise en forme commentaire

### DIFF
--- a/app/helpers/commentaire_helper.rb
+++ b/app/helpers/commentaire_helper.rb
@@ -22,4 +22,9 @@ module CommentaireHelper
     template = is_current_year ? :message_date : :message_date_with_year
     I18n.l(commentaire.created_at, format: template)
   end
+
+  def pretty_commentaire(commentaire)
+    body_formatted = commentaire.sent_by_system? ? commentaire.body : simple_format(commentaire.body)
+    sanitize(body_formatted)
+  end
 end

--- a/app/views/shared/dossiers/messages/_message.html.haml
+++ b/app/views/shared/dossiers/messages/_message.html.haml
@@ -8,7 +8,7 @@
       %span.guest Invité
     %span.date{ class: highlight_if_unseen_class(messagerie_seen_at, commentaire.created_at) }
       = commentaire_date(commentaire)
-  .rich-text= sanitize(simple_format(commentaire.body))
+  .rich-text= pretty_commentaire(commentaire)
 
   .message-extras.flex.justify-start
     - if commentaire.piece_jointe.attached?


### PR DESCRIPTION
Pour les commentaires générés automatiquement lors d'un changement d'état d'un dossier, la mise en forme des commentaires n'était pas celle attendue.

Cette PR transforme en html uniquement les commentaires déposés par les utilisateurs, ceux générés automatiquement lors des changements d'états étant déjà au format html.