### PR TITLE
views: allow unselecting all values from a multiple dropdown

### DIFF
--- a/app/views/shared/dossiers/editable_champs/_multiple_drop_down_list.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_multiple_drop_down_list.html.haml
@@ -1,10 +1,11 @@
 - if champ.options?
   - if champ.render_as_checkboxes?
-    - champ.enabled_non_empty_options.each do |option|
+    = form.collection_check_boxes(:value, champ.enabled_non_empty_options, :to_s, :to_s) do |b|
       .editable-champ.editable-champ-checkbox
-        %label
-          = form.check_box :value, { multiple: true, checked: champ&.value&.include?(option) }, option, nil
-          = option
+        = b.label do
+          = b.check_box({ multiple: true, checked: champ&.value&.include?(b.value) })
+          = b.text
+
   - else
     = form.select :value,
         champ.options,

--- a/spec/views/shared/dossiers/_edit.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_edit.html.haml_spec.rb
@@ -72,6 +72,10 @@ describe 'shared/dossiers/edit.html.haml', type: :view do
       it 'renders the list as checkboxes' do
         expect(subject).to have_selector('input[type=checkbox]', count: enabled_options.count)
       end
+
+      it 'adds an extra hidden input, to send a blank value even when all checkboxes are unchecked' do
+        expect(subject).to have_selector('input[type=hidden][value=""]')
+      end
     end
 
     context 'when the list is long' do


### PR DESCRIPTION
Currently, there's a bug when deselecting all values from a multiple dropdown rendered as checkboxes: it doesn't have any effect when submitting the form (the previous values are still there, instead of being deselected).

This is because unchecked checkboxes are not sent by the browser – so the "empty selection" never gets sent.

Rails `form.check_box` usually works around this by inserting an empty hidden checkbox element, that will be sent even if all others are de-selected. But the documentation warns that this is not possible when iterating over an array (rather than a model). Which is our case here.

To fix this, this commit uses `form.collection_check_boxes` instead. It will insert the proper hidden checkboxes in all cases, and fix our use case.

See https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-collection_check_boxes

### TODO:

- [x] Write a test