### PR TITLE
do not run ApiEntreprise jobs on missing etablissements

### DIFF
--- a/app/jobs/api_entreprise/job.rb
+++ b/app/jobs/api_entreprise/job.rb
@@ -3,6 +3,10 @@ class ApiEntreprise::Job < ApplicationJob
 
   DEFAULT_MAX_ATTEMPTS_API_ENTREPRISE_JOBS = 5
 
+  # If by the time the job runs the Etablissement has been deleted
+  # (it can happen through EtablissementUpdateJob for instance), ignore the job
+  discard_on ActiveRecord::RecordNotFound
+
   rescue_from(ApiEntreprise::API::ResourceNotFound) do |exception|
     error(self, exception)
   end

--- a/spec/jobs/api_entreprise/association_job_spec.rb
+++ b/spec/jobs/api_entreprise/association_job_spec.rb
@@ -18,4 +18,14 @@ RSpec.describe ApiEntreprise::AssociationJob, type: :job do
     subject
     expect(Etablissement.find(etablissement.id).association_rna).to eq('W595001988')
   end
+
+  context "when the etablissement has been deleted" do
+    before do
+      allow_any_instance_of(Etablissement).to receive(:find) { raise ActiveRecord::RecordNotFound }
+    end
+
+    it "ignores the error" do
+      expect { subject }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
J'ai l'impression que les jobs API entreprise qui échouent le font pour une raison légitime: l'établissement est bien supprimé:
 - s'il était mal sauvegardé, on aurait [une exception](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/app/services/api_entreprise_service.rb#L15)
 - on [supprime bien des établissements](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/app/jobs/etablissement_update_job.rb#L11)

Il est donc possible qu'on ait deux jobs concurrents qui passent et utilisent la même ressource, voici une timeline possible:
 - création de l'entreprise, et des jobs ApiEntreprise
 - mise à jour du dossier par l'usager, et de l'entreprise. Création d'un EtablissementUpdateJob
 - suppression de l'ancien établissement dans `EtablissementUpdateJob`
 - lorsqu'un job ApiEntreprise dépile un job pour une entreprise supprimée, il plante.