### PR TITLE
Revert counters display in Instructeur::ProceduresController::show

### DIFF
--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -102,7 +102,6 @@ module Instructeurs
       @has_termine_notifications = current_instructeur.notifications_for_procedure(@procedure, :termine).exists?
 
       @not_archived_notifications_dossier_ids = current_instructeur.notifications_for_procedure(@procedure, :not_archived).pluck(:id)
-      @counters = @procedure.dossiers_count_for_instructeur(current_instructeur)
 
       sorted_ids = procedure_presentation.sorted_ids(@dossiers, current_instructeur)
 

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -24,29 +24,29 @@
           = tab_item('à suivre',
             instructeur_procedure_path(@procedure, statut: 'a-suivre'),
             active: @statut == 'a-suivre',
-            badge: number_with_html_delimiter(@counters['a_suivre']))
+            badge: number_with_html_delimiter(@a_suivre_dossiers.count))
 
-          = tab_item(t('pluralize.followed', count: @counters['suivis']),
+          = tab_item(t('pluralize.followed', count: @followed_dossiers.count),
             instructeur_procedure_path(@procedure, statut: 'suivis'),
             active: @statut == 'suivis',
-            badge: number_with_html_delimiter(@counters['suivis']),
+            badge: number_with_html_delimiter(@followed_dossiers.count),
             notification: @has_en_cours_notifications)
 
-          = tab_item(t('pluralize.processed', count: @counters['termines']),
+          = tab_item(t('pluralize.processed', count: @termines_dossiers.count),
             instructeur_procedure_path(@procedure, statut: 'traites'),
             active: @statut == 'traites',
-            badge: number_with_html_delimiter(@counters['termines']),
+            badge: number_with_html_delimiter(@termines_dossiers.count),
             notification: @has_termine_notifications)
 
           = tab_item('tous les dossiers',
             instructeur_procedure_path(@procedure, statut: 'tous'),
             active: @statut == 'tous',
-            badge: number_with_html_delimiter(@counters['total']))
+            badge: number_with_html_delimiter(@all_state_dossiers.count))
 
           = tab_item(t('pluralize.archived', count: @archived_dossiers.count),
             instructeur_procedure_path(@procedure, statut: 'archives'),
             active: @statut == 'archives',
-            badge: number_with_html_delimiter(@counters['archived']))
+            badge: number_with_html_delimiter(@archived_dossiers.count))
 
       .procedure-actions
         = render partial: "download_dossiers",


### PR DESCRIPTION
In Instructeur::ProceduresController::show, we recently used a grouped query for counters

For some reason, this grouped query in procedure#dossiers_count_for_instructeur gives incorrect results.
I keep this method as is for now (instructeurs are complaining) and hotfix the controllers/view.

Je suis curieux d'avoir un avis tiers pour aller plus loin ; je ne vois pas la différence entre les 2 versions. Tous les compteurs semblent touchés, mais je ne reproduis pas dans des tests auto.

Exemple pour la requête pour les dossiers suivis (`@a_suivre.count.to_sql`, ci dessous) qui m'a l'air d'être la même que `a_suivre` en sortie de `procedure#dossiers_count_for_instructeur`.

```SQL
SELECT "dossiers".*
FROM "dossiers"
INNER JOIN "groupe_instructeurs" ON "dossiers"."groupe_instructeur_id" = "groupe_instructeurs"."id"
INNER JOIN "assign_tos" ON "groupe_instructeurs"."id" = "assign_tos"."groupe_instructeur_id"
LEFT OUTER JOIN "follows" ON "follows"."unfollowed_at" IS NULL
AND "follows"."dossier_id" = "dossiers"."id"
WHERE "dossiers"."hidden_at" IS NULL
  AND "assign_tos"."instructeur_id" = 14748
  AND "dossiers"."state" != 'brouillon'
  AND "groupe_instructeurs"."procedure_id" = 33580
  AND "follows"."id" IS NULL
```