### PR TITLE
piece justificative links in messages

### DIFF
--- a/app/controllers/champs/piece_justificative_controller.rb
+++ b/app/controllers/champs/piece_justificative_controller.rb
@@ -12,4 +12,13 @@ class Champs::PieceJustificativeController < ApplicationController
       render :json => { errors: errors }, :status => 422
     end
   end
+
+  def download
+    @champ = policy_scope(Champ).find(params[:champ_id])
+    if @champ&.is_a? Champs::PieceJustificativeChamp
+      redirect_to @champ.piece_justificative_file.service_url, status: :found
+    else
+      render :json => { errors: "Il n'y a pas de piece justificative #{params[:champ_id]}" }, :status => 404
+    end
+  end
 end

--- a/app/models/attestation_template.rb
+++ b/app/models/attestation_template.rb
@@ -48,7 +48,7 @@ class AttestationTemplate < ApplicationRecord
     used_tags.map do |used_tag|
       corresponding_champ = all_champs_with_libelle_index[used_tag]
 
-      if corresponding_champ && corresponding_champ.value.blank?
+      if corresponding_champ && corresponding_champ.value.blank? && corresponding_champ.champs.empty? && !corresponding_champ.piece_justificative_file.attached?
         corresponding_champ
       end
     end.compact

--- a/app/models/champs/piece_justificative_champ.rb
+++ b/app/models/champs/piece_justificative_champ.rb
@@ -15,6 +15,8 @@
 #  type_de_champ_id :integer
 #
 class Champs::PieceJustificativeChamp < Champ
+  include ActionView::Helpers::TagHelper
+
   MAX_SIZE = 200.megabytes
 
   validates :piece_justificative_file,
@@ -40,6 +42,14 @@ class Champs::PieceJustificativeChamp < Champ
   def for_api
     if piece_justificative_file.attached? && (piece_justificative_file.virus_scanner.safe? || piece_justificative_file.virus_scanner.pending?)
       piece_justificative_file.service_url
+    end
+  end
+
+  def for_tag
+    if piece_justificative_file.attached? && (piece_justificative_file.virus_scanner.safe? || piece_justificative_file.virus_scanner.pending?)
+      url = Rails.application.routes.url_helpers.champs_piece_justificative_download_url({ champ_id: id })
+      name = piece_justificative_file.filename.to_s
+      tag.a(name, { href: url, target: '_blank', rel: 'noopener', title: "Télécharger la pièce jointe" })
     end
   end
 end

--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -1,15 +1,22 @@
 require 'prawn/measurement_extensions'
 
+def prawn_text(message)
+  tags = ['a', 'b', 'br', 'color', 'font', 'i', 'strong', 'sub', 'sup', 'u']
+  atts = ['alt', 'character_spacing', 'href', 'name', 'rel', 'rgb', 'size', 'src', 'target']
+  text = ActionView::Base.safe_list_sanitizer.sanitize(message.to_s, tags: tags, attributes: atts)
+end
+
 def format_in_2_lines(pdf, label, text)
   pdf.font 'marianne', style: :bold, size: 10  do
     pdf.text label
   end
-  pdf.text text, size: 9
+  pdf.text prawn_text(text), size: 9, inline_format: true
   pdf.text "\n", size: 9
 end
 
 def render_box(pdf, text, x, width)
-  box = ::Prawn::Text::Box.new(text.to_s, { document: pdf, width: width, overflow: :expand, at: [x, pdf.cursor] })
+  blocks = ::Prawn::Text::Formatted::Parser.format(prawn_text(text))
+  box = ::Prawn::Text::Formatted::Box.new(blocks, { document: pdf, width: width, overflow: :expand, at: [x, pdf.cursor] })
   box.render
   box.height
 end
@@ -86,7 +93,10 @@ def render_single_champ(pdf, champ)
   when 'Champs::RepetitionChamp'
     raise 'There should not be a RepetitionChamp here !'
   when 'Champs::PieceJustificativeChamp'
-    return
+    url = Rails.application.routes.url_helpers.champs_piece_justificative_download_url({ champ_id: champ.id })
+    display = champ.piece_justificative_file.filename
+    link = content_tag :a, display, { href: url, target: '_blank', rel: 'noopener' }
+    format_in_2_columns(pdf, champ.libelle, link)
   when 'Champs::HeaderSectionChamp'
     pdf.font 'marianne', style: :bold, size: 14 do
       pdf.text champ.libelle
@@ -135,7 +145,7 @@ def add_message(pdf, message)
   end
 
   pdf.text "#{sender}, #{format_date(message.created_at)}", style: :bold
