### PR TITLE
models: return procedure revisions in  deterministic order

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -58,7 +58,7 @@ class Procedure < ApplicationRecord
 
   has_many :types_de_champ, -> { root.public_only.ordered }, inverse_of: :procedure, dependent: :destroy
   has_many :types_de_champ_private, -> { root.private_only.ordered }, class_name: 'TypeDeChamp', inverse_of: :procedure, dependent: :destroy
-  has_many :revisions, class_name: 'ProcedureRevision', inverse_of: :procedure, dependent: :destroy
+  has_many :revisions, -> { order(:id) }, class_name: 'ProcedureRevision', inverse_of: :procedure, dependent: :destroy
   belongs_to :draft_revision, class_name: 'ProcedureRevision', optional: true
   belongs_to :published_revision, class_name: 'ProcedureRevision', optional: true
   has_many :deleted_dossiers, dependent: :destroy


### PR DESCRIPTION
Fixes a randomly-failing spec in spec/models/procedure_revision_spec.rb.