### PR TITLE
Gem rails-i18n : locales files clean-up

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -140,7 +140,7 @@ module ApplicationHelper
   end
 
   def try_format_date(date)
-    date.present? ? I18n.l(date) : ''
+    date.present? ? I18n.l(date, format: :long) : ''
   end
 
   def try_format_datetime(datetime)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,9 +22,6 @@
 en:
   utils:
     deconnexion: "Log out"
-    involved: "See concerned people"
-    no-commentaires: "There is no message yet, feel free to start the first one."
-    depositaire: "Dépositaire"
     pj: "Attachments"
     asterisk_html: Fields marked by an asterisk ( <span class = mandatory>*</span> ) are mandatory.
     file_number: File number
@@ -61,55 +58,6 @@ en:
         publish: Publish
         reopen: Reopen
 
-  number:
-    currency:
-      format:
-        delimiter: ","
-        format: "%u%n"
-        precision: 2
-        separator: "."
-        significant: false
-        strip_insignificant_zeros: false
-        unit: "€"
-    format:
-      delimiter: ","
-      precision: 3
-      separator: "."
-      significant: false
-      strip_insignificant_zeros: false
-    human:
-      decimal_units:
-        format: "%n %u"
-        units:
-          billion: Billion
-          million: Million
-          quadrillion: Quadrillion
-          thousand: Thousand
-          trillion: Trillion
-          unit: ''
-      format:
-        delimiter: ''
-        precision: 3
-        significant: true
-        strip_insignificant_zeros: true
-      storage_units:
-        format: "%n %u"
-        units:
-          byte:
-            one: Byte
-            other: Bytes
-          gb: GB
-          kb: KB
-          mb: MB
-          pb: PB
-          tb: TB
-    percentage:
-      format:
-        delimiter: ''
-        format: "%n%"
-    precision:
-      format:
-        delimiter: ''
   activerecord:
     attributes:
       user:
@@ -119,13 +67,7 @@ en:
         password: 'password'
     errors:
       messages:
-        blank: "must be filled"
-        not_a_number: 'must be a number'
-        not_an_integer: 'must be an integer (without digit after the comma)'
-        greater_than: "must be greater than %{count}"
-        greater_than_or_equal_to: "must be greater than or equal to %{count}"
-        less_than: "must be less than %{count}"
-        less_than_or_equal_to: "must be less than or equal to %{count}"
+        not_a_phone: 'Invalid phone number'
       models:
         attestation_template:
           attributes:
@@ -190,98 +132,9 @@ en:
       # parcelles_agricoles_empty:
       #   one: "Aucune parcelle agricole sur la zone sélectionnée"
       #   other: "Aucune parcelle agricole sur les zones sélectionnées"
+      not_an_integer: "must be an integer (without any digit after the comma)"
+      blank: "can't be blank"
 
-  date:
-    abbr_day_names:
-      - Sun
-      - Mon
-      - Tue
-      - Wed
-      - Thu
-      - Fri
-      - Sat
-    abbr_month_names:
-      -
-      - Jan
-      - Feb
-      - Mar
-      - Apr
-      - May
-      - Jun
-      - Jul
-      - Aug
-      - Sep
-      - Oct
-      - Nov
-      - Dec
-    month_names:
-      -
-      - January
-      - February
-      - March
-      - April
-      - May
-      - June
-      - July
-      - August
-      - September
-      - October
-      - November
-      - December
-    order:
-      - :year
-      - :month
-      - :day
-    day_names:
-      - Sunday
-      - Monday
-      - Tuesday
-      - Wednesday
-      - Thursday
-      - Friday
-      - Saturday
-    formats:
-      default: "%Y-%m-%d"
-      long: "%B %d, %Y"
-      short: "%b %d"
-  datetime:
-    distance_in_words:
-      about_x_hours:
-        one: about an hour
-        other: about %{count} hours
-      about_x_months:
-        one: about a month
-        other: about %{count} months
-      about_x_years:
-        one: about a year
-        other: about %{count} years
-      almost_x_years:
-        one: almost a year
-        other: almost %{count} years
-      half_a_minute: half a minute
-      less_than_x_minutes:
-        zero: less than a minute
-        one: less than a minute
-        other: less than %{count} minutes
-      less_than_x_seconds:
-        zero: less than a second
-        one: less than a second
-        other: less than %{count} seconds
-      over_x_years:
-        one: more than a year
-        other: more than %{count} years
-      x_days:
-        one: 1 day
-        other: "%{count} days"
-      x_minutes:
-        one: 1 minute
-        other: "%{count} minutes"
-      x_months:
-        one: 1 month
-        other: "%{count} months"
-      x_seconds:
-        one: 1 second
-        other: "%{count} seconds"
   time:
     formats:
       default: "%B %d %Y %R"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -22,9 +22,6 @@
 fr:
   utils:
     deconnexion: "Déconnexion"
-    involved: "Voir les personnes impliquées"
-    no-commentaires: "Il n’y a aucun message dans le fil de discussion, n’hésitez pas à initier le premier."
-    depositaire: "Dépositaire"
     pj: "Pièces jointes"
     asterisk_html: Les champs suivis d’un astérisque ( <span class = mandatory> * </span> ) sont obligatoires.
     file_number: Numéro de dossier
@@ -61,54 +58,6 @@ fr:
         publish: Publier
         reopen: Réactiver
 
