### PR TITLE
Améliorations mineures des factories

### DIFF
--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -48,7 +48,7 @@ FactoryBot.define do
     factory :simple_procedure do
       after(:build) do |procedure, _evaluator|
         procedure.for_individual = true
-        procedure.types_de_champ << create(:type_de_champ, libelle: 'Texte obligatoire', mandatory: true)
+        procedure.types_de_champ << build(:type_de_champ, libelle: 'Texte obligatoire', mandatory: true)
         procedure.path = generate(:published_path)
         procedure.publish!
       end
@@ -97,7 +97,7 @@ FactoryBot.define do
 
       after(:build) do |procedure, evaluator|
         evaluator.types_de_champ_count.times do
-          type_de_champ = create(:type_de_champ)
+          type_de_champ = build(:type_de_champ)
 
           procedure.types_de_champ << type_de_champ
         end
@@ -111,7 +111,7 @@ FactoryBot.define do
 
       after(:build) do |procedure, evaluator|
         evaluator.types_de_champ_private_count.times do
-          type_de_champ = create(:type_de_champ, :private)
+          type_de_champ = build(:type_de_champ, :private)
 
           procedure.types_de_champ_private << type_de_champ
         end
@@ -120,7 +120,7 @@ FactoryBot.define do
 
     trait :with_type_de_champ_mandatory do
       after(:build) do |procedure, _evaluator|
-        type_de_champ = create(:type_de_champ, mandatory: true)
+        type_de_champ = build(:type_de_champ, mandatory: true)
 
         procedure.types_de_champ << type_de_champ
       end
@@ -128,7 +128,7 @@ FactoryBot.define do
 
     trait :with_datetime do
       after(:build) do |procedure, _evaluator|
-        type_de_champ = create(:type_de_champ_datetime, mandatory: true)
+        type_de_champ = build(:type_de_champ_datetime, mandatory: true)
 
         procedure.types_de_champ << type_de_champ
       end
@@ -136,7 +136,7 @@ FactoryBot.define do
 
     trait :with_dossier_link do
       after(:build) do |procedure, _evaluator|
-        type_de_champ = create(:type_de_champ_dossier_link)
+        type_de_champ = build(:type_de_champ_dossier_link)
 
         procedure.types_de_champ << type_de_champ
       end
@@ -144,7 +144,7 @@ FactoryBot.define do
 
     trait :with_yes_no do
       after(:build) do |procedure, _evaluator|
-        type_de_champ = create(:type_de_champ_yes_no)
+        type_de_champ = build(:type_de_champ_yes_no)
 
         procedure.types_de_champ << type_de_champ
       end
@@ -152,23 +152,24 @@ FactoryBot.define do
 
     trait :with_piece_justificative do
       after(:build) do |procedure, _evaluator|
-        type_de_champ = create(:type_de_champ_piece_justificative)
+        type_de_champ = build(:type_de_champ_piece_justificative)
+
         procedure.types_de_champ << type_de_champ
       end
     end
 
     trait :with_repetition do
       after(:build) do |procedure, _evaluator|
-        type_de_champ = create(:type_de_champ_repetition)
+        type_de_champ = build(:type_de_champ_repetition)
         procedure.types_de_champ << type_de_champ
 
-        type_de_champ.types_de_champ << create(:type_de_champ, libelle: 'sub type de champ')
+        type_de_champ.types_de_champ << build(:type_de_champ, libelle: 'sub type de champ')
       end
     end
 
     trait :with_number do
       after(:build) do |procedure, _evaluator|
-        type_de_champ = create(:type_de_champ_number)
+        type_de_champ = build(:type_de_champ_number)
 
         procedure.types_de_champ << type_de_champ
       end

--- a/spec/factories/type_de_champ.rb
+++ b/spec/factories/type_de_champ.rb
@@ -1,13 +1,11 @@
 FactoryBot.define do
   factory :type_de_champ do
-    private { false }
-
-    # Previous line is kept blank so that rubocop does not complain
     sequence(:libelle) { |n| "Libelle du champ #{n}" }
     sequence(:description) { |n| "description du champ #{n}" }
     type_champ { TypeDeChamp.type_champs.fetch(:text) }
     order_place { 1 }
     mandatory { false }
+    add_attribute(:private) { false }
 
     factory :type_de_champ_text do
       type_champ { TypeDeChamp.type_champs.fetch(:text) }
@@ -117,9 +115,7 @@ FactoryBot.define do
     end
 
     trait :private do
-      private { true }
-
-      # Previous line is kept blank so that rubocop does not complain
+      add_attribute(:private) { true }
       sequence(:libelle) { |n| "Libelle champ privé #{n}" }
       sequence(:description) { |n| "description du champ privé #{n}" }
     end


### PR DESCRIPTION
- Suppression d'un workaround pour Rubocop
- Autant que possible, on essaie que les factories dans des factories fassent des `build` plutôt que des `create`. Comme ça si le code appelant demande un `build`, rien ne sera persisté en base (c'est plus rapide) – et si l'appelant demande un `create`, tout sera persisté en base en une seule transaction.