### PR TITLE
Ensure polynesia numbers are ok

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -454,7 +454,7 @@ GEM
       ast (~> 2.4.1)
     pdf-core (0.7.0)
     pg (1.2.3)
-    phonelib (0.6.43)
+    phonelib (0.6.45)
     prawn (2.2.2)
       pdf-core (~> 0.7.0)
       ttfunk (~> 1.5)

--- a/app/models/champs/phone_champ.rb
+++ b/app/models/champs/phone_champ.rb
@@ -20,5 +20,5 @@ class Champs::PhoneChamp < Champs::TextChamp
       possible: true,
       allow_blank: true,
       message: I18n.t(:not_a_phone, scope: 'activerecord.errors.messages')
-    }
+    }, unless: -> { Phonelib.valid_for_country?(value, :pf) }
 end

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -698,6 +698,43 @@ describe Users::DossiersController, type: :controller do
         expect(instructeur.reload.followed_dossiers.with_notifications(instructeur)).to eq([dossier.reload])
       end
     end
+
+    context 'when the champ is a phone number' do
+      let(:procedure) { create(:procedure, :published, :with_phone) }
+      let!(:dossier) { create(:dossier, :en_construction, user: user, procedure: procedure) }
+      let(:first_champ) { dossier.champs.first }
+      let(:now) { Time.zone.parse('01/01/2100') }
+
+      let(:submit_payload) do
+        {
+          id: dossier.id,
+          dossier: {
+            champs_attributes: [
+              {
+                id: first_champ.id,
+                value: value
+              }
+            ]
+          }
+        }
+      end
+
+      context 'with a valid value sent as string' do
+        let(:value) { '0612345678' }
+        it 'updates the value' do
+          subject
+          expect(first_champ.reload.value).to eq('0612345678')
+        end
+      end
+
+      context 'with a valid value sent as number' do
+        let(:value) { '45187272'.to_i }
+        it 'updates the value' do
+          subject
+          expect(first_champ.reload.value).to eq('45187272')
+        end
+      end
+    end
   end
 
   describe '#index' do

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -182,6 +182,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_phone do
+      after(:build) do |procedure, _evaluator|
+        build(:type_de_champ_phone, procedure: procedure)
+      end
+    end
+
     trait :published do
       after(:build) do |procedure, _evaluator|
         procedure.path = generate(:published_path)

--- a/spec/models/champs/phone_champ_spec.rb
+++ b/spec/models/champs/phone_champ_spec.rb
@@ -20,6 +20,19 @@ describe Champs::PhoneChamp do
       expect(build(:champ_phone, value: "+1(0) - 123456789")).to be_valid
       expect(build(:champ_phone, value: "+49 2109 87654321")).to be_valid
       expect(build(:champ_phone, value: "012345678")).to be_valid
+      # polynesian numbers should not return errors in any way
+      ## landline numbers start with 40 or 45
+      expect(build(:champ_phone, value: "45187272")).to be_valid
+      expect(build(:champ_phone, value: "40 473 500")).to be_valid
+      expect(build(:champ_phone, value: "40473500")).to be_valid
+      expect(build(:champ_phone, value: "45473500")).to be_valid
+      ## +689 is the international indicator
+      expect(build(:champ_phone, value: "+689 45473500")).to be_valid
+      expect(build(:champ_phone, value: "0145473500")).to be_valid
+      ## polynesian mobile numbers start with 87, 88, 89
+      expect(build(:champ_phone, value: "87473500")).to be_valid
+      expect(build(:champ_phone, value: "88473500")).to be_valid
+      expect(build(:champ_phone, value: "89473500")).to be_valid
     end
   end
 end


### PR DESCRIPTION
Le problème des numéros de polynésie invalides vient des [numéro mobiles](https://en.wikipedia.org/wiki/Telephone_numbers_in_French_Polynesia#Mobile), qui commence par 87, 88, ou 89, possèdent 8 chiffres et sont traités différement des autres numéros par `phonelib`.

Il faut ajouter la polynésie dans la liste des pays (faites le test sur https://rawgit.com/googlei18n/libphonenumber/master/javascript/i18n/phonenumbers/demo-compiled.html, en mettant un numéro mobile, avec et sans préciser la polynésie, `pf`).

La librairie de google possède donc bien le validateur, et on peut le vérifier dans une console que c'est le cas aussi dans les binding ruby, mais toujours pas par défaut.

```
Phonelib.valid_for_country?('87473500', :pf)
 => true 
Phonelib.valid?('87473500')
 => false 
Phonelib.possible?('87473500')
 => false 
```


Je n'ai pas trouvé mieux pour ajouter la polynésie dans la listede pays :( j'aurais aimé pouvoir surcharger la liste des pays pour ajouter la polynésie (et non tout remplacer, ce qui semble [la seule option possible](https://github.com/daddyz/phonelib#activerecord-integration), mais vu que nos numéros sont essentiellement FR et PF, ça me semble acceptable.