### PR TITLE
Date champs: adding a placeholder for IE and Safari 

### DIFF
--- a/app/views/shared/dossiers/editable_champs/_date.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_date.html.haml
@@ -1,3 +1,4 @@
 = form.date_field :value,
   value: champ.value,
-  required: champ.mandatory?
+  required: champ.mandatory?,
+  placeholder: 'aaaa-mm-jj'


### PR DESCRIPTION
Safari and IE do not support the input type: "date", and consider them as "text" inputs.
I added a placeholder which suggests the required format.

Previously on Safari:
<img width="240" alt="image" src="https://user-images.githubusercontent.com/47247356/90004747-76873900-dc96-11ea-820c-7a8383e01435.png">

With this PR:
<img width="234" alt="image" src="https://user-images.githubusercontent.com/47247356/90152751-75363900-dd88-11ea-9501-ba0374308006.png">
_The format is aaaa-mm-jj because it is the format used in the DB and thus used to complete the field when we modify a dossier. If we wanted to print 'jj-mm-aaaa' we would need to translate the value. But then, it would not be understood anymore by browsers which support the 'date' input, and the value would be set to nil each time we modify a dossier._

📌 This placeholder will not appear in browsers which support the 'date' input type because they auto-generate specific a placeholder, with the right format expected.