### PR TITLE
Faster instructeur procedure show2

### DIFF
--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -98,6 +98,9 @@ module Instructeurs
         @archived_dossiers
       end
 
+      @has_en_cours_notifications = current_instructeur.notifications_for_procedure(@procedure, :en_cours).exists?
+      @has_termine_notifications = current_instructeur.notifications_for_procedure(@procedure, :termine).exists?
+
       @not_archived_notifications_dossier_ids = current_instructeur.notifications_for_procedure(@procedure, :not_archived).pluck(:id)
 
       sorted_ids = procedure_presentation.sorted_ids(@dossiers, current_instructeur)

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -98,6 +98,8 @@ module Instructeurs
         @archived_dossiers
       end
 
+      @not_archived_notifications_dossier_ids = current_instructeur.notifications_for_procedure(@procedure, :not_archived).pluck(:id)
+
       sorted_ids = procedure_presentation.sorted_ids(@dossiers, current_instructeur)
 
       if @current_filters.count > 0

--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -102,6 +102,7 @@ module Instructeurs
       @has_termine_notifications = current_instructeur.notifications_for_procedure(@procedure, :termine).exists?
 
       @not_archived_notifications_dossier_ids = current_instructeur.notifications_for_procedure(@procedure, :not_archived).pluck(:id)
+      @counters = @procedure.dossiers_count_for_instructeur(current_instructeur)
 
       sorted_ids = procedure_presentation.sorted_ids(@dossiers, current_instructeur)
 

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -630,6 +630,45 @@ class Procedure < ApplicationRecord
     draft_revision.deep_clone(include: [:revision_types_de_champ, :revision_types_de_champ_private])
   end
 
+  def dossiers_count_for_instructeur(instructeur)
+    query = <<-EOF
+  SELECT
+      COUNT(*) FILTER ( WHERE "dossiers"."state" in ('en_construction', 'en_instruction') and "follows"."id" IS NULL and not "dossiers"."archived" ) AS a_suivre,
+      COUNT(*) FILTER ( WHERE "dossiers"."state" in ('en_construction', 'en_instruction') and "follows"."instructeur_id" = :instructeur_id and not "dossiers"."archived" ) AS suivis,
+      COUNT(*) FILTER ( WHERE "dossiers"."state" in ('accepte', 'refuse', 'sans_suite') and not "dossiers"."archived" ) AS termines,
+      COUNT(*) FILTER ( WHERE "dossiers"."state" != 'brouillon' and not "dossiers"."archived" ) AS total,
+      COUNT(*) FILTER ( WHERE "dossiers"."archived" ) AS archived
+  FROM
+      "dossiers"
+  INNER JOIN
+      "groupe_instructeurs"
+          ON "dossiers"."groupe_instructeur_id" = "groupe_instructeurs"."id"
+  INNER JOIN
+      "assign_tos"
+          ON "groupe_instructeurs"."id" = "assign_tos"."groupe_instructeur_id"
+  INNER JOIN
+      "procedures"
+          ON "groupe_instructeurs"."procedure_id" = "procedures"."id"
+  LEFT OUTER JOIN
+      "follows"
+          ON "follows"."dossier_id" = "dossiers"."id"
+  WHERE
+      "dossiers"."hidden_at" IS NULL
+      AND "assign_tos"."instructeur_id" = :instructeur_id
+      AND "procedures"."id" = :procedure_id
+  GROUP BY
+      groupe_instructeurs.procedure_id, procedures.libelle
+    EOF
+
+    sanitized_query = ActiveRecord::Base.sanitize_sql([
+      query,
+      instructeur_id: instructeur.id,
+      procedure_id: self.id
+    ])
+
+    Procedure.connection.select_all(sanitized_query).first || { "a_suivre" => 0, "suivis" => 0, "termines" => 0, "total" => 0, "archived" => 0 }
+  end
+
   private
 
   def before_publish

--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -82,7 +82,6 @@ class ProcedurePresentation < ApplicationRecord
   end
 
   def displayed_field_values(dossier)
-    assert_matching_procedure(dossier)
     displayed_fields.map { |field| get_value(dossier, field['table'], field['column']) }
   end
 
@@ -253,12 +252,6 @@ class ProcedurePresentation < ApplicationRecord
     table, column = field.values_at('table', 'column')
     if !valid_column?(table, column, extra_columns)
       errors.add(kind, "#{table}.#{column} n’est pas une colonne permise")
-    end
-  end
-
-  def assert_matching_procedure(dossier)
-    if dossier.procedure != procedure
-      raise "Procedure mismatch (expected #{procedure.id}, got #{dossier.procedure.id})"
     end
   end
 

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -30,13 +30,13 @@
             instructeur_procedure_path(@procedure, statut: 'suivis'),
             active: @statut == 'suivis',
             badge: number_with_html_delimiter(@followed_dossiers.count),
