### PR TITLE
Améliorations des performances du tableau de bord instructeur

### DIFF
--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -37,6 +37,9 @@ module Instructeurs
         'dossiers' => @dossiers_count_per_procedure.sum { |_, v| v },
         'archivés' => @dossiers_archived_count_per_procedure.sum { |_, v| v }
       }
+
+      @procedure_ids_en_cours_with_notifications = current_instructeur.procedure_ids_with_notifications(:en_cours)
+      @procedure_ids_termines_with_notifications = current_instructeur.procedure_ids_with_notifications(:termine)
     end
 
     def show

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -30,17 +30,13 @@ module Instructeurs
         .reorder(nil)
         .count
 
-      @all_dossiers_counts = {}
-      @all_dossiers_counts['à suivre'] = dossiers.without_followers.en_cours.count
-      @all_dossiers_counts['suivis'] = current_instructeur
-        .followed_dossiers
-        .joins(:groupe_instructeur)
-        .en_cours
-        .where(groupe_instructeur_id: groupe_ids)
-        .count
-      @all_dossiers_counts['traités'] = dossiers.termine.count
-      @all_dossiers_counts['dossiers'] = dossiers.all_state.count
-      @all_dossiers_counts['archivés'] = dossiers.archived.count
+      @all_dossiers_counts = {
+        'à suivre' => @dossiers_a_suivre_count_per_procedure.sum { |_, v| v },
+        'suivis' => @followed_dossiers_count_per_procedure.sum { |_, v| v },
+        'traités' => @dossiers_termines_count_per_procedure.sum { |_, v| v },
+        'dossiers' => @dossiers_count_per_procedure.sum { |_, v| v },
+        'archivés' => @dossiers_archived_count_per_procedure.sum { |_, v| v }
+      }
     end
 
     def show

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -144,17 +144,14 @@ class Instructeur < ApplicationRecord
       .with_notifications(self)
   end
 
-  def procedures_with_notifications(scope)
-    dossiers = Dossier
+  def procedure_ids_with_notifications(scope)
+    groupe_instructeur_ids = Dossier
       .send(scope) # :en_cours or :termine (or any other Dossier scope)
       .merge(followed_dossiers)
       .with_notifications(self)
+      .select(:groupe_instructeur_id)
 
-    Procedure
-      .where(id: dossiers.joins(:groupe_instructeur)
-        .select('groupe_instructeurs.procedure_id')
-        .distinct)
-      .distinct
+    GroupeInstructeur.where(id: groupe_instructeur_ids).pluck(:procedure_id)
   end
 
   def mark_tab_as_seen(dossier, tab)

--- a/app/views/instructeurs/procedures/_list.html.haml
+++ b/app/views/instructeurs/procedures/_list.html.haml
@@ -21,7 +21,7 @@
               %li
                 %object
                   = link_to(instructeur_procedure_path(p, statut: 'suivis')) do
-                    - if current_instructeur.procedure_ids_with_notifications(:en_cours).include?(p.id)
+                    - if procedure_ids_en_cours_with_notifications.include?(p.id)
                       %span.notifications{ 'aria-label': "notifications" }
                     - followed_count = followed_dossiers_count_per_procedure[p.id] || 0
                     .stats-number
@@ -31,7 +31,7 @@
               %li
                 %object
                   = link_to(instructeur_procedure_path(p, statut: 'traites')) do
-                    - if current_instructeur.procedure_ids_with_notifications(:termine).include?(p.id)
+                    - if procedure_ids_termines_with_notifications.include?(p.id)
                       %span.notifications{ 'aria-label': "notifications" }
                     - termines_count = dossiers_termines_count_per_procedure[p.id] || 0
                     .stats-number

--- a/app/views/instructeurs/procedures/_list.html.haml
+++ b/app/views/instructeurs/procedures/_list.html.haml
@@ -1,63 +1,61 @@
-%ul.procedure-list
-  - procedures.each do |p|
-    %li.procedure-item.flex.align-start
-      = link_to(instructeur_procedure_path(p)) do
-        .flex
+%li.procedure-item.flex.align-start
+  = link_to(instructeur_procedure_path(p)) do
+    .flex
 
-          .procedure-logo{ style: "background-image: url(#{p.logo_url})" }
+      .procedure-logo{ style: "background-image: url(#{p.logo_url})" }
 
