### PR TITLE
#5571 - Cleanup flipper gates

### DIFF
--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -16,7 +16,7 @@ module Types
         end
       end
 
-      if administrateur && Flipper.enabled?(:administrateur_graphql, administrateur.user)
+      if administrateur
         context[:authorized][demarche.id] = true
         true
       end

--- a/app/models/dossier_operation_log.rb
+++ b/app/models/dossier_operation_log.rb
@@ -85,8 +85,6 @@ class DossierOperationLog < ApplicationRecord
   def self.serialize_subject(subject)
     if subject.nil?
       nil
-    elsif !Flipper.enabled?(:operation_log_serialize_subject)
-      { id: subject.id }
     else
       case subject
       when Dossier

--- a/app/views/layouts/_main_container.html.haml
+++ b/app/views/layouts/_main_container.html.haml
@@ -1,7 +1,5 @@
 #main-container{ class: "col-xs-#{main_container_size}" }
   .row
-    - if feature_enabled?(:team_on_strike)
-      = render partial: 'layouts/strike_banner'
     = render partial: 'layouts/outdated_browser_banner'
     = render partial: 'layouts/pre_maintenance'
   .row

--- a/app/views/layouts/_strike_banner.html.haml
+++ b/app/views/layouts/_strike_banner.html.haml
@@ -1,8 +1,0 @@
-#strike-banner.site-banner
-  .container
-    .site-banner-icon ⚠️
-    .site-banner-text
-      %strong
-        En raison d’une grève nationale interprofessionnelle, une partie du personnel de #{APPLICATION_NAME} ne travaille pas.
-      %br
-      Les délais de réponse aux questions techniques pourront être perturbés pendant les prochains jours.

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -25,8 +25,6 @@
 
   %body{ id: content_for(:page_id), class: browser.platform.ios? ? 'ios' : nil }
     .page-wrapper
-      - if feature_enabled?(:team_on_strike)
-        = render partial: 'layouts/strike_banner'
       = render partial: "layouts/outdated_browser_banner"
       = render partial: 'layouts/pre_maintenance'
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -20,7 +20,7 @@
 
     = Gon::Base.render_data(camel_case: true, init: true, nonce:  request.content_security_policy_nonce)
 
-    - if feature_enabled?(:xray)
+    - if Rails.env.development? && feature_enabled?(:xray)
       = stylesheet_link_tag :xray
 
   %body{ id: content_for(:page_id), class: browser.platform.ios? ? 'ios' : nil }
@@ -40,7 +40,7 @@
       - if content_for?(:footer)
         = content_for(:footer)
 
-      - if feature_enabled?(:xray)
+      - if Rails.env.development? && feature_enabled?(:xray)
         = javascript_include_tag :xray
 
       = yield :charts_js

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -33,7 +33,6 @@ features = [
   :autosave_dossier_draft,
   :maintenance_mode,
   :mini_profiler,
-  :operation_log_serialize_subject,
   :xray,
   :carte_ign,
   :localization

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -25,7 +25,6 @@ end
 
 # A list of features to be deployed on first push
 features = [
-  :administrateur_graphql,
   :administrateur_web_hook,
   :insee_api_v3,
   :instructeur_bypass_email_login_token,

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -25,7 +25,6 @@ end
 
 # A list of features to be deployed on first push
 features = [
-  :administrateur_champ_integer_number,
   :administrateur_graphql,
   :administrateur_web_hook,
   :insee_api_v3,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -210,7 +210,7 @@ Rails.application.routes.draw do
   # API
   #
 
-  authenticated :user, lambda { |user| user.administrateur_id && Flipper.enabled?(:administrateur_graphql, user) } do
+  authenticated :user, lambda { |user| user.administrateur_id } do
     mount GraphqlPlayground::Rails::Engine, at: "/graphql", graphql_path: "/api/v2/graphql"
   end
 

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -106,10 +106,6 @@ describe API::V2::GraphqlController do
 
   subject { post :execute, params: { query: query } }
 
-  before do
-    Flipper.enable(:administrateur_graphql, admin.user)
-  end
-
   context "when authenticated" do
     let(:authorization_header) { ActionController::HttpAuthentication::Token.encode_credentials(token) }
 

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -307,6 +307,7 @@ describe Instructeurs::DossiersController, type: :controller do
         before do
           attestation = Attestation.new
           allow(attestation).to receive(:pdf).and_return(double(read: 'pdf', size: 2.megabytes))
+          allow(attestation).to receive(:pdf_url).and_return('http://some_document_url')
 
           allow_any_instance_of(Dossier).to receive(:build_attestation).and_return(attestation)
         end


### PR DESCRIPTION
Suppression de `gates` Flipper obsolètes, une étape de #5571

## à virer de l'UI après MEP de cette PR

 - :administrateur_graphql
 - :administrateur_champ_integer_number
 - :team_on_strike
 - :operation_log_serialize_subject

## absents du code, on peut les supprimer dès à présent

 - :heavy_check_mark:  :new_map_editor
 - :heavy_check_mark: :routage (devenu :administrateur_routage)

## dans une PR séparée

 - :autosave_dossier_draft