-            notification: current_instructeur.notifications_for_procedure(@procedure, :en_cours).exists?)
+            notification: @has_en_cours_notifications)
 
           = tab_item(t('pluralize.processed', count: @termines_dossiers.count),
             instructeur_procedure_path(@procedure, statut: 'traites'),
             active: @statut == 'traites',
             badge: number_with_html_delimiter(@termines_dossiers.count),
-            notification: current_instructeur.notifications_for_procedure(@procedure, :termine).exists?)
+            notification: @has_termine_notifications)
 
           = tab_item('tous les dossiers',
             instructeur_procedure_path(@procedure, statut: 'tous'),

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -135,7 +135,7 @@
               %td.folder-col
                 = link_to(instructeur_dossier_path(@procedure, dossier), class: 'cell-link') do
                   %span.icon.folder
-                    - if current_instructeur.notifications_for_procedure(@procedure, :not_archived).include?(dossier)
+                    - if @not_archived_notifications_dossier_ids.include?(dossier.id)
                       %span.notifications{ 'aria-label': 'notifications' }
 
               %td.number-col

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -24,29 +24,29 @@
           = tab_item('à suivre',
             instructeur_procedure_path(@procedure, statut: 'a-suivre'),
             active: @statut == 'a-suivre',
-            badge: number_with_html_delimiter(@a_suivre_dossiers.count))
+            badge: number_with_html_delimiter(@counters['a_suivre']))
 
-          = tab_item(t('pluralize.followed', count: @followed_dossiers.count),
+          = tab_item(t('pluralize.followed', count: @counters['suivis']),
             instructeur_procedure_path(@procedure, statut: 'suivis'),
             active: @statut == 'suivis',
-            badge: number_with_html_delimiter(@followed_dossiers.count),
+            badge: number_with_html_delimiter(@counters['suivis']),
             notification: @has_en_cours_notifications)
 
-          = tab_item(t('pluralize.processed', count: @termines_dossiers.count),
+          = tab_item(t('pluralize.processed', count: @counters['termines']),
             instructeur_procedure_path(@procedure, statut: 'traites'),
             active: @statut == 'traites',
-            badge: number_with_html_delimiter(@termines_dossiers.count),
+            badge: number_with_html_delimiter(@counters['termines']),
             notification: @has_termine_notifications)
 
           = tab_item('tous les dossiers',
             instructeur_procedure_path(@procedure, statut: 'tous'),
             active: @statut == 'tous',
-            badge: number_with_html_delimiter(@all_state_dossiers.count))
+            badge: number_with_html_delimiter(@counters['total']))
 
           = tab_item(t('pluralize.archived', count: @archived_dossiers.count),
             instructeur_procedure_path(@procedure, statut: 'archives'),
             active: @statut == 'archives',
-            badge: number_with_html_delimiter(@archived_dossiers.count))
+            badge: number_with_html_delimiter(@counters['archived']))
 
       .procedure-actions
         = render partial: "download_dossiers",

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -1102,6 +1102,16 @@ describe Procedure do
           it { expect(subject['suivis']).to eq(2) }
           it { expect(subject['total']).to eq(2) }
         end
+
+        context 'and dossier with a follower is unfollowed' do
+          before do
+            instructeur.unfollow(new_followed_dossier)
+          end
+
+          it { expect(subject['a_suivre']).to eq(1) }
+          it { expect(subject['suivis']).to eq(0) }
+          it { expect(subject['total']).to eq(1) }
+        end
       end
 
       context 'with a termine dossier' do

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -1023,4 +1023,126 @@ describe Procedure do
       it { is_expected.to be false }
     end
   end
