### PR TITLE
jobs: ignore deleted file in Virus Scan

### DIFF
--- a/app/jobs/virus_scanner_job.rb
+++ b/app/jobs/virus_scanner_job.rb
@@ -1,7 +1,10 @@
 class VirusScannerJob < ApplicationJob
   queue_as :active_storage_analysis
 
+  # If by the time the job runs the blob has been deleted, ignore the error
   discard_on ActiveRecord::RecordNotFound
+  # If the file is deleted during the scan, ignore the error
+  discard_on ActiveStorage::FileNotFoundError
 
   def perform(blob)
     metadata = extract_metadata_via_virus_scanner(blob)


### PR DESCRIPTION
We have errors in production where the job starts correctly (i.e. the blob exists), but `blob.open` fails with a `ActiveStorage::FileNotFound` error.

When checking later in production, the blob has been deleted.

This points to the blob (and the file) being deleted during the virus scan job.

In that case, ignore the error (rather than retrying the job).

Fix https://sentry.io/organizations/demarches-simplifiees/issues/1775101908/