-          .procedure-details
-            %p.procedure-title
-              = procedure_libelle p
-            %ul.procedure-stats.flex
-              %li
-                %object
-                  = link_to(instructeur_procedure_path(p, statut: 'a-suivre')) do
-                    - a_suivre_count = dossiers_a_suivre_count_per_procedure[p.id] || 0
-                    .stats-number
-                      = number_with_html_delimiter(a_suivre_count)
-                    .stats-legend
-                      à suivre
-              %li
-                %object
-                  = link_to(instructeur_procedure_path(p, statut: 'suivis')) do
-                    - if procedure_ids_en_cours_with_notifications.include?(p.id)
-                      %span.notifications{ 'aria-label': "notifications" }
-                    - followed_count = followed_dossiers_count_per_procedure[p.id] || 0
-                    .stats-number
-                      = number_with_html_delimiter(followed_count)
-                    .stats-legend
-                      = t('pluralize.followed', count: followed_count)
-              %li
-                %object
-                  = link_to(instructeur_procedure_path(p, statut: 'traites')) do
-                    - if procedure_ids_termines_with_notifications.include?(p.id)
-                      %span.notifications{ 'aria-label': "notifications" }
-                    - termines_count = dossiers_termines_count_per_procedure[p.id] || 0
-                    .stats-number
-                      = number_with_html_delimiter(termines_count)
-                    .stats-legend
-                      = t('pluralize.processed', count: termines_count)
-              %li
-                %object
-                  = link_to(instructeur_procedure_path(p, statut: 'tous')) do
-                    - dossier_count = dossiers_count_per_procedure[p.id] || 0
-                    .stats-number
-                      = number_with_html_delimiter(dossier_count)
-                    .stats-legend
-                      = t('pluralize.case', count: dossier_count)
-              %li
-                %object
-                  = link_to(instructeur_procedure_path(p, statut: 'archives')) do
-                    - archived_count = dossiers_archived_count_per_procedure[p.id] || 0
-                    .stats-number
-                      = number_with_html_delimiter(archived_count)
-                    .stats-legend
-                      = t('pluralize.archived', count: archived_count)
+      .procedure-details
+        %p.procedure-title
+          = procedure_libelle p
+        %ul.procedure-stats.flex
+          %li
+            %object
+              = link_to(instructeur_procedure_path(p, statut: 'a-suivre')) do
+                - a_suivre_count = dossiers_a_suivre_count_per_procedure[p.id] || 0
+                .stats-number
+                  = number_with_html_delimiter(a_suivre_count)
+                .stats-legend
+                  à suivre
+          %li
+            %object
+              = link_to(instructeur_procedure_path(p, statut: 'suivis')) do
+                - if procedure_ids_en_cours_with_notifications.include?(p.id)
+                  %span.notifications{ 'aria-label': "notifications" }
+                - followed_count = followed_dossiers_count_per_procedure[p.id] || 0
+                .stats-number
+                  = number_with_html_delimiter(followed_count)
+                .stats-legend
+                  = t('pluralize.followed', count: followed_count)
+          %li
+            %object
+              = link_to(instructeur_procedure_path(p, statut: 'traites')) do
+                - if procedure_ids_termines_with_notifications.include?(p.id)
+                  %span.notifications{ 'aria-label': "notifications" }
+                - termines_count = dossiers_termines_count_per_procedure[p.id] || 0
+                .stats-number
+                  = number_with_html_delimiter(termines_count)
+                .stats-legend
+                  = t('pluralize.processed', count: termines_count)
+          %li
+            %object
+              = link_to(instructeur_procedure_path(p, statut: 'tous')) do
+                - dossier_count = dossiers_count_per_procedure[p.id] || 0
+                .stats-number
+                  = number_with_html_delimiter(dossier_count)
+                .stats-legend
+                  = t('pluralize.case', count: dossier_count)
+          %li
+            %object
+              = link_to(instructeur_procedure_path(p, statut: 'archives')) do
+                - archived_count = dossiers_archived_count_per_procedure[p.id] || 0
+                .stats-number
+                  = number_with_html_delimiter(archived_count)
+                .stats-legend
+                  = t('pluralize.archived', count: archived_count)
 
-          - if p.close?
-            .procedure-status
-              %span.label Close
-          - elsif p.depubliee?
-            .procedure-status
-              %span.label Dépubliée
+      - if p.close?
+        .procedure-status
+          %span.label Close
+      - elsif p.depubliee?
+        .procedure-status
+          %span.label Dépubliée

--- a/app/views/instructeurs/procedures/_list.html.haml
+++ b/app/views/instructeurs/procedures/_list.html.haml
@@ -21,7 +21,7 @@
               %li
                 %object
                   = link_to(instructeur_procedure_path(p, statut: 'suivis')) do
