### PR TITLE
reduce footer length after font change

### DIFF
--- a/app/models/attestation_template.rb
+++ b/app/models/attestation_template.rb
@@ -15,12 +15,14 @@ class AttestationTemplate < ApplicationRecord
   include ActionView::Helpers::NumberHelper
   include TagsSubstitutionConcern
 
+  FOOTER_MAX_LENGTH = 175
+
   belongs_to :procedure, optional: false
 
   has_one_attached :logo
   has_one_attached :signature
 
-  validates :footer, length: { maximum: 190 }
+  validates :footer, length: { maximum: FOOTER_MAX_LENGTH }
   validates :logo, content_type: ['image/png', 'image/jpg', 'image/jpeg'], size: { less_than: 1.megabytes }
   validates :signature, content_type: ['image/png', 'image/jpg', 'image/jpeg'], size: { less_than: 1.megabytes }
 

--- a/app/views/new_administrateur/attestation_templates/_informations.html.haml
+++ b/app/views/new_administrateur/attestation_templates/_informations.html.haml
@@ -41,5 +41,5 @@
   Dimensions conseillées : au minimum 500 px de largeur ou de hauteur, poids maximum : 0,5 Mo.
 
 = f.label :footer do
-  Pied de page
-= f.text_field :footer, class: 'form-control', maxlength: 190
+  Pied de page (#{AttestationTemplate::FOOTER_MAX_LENGTH} caractères max.)
+= f.text_field :footer, class: 'form-control', maxlength: AttestationTemplate::FOOTER_MAX_LENGTH

--- a/spec/models/attestation_template_spec.rb
+++ b/spec/models/attestation_template_spec.rb
@@ -49,9 +49,9 @@ describe AttestationTemplate, type: :model do
     end
 
     context 'when the footer is too long' do
-      let(:footer) { 'a' * 191 }
+      let(:footer) { 'a' * 176 }
 
-      it { is_expected.to match({ footer: [{ error: :too_long, count: 190 }] }) }
+      it { is_expected.to match({ footer: [{ error: :too_long, count: 175 }] }) }
     end
   end
 


### PR DESCRIPTION
Alors https://github.com/betagouv/demarches-simplifiees.fr/issues/5533 n'était pas si incroyable car on avait déjà une validation, mais j'imagine que le changement récent de police a modifié le problème.

J'ai rendu le template plus informatif, car en l'état on tronque le footer sans explications, on peut passer à coté.

![image](https://user-images.githubusercontent.com/1223316/92129254-90ceb580-ee03-11ea-97bb-804c061f1f12.png)
