### PR TITLE
Ensure valid excel worksheet names

### DIFF
--- a/app/services/procedure_export_service.rb
+++ b/app/services/procedure_export_service.rb
@@ -73,10 +73,12 @@ class ProcedureExportService
       { instances: table.last, sheet_name: table.first }
     end.merge(DEFAULT_STYLES)
 
-    # transliterate: convert to ASCII characteres
+    # transliterate: convert to ASCII characters
     # to ensure truncate respects 30 bytes
-    options[:sheet_name] = I18n.transliterate(options[:sheet_name], '')
-      .truncate(30, omission: '')
+    # /\*?[] are invalid Excel worksheet characters
+    options[:sheet_name] = I18n.transliterate(
+      ActiveStorage::Filename.new(options[:sheet_name].delete('[]*?')).sanitized, '', locale: :en
+    ).truncate(30, omission: '')
 
     options
   end

--- a/app/services/procedure_export_service.rb
+++ b/app/services/procedure_export_service.rb
@@ -76,9 +76,9 @@ class ProcedureExportService
     # transliterate: convert to ASCII characters
     # to ensure truncate respects 30 bytes
     # /\*?[] are invalid Excel worksheet characters
-    options[:sheet_name] = I18n.transliterate(
-      ActiveStorage::Filename.new(options[:sheet_name].delete('[]*?')).sanitized, '', locale: :en
-    ).truncate(30, omission: '')
+    options[:sheet_name] = I18n.transliterate(options[:sheet_name], '', locale: :en)
+      .delete('/\*?[]')
+      .truncate(30, omission: '')
 
     options
   end

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -359,7 +359,7 @@ describe ProcedureExportService do
       context 'with long libelle composed of utf8 characteres' do
         before do
           procedure.types_de_champ.each do |c|
-            c.update!(libelle: "#{c.id} - éééé ééé ééé ééééééé ééééééé ééééééé éééééééé. ééé éé éééééééé éé ééé. ééééé éééééééé ééé ééé.")
+            c.update!(libelle: "#{c.id} - éééé ééé ééé ééééééé ???? ééééééé éééééééé. ééé éé éééééééé éé ééé. ééééé éééééééé ééé ééé.")
           end
           champ_repetition.champs.each do |c|
             c.type_de_champ.update!(libelle: "#{c.id} - Quam rem nam maiores numquam dolorem nesciunt. Cum et possimus et aut. Fugit voluptas qui qui.")

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -359,7 +359,7 @@ describe ProcedureExportService do
       context 'with long libelle composed of utf8 characteres' do
         before do
           procedure.types_de_champ.each do |c|
-            c.update!(libelle: "#{c.id} - éééé ééé ééé ééééééé ???? ééééééé éééééééé. ééé éé éééééééé éé ééé. ééééé éééééééé ééé ééé.")
+            c.update!(libelle: "#{c.id} - ?/[] ééé ééé ééééééé ééééééé éééééééé. ééé éé éééééééé éé ééé. ééééé éééééééé ééé ééé.")
           end
           champ_repetition.champs.each do |c|
             c.type_de_champ.update!(libelle: "#{c.id} - Quam rem nam maiores numquam dolorem nesciunt. Cum et possimus et aut. Fugit voluptas qui qui.")


### PR DESCRIPTION
Corrige les ArgumentError sur les noms de feuille excel. Si on en a encore après ça, je ne sais plus quoi faire.


> ArgumentError app/services/procedure_export_service.rb in block in to_xlsx
> error Your worksheet name '(123456) Membre de famille d?' contains a character which is not allowed by MS Excel and will cause repair warnings. Please chang
