### PR TITLE
Fix geometry errors

### DIFF
--- a/app/helpers/champ_helper.rb
+++ b/app/helpers/champ_helper.rb
@@ -45,12 +45,20 @@ module ChampHelper
       "Culture : #{geo_area.culture} - Surface : #{geo_area.surface} ha"
     when GeoArea.sources.fetch(:selection_utilisateur)
       if geo_area.polygon?
-        capture do
-          concat "Une aire de surface #{geo_area.area} m"
-          concat content_tag(:sup, "2")
+        if geo_area.area.present?
+          capture do
+            concat "Une aire de surface #{geo_area.area} m"
+            concat content_tag(:sup, "2")
+          end
+        else
+          "Une aire de surface inconnue"
         end
       elsif geo_area.line?
-        "Une ligne longue de #{geo_area.length} m"
+        if geo_area.length.present?
+          "Une ligne longue de #{geo_area.length} m"
+        else
+          "Une ligne de longueur inconnue"
+        end
       elsif geo_area.point?
         "Un point situé à #{geo_area.location}"
       end

--- a/app/javascript/components/MapEditor/utils.js
+++ b/app/javascript/components/MapEditor/utils.js
@@ -1,3 +1,5 @@
+import { gpx, kml } from '@tmcw/togeojson/dist/togeojson.es.js';
+
 export const polygonCadastresFill = {
   'fill-color': '#EC3323',
   'fill-opacity': 0.3
@@ -8,3 +10,81 @@ export const polygonCadastresLine = {
   'line-width': 4,
   'line-dasharray': [1, 1]
 };
+
+export function normalizeFeatureCollection(featureCollection) {
+  const features = [];
+  for (const feature of featureCollection.features) {
+    switch (feature.geometry.type) {
+      case 'MultiPoint':
+        for (const coordinates of feature.geometry.coordinates) {
+          features.push({
+            type: 'Feature',
+            geometry: {
+              type: 'Point',
+              coordinates
+            },
+            properties: feature.properties
+          });
+        }
+        break;
+      case 'MultiLineString':
+        for (const coordinates of feature.geometry.coordinates) {
+          features.push({
+            type: 'Feature',
+            geometry: {
+              type: 'LineString',
+              coordinates
+            },
+            properties: feature.properties
+          });
+        }
+        break;
+      case 'MultiPolygon':
+        for (const coordinates of feature.geometry.coordinates) {
+          features.push({
+            type: 'Feature',
+            geometry: {
+              type: 'Polygon',
+              coordinates
+            },
+            properties: feature.properties
+          });
+        }
+        break;
+      case 'GeometryCollection':
+        for (const geometry of feature.geometry.geometries) {
+          features.push({
+            type: 'Feature',
+            geometry,
+            properties: feature.properties
+          });
+        }
+        break;
+      default:
+        features.push(feature);
+    }
+  }
+
+  featureCollection.features = features;
+  return featureCollection;
+}
+
+export function readGeoFile(file) {
+  const isGpxFile = file.name.includes('.gpx');
+  const reader = new FileReader();
+
+  return new Promise((resolve) => {
+    reader.onload = (event) => {
+      const xml = new DOMParser().parseFromString(
+        event.target.result,
+        'text/xml'
+      );
+      const featureCollection = normalizeFeatureCollection(
+        isGpxFile ? gpx(xml) : kml(xml)
+      );
+
+      resolve(featureCollection);
+    };
+    reader.readAsText(file, 'UTF-8');
+  });
+}

--- a/app/models/geo_area.rb
+++ b/app/models/geo_area.rb
@@ -79,13 +79,13 @@ class GeoArea < ApplicationRecord
 
   def area
     if polygon? && RGeo::Geos.supported?
-      rgeo_geometry.area.round(1)
+      rgeo_geometry.area&.round(1)
     end
   end
 
   def length
     if line? && RGeo::Geos.supported?
-      rgeo_geometry.length.round(1)
+      rgeo_geometry.length&.round(1)
     end
   end
 


### PR DESCRIPTION
Cette PR corrige les erreurs de géométrie sur les démarches avec carto.

Après audit du package https://github.com/tmcw/togeojson il apparait que l'import produit des géométries qu'on ne sait pas gérer au niveau de notre backend (`GeometryCollection` `MultiLineString`). Cette PR introduit une fonction qui normalise les géométries.

Nous avons aussi des cas où la gem qu'on utilise pour calculer l’air n'arrive pas à faire le calcul. Par exemple les polygones en “sablier”. On check les valeurs `nil` désormais.