### PR TITLE
Ajout d'un écran de synthèse des emails dans /manager

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ gem 'rgeo-geojson'
 gem 'sanitize-url'
 gem 'sassc-rails' # Use SCSS for stylesheets
 gem 'sentry-raven'
+gem 'sib-api-v3-sdk'
 gem 'skylight'
 gem 'smart_listing'
 gem 'spreadsheet_architect'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
       rake (>= 10.4, < 14.0)
     ast (2.4.1)
     attr_required (1.0.1)
-    autoprefixer-rails (10.0.0.2)
+    autoprefixer-rails (10.0.1.0)
       execjs
     axe-matchers (2.6.1)
       dumb_delegator (~> 0.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,6 +348,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.3.1)
     json-jwt (1.13.0)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -658,6 +659,9 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (4.4.1)
       activesupport (>= 4.2.0)
+    sib-api-v3-sdk (7.0.0)
+      json (~> 2.1, >= 2.1.0)
+      typhoeus (~> 1.0, >= 1.0.1)
     simple_xlsx_reader (1.0.4)
       nokogiri
       rubyzip
@@ -860,6 +864,7 @@ DEPENDENCIES
   scss_lint
   sentry-raven
   shoulda-matchers
+  sib-api-v3-sdk
   simple_xlsx_reader
   skylight
   smart_listing

--- a/app/controllers/manager/users_controller.rb
+++ b/app/controllers/manager/users_controller.rb
@@ -50,6 +50,23 @@ module Manager
     def emails
       @user = User.find(params[:id])
 
+      transactionnal_api = ::SibApiV3Sdk::TransactionalEmailsApi.new
+
+      @transactionnal_emails = transactionnal_api.get_transac_emails_list(email: @user.email)
+      @events = transactionnal_api.get_email_event_report(email: @user.email, days: 30)
+
+    rescue ::SibApiV3Sdk::ApiError => e
+      flash.alert = "Impossible de récupérer les emails de cet utilisateur chez Sendinblue : #{e.message}"
+    end
+
+    def unblock_user
+      @user = User.find(params[:id])
+
+      transactionnal_api = ::SibApiV3Sdk::TransactionalEmailsApi.new
+      transactionnal_api.smtp_blocked_contacts_email_delete(@user)
+
+    rescue ::SibApiV3Sdk::ApiError => e
+      flash.alert = "Impossible de débloquer cet email auprès de Sendinblue : #{e.message}"
     end
   end
 end

--- a/app/controllers/manager/users_controller.rb
+++ b/app/controllers/manager/users_controller.rb
@@ -63,7 +63,7 @@ module Manager
       @user = User.find(params[:id])
 
       transactionnal_api = ::SibApiV3Sdk::TransactionalEmailsApi.new
-      transactionnal_api.smtp_blocked_contacts_email_delete(@user)
+      transactionnal_api.smtp_blocked_contacts_email_delete(@user.email)
 
     rescue ::SibApiV3Sdk::ApiError => e
       flash.alert = "Impossible de débloquer cet email auprès de Sendinblue : #{e.message}"

--- a/app/controllers/manager/users_controller.rb
+++ b/app/controllers/manager/users_controller.rb
@@ -46,5 +46,10 @@ module Manager
 
       redirect_to manager_users_path
     end
+
+    def emails
+      @user = User.find(params[:id])
+
+    end
   end
 end

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -26,6 +26,8 @@ class WebhookController < ActionController::Base
         html << link_to_manager(administrateur, url)
       end
 
+      html << email_link_to_manager(user)
+
       render json: { html: html.join('<br>') }
     end
   end
@@ -34,6 +36,11 @@ class WebhookController < ActionController::Base
 
   def link_to_manager(model, url)
     "<a target='_blank' href='#{url}' rel='noopener'>#{model.model_name.human}##{model.id}</a>"
+  end
+
+  def email_link_to_manager(user)
+    url = emails_manager_user_url(user)
+    "<a target='_blank' href='#{url}' rel='noopener'>Emails##{user.id}</a>"
   end
 
   def verify_signature!

