### PR TITLE
Length sanitization for worksheet exports

### DIFF
--- a/app/models/champs/repetition_champ.rb
+++ b/app/models/champs/repetition_champ.rb
@@ -53,7 +53,7 @@ class Champs::RepetitionChamp < Champ
   def libelle_for_export
     str = "(#{stable_id}) #{libelle}"
     # /\*?[] are invalid Excel worksheet characters
-    ActiveStorage::Filename.new(str.delete('[]*?')).sanitized.truncate(30)
+    ActiveStorage::Filename.new(str.delete('[]*?')).sanitized
   end
 
   class Row < Hashie::Dash

--- a/app/services/procedure_export_service.rb
+++ b/app/services/procedure_export_service.rb
@@ -62,7 +62,7 @@ class ProcedureExportService
   }
 
   def options_for(table, format)
-    case table
+    options = case table
     when :dossiers
       { instances: dossiers.to_a, sheet_name: 'Dossiers', spreadsheet_columns: :"spreadsheet_columns_#{format}" }
     when :etablissements
@@ -72,5 +72,8 @@ class ProcedureExportService
     when Array
       { instances: table.last, sheet_name: table.first }
     end.merge(DEFAULT_STYLES)
+
+    options[:sheet_name] = options[:sheet_name].truncate(30)
+    options
   end
 end

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -356,6 +356,21 @@ describe ProcedureExportService do
         end
       end
 
+      context 'with long libelle' do
+        before do
+          procedure.types_de_champ.each do |c|
+            c.update!(libelle: "#{c.id} - Quam rem nam maiores numquam dolorem nesciunt. Cum et possimus et aut. Fugit voluptas qui qui.")
+          end
+          champ_repetition.champs.each do |c|
+            c.type_de_champ.update!(libelle: "#{c.id} - Quam rem nam maiores numquam dolorem nesciunt. Cum et possimus et aut. Fugit voluptas qui qui.")
+          end
+        end
+
+        it 'should have valid sheet name' do
+          expect { subject }.not_to raise_error(ArgumentError)
+        end
+      end
+
       context 'with non unique labels' do
         let(:dossier) { create(:dossier, :en_instruction, :with_all_champs, :with_individual, procedure: procedure) }
         let(:champ_repetition) { dossier.champs.find { |champ| champ.type_champ == 'repetition' } }


### PR DESCRIPTION
Fix pour les `ArgumentError` qui empêchent certains exports excels.

```
ArgumentError

Your worksheet name '(123) Pièce d'identité R...' is too long. Worksheet names must be 31 characters (bytes) or less
```

Je ne reproduis pas tout à fait la situation qui pose problème (on tronque déjà les champs répétition), mais avec un fix à ce niveau là on filtre tous les noms de feuilles donc on devrait être tranquille.