-  pdf.text ActionView::Base.full_sanitizer.sanitize(message.body), size: 9
+  pdf.text prawn_text(message.body), size: 9, inline_format: true
   pdf.text "\n", size: 9
 end
 
@@ -145,7 +155,7 @@ def add_avis(pdf, avis)
     pdf.text "(confidentiel)", style: :bold
   end
   text = avis.answer || 'En attente de réponse'
-  pdf.text text
+  pdf.text prawn_text(text), inline_format: true
   pdf.text "\n"
 end
 
@@ -167,6 +177,8 @@ prawn_document(page_size: "A4") do |pdf|
   pdf.font_families.update( 'marianne' => {
     normal: Rails.root.join('lib/prawn/fonts/marianne/marianne-regular.ttf' ),
     bold: Rails.root.join('lib/prawn/fonts/marianne/marianne-bold.ttf' ),
+    bold_italic: Rails.root.join('lib/prawn/fonts/marianne/marianne-bold.ttf' ),
+    italic: Rails.root.join('lib/prawn/fonts/marianne/marianne-bold.ttf' ),
   })
   pdf.font 'marianne'
 

--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -26,6 +26,7 @@ def format_in_2_columns(pdf, label, text)
   h2 = render_box(pdf, ':', 100, 10)
   h3 = render_box(pdf, text, 110, pdf.bounds.width - 110)
   pdf.move_down 5 + [h1,h2,h3].max
+  pp "#{label}:#{text}"
 end
 
 def add_title(pdf, title)
@@ -89,6 +90,7 @@ def render_identite_etablissement(pdf, etablissement)
 end
 
 def render_single_champ(pdf, champ)
+  pp "single champ : #{champ.libelle}:#{champ.value}"
   case champ.type
   when 'Champs::RepetitionChamp'
     raise 'There should not be a RepetitionChamp here !'
@@ -103,9 +105,9 @@ def render_single_champ(pdf, champ)
     end
     pdf.text "\n"
   when 'Champs::ExplicationChamp'
-    format_in_2_lines(pdf, champ.libelle, champ.description)
+    format_in_2_columns(pdf, champ.libelle, champ.description)
   when 'Champs::CarteChamp'
-    format_in_2_lines(pdf, champ.libelle, champ.to_feature_collection.to_json)
+    format_in_2_columns(pdf, champ.libelle, champ.to_feature_collection.to_json)
   when 'Champs::SiretChamp'
     pdf.font 'marianne', style: :bold, size: 9 do
       pdf.text champ.libelle
@@ -115,10 +117,10 @@ def render_single_champ(pdf, champ)
     pdf.text "\n"
   when 'Champs::NumberChamp'
     value = number_with_delimiter(champ.to_s)
-    format_in_2_lines(pdf, champ.libelle, value)
+    format_in_2_columns(pdf, champ.libelle, value)
   else
     value = champ.to_s.empty? ? 'Non communiqué' : champ.to_s
-    format_in_2_lines(pdf, champ.libelle, value)
+    format_in_2_columns(pdf, champ.libelle, value)
   end
 end
 
@@ -193,7 +195,7 @@ prawn_document(page_size: "A4") do |pdf|
   pdf.text "Ce dossier est <b>#{dossier_display_state(@dossier, lower: true)}</b>.", inline_format: true
   pdf.text "\n"
   if @dossier.motivation.present?
-    format_in_2_lines(pdf, "Motif de la décision", @dossier.motivation)
+    format_in_2_columns(pdf, "Motif de la décision", @dossier.motivation)
   end
   add_title(pdf, 'Historique')
   add_etats_dossier(pdf, @dossier)

--- a/app/views/instructeurs/dossiers/_state_button_motivation.html.haml
+++ b/app/views/instructeurs/dossiers/_state_button_motivation.html.haml
@@ -16,7 +16,7 @@
       - if unspecified_attestation_champs.present?
         .warning
           Attention, les valeurs suivantes n'ont pas été renseignées mais sont nécessaires pour pouvoir envoyer une attestation valide :
-          - unspecified_champs, unspecified_annotations_privees = unspecified_attestation_champs.partition(&:private)
+          - unspecified_annotations_privees, unspecified_champs = unspecified_attestation_champs.partition(&:private)
 
           - if unspecified_champs.present?
             %h4 Champs de la demande

--- a/app/views/new_administrateur/attestation_templates/show.pdf.prawn
+++ b/app/views/new_administrateur/attestation_templates/show.pdf.prawn
@@ -32,7 +32,12 @@ logo = @attestation[:logo]
 signature = @attestation[:signature]
 
 prawn_document(margin: [top_margin, right_margin, bottom_margin, left_margin], page_size: page_size) do |pdf|
