### PR TITLE
 config: remove comment about ActiveStorage integration with VirusScanner 

### DIFF
--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,11 +1,5 @@
 Rails.application.config.active_storage.service_urls_expire_in = 1.hour
 
-# In Rails 5.2, we have to hook at `on_load` on the blob themeselves, which is
-# not ideal.
-#
-# Rails 6 adds support for `.on_load(:active_storage_attachment)`, which is
-# cleaner (as it allows to enqueue the virus scan on attachment creation, rather
-# than on blob creation).
 ActiveSupport.on_load(:active_storage_blob) do
   include BlobSignedIdConcern
   include BlobVirusScannerConcern


### PR DESCRIPTION
As the comment states, it would be nice to load the Virus Scanner on the Attachment (rather than the blob).

However, in order not to clobber the blob metadata, we want to run the VirusScanner once the blob analyzer did run.

And the most direct way to detect that the blob analyzer did run is to add an `on_update_commit` hook on the blob, as this hook will be trigerred when saving changes to the metadata. This is what the current solution uses. 

So the current solution is almost optimal, and has a low chance of accidentally clobbering the blob metadata – as the virus scanner is only started when the analysis phase is finished.

Ref #4354