-                    - if current_instructeur.procedures_with_notifications(:en_cours).include?(p)
+                    - if current_instructeur.procedure_ids_with_notifications(:en_cours).include?(p.id)
                       %span.notifications{ 'aria-label': "notifications" }
                     - followed_count = followed_dossiers_count_per_procedure[p.id] || 0
                     .stats-number
@@ -31,7 +31,7 @@
               %li
                 %object
                   = link_to(instructeur_procedure_path(p, statut: 'traites')) do
-                    - if current_instructeur.procedures_with_notifications(:termine).include?(p)
+                    - if current_instructeur.procedure_ids_with_notifications(:termine).include?(p.id)
                       %span.notifications{ 'aria-label': "notifications" }
                     - termines_count = dossiers_termines_count_per_procedure[p.id] || 0
                     .stats-number

--- a/app/views/instructeurs/procedures/index.html.haml
+++ b/app/views/instructeurs/procedures/index.html.haml
@@ -9,4 +9,6 @@
     dossiers_a_suivre_count_per_procedure: @dossiers_a_suivre_count_per_procedure,
     dossiers_archived_count_per_procedure: @dossiers_archived_count_per_procedure,
     dossiers_termines_count_per_procedure: @dossiers_termines_count_per_procedure,
-    followed_dossiers_count_per_procedure: @followed_dossiers_count_per_procedure }
+    followed_dossiers_count_per_procedure: @followed_dossiers_count_per_procedure,
+    procedure_ids_en_cours_with_notifications: @procedure_ids_en_cours_with_notifications,
+    procedure_ids_termines_with_notifications: @procedure_ids_termines_with_notifications }

--- a/app/views/instructeurs/procedures/index.html.haml
+++ b/app/views/instructeurs/procedures/index.html.haml
@@ -4,11 +4,14 @@
   %h1.page-title Démarches
   = render partial: 'instructeurs/procedures/synthese', locals: { procedures: @procedures, all_dossiers_counts: @all_dossiers_counts }
 
-  = render partial: 'instructeurs/procedures/list', locals: { procedures: @procedures,
-    dossiers_count_per_procedure: @dossiers_count_per_procedure,
-    dossiers_a_suivre_count_per_procedure: @dossiers_a_suivre_count_per_procedure,
-    dossiers_archived_count_per_procedure: @dossiers_archived_count_per_procedure,
-    dossiers_termines_count_per_procedure: @dossiers_termines_count_per_procedure,
-    followed_dossiers_count_per_procedure: @followed_dossiers_count_per_procedure,
-    procedure_ids_en_cours_with_notifications: @procedure_ids_en_cours_with_notifications,
-    procedure_ids_termines_with_notifications: @procedure_ids_termines_with_notifications }
+  %ul.procedure-list
+    = render partial: 'instructeurs/procedures/list',
+      collection: @procedures,
+      as: :p,
+      locals: { dossiers_count_per_procedure: @dossiers_count_per_procedure,
+        dossiers_a_suivre_count_per_procedure: @dossiers_a_suivre_count_per_procedure,
+        dossiers_archived_count_per_procedure: @dossiers_archived_count_per_procedure,
+        dossiers_termines_count_per_procedure: @dossiers_termines_count_per_procedure,
+        followed_dossiers_count_per_procedure: @followed_dossiers_count_per_procedure,
+        procedure_ids_en_cours_with_notifications: @procedure_ids_en_cours_with_notifications,
+        procedure_ids_termines_with_notifications: @procedure_ids_termines_with_notifications }

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -352,17 +352,17 @@ describe Instructeur, type: :model do
     end
   end
 
-  describe '#notifications_per_procedure' do
+  describe '#procedure_ids_with_notifications' do
     let!(:dossier) { create(:dossier, :followed, state: Dossier.states.fetch(:en_construction)) }
     let(:instructeur) { dossier.follows.first.instructeur }
     let(:procedure) { dossier.procedure }
 
-    subject { instructeur.procedures_with_notifications(:en_cours) }
+    subject { instructeur.procedure_ids_with_notifications(:en_cours) }
 
     context 'when there is a modification on public champs' do
       before { dossier.update!(last_champ_updated_at: Time.zone.now) }
 
-      it { is_expected.to match([procedure]) }
+      it { is_expected.to match([procedure.id]) }
     end
   end
 


### PR DESCRIPTION
super seed #5558 #5557 .

Permets de rendre le tableau de bords le plus pathologique en 5s sur ma machine en ayant activé le cache de notifications.

![Screenshot_2020-09-10 Démarches · demarches-simplifiees fr(2)](https://user-images.githubusercontent.com/907405/92789323-078f2400-f3ab-11ea-8afc-61bcb9361f83.png)