--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -1,0 +1,12 @@
+module EmailHelper
+  def event_color_code(email_events)
+    unique_events = email_events.map(&:event)
+    if unique_events.include?('delivered')
+      return 'email-sent'
+    elsif unique_events.include?('blocked') || unique_events.include?('hardBounces')
+      return 'email-blocked'
+    else
+      return ''
+    end
+  end
+end

--- a/app/views/manager/administrateurs/show.html.erb
+++ b/app/views/manager/administrateurs/show.html.erb
@@ -42,6 +42,7 @@ as well as a link to its edit page.
 </header>
 
 <section class="main-content__body">
+  <%= render partial: 'manager/application/user_meta', locals: {user: page.resource&.user} %>
   <dl>
     <% page.attributes.each do |attribute| %>
       <dt class="attribute-label" id="<%= attribute.name %>">

--- a/app/views/manager/application/_user_meta.html.erb
+++ b/app/views/manager/application/_user_meta.html.erb
@@ -1,5 +1,13 @@
 <dl>
   <dt class="attribute-label" id="meta-usager">
+    Emails
+  </dt>
+  <dd class="attribute-data attribute-data--meta-usager">
+    <%= link_to('Voir les derniers emails', emails_manager_user_path(user)) %>
+  </dd>
+</dl>
+<dl>
+  <dt class="attribute-label" id="meta-usager">
     Usager
   </dt>
   <dd class="attribute-data attribute-data--meta-usager">

--- a/app/views/manager/application/_user_meta.html.erb
+++ b/app/views/manager/application/_user_meta.html.erb
@@ -1,0 +1,35 @@
+<dl>
+  <dt class="attribute-label" id="meta-usager">
+    Usager
+  </dt>
+  <dd class="attribute-data attribute-data--meta-usager">
+    <%= link_to('Voir son compte utilisateur', manager_user_path(user)) %>
+  </dd>
+</dl>
+
+<dl>
+  <dt class="attribute-label" id="meta-usager">
+    Instructeur
+  </dt>
+  <dd class="attribute-data attribute-data--meta-usager">
+    <% if user.instructeur.present? %>
+      <%= link_to('Voir son compte instructeur', manager_instructeur_path(user.instructeur)) %>
+    <% else %>
+      Pas instructeur !
+    <% end %>
+  </dd>
+</dl>
+
+<dl>
+  <dt class="attribute-label" id="meta-usager">
+    Administrateur
+  </dt>
+  <dd class="attribute-data attribute-data--meta-usager">
+    <% if user.administrateur.present? %>
+      <%= link_to('Voir son compte administrateur', manager_administrateur_path(user.administrateur)) %>
+    <% else %>
+      Pas administrateur !
+    <% end %>
+  </dd>
+</dl>
+<hr />

--- a/app/views/manager/instructeurs/show.html.erb
+++ b/app/views/manager/instructeurs/show.html.erb
@@ -41,6 +41,7 @@ as well as a link to its edit page.
 </header>
 
 <section class="main-content__body">
+  <%= render partial: 'manager/application/user_meta', locals: {user: page.resource&.user} %>
   <dl>
     <% page.attributes.each do |attribute| %>
       <dt class="attribute-label" id="<%= attribute.name %>">

--- a/app/views/manager/users/emails.html.erb
+++ b/app/views/manager/users/emails.html.erb
@@ -1,5 +1,15 @@
 <% content_for(:title) { "Emails vers #{@user.email}" } %>
 
+<style>
+  .hidden { display: none }
+  .email-sent { color: green !important}
+  .email-blocked { color: red }
+</style>
+<script type="text/javascript" charset="utf-8">
+  function reveal_email(id) {
+      document.querySelector(id).classList.toggle('hidden');
+  }
+</script>
 <header class="main-content__header" role="banner">
   <h1 class="main-content__page-title">
     <%= content_for(:title) %>
@@ -7,7 +17,101 @@
 </header>
 
 <section class="main-content__body">
