### PR TITLE
ajout valeur blanc par default liste groupe instructeur

### DIFF
--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -44,8 +44,9 @@
       -# or adding some "(please select an option)" wording aside the label of the default group.
       -# CSS
       = f.select :groupe_instructeur_id,
-        dossier.procedure.groupe_instructeurs.order(:label).map { |gi| [gi.label, gi.id] },
-        { include_blank: false }
+        options_for_select(dossier.procedure.groupe_instructeurs.order(:label).map { |gi| [gi.label, gi.id] }),
+        { include_blank: true },
+        required: true
 
     = f.fields_for :champs, dossier.champs do |champ_form|
       - champ = champ_form.object


### PR DESCRIPTION

Ajout de la valeur blank par default au moment où l'usager choisit son groupe instructeur.