-  number:
-    currency:
-      format:
-        delimiter: " "
-        format: "%n %u"
-        precision: 2
-        separator: ","
-        significant: false
-        strip_insignificant_zeros: false
-        unit: "€"
-    format:
-      delimiter: " "
-      precision: 3
-      separator: ","
-      significant: false
-      strip_insignificant_zeros: false
-    human:
-      decimal_units:
-        format: "%n %u"
-        units:
-          billion: milliard
-          million: million
-          quadrillion: million de milliards
-          thousand: millier
-          trillion: billion
-          unit: ''
-      format:
-        delimiter: ''
-        precision: 3
-        significant: true
-        strip_insignificant_zeros: true
-      storage_units:
-        format: "%n %u"
-        units:
-          byte:
-            one: octet
-            other: octets
-          gb: Go
-          kb: ko
-          mb: Mo
-          tb: To
-    percentage:
-      format:
-        delimiter: ''
-        format: "%n%"
-    precision:
-      format:
-        delimiter: ''
   activerecord:
     attributes:
       user:
@@ -118,14 +67,7 @@ fr:
         password: 'Le mot de passe'
     errors:
       messages:
-        blank: "doit être rempli"
-        not_a_number: 'doit être un nombre'
-        not_an_integer: 'doit être un nombre entier (sans chiffres après la virgule)'
         not_a_phone: 'Numéro de téléphone invalide'
-        greater_than: "doit être supérieur à %{count}"
-        greater_than_or_equal_to: "doit être supérieur ou égal à %{count}"
-        less_than: "doit être inférieur à %{count}"
-        less_than_or_equal_to: "doit être inférieur ou égal à %{count}"
       models:
         attestation_template:
           attributes:
@@ -190,98 +132,9 @@ fr:
       parcelles_agricoles_empty:
         one: "Aucune parcelle agricole sur la zone sélectionnée"
         other: "Aucune parcelle agricole sur les zones sélectionnées"
+      not_an_integer: "doit être un nombre entier (sans chiffres après la virgule)"
+      blank: "doit être rempli"
 
-  date:
-    abbr_day_names:
-      - dim
-      - lun
-      - mar
-      - mer
-      - jeu
-      - ven
-      - sam
-    abbr_month_names:
-      -
-      - jan.
-      - fév.
-      - mar.
-      - avr.
-      - mai
-      - juin
-      - juil.
-      - août
-      - sept.
-      - oct.
-      - nov.
-      - déc.
-    month_names:
-      -
-      - janvier
-      - février
-      - mars
-      - avril
-      - mai
-      - juin
-      - juillet
-      - août
-      - septembre
-      - octobre
-      - novembre
-      - décembre
-    order:
-      - :day
-      - :month
-      - :year
-    day_names:
-      - dimanche
-      - lundi
-      - mardi
-      - mercredi
-      - jeudi
-      - vendredi
-      - samedi
-    formats:
-      default: "%d %B %Y"
-      short: "%e %b"
-      long: "%e %B %Y"
-  datetime:
-    distance_in_words:
-      about_x_hours:
-        one: environ une heure
-        other: environ %{count} heures
-      about_x_months:
-        one: environ un mois
-        other: environ %{count} mois
-      about_x_years:
-        one: environ un an
-        other: environ %{count} ans
-      almost_x_years:
-        one: presqu’un an
-        other: presque %{count} ans
-      half_a_minute: une demi-minute
-      less_than_x_minutes:
-        zero: moins d’une minute
-        one: moins d’une minute
-        other: moins de %{count} minutes
-      less_than_x_seconds:
-        zero: moins d’une seconde
-        one: moins d’une seconde
-        other: moins de %{count} secondes
-      over_x_years:
-        one: plus d’un an
-        other: plus de %{count} ans
-      x_days:
-        one: 1 jour
-        other: "%{count} jours"
-      x_minutes:
-        one: 1 minute
-        other: "%{count} minutes"
-      x_months:
-        one: 1 mois
-        other: "%{count} mois"
-      x_seconds:
-        one: 1 seconde
-        other: "%{count} secondes"
   time:
     formats:
       default: "%d %B %Y %R"

--- a/spec/models/champs/decimal_number_champ_spec.rb
+++ b/spec/models/champs/decimal_number_champ_spec.rb
@@ -18,7 +18,7 @@ describe Champs::DecimalNumberChamp do
       let(:value) { 'toto' }
 
       it { is_expected.to_not be_valid }
-      it { expect(subject.errors[:value]).to eq(["« #{subject.libelle} » doit être un nombre"]) }
+      it { expect(subject.errors[:value]).to eq(["« #{subject.libelle} » n'est pas un nombre"]) }
     end
 
     context 'when the value is blank' do

--- a/spec/views/shared/dossiers/_demande.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_demande.html.haml_spec.rb
@@ -38,7 +38,7 @@ describe 'shared/dossiers/demande.html.haml', type: :view do
       expect(subject).to include(individual.gender)
       expect(subject).to include(individual.nom)
       expect(subject).to include(individual.prenom)
-      expect(subject).to include(I18n.l(individual.birthdate))
+      expect(subject).to include(I18n.l(individual.birthdate, format: :long))
     end
   end
 


### PR DESCRIPTION
The gem [rails-i18n](https://github.com/svenfuchs/rails-i18n/tree/c5e0ec777cdf7b979b481b630600727f26b1b6dd) manages the dates, mathematical operators, number format, etc. in multi-language.

Until now, we already had the gem but we also copied its values in our code (in config/locales/*.yml), so I removed them from there.