### PR TITLE
DB : ajout de contraintes d'unicités sur les colonnes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -805,7 +805,7 @@ Rails/UniqBeforePluck:
   Enabled: true
 
 Rails/UniqueValidationWithoutIndex:
-  Enabled: false
+  Enabled: true
 
 Rails/UnknownEnv:
   Enabled: false

--- a/db/migrate/20200903133440_add_unique_index_to_champs.rb
+++ b/db/migrate/20200903133440_add_unique_index_to_champs.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToChamps < ActiveRecord::Migration[6.0]
+  def change
+    add_index :champs, [:type_de_champ_id, :dossier_id, :row], unique: true
+  end
+end

--- a/db/migrate/20200903133531_add_unique_index_to_deleted_dossiers.rb
+++ b/db/migrate/20200903133531_add_unique_index_to_deleted_dossiers.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToDeletedDossiers < ActiveRecord::Migration[6.0]
+  def change
+    add_index :deleted_dossiers, [:dossier_id], unique: true
+  end
+end

--- a/db/migrate/20200903133553_add_unique_index_to_etablissement.rb
+++ b/db/migrate/20200903133553_add_unique_index_to_etablissement.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToEtablissement < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :etablissements, :dossier_id
+    add_index :etablissements, :dossier_id, unique: true
+  end
+end

--- a/db/migrate/20200903133608_add_unique_index_to_individual.rb
+++ b/db/migrate/20200903133608_add_unique_index_to_individual.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToIndividual < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :individuals, :dossier_id
+    add_index :individuals, :dossier_id, unique: true
+  end
+end

--- a/db/migrate/20200903133621_add_unique_index_to_invite.rb
+++ b/db/migrate/20200903133621_add_unique_index_to_invite.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToInvite < ActiveRecord::Migration[6.0]
+  def change
+    add_index :invites, [:email, :dossier_id], unique: true
+  end
+end

--- a/db/migrate/20200903133655_add_unique_index_to_procedure.rb
+++ b/db/migrate/20200903133655_add_unique_index_to_procedure.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToProcedure < ActiveRecord::Migration[6.0]
+  def change
+    add_index :procedures, [:path, :closed_at, :hidden_at, :unpublished_at], unique: true, name: 'path_uniqueness'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -464,6 +464,7 @@ ActiveRecord::Schema.define(version: 2021_02_04_180955) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text "message"
+    t.index ["email", "dossier_id"], name: "index_invites_on_email_and_dossier_id", unique: true
   end
 
   create_table "module_api_cartos", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -204,6 +204,7 @@ ActiveRecord::Schema.define(version: 2021_02_04_180955) do
     t.bigint "user_id"
     t.bigint "groupe_instructeur_id"
     t.bigint "revision_id"
+    t.index ["dossier_id"], name: "index_deleted_dossiers_on_dossier_id", unique: true
     t.index ["procedure_id"], name: "index_deleted_dossiers_on_procedure_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -313,7 +313,7 @@ ActiveRecord::Schema.define(version: 2021_02_04_180955) do
     t.jsonb "entreprise_bilans_bdf"
     t.string "entreprise_bilans_bdf_monnaie"
     t.string "enseigne"
-    t.index ["dossier_id"], name: "index_etablissements_on_dossier_id"
+    t.index ["dossier_id"], name: "index_etablissements_on_dossier_id", unique: true
   end
 
   create_table "exercices", id: :serial, force: :cascade do |t|
@@ -438,7 +438,7 @@ ActiveRecord::Schema.define(version: 2021_02_04_180955) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.date "birthdate"
-    t.index ["dossier_id"], name: "index_individuals_on_dossier_id"
+    t.index ["dossier_id"], name: "index_individuals_on_dossier_id", unique: true
   end
 
   create_table "initiated_mails", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -554,6 +554,7 @@ ActiveRecord::Schema.define(version: 2021_02_04_180955) do
     t.index ["draft_revision_id"], name: "index_procedures_on_draft_revision_id"
     t.index ["hidden_at"], name: "index_procedures_on_hidden_at"
     t.index ["parent_procedure_id"], name: "index_procedures_on_parent_procedure_id"
+    t.index ["path", "closed_at", "hidden_at", "unpublished_at"], name: "path_uniqueness", unique: true
     t.index ["path", "closed_at", "hidden_at"], name: "index_procedures_on_path_and_closed_at_and_hidden_at", unique: true
     t.index ["published_revision_id"], name: "index_procedures_on_published_revision_id"
     t.index ["service_id"], name: "index_procedures_on_service_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -152,6 +152,7 @@ ActiveRecord::Schema.define(version: 2021_02_04_180955) do
     t.index ["parent_id"], name: "index_champs_on_parent_id"
     t.index ["private"], name: "index_champs_on_private"
     t.index ["row"], name: "index_champs_on_row"
+    t.index ["type_de_champ_id", "dossier_id", "row"], name: "index_champs_on_type_de_champ_id_and_dossier_id_and_row", unique: true
     t.index ["type_de_champ_id"], name: "index_champs_on_type_de_champ_id"
   end
 


### PR DESCRIPTION
La config Rails 6 de Rubocop nous prévient lorsqu'on a des modèles qui ont une contrainte d'unicité au niveau Rails, mais que cette contrainte n'est pas présente dans la base de donnée. C'est effectivement une bonne udée, parce que le validateur Rails ne fonctionne qu'au niveau d'une instance web donnée : il peut y avoir des race-conditions sur l'ajout de colonnes uniques, qui doivent être résolues par la base de donnée.

Lors du passage à Rails 6, on a désactivé ce linter spécifique, le temps d'essuyer les plâtres.

Mais maintenant, il est temps de ré-activer ce linter, et de rajouter les contraintes qui manquent.

Fix #4354