### PR TITLE
#5600 - Fix GraphQL entreprise nil values

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -713,8 +713,12 @@ type Effectif {
 type Entreprise {
   attestationFiscaleAttachment: File
   attestationSocialeAttachment: File
+
+  """
+  capital social de l’entreprise. -1 si inconnu.
+  """
   capitalSocial: BigInt!
-  codeEffectifEntreprise: String!
+  codeEffectifEntreprise: String
   dateCreation: ISO8601Date!
 
   """
@@ -1011,10 +1015,10 @@ type PersonneMorale implements Demandeur {
   localite: String!
   naf: String!
   nomVoie: String!
-  numeroVoie: String!
+  numeroVoie: String
   siegeSocial: Boolean!
   siret: String!
-  typeVoie: String!
+  typeVoie: String
 }
 
 type PersonnePhysique implements Demandeur {

--- a/app/graphql/types/personne_morale_type.rb
+++ b/app/graphql/types/personne_morale_type.rb
@@ -14,7 +14,7 @@ module Types
       field :nom_commercial, String, null: false
       field :raison_sociale, String, null: false
       field :siret_siege_social, String, null: false
-      field :code_effectif_entreprise, String, null: false
+      field :code_effectif_entreprise, String, null: true
       field :effectif_mensuel, EffectifType, null: true, description: "effectif pour un mois donné"
       field :effectif_annuel, EffectifType, null: true, description: "effectif moyen d'une année"
       field :date_creation, GraphQL::Types::ISO8601Date, null: false
@@ -39,6 +39,16 @@ module Types
             nb: object.effectif_mensuel
           }
         end
+      end
+
+      def capital_social
+        # capital_social is defined as a BigInt, so we can't return an empty string when value is unknown
+        # 0 could appear to be a legitimate value, so a negative value helps to ensure the value is not known
+        object.capital_social || '-1'
+      end
+
+      def code_effectif_entreprise
+        object.code_effectif_entreprise || ''
       end
 
       def effectif_annuel

--- a/app/graphql/types/personne_morale_type.rb
+++ b/app/graphql/types/personne_morale_type.rb
@@ -7,7 +7,7 @@ module Types
       end
 
       field :siren, String, null: false
-      field :capital_social, GraphQL::Types::BigInt, null: false
+      field :capital_social, GraphQL::Types::BigInt, null: false, description: "capital social de l’entreprise. -1 si inconnu."
       field :numero_tva_intracommunautaire, String, null: false
       field :forme_juridique, String, null: false
       field :forme_juridique_code, String, null: false
@@ -48,7 +48,8 @@ module Types
       end
 
       def code_effectif_entreprise
-        object.code_effectif_entreprise || ''
+        # we need this in order to bypass Hashie::Dash deserialization issue on nil values
+        object.code_effectif_entreprise
       end
 
       def effectif_annuel
@@ -86,8 +87,8 @@ module Types
     field :naf, String, null: false
     field :libelle_naf, String, null: false
     field :adresse, String, null: false
-    field :numero_voie, String, null: false
-    field :type_voie, String, null: false
+    field :numero_voie, String, null: true
+    field :type_voie, String, null: true
     field :nom_voie, String, null: false
     field :complement_adresse, String, null: false
     field :code_postal, String, null: false

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -429,7 +429,7 @@ describe API::V2::GraphqlController do
                   siren: dossier.etablissement.entreprise_siren,
                   dateCreation: dossier.etablissement.entreprise_date_creation.iso8601,
                   capitalSocial: dossier.etablissement.entreprise_capital_social.to_s,
-                  codeEffectifEntreprise: dossier.etablissement.entreprise_code_effectif_entreprise.to_s,
+                  codeEffectifEntreprise: dossier.etablissement.entreprise_code_effectif_entreprise.to_s
                 }
               }
             })

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -453,7 +453,7 @@ describe API::V2::GraphqlController do
                 entreprise: {
                   siren: dossier.etablissement.entreprise_siren,
                   dateCreation: dossier.etablissement.entreprise_date_creation.iso8601,
-                  capitalSocial: '',
+                  capitalSocial: '-1',
                   codeEffectifEntreprise: ''
                 }
               }

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -400,6 +400,7 @@ describe API::V2::GraphqlController do
                     siren
                     dateCreation
                     capitalSocial
+                    codeEffectifEntreprise
                   }
                 }
               }
@@ -423,7 +424,8 @@ describe API::V2::GraphqlController do
               entreprise: {
                 siren: dossier.etablissement.entreprise_siren,
                 dateCreation: dossier.etablissement.entreprise_date_creation.iso8601,
-                capitalSocial: dossier.etablissement.entreprise_capital_social.to_s
+                capitalSocial: dossier.etablissement.entreprise_capital_social.to_s,
+                codeEffectifEntreprise: dossier.etablissement.entreprise_code_effectif_entreprise.to_s
               }
             }
           })

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -396,6 +396,8 @@ describe API::V2::GraphqlController do
                 ... on PersonneMorale {
                   siret
                   siegeSocial
+                  numeroVoie
+                  typeVoie
                   entreprise {
                     siren
                     dateCreation
@@ -421,11 +423,13 @@ describe API::V2::GraphqlController do
                 id: dossier.etablissement.to_typed_id,
                 siret: dossier.etablissement.siret,
                 siegeSocial: dossier.etablissement.siege_social,
+                numeroVoie: dossier.etablissement.numero_voie.to_s,
+                typeVoie: dossier.etablissement.type_voie.to_s,
                 entreprise: {
                   siren: dossier.etablissement.entreprise_siren,
                   dateCreation: dossier.etablissement.entreprise_date_creation.iso8601,
                   capitalSocial: dossier.etablissement.entreprise_capital_social.to_s,
-                  codeEffectifEntreprise: dossier.etablissement.entreprise_code_effectif_entreprise.to_s
+                  codeEffectifEntreprise: dossier.etablissement.entreprise_code_effectif_entreprise.to_s,
                 }
               }
             })
@@ -434,7 +438,8 @@ describe API::V2::GraphqlController do
 
         context "when there are missing data" do
           before do
-            dossier.etablissement.update!(entreprise_code_effectif_entreprise: nil, entreprise_capital_social: nil)
+            dossier.etablissement.update!(entreprise_code_effectif_entreprise: nil, entreprise_capital_social: nil,
+                                          numero_voie: nil, type_voie: nil)
           end
 
           it "should be returned" do
@@ -450,6 +455,8 @@ describe API::V2::GraphqlController do
                 id: dossier.etablissement.to_typed_id,
                 siret: dossier.etablissement.siret,
                 siegeSocial: dossier.etablissement.siege_social,
+                numeroVoie: nil,
+                typeVoie: nil,
                 entreprise: {
                   siren: dossier.etablissement.entreprise_siren,
                   dateCreation: dossier.etablissement.entreprise_date_creation.iso8601,

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -461,7 +461,7 @@ describe API::V2::GraphqlController do
                   siren: dossier.etablissement.entreprise_siren,
                   dateCreation: dossier.etablissement.entreprise_date_creation.iso8601,
                   capitalSocial: '-1',
-                  codeEffectifEntreprise: ''
+                  codeEffectifEntreprise: nil
                 }
               }
             })

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -407,28 +407,58 @@ describe API::V2::GraphqlController do
             }
           }"
         end
-
-        it "should be returned" do
-          expect(gql_errors).to eq(nil)
-          expect(gql_data).to eq(dossier: {
-            id: dossier.to_typed_id,
-            number: dossier.id,
-            usager: {
-              id: dossier.user.to_typed_id,
-              email: dossier.user.email
-            },
-            demandeur: {
-              id: dossier.etablissement.to_typed_id,
-              siret: dossier.etablissement.siret,
-              siegeSocial: dossier.etablissement.siege_social,
-              entreprise: {
-                siren: dossier.etablissement.entreprise_siren,
-                dateCreation: dossier.etablissement.entreprise_date_creation.iso8601,
-                capitalSocial: dossier.etablissement.entreprise_capital_social.to_s,
-                codeEffectifEntreprise: dossier.etablissement.entreprise_code_effectif_entreprise.to_s
+        context "in the nominal case" do
+          it "should be returned" do
+            expect(gql_errors).to eq(nil)
+            expect(gql_data).to eq(dossier: {
+              id: dossier.to_typed_id,
+              number: dossier.id,
+              usager: {
+                id: dossier.user.to_typed_id,
+                email: dossier.user.email
+              },
+              demandeur: {
+                id: dossier.etablissement.to_typed_id,
+                siret: dossier.etablissement.siret,
+                siegeSocial: dossier.etablissement.siege_social,
+                entreprise: {
+                  siren: dossier.etablissement.entreprise_siren,
+                  dateCreation: dossier.etablissement.entreprise_date_creation.iso8601,
+                  capitalSocial: dossier.etablissement.entreprise_capital_social.to_s,
+                  codeEffectifEntreprise: dossier.etablissement.entreprise_code_effectif_entreprise.to_s
+                }
               }
-            }
-          })
+            })
+          end
+        end
+
+        context "when there are missing data" do
+          before do
+            dossier.etablissement.update!(entreprise_code_effectif_entreprise: nil, entreprise_capital_social: nil)
+          end
+
+          it "should be returned" do
+            expect(gql_errors).to eq(nil)
+            expect(gql_data).to eq(dossier: {
+              id: dossier.to_typed_id,
+              number: dossier.id,
+              usager: {
+                id: dossier.user.to_typed_id,
+                email: dossier.user.email
+              },
+              demandeur: {
+                id: dossier.etablissement.to_typed_id,
+                siret: dossier.etablissement.siret,
+                siegeSocial: dossier.etablissement.siege_social,
+                entreprise: {
+                  siren: dossier.etablissement.entreprise_siren,
+                  dateCreation: dossier.etablissement.entreprise_date_creation.iso8601,
+                  capitalSocial: '',
+                  codeEffectifEntreprise: ''
+                }
+              }
+            })
+          end
         end
       end
     end


### PR DESCRIPTION
https://github.com/betagouv/demarches-simplifiees.fr/issues/5600

> Quand le capitalSocial ou le codeEffectif d'une entreprise est nul, requêter ce champ fait planter la requête, qui renvoie alors une erreur 500.

Hashie/Dash semble [ne pas aimer les valeurs nulles](https://www.rubydoc.info/github/intridea/hashie/Hashie/Dash#property-class_method). On a un `Entreprise < Hashie::Dash`, qui semble créer un conflit avec la définition actuelle de `Types::PersonneMoraleType`

```bash
NoMethodError:
       The property 'capital_social' is not defined for Entreprise.
     # /…/gems/hashie-4.1.0/lib/hashie/dash.rb:227:in `fail_no_property_error!'
     # /…/gems/hashie-4.1.0/lib/hashie/dash.rb:204:in `assert_property_exists!'
     # /…/gems/hashie-4.1.0/lib/hashie/dash.rb:131:in `[]'
     # /…/gems/graphql-1.10.9/lib/graphql/schema/field.rb:614:in `resolve_field_method'
     # /…/gems/graphql-1.10.9/lib/graphql/schema/field.rb:581:in `block in resolve'
     # /…/gems/graphql-1.10.9/lib/graphql/schema/field.rb:730:in `with_extensions'
     # /…/gems/graphql-1.10.9/lib/graphql/schema/field.rb:561:in `resolve'
```


Pas sûr que ce soit la meilleur manière de faire (peut-être ajouter une entrée "gql_errors" ?), ni que ce fix soit exhaustif