### PR TITLE
ci: add workflow to publish releases to Sentry

### DIFF
--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -1,0 +1,18 @@
+on:
+  push:
+    tags:
+    - '*'
+name: Publish release on Sentry
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Sentry Release
+      uses: getsentry/action-release@v1.0.0
+      env:
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+        SENTRY_PROJECT: rails
+      with:
+        environment: production


### PR DESCRIPTION
Voir https://blog.sentry.io/2020/07/30/automate-release-management-with-the-sentry-release-github-action

C'est un peu expérimental. Si ça marche, ça permettra à Sentry de nous dire "Ce problème est apparu depuis la release 2020-07-11", par exemple.