+
+  describe "#dossiers_count_for_instructeur" do
+    let(:instructeur) { create(:instructeur) }
+    let(:procedure) { create(:procedure, instructeurs: [instructeur]) }
+    let(:gi_2) { procedure.groupe_instructeurs.create(label: '2') }
+    let(:gi_3) { procedure.groupe_instructeurs.create(label: '3') }
+
+    subject do
+      procedure.dossiers_count_for_instructeur(instructeur)
+    end
+
+    context "when logged in, and belonging to gi_1, gi_2" do
+      before do
+        instructeur.groupe_instructeurs << gi_2
+      end
+
+      context "without any dossier" do
+        it { expect(subject['a_suivre']).to eq(0) }
+        it { expect(subject['suivis']).to eq(0) }
+        it { expect(subject['termines']).to eq(0) }
+        it { expect(subject['total']).to eq(0) }
+        it { expect(subject['archived']).to eq(0) }
+      end
+
+      context 'with a new brouillon dossier' do
+        let!(:brouillon_dossier) { create(:dossier, procedure: procedure, state: Dossier.states.fetch(:brouillon)) }
+
+        it { expect(subject['a_suivre']).to eq(0) }
+        it { expect(subject['suivis']).to eq(0) }
+        it { expect(subject['termines']).to eq(0) }
+        it { expect(subject['total']).to eq(0) }
+        it { expect(subject['archived']).to eq(0) }
+      end
+
+      context 'with a new dossier without follower' do
+        let!(:new_unfollow_dossier) { create(:dossier, procedure: procedure, state: Dossier.states.fetch(:en_instruction)) }
+
+        it { expect(subject['a_suivre']).to eq(1) }
+        it { expect(subject['suivis']).to eq(0) }
+        it { expect(subject['termines']).to eq(0) }
+        it { expect(subject['total']).to eq(1) }
+        it { expect(subject['archived']).to eq(0) }
+
+        context 'and dossiers without follower on each of the others groups' do
+          let!(:new_unfollow_dossier_on_gi_2) { create(:dossier, groupe_instructeur: gi_2, state: Dossier.states.fetch(:en_instruction)) }
+          let!(:new_unfollow_dossier_on_gi_3) { create(:dossier, groupe_instructeur: gi_3, state: Dossier.states.fetch(:en_instruction)) }
+
+          before { subject }
+
+          it { expect(subject['a_suivre']).to eq(2) }
+          it { expect(subject['total']).to eq(2) }
+        end
+      end
+
+      context 'with a new dossier with a follower' do
+        let!(:new_followed_dossier) { create(:dossier, procedure: procedure, state: Dossier.states.fetch(:en_instruction)) }
+
+        before do
+          instructeur.followed_dossiers << new_followed_dossier
+        end
+
+        it { expect(subject['a_suivre']).to eq(0) }
+        it { expect(subject['suivis']).to eq(1) }
+        it { expect(subject['termines']).to eq(0) }
+        it { expect(subject['total']).to eq(1) }
+        it { expect(subject['archived']).to eq(0) }
+
+        context 'and dossier with a follower on each of the others groups' do
+          let!(:new_follow_dossier_on_gi_2) { create(:dossier, groupe_instructeur: gi_2, state: Dossier.states.fetch(:en_instruction)) }
+          let!(:new_follow_dossier_on_gi_3) { create(:dossier, groupe_instructeur: gi_3, state: Dossier.states.fetch(:en_instruction)) }
+
+          before do
+            instructeur.followed_dossiers << new_follow_dossier_on_gi_2 << new_follow_dossier_on_gi_3
+          end
+
+          # followed dossiers on another groupe should not be displayed
+          it { expect(subject['suivis']).to eq(2) }
+          it { expect(subject['total']).to eq(2) }
+        end
+      end
+
+      context 'with a termine dossier' do
+        let!(:termine_dossier) { create(:dossier, procedure: procedure, state: Dossier.states.fetch(:accepte)) }
+
+        it { expect(subject['a_suivre']).to eq(0) }
+        it { expect(subject['suivis']).to eq(0) }
+        it { expect(subject['termines']).to eq(1) }
+        it { expect(subject['total']).to eq(1) }
+        it { expect(subject['archived']).to eq(0) }
+
+        context 'and terminer dossiers on each of the others groups' do
+          let!(:termine_dossier_on_gi_2) { create(:dossier, groupe_instructeur: gi_2, state: Dossier.states.fetch(:accepte)) }
+          let!(:termine_dossier_on_gi_3) { create(:dossier, groupe_instructeur: gi_3, state: Dossier.states.fetch(:accepte)) }
+
+          before { subject }
+
+          it { expect(subject['a_suivre']).to eq(0) }
+          it { expect(subject['suivis']).to eq(0) }
+          it { expect(subject['termines']).to eq(2) }
+          it { expect(subject['total']).to eq(2) }
+          it { expect(subject['archived']).to eq(0) }
+        end
+      end
+
+      context 'with an archived dossier' do
+        let!(:archived_dossier) { create(:dossier, procedure: procedure, state: Dossier.states.fetch(:en_instruction), archived: true) }
+
+        it { expect(subject['a_suivre']).to eq(0) }
+        it { expect(subject['suivis']).to eq(0) }
+        it { expect(subject['termines']).to eq(0) }
+        it { expect(subject['total']).to eq(0) }
+        it { expect(subject['archived']).to eq(1) }
+
+        context 'and terminer dossiers on each of the others groups' do
+          let!(:archived_dossier_on_gi_2) { create(:dossier, groupe_instructeur: gi_2, state: Dossier.states.fetch(:en_instruction), archived: true) }
+          let!(:archived_dossier_on_gi_3) { create(:dossier, groupe_instructeur: gi_3, state: Dossier.states.fetch(:en_instruction), archived: true) }
+
+          it { expect(subject['archived']).to eq(2) }
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Version un peu différente de https://github.com/betagouv/demarches-simplifiees.fr/pull/5564, mais plus prometteuse pour accélérer  `Instructeur::ProceduresController#show` :

 - Sur les procédures avec beaucoup (30k) de dossiers, ~50% du temps de chargement vient des 6 counts
 - Sur les procédures avec peu (3000) de dossiers, c'est ProcedurePresentation#sorted_ids qui fait une requête de la mort.

Pour le moment j'ai surtout réorganisé le code de cet écran pour que tout se passe dans le contrôleur, avec une requête dédiée pour les compteurs, tel que suggéré dans https://github.com/betagouv/demarches-simplifiees.fr/issues/5659

En l'état, comme dans la version antérieure, on semble gagner 20-25% sur cette page.

Concerne https://github.com/betagouv/demarches-simplifiees.fr/issues/5689