### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Dependabot's documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+
+#  - package-ecosystem: "npm" # See documentation for possible values
+#    directory: "/" # Location of package manifests
+#    schedule:
+#      interval: "daily"


### PR DESCRIPTION
Proposition: utiliser dependabot pour générer les MAJs de dépendances.
Je n'ai activé que celles pour ruby, mais si ça nous va on pourra prévoir les dépendances javascript également.
Il y a quelques options pour affiner là: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#package-ecosystem

On le fait déjà pour les MAJs importantes de sécurité. J'ai l'impression qu'on peut tester, et qu'on affinera la granularité temporelle en fonction du nombre de PRs ouvertes

Si on merge cette PR, on aura des update dans https://github.com/betagouv/demarches-simplifiees.fr/network/updates