### PR TITLE
Cache intermediate notification list

### DIFF
--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -145,16 +145,13 @@ class Instructeur < ApplicationRecord
   end
 
   def procedures_with_notifications(scope)
-    dossiers = Dossier
+    groupe_instructeur_ids = Dossier
       .send(scope) # :en_cours or :termine (or any other Dossier scope)
       .merge(followed_dossiers)
       .with_notifications(self)
+      .select(:groupe_instructeur_id)
 
-    Procedure
-      .where(id: dossiers.joins(:groupe_instructeur)
-        .select('groupe_instructeurs.procedure_id')
-        .distinct)
-      .distinct
+    GroupeInstructeur.where(id: groupe_instructeur_ids).pluck(:procedure_id)
   end
 
   def mark_tab_as_seen(dossier, tab)

--- a/app/views/instructeurs/procedures/_list.html.haml
+++ b/app/views/instructeurs/procedures/_list.html.haml
@@ -21,7 +21,7 @@
               %li
                 %object
                   = link_to(instructeur_procedure_path(p, statut: 'suivis')) do
-                    - if current_instructeur.procedures_with_notifications(:en_cours).include?(p)
+                    - if current_instructeur.procedures_with_notifications(:en_cours).include?(p.id)
                       %span.notifications{ 'aria-label': "notifications" }
                     - followed_count = followed_dossiers_count_per_procedure[p.id] || 0
                     .stats-number
@@ -31,7 +31,7 @@
               %li
                 %object
                   = link_to(instructeur_procedure_path(p, statut: 'traites')) do
-                    - if current_instructeur.procedures_with_notifications(:termine).include?(p)
+                    - if current_instructeur.procedures_with_notifications(:termine).include?(p.id)
                       %span.notifications{ 'aria-label': "notifications" }
                     - termines_count = dossiers_termines_count_per_procedure[p.id] || 0
                     .stats-number


### PR DESCRIPTION
Improves the performances for `/procedures`. Its the page where instructeurs land after login.
According to skylight.io, the agony is strong on this page.

We store the notifications result once in the controller, in order to avoid recomputing it at every step of the loop.

# before

The worst case scenario for this page takes 108 (!) seconds to load on my local machine.
It's an instructeur that follows ~128k dossiers

![image](https://user-images.githubusercontent.com/1223316/92695487-cfef9000-f348-11ea-8223-111a6009d886.png)

A huge chuck of this −96s here− is spent in the SQL, fetching the notifications for each procedure over and over. For some reason, rails does not cache this result.

![image](https://user-images.githubusercontent.com/1223316/92695641-0b8a5a00-f349-11ea-8daf-4da42fc0e966.png)

# after

When caching the loop result, it now takes between 8 and 20 seconds to load.

![image](https://user-images.githubusercontent.com/1223316/92695299-8a32c780-f348-11ea-8442-b1abe099ac2d.png)

That's still far from perfect ! but : 
 - we've spent a lot of time trying to improve the raw SQL query. With a lot of dossiers, indexes are not used and a sequential scan is performed.
 - that's a worse case scenario: most instructeurs have way less than 128k dossiers
 - 8s is still acceptable
 - this is not a screen you need to update often, so users who know this screen is slow can keep it open once it loaded