### PR TITLE
Faster Instructeur::ProceduresController#show

### DIFF
--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -52,7 +52,7 @@ module Instructeurs
       @procedure_presentation = procedure_presentation
       @displayed_fields_values = displayed_fields_values
 
-      @a_suivre_dossiers = current_instructeur
+      a_suivre_dossiers = current_instructeur
         .dossiers
         .for_procedure(procedure)
         .without_followers
@@ -64,36 +64,40 @@ module Instructeurs
         .for_procedure(procedure)
         .en_cours
 
-      @followed_dossiers_count = followed_dossiers.count
-      @followed_dossiers_id = followed_dossiers.pluck(:id)
-
-      @termines_dossiers = current_instructeur
+      termines_dossiers = current_instructeur
         .dossiers
         .for_procedure(procedure)
         .termine
 
-      @all_state_dossiers = current_instructeur
+      all_state_dossiers = current_instructeur
         .dossiers
         .for_procedure(procedure)
         .all_state
 
-      @archived_dossiers = current_instructeur
+      archived_dossiers = current_instructeur
         .dossiers
         .for_procedure(procedure)
         .archived
 
       @dossiers = case statut
       when 'a-suivre'
-        @a_suivre_dossiers
+        a_suivre_dossiers
       when 'suivis'
         followed_dossiers
       when 'traites'
-        @termines_dossiers
+        termines_dossiers
       when 'tous'
-        @all_state_dossiers
+        all_state_dossiers
       when 'archives'
-        @archived_dossiers
+        archived_dossiers
       end
+
+      @a_suivre_dossiers_count = a_suivre_dossiers.count
+      @followed_dossiers_count = followed_dossiers.count
+      @followed_dossiers_id = followed_dossiers.pluck(:id)
+      @termines_dossiers_count = termines_dossiers.count
+      @all_state_dossiers_count = all_state_dossiers.count
+      @archived_dossiers_count = archived_dossiers.count
 
       @not_archived_notifications_dossier_ids = current_instructeur.notifications_for_procedure(@procedure, :not_archived).pluck(:id)
 

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -99,6 +99,9 @@ module Instructeurs
       @all_state_dossiers_count = all_state_dossiers.count
       @archived_dossiers_count = archived_dossiers.count
 
+      @has_en_cours_notifications = current_instructeur.notifications_for_procedure(@procedure, :en_cours).exists?
+      @has_termine_notifications = current_instructeur.notifications_for_procedure(@procedure, :termine).exists?
+
       @not_archived_notifications_dossier_ids = current_instructeur.notifications_for_procedure(@procedure, :not_archived).pluck(:id)
 
       sorted_ids = procedure_presentation.sorted_ids(@dossiers, current_instructeur)

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -98,6 +98,8 @@ module Instructeurs
         @archived_dossiers
       end
 
+      @not_archived_notifications_dossier_ids = current_instructeur.notifications_for_procedure(@procedure, :not_archived).pluck(:id)
+
       sorted_ids = procedure_presentation.sorted_ids(@dossiers, current_instructeur)
 
       if @current_filters.count > 0

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -58,17 +58,14 @@ module Instructeurs
         .without_followers
         .en_cours
 
-      @followed_dossiers = current_instructeur
+      followed_dossiers = current_instructeur
         .followed_dossiers
         .where(groupe_instructeur: current_instructeur.groupe_instructeurs)
         .for_procedure(procedure)
         .en_cours
 
-      @followed_dossiers_id = current_instructeur
-        .followed_dossiers
-        .where(groupe_instructeur: current_instructeur.groupe_instructeurs)
-        .for_procedure(procedure)
-        .pluck(:id)
+      @followed_dossiers_count = followed_dossiers.count
+      @followed_dossiers_id = followed_dossiers.pluck(:id)
 
       @termines_dossiers = current_instructeur
         .dossiers
@@ -89,7 +86,7 @@ module Instructeurs
       when 'a-suivre'
         @a_suivre_dossiers
       when 'suivis'
-        @followed_dossiers
+        followed_dossiers
       when 'traites'
         @termines_dossiers
       when 'tous'

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -102,6 +102,8 @@ module Instructeurs
       @has_en_cours_notifications = current_instructeur.notifications_for_procedure(@procedure, :en_cours).exists?
       @has_termine_notifications = current_instructeur.notifications_for_procedure(@procedure, :termine).exists?
 
+      @has_dossiers_not_brouillon = @procedure.dossiers.state_not_brouillon.any?
+
       @not_archived_notifications_dossier_ids = current_instructeur.notifications_for_procedure(@procedure, :not_archived).pluck(:id)
 
       sorted_ids = procedure_presentation.sorted_ids(@dossiers, current_instructeur)

--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -82,7 +82,6 @@ class ProcedurePresentation < ApplicationRecord
   end
 
   def displayed_field_values(dossier)
-    assert_matching_procedure(dossier)
     displayed_fields.map { |field| get_value(dossier, field['table'], field['column']) }
   end
 
@@ -253,12 +252,6 @@ class ProcedurePresentation < ApplicationRecord
     table, column = field.values_at('table', 'column')
     if !valid_column?(table, column, extra_columns)
       errors.add(kind, "#{table}.#{column} n’est pas une colonne permise")
-    end
-  end
-
-  def assert_matching_procedure(dossier)
-    if dossier.procedure != procedure
-      raise "Procedure mismatch (expected #{procedure.id}, got #{dossier.procedure.id})"
     end
   end
 

