### PR TITLE
create export after commiting the export object

### DIFF
--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -24,7 +24,7 @@ class Export < ApplicationRecord
 
   scope :stale, -> { where('updated_at < ?', (Time.zone.now - MAX_DUREE_CONSERVATION_EXPORT)) }
 
-  after_create :compute_async
+  after_save_commit :compute_async
 
   def compute_async
     ExportJob.perform_later(self)


### PR DESCRIPTION
`after_create` [semble](https://www.justinweiss.com/articles/a-couple-callback-gotchas-and-a-rails-5-fix/) être une source de problèmes possible pour les exports qui ne sont pas générés.

> ActiveRecord::RecordNotFound (Couldn't find Export with 'id'=123)


L'utilisation de [`after_save_commit`](https://blog.saeloun.com/2019/10/29/rails-6-after-save-commit.html) semble pouvoir corriger ce problème (ou en tout cas, nous permettre d'avancer)