-  pdf.font_families.update( 'marianne' => { normal: Rails.root.join('lib/prawn/fonts/marianne/marianne-regular.ttf' )})
+  pdf.font_families.update( 'marianne' => {
+    normal: Rails.root.join('lib/prawn/fonts/marianne/marianne-regular.ttf' ),
+    bold: Rails.root.join('lib/prawn/fonts/marianne/marianne-bold.ttf' ),
+    bold_italic: Rails.root.join('lib/prawn/fonts/marianne/marianne-bold.ttf' ),
+    italic: Rails.root.join('lib/prawn/fonts/marianne/marianne-bold.ttf' ),
+  })
   pdf.font 'marianne'
 
   grey = '555555'
@@ -57,7 +62,7 @@ prawn_document(margin: [top_margin, right_margin, bottom_margin, left_margin], p
     pdf.pad_top(40) { pdf.text title, size: 14, character_spacing: -0.2 }
 
     pdf.fill_color grey
-    pdf.pad_top(30) { pdf.text body, size: 9, character_spacing: -0.2, align: :justify }
+    pdf.pad_top(30) { pdf.text body, size: 9, character_spacing: -0.2, align: :justify, inline_format: true }
 
     if signature.present?
       pdf.pad_top(40) do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -131,6 +131,7 @@ Rails.application.routes.draw do
 
     post ':position/repetition', to: 'repetition#show', as: :repetition
     put 'piece_justificative/:champ_id', to: 'piece_justificative#update', as: :piece_justificative
+    get 'piece_justificative/:champ_id', to: 'piece_justificative#download', as: :piece_justificative_download
   end
 
   resources :attachments, only: [:show, :destroy]


### PR DESCRIPTION
Pour le lien vers une piece justificative: 
 * j'ai créé une route qui permet de vérifier les droits et qui reste stable dans le temps plutot que le lien activestorage. Ok pour vous ? 

Quelques points à prendre en compte pour les Pdfs: 
* l'affichage des liens dans les pdf se fait à travers l'option inline_format qui permet aussi d'insérer du gras/souligné etc... 
* Du coup, que ce soit pour le pdf du dossier ou le pdf de l'attestation, on nettoie/sanitize le code HTML en ne gardant que les balises comprises par prawn et cela donne un meilleur résultat dans l'affichage des notifications automatiques du dossier par exemple. 
**Note**: Comme la fonte Marianne n'existe pas en italic et qu'une notification pourrait afficher de l'italique, je place quand meme la fonte marianne bold en remplacement pour éviter une exception. 

Voici quelques exemples de sorties: 

### Dans une attestation PDF
* <img width='40%' src="https://user-images.githubusercontent.com/15379878/96624886-1d94dc00-12a9-11eb-9ba9-f95e20a7ecec.png"/>

### Dans une notification
* <img width='70%' src="https://user-images.githubusercontent.com/15379878/96624915-284f7100-12a9-11eb-892c-9b08b2027ab2.png"/>

### Dans un dossier PDF 
* <img width='70%' src="https://user-images.githubusercontent.com/15379878/96625008-4ae18a00-12a9-11eb-949b-fbcdda938e4c.png"/>

### **Ajout de dernière minute**
Les champs du formulaires sont affichés sur deux lignes. 
Les champs de l'identification sont affichés sur deux colonnes. 
Ceci parce que initialement, la fonction format_in_2_columns ne gérait pas bien la hauteur des champs. Mais j'avais fait une correction qui maintenant autorise d'afficher les champs du formulaires sur 2 colonnes comme ci dessous ou on peut voir le formatage d'un long texte. 
Du coup je propose d'afficher tous les champs en mode '2 colonnes'. 
* <img width='70%' src="https://user-images.githubusercontent.com/15379878/96657996-4637c880-12df-11eb-8ed8-f915096c082f.png" />

### accepter un dossier
Lorsque l'on accepte un dossier, DS vérifie que les champs référencés dans l'attestation sont bien renseignés. 
Il y avait une petite coquille: quand un champ de la demande manquait, cela affichait 'Annotations privés' et inversement comme ci dessous où cela devrait afficher 'Champs de la demande'
* <img width='50%' src="https://user-images.githubusercontent.com/15379878/96661049-e5ac8980-12e6-11eb-9f9b-dc5771c5acec.png"/>


Pour faciliter l'échange, je vous propose le tout dans la meme PR, vous me dites ce que vous retenez et j'adapte la PR en fonction :-)