--- a/app/views/instructeurs/procedures/_download_dossiers.html.haml
+++ b/app/views/instructeurs/procedures/_download_dossiers.html.haml
@@ -1,4 +1,4 @@
-- if procedure.dossiers.state_not_brouillon.any?
+- if has_dossiers_not_brouillon
   %span.dropdown
     %button.button.dropdown-button
       Télécharger tous les dossiers

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -24,7 +24,7 @@
           = tab_item('à suivre',
             instructeur_procedure_path(@procedure, statut: 'a-suivre'),
             active: @statut == 'a-suivre',
-            badge: number_with_html_delimiter(@a_suivre_dossiers.count))
+            badge: number_with_html_delimiter(@a_suivre_dossiers_count))
 
           = tab_item(t('pluralize.followed', count: @followed_dossiers_count),
             instructeur_procedure_path(@procedure, statut: 'suivis'),
@@ -32,21 +32,21 @@
             badge: number_with_html_delimiter(@followed_dossiers_count),
             notification: current_instructeur.notifications_for_procedure(@procedure, :en_cours).exists?)
 
-          = tab_item(t('pluralize.processed', count: @termines_dossiers.count),
+          = tab_item(t('pluralize.processed', count: @termines_dossiers_count),
             instructeur_procedure_path(@procedure, statut: 'traites'),
             active: @statut == 'traites',
-            badge: number_with_html_delimiter(@termines_dossiers.count),
+            badge: number_with_html_delimiter(@termines_dossiers_count),
             notification: current_instructeur.notifications_for_procedure(@procedure, :termine).exists?)
 
           = tab_item('tous les dossiers',
             instructeur_procedure_path(@procedure, statut: 'tous'),
             active: @statut == 'tous',
-            badge: number_with_html_delimiter(@all_state_dossiers.count))
+            badge: number_with_html_delimiter(@all_state_dossiers_count))
 
-          = tab_item(t('pluralize.archived', count: @archived_dossiers.count),
+          = tab_item(t('pluralize.archived', count: @archived_dossiers_count),
             instructeur_procedure_path(@procedure, statut: 'archives'),
             active: @statut == 'archives',
-            badge: number_with_html_delimiter(@archived_dossiers.count))
+            badge: number_with_html_delimiter(@archived_dossiers_count))
 
       .procedure-actions
         = render partial: "download_dossiers",

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -135,7 +135,7 @@
               %td.folder-col
                 = link_to(instructeur_dossier_path(@procedure, dossier), class: 'cell-link') do
                   %span.icon.folder
-                    - if current_instructeur.notifications_for_procedure(@procedure, :not_archived).include?(dossier)
+                    - if @not_archived_notifications_dossier_ids.include?(dossier.id)
                       %span.notifications{ 'aria-label': 'notifications' }
 
               %td.number-col

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -26,10 +26,10 @@
             active: @statut == 'a-suivre',
             badge: number_with_html_delimiter(@a_suivre_dossiers.count))
 
-          = tab_item(t('pluralize.followed', count: @followed_dossiers.count),
+          = tab_item(t('pluralize.followed', count: @followed_dossiers_count),
             instructeur_procedure_path(@procedure, statut: 'suivis'),
             active: @statut == 'suivis',
-            badge: number_with_html_delimiter(@followed_dossiers.count),
+            badge: number_with_html_delimiter(@followed_dossiers_count),
             notification: current_instructeur.notifications_for_procedure(@procedure, :en_cours).exists?)
 
           = tab_item(t('pluralize.processed', count: @termines_dossiers.count),

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -50,7 +50,7 @@
 
       .procedure-actions
         = render partial: "download_dossiers",
-          locals: { procedure: @procedure, xlsx_export: @xlsx_export, csv_export: @csv_export, ods_export: @ods_export }
+          locals: { procedure: @procedure, xlsx_export: @xlsx_export, csv_export: @csv_export, ods_export: @ods_export, has_dossiers_not_brouillon: @has_dossiers_not_brouillon }
 
   .container
     - if @statut == 'a-suivre'

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -30,13 +30,13 @@
             instructeur_procedure_path(@procedure, statut: 'suivis'),
             active: @statut == 'suivis',
             badge: number_with_html_delimiter(@followed_dossiers_count),
-            notification: current_instructeur.notifications_for_procedure(@procedure, :en_cours).exists?)
+            notification: @has_en_cours_notifications)
 
           = tab_item(t('pluralize.processed', count: @termines_dossiers_count),
             instructeur_procedure_path(@procedure, statut: 'traites'),
             active: @statut == 'traites',
             badge: number_with_html_delimiter(@termines_dossiers_count),
-            notification: current_instructeur.notifications_for_procedure(@procedure, :termine).exists?)
+            notification: @has_termine_notifications)
 
           = tab_item('tous les dossiers',
             instructeur_procedure_path(@procedure, statut: 'tous'),


### PR DESCRIPTION
Bout de travail sur l'écran `Instructeur::ProceduresController#show` :
 - Sur les procédures avec beaucoup (30k) de dossiers, ~50% du temps de chargement vient des 6 counts
 - Sur les procédures avec peu (3000) de dossiers, c'est `ProcedurePresentation#sorted_ids` qui fait une requête de la mort.

Pour le moment j'ai surtout réorganisé le code de cet écran pour que tout se passe dans le contrôleur.

En l'état on semble gagner 20-25% sur cette page.