### PR TITLE
fix broken nil values in france_connect_information

### DIFF
--- a/app/views/shared/dossiers/_france_connect_informations.html.haml
+++ b/app/views/shared/dossiers/_france_connect_informations.html.haml
@@ -1,4 +1,8 @@
 .card.featured
   .flex.justify-center
     = image_tag "logo-france-connect.png", alt: "France Connect logo", width: 200, class: "mb-2"
-  .card-title Le dossier a été déposé par le compte de #{user_information.given_name} #{user_information.family_name}, authentifié par France Connect le #{user_information.updated_at.strftime('%d/%m/%Y')}.
+  .card-title
+    - if user_information.updated_at.present?
+      Le dossier a été déposé par le compte de #{user_information&.given_name} #{user_information&.family_name}, authentifié par France Connect le #{user_information.updated_at.strftime('%d/%m/%Y')}.
+    - else
+      Le dossier a été déposé par le compte de #{user_information&.given_name} #{user_information&.family_name}.

--- a/spec/views/shared/dossiers/_france_connect_information.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_france_connect_information.html.haml_spec.rb
@@ -1,0 +1,32 @@
+describe 'shared/dossiers/france_connect_informations.html.haml', type: :view do
+  subject do
+    render(
+      'shared/dossiers/france_connect_informations.html.haml',
+      user_information: user_information
+    )
+  end
+
+  context "with complete france_connect information" do
+    let(:user_information) { build(:france_connect_information, updated_at: Time.zone.now) }
+    it {
+      expect(subject).to have_text("Le dossier a été déposé par le compte de #{user_information.given_name} #{user_information.family_name}, authentifié par France Connect le #{user_information.updated_at.strftime('%d/%m/%Y')}")
+    }
+  end
+
+  context "with missing updated_at" do
+    let(:user_information) { build(:france_connect_information, updated_at: nil) }
+
+    it {
+      expect(subject).to have_text("Le dossier a été déposé par le compte de #{user_information.given_name} #{user_information.family_name}")
+      expect(subject).not_to have_text("authentifié par France Connect le ")
+    }
+  end
+
+  context "with missing given_name" do
+    let(:user_information) { build(:france_connect_information, given_name: nil) }
+
+    it {
+      expect(subject).to have_text("Le dossier a été déposé par le compte de  #{user_information.family_name}")
+    }
+  end
+end


### PR DESCRIPTION
Fix pour
```
NoMethodError

undefined method `strftime' for nil:NilClass
```

déclenché par certaines entrées france_connect qui ont des `updated_at` nuls.
