### PR TITLE
Remove TypeDeChamp.to_stable_id

### DIFF
--- a/app/controllers/new_administrateur/types_de_champ_controller.rb
+++ b/app/controllers/new_administrateur/types_de_champ_controller.rb
@@ -15,7 +15,7 @@ module NewAdministrateur
     end
 
     def update
-      type_de_champ = @procedure.draft_revision.find_or_clone_type_de_champ(TypeDeChamp.to_stable_id(params[:id]))
+      type_de_champ = @procedure.draft_revision.find_or_clone_type_de_champ(params[:id])
 
       if type_de_champ.update(type_de_champ_update_params)
         reset_procedure
@@ -26,13 +26,13 @@ module NewAdministrateur
     end
 
     def move
-      @procedure.draft_revision.move_type_de_champ(TypeDeChamp.to_stable_id(params[:id]), (params[:position] || params[:order_place]).to_i)
+      @procedure.draft_revision.move_type_de_champ(params[:id], (params[:position] || params[:order_place]).to_i)
 
       head :no_content
     end
 
     def destroy
-      @procedure.draft_revision.remove_type_de_champ(TypeDeChamp.to_stable_id(params[:id]))
+      @procedure.draft_revision.remove_type_de_champ(params[:id])
       reset_procedure
 
       head :no_content
@@ -67,7 +67,7 @@ module NewAdministrateur
     end
 
     def type_de_champ_create_params
-      type_de_champ_params = params.required(:type_de_champ).permit(:type_champ,
+      params.required(:type_de_champ).permit(:type_champ,
         :libelle,
         :description,
         :mandatory,
@@ -77,12 +77,6 @@ module NewAdministrateur
         :piece_justificative_template,
         :cadastres,
         :mnhn)
-
-      if type_de_champ_params[:parent_id].present?
-        type_de_champ_params[:parent_id] = TypeDeChamp.to_stable_id(type_de_champ_params[:parent_id])
-      end
-
-      type_de_champ_params
     end
 
     def type_de_champ_update_params

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -17,8 +17,6 @@
 #  stable_id   :bigint
 #
 class TypeDeChamp < ApplicationRecord
-  self.ignored_columns = ['procedure_id']
-
   enum type_champs: {
     text: 'text',
     textarea: 'textarea',

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -309,21 +309,6 @@ class TypeDeChamp < ApplicationRecord
     end
   end
 
-  # FIXME: We are changing how id is exposed to the editor.
-  # We used to expose type_de_champ.id as primary key to the editor. With revisions
-  # we need primary key to be type_de_champ.stable_id because any update can create
-  # a new version but we do not want editor to know about this.
-  # This is only needed for a clean migration without downtime. We want to ensure
-  # that if editor send a simple id because it was loaded before deployment
-  # we would still do the right thing.
-  def self.to_stable_id(id_or_stable_id)
-    if id_or_stable_id.to_s =~ /^stable:/
-      id_or_stable_id.to_s.gsub(/^stable:/, '')
-    else
-      id_or_stable_id
-    end
-  end
-
   private
 
   def parse_drop_down_list_value(value)


### PR DESCRIPTION
- [x] depends on #5525

Dernière étape de nettoyage de la gestion des id/stable_id dans l'éditeur de types de champ.