### PR TITLE
[GraphQL] add better errors when attachments are not properly used

### DIFF
--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -1,4 +1,16 @@
 module Mutations
   class BaseMutation < GraphQL::Schema::RelayClassicMutation
+    def validate_blob(blob_id)
+      if blob_id.present?
+        begin
+          blob = ActiveStorage::Blob.find_signed(blob_id)
+          blob.identify
+        rescue ActiveStorage::FileNotFoundError
+          return { errors: ['Le fichier n’a pas été correctement téléversé sur le serveur de stockage'] }
+        rescue ActiveSupport::MessageVerifier::InvalidSignature
+          return { errors: ['L’identifiant du fichier téléversé est invalide'] }
+        end
+      end
+    end
   end
 end

--- a/app/graphql/mutations/dossier_accepter.rb
+++ b/app/graphql/mutations/dossier_accepter.rb
@@ -14,6 +14,10 @@ module Mutations
 
     def resolve(dossier:, instructeur:, motivation: nil, justificatif: nil)
       if dossier.en_instruction?
+        errors = validate_blob(justificatif)
+        if errors
+          return errors
+        end
         dossier.accepter!(instructeur, motivation, justificatif)
 
         { dossier: dossier }

--- a/app/graphql/mutations/dossier_classer_sans_suite.rb
+++ b/app/graphql/mutations/dossier_classer_sans_suite.rb
@@ -14,6 +14,10 @@ module Mutations
 
     def resolve(dossier:, instructeur:, motivation:, justificatif: nil)
       if dossier.en_instruction?
+        errors = validate_blob(justificatif)
+        if errors
+          return errors
+        end
         dossier.classer_sans_suite!(instructeur, motivation, justificatif)
 
         { dossier: dossier }

--- a/app/graphql/mutations/dossier_envoyer_message.rb
+++ b/app/graphql/mutations/dossier_envoyer_message.rb
@@ -11,6 +11,10 @@ module Mutations
     field :errors, [Types::ValidationErrorType], null: true
 
     def resolve(dossier:, instructeur:, body:, attachment: nil)
+      errors = validate_blob(attachment)
+      if errors
+        return errors
+      end
       message = CommentaireService.build(instructeur, dossier, body: body, piece_jointe: attachment)
 
       if message.save

--- a/app/graphql/mutations/dossier_refuser.rb
+++ b/app/graphql/mutations/dossier_refuser.rb
@@ -14,6 +14,10 @@ module Mutations
 
     def resolve(dossier:, instructeur:, motivation:, justificatif: nil)
       if dossier.en_instruction?
+        errors = validate_blob(justificatif)
+        if errors
+          return errors
+        end
         dossier.refuser!(instructeur, motivation, justificatif)
 
         { dossier: dossier }

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -604,6 +604,34 @@ describe API::V2::GraphqlController do
             })
           end
         end
+
+        context 'upload error' do
+          let(:query) do
+            "mutation {
+              dossierEnvoyerMessage(input: {
+                dossierId: \"#{dossier.to_typed_id}\",
+                instructeurId: \"#{instructeur.to_typed_id}\",
+                body: \"Hello world\",
+                attachment: \"fake\"
+              }) {
+                message {
+                  body
+                }
+                errors {
+                  message
+                }
+              }
+            }"
+          end
+
+          it "should fail" do
+            expect(gql_errors).to eq(nil)
+            expect(gql_data).to eq(dossierEnvoyerMessage: {
+              errors: [{ message: "L’identifiant du fichier téléversé est invalide" }],
+              message: nil
+            })
+          end
+        end
       end
 
       describe 'dossierPasserEnInstruction' do


### PR DESCRIPTION
Actuellement, le fait d'essayer d'attacher un blob invalide ou sans fichier uploadé genre une 500 incompréhensible et crée du bruit au support