### PR TITLE
services: make etablissement save raise on error

### DIFF
--- a/app/services/api_entreprise_service.rb
+++ b/app/services/api_entreprise_service.rb
@@ -12,7 +12,7 @@ class ApiEntrepriseService
     return nil if etablissement_params.empty?
 
     etablissement = dossier_or_champ.build_etablissement(etablissement_params)
-    etablissement.save
+    etablissement.save!
 
     [
       ApiEntreprise::EntrepriseJob, ApiEntreprise::AssociationJob, ApiEntreprise::ExercicesJob,


### PR DESCRIPTION
Before, if saving the etablissement failed, the error would be ignored silently.

(This is not an issue in production ; just an improvement to be extra-safe if ever something bites us in the future.)