-  <dl>
+  <h2>Historique des email</h2>
+<% if @transactionnal_emails.present? %>
+  <p>
+  Cet historique contient les 30 derniers jours. Pour un recherche plus fine, il faut <a href="https://app-smtp.sendinblue.com/log">fouiller les logs</a>.
+  </p>
+  <table>
+    <thead>
+    <tr>
+      <th class="cell-label cell-label--string cell-label--false" scope="col" role="columnheader" aria-sort="none">
+        Émetteur
+      </th>
+      <th class="cell-label cell-label--string cell-label--false" scope="col" role="columnheader" aria-sort="none">
+        Sujet
+      </th>
+      <th class="cell-label cell-label--string cell-label--false" scope="col" role="columnheader" aria-sort="none">
+        Date
+      </th>
+    </tr>
+    </thead>
+    <tbody>
+      <% @transactionnal_emails&.transactional_emails&.reverse&.each do |email| %>
+        <% matching_events = @events&.events&.select { |e| e.message_id == email.message_id } %>
+      <tr class="<%= event_color_code(matching_events) %>">
+        <td class="cell-data cell-data--string" style="">
+          <%= email.from %>
+        </td>
+        <td class="cell-data cell-data--string" style="">
+        <%= email.subject %>
+        </td>
+        <td class="cell-data cell-data--string" style="text-align: center;">
+        <%= l(email.date, format: '%d/%m/%y à %H:%M') %>
+        </td>
+        <td class="cell-data cell-data--string" style="text-align: center;">
+          <ul>
 
-  </dl>
+          <% matching_events.each do |event|%>
+          <li><%= event.event %></li>
+          <% end %>
+          </ul>
+        </td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p>Historique indisponible. Cet email n'existe pas chez Sendinblue, ou nous n'avons pas réussi à échanger.
+    Vous pouvez éventuellement <a href="https://app-smtp.sendinblue.com/log">fouiller leurs logs</a>.</p>
+<% end %>
+
+  <h2>Problèmes potentiel</h2>
+
+  <% if @user.confirmed? %>
+    <p><strong>Compte activé, n'arrive pas à se connecter</strong> ? <button class="btn btn-secondary btn-small" onclick="reveal_email('#activated-cant-connect')">Voir la suggestion d’email</button></p>
+    <pre class="hidden" id="activated-cant-connect">
+Bonjour,
+votre compte est activé de notre côté.
+Vous pouvez vous connecter à votre compte de deux manières :
+- à cette adresse, afin de consulter vos dossiers : https://www.demarches-simplifiees.fr/users/sign_in
+- depuis la page de démarrage d’une démarche qu'on vous a communiqué, afin de déposer un dossier.
+
+Si vous avez oublié votre mot de passe, vous pouvez aussi en demander un nouveau via:
+https://www.demarches-simplifiees.fr/users/password/new
+
+Bien cordialement</pre>
+  <% else %>
+    <p><strong>Ce compte n'est pas activé</strong>. Vous pouvez lui <%= link_to('renvoyer l’email de confirmation', [:resend_confirmation_instructions, namespace, 'user'], method: :post, class: 'button') %>, puis un email. <button class="btn btn-secondary btn-small" onclick="reveal_email('#not-activated')">Voir la suggestion d’email</button> </p>
+    <pre class="hidden" id="not-activated">
+Bonjour,
+
+Votre compte n'a pas été confirmé. Je vous ai transmis à nouveau un code de confirmation
+dans un email séparé ; après avoir cliqué sur le lien qui s'y trouve, vous pourrez vous connecter
+à votre compte, voir les dossiers déposés et en déposer de nouveaux.
+
+Si vous avez oublié votre mot de passe, vous pouvez aussi en demander un autre via:
+https://www.demarches-simplifiees.fr/users/password/new
+
+Cordialement</pre>
+  <% end %>
+  <p><strong>Compte <a href="https://app-smtp.sendinblue.com/block">bloqué</a> chez Sendinblue ?</strong> Vous pouvez le <%= link_to('débloquer', manager_user_unblock_email_path(@user), method: :put, class: 'button', remote: true) %>  puis lui envoyer <button class="btn btn-secondary btn-small" onclick="reveal_email('#unblock_email')">le mail suivant</button></p>
+    <pre class="hidden" id="unblock_email">
+Bonjour,
+
+votre email était bloqué par notre prestataire.
+Je l'ai débloqué, vous devriez recevoir les mails à venir.
+
+Cela peut arriver si vous, ou ceux qui gèrent vos emails, marquent nos emails comme spam.
+
+Nous vous invitons donc à autoriser les emails émis depuis demarches-simplifiees.fr
+
+Bien cordialement</pre>
+<p><strong>Problème chez Sendinblue ?</strong> Regardez leur <a href="https://status.sendinblue.com/">page de status</a>. <button class="btn btn-secondary btn-small" onclick="reveal_email('#pb-sendinblue')">Voir la suggestion d’email</button></p>
+  <pre class="hidden" id="pb-sendinblue">
+Bonjour,
+Désolé, notre prestataire d'envoi d'email subit actuellement des soucis avec sa plateforme ;
+vous allez recevoir cet email sous peu.
+
+Bien cordialement,</pre>
 </section>

