### PR TITLE
remove duplicate private champ

### DIFF
--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -50,10 +50,13 @@ class Champ < ApplicationRecord
   scope :public_ordered, -> { public_only.joins(dossier: { revision: :revision_types_de_champ }).where('procedure_revision_types_de_champ.type_de_champ_id = champs.type_de_champ_id').order(:position) }
   # we need to do private champs order as manual join to avoid conflicting join names
   scope :private_ordered, -> do
-    private_only.joins('INNER JOIN types_de_champ types_de_champ_private
-      ON types_de_champ_private.id = champs.type_de_champ_id AND types_de_champ_private.private = true
+    private_only.joins('
+      INNER JOIN dossiers dossiers_private on dossiers_private.id = champs.dossier_id
+      INNER JOIN types_de_champ types_de_champ_private on types_de_champ_private.id = champs.type_de_champ_id
       INNER JOIN procedure_revision_types_de_champ procedure_revision_types_de_champ_private
-      ON procedure_revision_types_de_champ_private.type_de_champ_id = types_de_champ_private.id').order(:position)
+      ON procedure_revision_types_de_champ_private.revision_id = dossiers_private.revision_id')
+      .where('procedure_revision_types_de_champ_private.type_de_champ_id = champs.type_de_champ_id')
+      .order(:position)
   end
 
   scope :root, -> { where(parent_id: nil) }

--- a/spec/models/champ_spec.rb
+++ b/spec/models/champ_spec.rb
@@ -41,6 +41,32 @@ describe Champ do
     end
   end
 
+  describe '#public_ordered' do
+    let(:procedure) { create(:simple_procedure) }
+    let(:dossier) { create(:dossier, procedure: procedure) }
+
+    context 'when a procedure has 2 revisions' do
+      it 'does not duplicate the champs' do
+        expect(dossier.champs.count).to eq(1)
+        expect(procedure.revisions.count).to eq(2)
+      end
+    end
+  end
+
+  describe '#private_ordered' do
+    let(:procedure) { create(:procedure, :with_type_de_champ_private) }
+    let(:dossier) { create(:dossier, procedure: procedure) }
+
+    context 'when a procedure has 2 revisions' do
+      before { procedure.publish }
+
+      it 'does not duplicate the champs private' do
+        expect(dossier.champs_private.count).to eq(1)
+        expect(procedure.revisions.count).to eq(2)
+      end
+    end
+  end
+
   describe '#siblings' do
     let(:procedure) { create(:procedure, :with_type_de_champ, :with_type_de_champ_private, :with_repetition, types_de_champ_count: 1, types_de_champ_private_count: 1) }
     let(:dossier) { create(:dossier, procedure: procedure) }


### PR DESCRIPTION
Le fix https://github.com/betagouv/demarches-simplifiees.fr/pull/5538 introduit une régression en affichant en double les champs privés. (poke @tchak , pour info)
Ce nouveau fix les filtre.