### PR TITLE
Redirections for deprecated procedure editor routes

### DIFF
--- a/app/controllers/admin/procedures_controller.rb
+++ b/app/controllers/admin/procedures_controller.rb
@@ -17,28 +17,6 @@ class Admin::ProceduresController < AdminController
     end
   end
 
-  def archived
-    @procedures = smart_listing_create :procedures,
-      current_administrateur.procedures.closes.order(published_at: :desc),
-      partial: "admin/procedures/list",
-      array: true
-
-    archived_class
-
-    render 'index'
-  end
-
-  def draft
-    @procedures = smart_listing_create :procedures,
-      current_administrateur.procedures.brouillons.order(created_at: :desc),
-      partial: "admin/procedures/list",
-      array: true
-
-    draft_class
-
-    render 'index'
-  end
-
   def show
     if @procedure.brouillon?
       @procedure_lien = commencer_test_url(path: @procedure.path)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -174,8 +174,8 @@ Rails.application.routes.draw do
   namespace :admin do
     get 'activate' => '/administrateurs/activate#new'
     patch 'activate' => '/administrateurs/activate#create'
-    get 'procedures/archived' => 'procedures#archived'
-    get 'procedures/draft' => 'procedures#draft'
+    get 'procedures/archived', to: redirect('/admin/procedures?statut=archivees')
+    get 'procedures/draft', to: redirect('/admin/procedures?statut=brouillons')
 
     resources :procedures, only: [:destroy] do
       collection do

--- a/spec/features/admin/procedure_publish_spec.rb
+++ b/spec/features/admin/procedure_publish_spec.rb
@@ -18,6 +18,18 @@ feature 'Publication de démarches', js: true do
     login_as administrateur.user, scope: :user
   end
 
+  context "lorsqu'on essaie d'accéder au backoffice déprécié" do
+    scenario "on est redirigé pour les démarches brouillon" do
+      visit admin_procedures_draft_path
+      expect(page).to have_current_path(admin_procedures_path(statut: "brouillons"))
+    end
+
+    scenario "on est redirigé pour les démarches archivées" do
+      visit admin_procedures_archived_path
+      expect(page).to have_current_path(admin_procedures_path(statut: "archivees"))
+    end
+  end
+
   context 'lorsqu’une démarche est en test' do
     scenario 'un administrateur peut la publier' do
       visit admin_procedures_path(statut: "brouillons")


### PR DESCRIPTION
Fix pour les erreurs `ActionView::MissingTemplate` suite à la mise en ligne du nouvel éditeur de démarches.
