### PR TITLE
smaller font-size for large footers in attestation

### DIFF
--- a/app/views/new_administrateur/attestation_templates/show.pdf.prawn
+++ b/app/views/new_administrateur/attestation_templates/show.pdf.prawn
@@ -74,6 +74,11 @@ prawn_document(margin: [top_margin, right_margin, bottom_margin, left_margin], p
   pdf.repeat(:all) do
     pdf.move_cursor_to footer_height - 10
     pdf.fill_color grey
-    pdf.text footer, align: :center, size: 8
+    if footer.present?
+      # We reduce the size of large footer so they can be drawn in the corresponding area.
+      # This is due to a font change, the replacing font is slightly bigger than the previous one
+      footer_font_size = footer.length > 170 ? 7 : 8
+      pdf.text footer, align: :center, size: footer_font_size
+    end
   end
 end

--- a/spec/controllers/new_administrateur/attestation_templates_controller_spec.rb
+++ b/spec/controllers/new_administrateur/attestation_templates_controller_spec.rb
@@ -66,6 +66,22 @@ describe NewAdministrateur::AttestationTemplatesController, type: :controller do
         it { expect(assigns(:attestation)[:signature]).to eq(nil) }
         it_behaves_like 'rendering a PDF successfully'
       end
+
+      context 'with empty footer' do
+        let!(:attestation_template) do
+          create(:attestation_template, { title: 't', body: 'b', footer: nil })
+        end
+
+        it_behaves_like 'rendering a PDF successfully'
+      end
+
+      context 'with large footer' do
+        let!(:attestation_params) do
+          create(:attestation_template, { title: 't', body: 'b', footer: ' ' * 190 })
+        end
+
+        it_behaves_like 'rendering a PDF successfully'
+      end
     end
   end
 


### PR DESCRIPTION
Suite au problème https://github.com/betagouv/demarches-simplifiees.fr/issues/5533, l'idée de https://github.com/betagouv/demarches-simplifiees.fr/pull/5537 de réduire le nombre de caractères dans l'attestion est une mauvaise idée (faut notifier tout le monde, la maj est compliquée…).

Du coup j'ai réduit la taille de la police pour les longs footers.

