### PR TITLE
Fix deserialization issues delayed job

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -15,12 +15,7 @@ class InvitesController < ApplicationController
     )
 
     if invite.valid?
-      if invite.user.present?
-        InviteMailer.invite_user(invite).deliver_later
-      else
-        InviteMailer.invite_guest(invite).deliver_later
-      end
-
+      # The notification is sent through an after commit hook in order to avoir concurrency issues
       flash.notice = "Une invitation a été envoyée à #{invite.email}."
     else
       flash.alert = invite.errors.full_messages

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -308,7 +308,7 @@ class Dossier < ApplicationRecord
 
   after_save :send_dossier_received
   after_save :send_web_hook
-  after_create :send_draft_notification_email
+  after_save_commit :send_draft_notification_email
 
   validates :user, presence: true
   validates :individual, presence: true, if: -> { revision.procedure.for_individual? }

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -308,7 +308,7 @@ class Dossier < ApplicationRecord
 
   after_save :send_dossier_received
   after_save :send_web_hook
-  after_save_commit :send_draft_notification_email
+  after_create_commit :send_draft_notification_email
 
   validates :user, presence: true
   validates :individual, presence: true, if: -> { revision.procedure.for_individual? }

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -19,6 +19,8 @@ class Invite < ApplicationRecord
 
   before_validation -> { sanitize_email(:email) }
 
+  after_save_commit :send_notification
+
   validates :email, presence: true
   validates :email, uniqueness: { scope: :dossier_id }
 
@@ -32,4 +34,12 @@ class Invite < ApplicationRecord
   scope :kept, -> { joins(:dossier).merge(Dossier.kept) }
 
   default_scope { kept }
+
+  def send_notification
+    if self.user.present?
+      InviteMailer.invite_user(self).deliver_later
+    else
+      InviteMailer.invite_guest(self).deliver_later
+    end
+  end
 end

--- a/app/models/invite.rb
+++ b/app/models/invite.rb
@@ -19,7 +19,7 @@ class Invite < ApplicationRecord
 
   before_validation -> { sanitize_email(:email) }
 
-  after_save_commit :send_notification
+  after_create_commit :send_notification
 
   validates :email, presence: true
   validates :email, uniqueness: { scope: :dossier_id }


### PR DESCRIPTION
Passage en `after_save_commit` pour éviter les mails qui ne partent pas:
 - pour les dossiers draft
 - pour les invitations

```
ActionView::Template::Error app/views/invite_mailer/invite_guest.html.haml in ?
error undefined method `procedure' for nil:NilClassdelayed_job
```

On a un pic de ce dernier depuis le 22 (passage de 0 erreurs à ~10/j).