### PR TITLE
Ensure a dossier_id is set for champs in Repetition

### DIFF
--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -61,6 +61,7 @@ class Champ < ApplicationRecord
 
   scope :root, -> { where(parent_id: nil) }
 
+  before_create :set_dossier_id, if: :needs_dossier_id?
   before_validation :set_dossier_id, if: :needs_dossier_id?
 
   validates :type_de_champ_id, uniqueness: { scope: [:dossier_id, :row] }


### PR DESCRIPTION
Depuis l'introduction le 20/08 de https://github.com/betagouv/demarches-simplifiees.fr/commit/6328011f607928b7a90b0da90870fea39e73af06#diff-b15fda4251417f8bc6be6bc4139b7b2eL52, certains champs n'ont pas de dossier_id.
Cela casse l'upload de pièces justificatives dans les champs répétition : la jointure faite sur `dossier` dans `ChampPolicy`, nécessaire afin de vérifier que l'utilisateur écrit bien dans un champ à lui, ne renvoit aucun champ, et donc déclenche des 404 lors de l'upload.