### PR TITLE
changement de l'adresse de création de compte administrateur

### DIFF
--- a/app/views/root/administration.html.haml
+++ b/app/views/root/administration.html.haml
@@ -47,8 +47,8 @@
 
 
 
-        = link_to "Créez une démarche de test",
-            new_demande_path,
+        = link_to "Créer votre compte administrateur",
+            DEMANDE_INSCRIPTION_ADMIN_PAGE_URL,
             class: "role-panel-button-primary",
             rel: "noopener noreferrer"
         %br
@@ -204,8 +204,8 @@
       .half.first-half
         %h1.cta-panel-title Vous êtes prêt pour dématérialiser ?
         %p.cta-panel-explanation Réduisez vos temps d'instruction de 50 %
-        = link_to "Créer une démarche de test",
-          new_demande_path,
+        = link_to "Créer votre compte administrateur",
+          DEMANDE_INSCRIPTION_ADMIN_PAGE_URL,
           class: "cta-panel-button-blue"
 
       .half

--- a/config/initializers/urls.rb
+++ b/config/initializers/urls.rb
@@ -40,6 +40,7 @@ FAQ_OU_EN_EST_MON_DOSSIER_URL = [FAQ_URL, "article", "11-je-veux-savoir-ou-en-es
 FAQ_ERREUR_SIRET_URL = [FAQ_URL, "article", "4-erreur-siret"].join("/")
 
 STATUS_PAGE_URL = ENV.fetch("STATUS_PAGE_URL", "https://status.demarches-simplifiees.fr")
+DEMANDE_INSCRIPTION_ADMIN_PAGE_URL = ENV.fetch("DEMANDE_INSCRIPTION_ADMIN_PAGE_URL", "https://www.demarches-simplifiees.fr/commencer/demande-d-inscription-a-demarches-simplifiees")
 MATOMO_IFRAME_URL = "https://stats.data.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=fr&&fontColor=333333&fontSize=16px&fontFamily=Muli"
 
 # rubocop:enable DS/ApplicationName


### PR DESCRIPTION
Sur demarches-simplifiees.fr/administration, les deux boutons "créez une demarche de test" deviennent "créer votre compte admin".



![image](https://user-images.githubusercontent.com/1223316/93783783-6ca90c00-fc2c-11ea-9b9a-3fb455453b25.png)
et
![image](https://user-images.githubusercontent.com/1223316/93783886-8d716180-fc2c-11ea-89bd-3e0e7cbe4a0e.png)