--- a/app/views/manager/users/emails.html.erb
+++ b/app/views/manager/users/emails.html.erb
@@ -1,0 +1,13 @@
+<% content_for(:title) { "Emails vers #{@user.email}" } %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title">
+    <%= content_for(:title) %>
+  </h1>
+</header>
+
+<section class="main-content__body">
+  <dl>
+
+  </dl>
+</section>

--- a/app/views/manager/users/show.html.erb
+++ b/app/views/manager/users/show.html.erb
@@ -34,7 +34,7 @@ as well as a link to its edit page.
     <% if !user.confirmed? %>
       <%= link_to('Renvoyer l’email de confirmation', [:resend_confirmation_instructions, namespace, page.resource], method: :post, class: 'button') %>
     <% end %>
-  <div>
+  </div>
 </header>
 
 <section class="main-content__body">

--- a/app/views/manager/users/show.html.erb
+++ b/app/views/manager/users/show.html.erb
@@ -38,6 +38,7 @@ as well as a link to its edit page.
 </header>
 
 <section class="main-content__body">
+  <%= render partial: 'manager/application/user_meta', locals: {user: user} %>
   <dl>
     <% page.attributes.each do |attribute| %>
       <dt class="attribute-label" id="<%= attribute.name %>">

--- a/config/initializers/sendinblue.rb
+++ b/config/initializers/sendinblue.rb
@@ -1,0 +1,5 @@
+require 'sib-api-v3-sdk'
+
+SibApiV3Sdk.configure do |config|
+  config.api_key['api-key'] = ENV.fetch('SENDINBLUE_API_V3_KEY', '')
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
       delete 'delete', on: :member
       post 'resend_confirmation_instructions', on: :member
       put 'enable_feature', on: :member
+      get 'emails', on: :member
     end
 
     resources :instructeurs, only: [:index, :show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
       post 'resend_confirmation_instructions', on: :member
       put 'enable_feature', on: :member
       get 'emails', on: :member
+      put 'unblock_email'
     end
 
     resources :instructeurs, only: [:index, :show] do


### PR DESCRIPTION
Ajout d'un écran de debug des emails pour le support, avec les infos sur les situations courantes, les actions pour y remédier et des suggestions d'emails.

![image](https://user-images.githubusercontent.com/1223316/95747696-24b05e80-0c99-11eb-8121-f1b75cfe6e3f.png)

Je me suis également offert des boutons qui me manquent depuis un moment, pour passer de l'usager à l'instructeur puis à l'administrateur, ou savoir si un usager est l'un ou l'autre.

![image](https://user-images.githubusercontent.com/1223316/95747918-7fe25100-0c99-11eb-9618-78db25d9d13f.png)
