### PR TITLE
informe l'administrateur si la procédure a un jeton spécifique

### DIFF
--- a/app/views/new_administrateur/procedures/jeton.html.haml
+++ b/app/views/new_administrateur/procedures/jeton.html.haml
@@ -19,6 +19,6 @@
       propre à votre démarche.
 
     = f.label :api_entreprise_token, "Jeton"
-    = f.password_field :api_entreprise_token, class: 'form-control'
+    = f.password_field :api_entreprise_token, value: @procedure.read_attribute(:api_entreprise_token), class: 'form-control'
     .text-right
       = f.button 'Enregistrer', class: 'button primary send'


### PR DESCRIPTION
Cette PR permet à l'administrateur de savoir si la procédure a un jeton spécifique.
Lorsque tel est le cas, le champ jeton a des caractères masqués.

![jeton](https://user-images.githubusercontent.com/1111966/95224692-4625cc00-07fb-11eb-95c5-8bffc96ba0ae.png)
