### PR TITLE
gem http_accept_language installed and (de)activable with feature flag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'graphql_playground-rails'
 gem 'groupdate'
 gem 'haml-rails'
 gem 'hashie'
+gem 'http_accept_language'
 gem 'jquery-rails' # Use jquery as the JavaScript library
 gem 'jwt'
 gem 'kaminari', '1.2.1' # Pagination

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,7 @@ class ApplicationController < ActionController::Base
   before_action :set_active_storage_host
   before_action :setup_javascript_settings
   before_action :setup_tracking
+  before_action :set_locale
 
   helper_method :multiple_devise_profile_connect?, :instructeur_signed_in?, :current_instructeur,
     :administrateur_signed_in?, :current_administrateur, :current_account
@@ -298,5 +299,11 @@ class ApplicationController < ActionController::Base
 
   def current_email
     current_user&.email
+  end
+
+  def set_locale
+    if feature_enabled?(:localization)
+      I18n.locale = http_accept_language.compatible_language_from(I18n.available_locales)
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,11 +25,12 @@ module TPS
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     config.time_zone = 'Paris'
 
-    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
+    # The default locale is :fr and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     config.i18n.default_locale = :fr
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
-    config.i18n.available_locales = [:fr]
+    config.i18n.available_locales = [:fr, :en]
+    config.i18n.fallbacks = [:fr]
 
     config.assets.paths << Rails.root.join('app', 'assets', 'javascript')
     config.assets.paths << Rails.root.join('app', 'assets', 'fonts')

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -36,7 +36,8 @@ features = [
   :operation_log_serialize_subject,
   :pre_maintenance_mode,
   :xray,
-  :carte_ign
+  :carte_ign,
+  :localization
 ]
 
 def database_exists?


### PR DESCRIPTION
Remplaces #5498

Using the gem [http_accept_langage](https://github.com/iain/http_accept_language/tree/master) which detects the preferred languages of the users' navigators and sets the website to the first preferred language available **ONLY if the feature flag is activated**.

Fallback set to French, in case translations are missing in English/other languages.