### PR TITLE
Add titre identite champ to GraphQL

### DIFF
--- a/app/graphql/api/v2/schema.rb
+++ b/app/graphql/api/v2/schema.rb
@@ -50,6 +50,7 @@ class Api::V2::Schema < GraphQL::Schema
     Types::Champs::RepetitionChampType,
     Types::Champs::SiretChampType,
     Types::Champs::TextChampType,
+    Types::Champs::TitreIdentiteChampType,
     Types::GeoAreas::ParcelleCadastraleType,
     Types::GeoAreas::SelectionUtilisateurType,
     Types::PersonneMoraleType,

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -1197,6 +1197,33 @@ type TextChamp implements Champ {
   value: String
 }
 
+type TitreIdentiteChamp implements Champ {
+  grantType: TitreIdentiteGrantType!
+  id: ID!
+
+  """
+  Libellé du champ.
+  """
+  label: String!
+
+  """
+  La valeur du champ sous forme texte.
+  """
+  stringValue: String
+}
+
+enum TitreIdentiteGrantType {
+  """
+  Françe Connect
+  """
+  france_connect
+
+  """
+  Pièce justificative
+  """
+  piece_justificative
+}
+
 enum TypeDeChamp {
   """
   Adresse

--- a/app/graphql/types/champ_type.rb
+++ b/app/graphql/types/champ_type.rb
@@ -33,6 +33,8 @@ module Types
           Types::Champs::LinkedDropDownListChampType
         when ::Champs::CiviliteChamp
           Types::Champs::CiviliteChampType
+        when ::Champs::TitreIdentiteChamp
+          Types::Champs::TitreIdentiteChampType
         else
           Types::Champs::TextChampType
         end

--- a/app/graphql/types/champs/titre_identite_champ_type.rb
+++ b/app/graphql/types/champs/titre_identite_champ_type.rb
@@ -1,0 +1,16 @@
+module Types::Champs
+  class TitreIdentiteChampType < Types::BaseObject
+    implements Types::ChampType
+
+    class TitreIdentiteGrantTypeType < Types::BaseEnum
+      value(TypesDeChamp::TitreIdentiteTypeDeChamp::FRANCE_CONNECT, "Françe Connect")
+      value(TypesDeChamp::TitreIdentiteTypeDeChamp::PIECE_JUSTIFICATIVE, "Pièce justificative")
+    end
+
+    field :grant_type, TitreIdentiteGrantTypeType, null: false
+
+    def grant_type
+      TypesDeChamp::TitreIdentiteTypeDeChamp::PIECE_JUSTIFICATIVE
+    end
+  end
+end

--- a/app/models/types_de_champ/titre_identite_type_de_champ.rb
+++ b/app/models/types_de_champ/titre_identite_type_de_champ.rb
@@ -1,2 +1,4 @@
 class TypesDeChamp::TitreIdentiteTypeDeChamp < TypesDeChamp::TypeDeChampBase
+  FRANCE_CONNECT = 'france_connect'
+  PIECE_JUSTIFICATIVE = 'piece_justificative'
 end


### PR DESCRIPTION
Ajoute le type “titre identite” sur l'API. Le champ à un `grant_type` : `piece_justificative` ou `france_connect`. `piece_justificative` est le seul utilisé pour l'instant.