### PR TITLE
Fix procedures list layout on Safari

### DIFF
--- a/app/assets/stylesheets/new_design/admin-procedures-list.scss
+++ b/app/assets/stylesheets/new_design/admin-procedures-list.scss
@@ -2,3 +2,10 @@
 .admin-procedures-list-timestamps {
   margin-left: auto;
 }
+
+// Fix a Safari flexbox bug where the inner procedure logo
+// would stretch the container vertically.
+// See https://stackoverflow.com/questions/57516373/image-stretching-in-flexbox-in-safari
+.admin-procedures-list-row.infos {
+  align-items: flex-start;
+}

--- a/app/assets/stylesheets/new_design/admin-procedures-list.scss
+++ b/app/assets/stylesheets/new_design/admin-procedures-list.scss
@@ -1,0 +1,4 @@
+// Push the timestamps column to the right of the row
+.admin-procedures-list-timestamps {
+  margin-left: auto;
+}

--- a/app/views/new_administrateur/procedures/_procedures_list.html.haml
+++ b/app/views/new_administrateur/procedures/_procedures_list.html.haml
@@ -1,6 +1,6 @@
 - procedures.each do |procedure|
   .card
-    .flex
+    .admin-procedures-list-row.infos.flex
       - if procedure.logo.present?
         = image_tag procedure.logo, alt: procedure.libelle, width: '100'
       .flex.column.ml-1
@@ -16,7 +16,7 @@
         - if procedure.closed_at.present?
           %p.notice archivée le #{procedure.closed_at.strftime('%d/%m/%Y')}
 
-    .flex.justify-between
+    .admin-procedures-list-row.actions.flex.justify-between
       %div
         - if feature_enabled?(:administrateur_routage)
           %span.icon.person

--- a/app/views/new_administrateur/procedures/_procedures_list.html.haml
+++ b/app/views/new_administrateur/procedures/_procedures_list.html.haml
@@ -1,15 +1,14 @@
 - procedures.each do |procedure|
   .card
-    .flex.justify-between
-      .flex
-        - if procedure.logo.present?
-          = image_tag procedure.logo, alt: procedure.libelle, width: '100'
-        .flex.column.ml-1
-          .card-title
-            = link_to procedure.libelle, admin_procedure_path(procedure), style: 'color: black;'
-          = link_to(procedure_lien(procedure), procedure_lien(procedure), class: 'procedure-lien mb-1')
+    .flex
+      - if procedure.logo.present?
+        = image_tag procedure.logo, alt: procedure.libelle, width: '100'
+      .flex.column.ml-1
+        .card-title
+          = link_to procedure.libelle, admin_procedure_path(procedure), style: 'color: black;'
+        = link_to(procedure_lien(procedure), procedure_lien(procedure), class: 'procedure-lien mb-1')
 
-      %div
+      .admin-procedures-list-timestamps
         %p.notice N° #{procedure.id}
         %p.notice créée le #{procedure.created_at.strftime('%d/%m/%Y')}
         - if procedure.published_at.present?


### PR DESCRIPTION
Workaround pour les bugs flexbox chelous de Safari.

## Avant

<img width="1044" alt="Capture d’écran 2020-09-01 à 17 58 25" src="https://user-images.githubusercontent.com/179923/91876280-cf863380-ec7c-11ea-9997-59f4eb14a2af.png">

## Après

<img width="1044" alt="Capture d’écran 2020-09-01 à 17 58 13" src="https://user-images.githubusercontent.com/179923/91876300-d4e37e00-ec7c-11ea-954c-86edc7607c9b.png">
