### PR TITLE
Sign-in page: autofocus on 'input: password' removed

### DIFF
--- a/app/views/instructeurs/avis/sign_up.html.haml
+++ b/app/views/instructeurs/avis/sign_up.html.haml
@@ -11,6 +11,6 @@
         = f.email_field :email, value: @email, disabled: true
 
         = f.label :password, "Mot de passe"
-        = f.password_field :password, autofocus: true, required: true, placeholder: "#{PASSWORD_MIN_LENGTH} caractères minimum"
+        = f.password_field :password, required: true, placeholder: "#{PASSWORD_MIN_LENGTH} caractères minimum"
 
         = f.submit "Créer un compte", class: "button large primary expand"


### PR DESCRIPTION
According to accessibility audit requirements. 
(No change noticed)
#5162 