### PR TITLE
move all the cron jobs in a dedicated directory

### DIFF
--- a/app/jobs/cron/administrateur_activate_before_expiration_job.rb
+++ b/app/jobs/cron/administrateur_activate_before_expiration_job.rb
@@ -1,4 +1,4 @@
-class AdministrateurActivateBeforeExpirationJob < CronJob
+class Cron::AdministrateurActivateBeforeExpirationJob < Cron::CronJob
   self.schedule_expression = "every day at 8 am"
 
   def perform(*args)

--- a/app/jobs/cron/auto_archive_procedure_job.rb
+++ b/app/jobs/cron/auto_archive_procedure_job.rb
@@ -1,4 +1,4 @@
-class AutoArchiveProcedureJob < CronJob
+class Cron::AutoArchiveProcedureJob < Cron::CronJob
   self.schedule_expression = "every 1 minute"
 
   def perform(*args)

--- a/app/jobs/cron/cron_job.rb
+++ b/app/jobs/cron/cron_job.rb
@@ -1,4 +1,4 @@
-class CronJob < ApplicationJob
+class Cron::CronJob < ApplicationJob
   queue_as :cron
   class_attribute :schedule_expression
 

--- a/app/jobs/cron/declarative_procedures_job.rb
+++ b/app/jobs/cron/declarative_procedures_job.rb
@@ -1,4 +1,4 @@
-class DeclarativeProceduresJob < CronJob
+class Cron::DeclarativeProceduresJob < Cron::CronJob
   self.schedule_expression = "every 1 minute"
 
   def perform(*args)

--- a/app/jobs/cron/discarded_dossiers_deletion_job.rb
+++ b/app/jobs/cron/discarded_dossiers_deletion_job.rb
@@ -1,4 +1,4 @@
-class DiscardedDossiersDeletionJob < CronJob
+class Cron::DiscardedDossiersDeletionJob < Cron::CronJob
   self.schedule_expression = "every day at 2 am"
 
   def perform(*args)

--- a/app/jobs/cron/discarded_procedures_deletion_job.rb
+++ b/app/jobs/cron/discarded_procedures_deletion_job.rb
@@ -1,4 +1,4 @@
-class DiscardedProceduresDeletionJob < CronJob
+class Cron::DiscardedProceduresDeletionJob < Cron::CronJob
   self.schedule_expression = "every day at 1 am"
 
   def perform(*args)

--- a/app/jobs/cron/expired_dossiers_deletion_job.rb
+++ b/app/jobs/cron/expired_dossiers_deletion_job.rb
@@ -1,4 +1,4 @@
-class ExpiredDossiersDeletionJob < CronJob
+class Cron::ExpiredDossiersDeletionJob < Cron::CronJob
   self.schedule_expression = "every day at 7 am"
 
   def perform(*args)

--- a/app/jobs/cron/find_dubious_procedures_job.rb
+++ b/app/jobs/cron/find_dubious_procedures_job.rb
@@ -1,4 +1,4 @@
-class FindDubiousProceduresJob < CronJob
+class Cron::FindDubiousProceduresJob < Cron::CronJob
   self.schedule_expression = "every day at midnight"
 
   FORBIDDEN_KEYWORDS = [

--- a/app/jobs/cron/instructeur_email_notification_job.rb
+++ b/app/jobs/cron/instructeur_email_notification_job.rb
@@ -1,4 +1,4 @@
-class InstructeurEmailNotificationJob < CronJob
+class Cron::InstructeurEmailNotificationJob < Cron::CronJob
   self.schedule_expression = "from monday through friday at 10 am"
 
   def perform(*args)

--- a/app/jobs/cron/notify_draft_not_submitted_job.rb
+++ b/app/jobs/cron/notify_draft_not_submitted_job.rb
@@ -1,4 +1,4 @@
-class NotifyDraftNotSubmittedJob < CronJob
+class Cron::NotifyDraftNotSubmittedJob < Cron::CronJob
   self.schedule_expression = "from monday through friday at 7 am"
 
   def perform(*args)

--- a/app/jobs/cron/operations_signature_job.rb
+++ b/app/jobs/cron/operations_signature_job.rb
@@ -1,4 +1,4 @@
-class OperationsSignatureJob < CronJob
+class Cron::OperationsSignatureJob < Cron::CronJob
   self.schedule_expression = "every day at 6 am"
 
   def perform(*args)

--- a/app/jobs/cron/purge_stale_exports_job.rb
+++ b/app/jobs/cron/purge_stale_exports_job.rb
@@ -1,4 +1,4 @@
-class PurgeStaleExportsJob < CronJob
+class Cron::PurgeStaleExportsJob < Cron::CronJob
   self.schedule_expression = "every 5 minutes"
 
   def perform

--- a/app/jobs/cron/purge_unattached_blobs_job.rb
+++ b/app/jobs/cron/purge_unattached_blobs_job.rb
@@ -1,4 +1,4 @@
-class PurgeUnattachedBlobsJob < CronJob
+class Cron::PurgeUnattachedBlobsJob < Cron::CronJob
   self.schedule_expression = "every day at midnight"
 
   def perform(*args)

--- a/app/jobs/cron/update_administrateur_usage_statistics_job.rb
+++ b/app/jobs/cron/update_administrateur_usage_statistics_job.rb
@@ -1,4 +1,4 @@
-class UpdateAdministrateurUsageStatisticsJob < CronJob
+class Cron::UpdateAdministrateurUsageStatisticsJob < Cron::CronJob
   self.schedule_expression = "every day at 10 am"
 
   def perform

--- a/app/jobs/cron/update_stats_job.rb
+++ b/app/jobs/cron/update_stats_job.rb
@@ -1,4 +1,4 @@
-class UpdateStatsJob < CronJob
+class Cron::UpdateStatsJob < Cron::CronJob
   self.schedule_expression = "every 1 hour"
 
   def perform(*args)

--- a/app/jobs/cron/weekly_overview_job.rb
+++ b/app/jobs/cron/weekly_overview_job.rb
@@ -1,4 +1,4 @@
-class WeeklyOverviewJob < CronJob
+class Cron::WeeklyOverviewJob < Cron::CronJob
   self.schedule_expression = "every monday at 7 am"
 
   def perform(*args)

--- a/spec/jobs/cron/administrateur_activate_before_expiration_job_spec.rb
+++ b/spec/jobs/cron/administrateur_activate_before_expiration_job_spec.rb
@@ -1,10 +1,10 @@
-RSpec.describe AdministrateurActivateBeforeExpirationJob, type: :job do
+RSpec.describe Cron::AdministrateurActivateBeforeExpirationJob, type: :job do
   describe 'perform' do
     let(:administrateur) { create(:administrateur) }
     let(:user) { administrateur.user }
     let(:mailer_double) { double('mailer', deliver_later: true) }
 
-    subject { AdministrateurActivateBeforeExpirationJob.perform_now }
+    subject { Cron::AdministrateurActivateBeforeExpirationJob.perform_now }
 
     before do
       Timecop.freeze(Time.zone.local(2018, 03, 20))

--- a/spec/jobs/cron/auto_archive_procedure_job_spec.rb
+++ b/spec/jobs/cron/auto_archive_procedure_job_spec.rb
@@ -1,10 +1,10 @@
-RSpec.describe AutoArchiveProcedureJob, type: :job do
+RSpec.describe Cron::AutoArchiveProcedureJob, type: :job do
   let!(:procedure) { create(:procedure, :published, :with_instructeur, auto_archive_on: nil) }
   let!(:procedure_hier) { create(:procedure, :published, :with_instructeur, auto_archive_on: 1.day.ago.to_date) }
   let!(:procedure_aujourdhui) { create(:procedure, :published, :with_instructeur, auto_archive_on: Time.zone.today) }
   let!(:procedure_demain) { create(:procedure, :published, :with_instructeur, auto_archive_on: 1.day.from_now.to_date) }
 
-  subject { AutoArchiveProcedureJob.new.perform }
+  subject { Cron::AutoArchiveProcedureJob.new.perform }
 
   context "when procedures have no auto_archive_on" do
     before do

--- a/spec/jobs/cron/declarative_procedures_job_spec.rb
+++ b/spec/jobs/cron/declarative_procedures_job_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe DeclarativeProceduresJob, type: :job do
+RSpec.describe Cron::DeclarativeProceduresJob, type: :job do
   describe "perform" do
     let(:date) { Time.utc(2017, 9, 1, 10, 5, 0) }
     let(:instruction_date) { date + 120 }
@@ -20,7 +20,7 @@ RSpec.describe DeclarativeProceduresJob, type: :job do
       ]
 
       create(:attestation_template, procedure: procedure)
-      DeclarativeProceduresJob.new.perform
+      Cron::DeclarativeProceduresJob.new.perform
 
       dossiers.each(&:reload)
     end

--- a/spec/jobs/cron/find_dubious_procedures_job_spec.rb
+++ b/spec/jobs/cron/find_dubious_procedures_job_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe FindDubiousProceduresJob, type: :job do
+RSpec.describe Cron::FindDubiousProceduresJob, type: :job do
   describe 'perform' do
     let(:mailer_double) { double('mailer', deliver_later: true) }
     let(:procedure) { create(:procedure, types_de_champ: tdcs) }
@@ -11,7 +11,7 @@ RSpec.describe FindDubiousProceduresJob, type: :job do
         @dubious_procedures_args = arg
       end.and_return(mailer_double)
 
-      FindDubiousProceduresJob.new.perform
+      Cron::FindDubiousProceduresJob.new.perform
     end
 
     context 'with suspicious champs' do

--- a/spec/jobs/cron/weekly_overview_job_spec.rb
+++ b/spec/jobs/cron/weekly_overview_job_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe WeeklyOverviewJob, type: :job do
+RSpec.describe Cron::WeeklyOverviewJob, type: :job do
   describe 'perform' do
     let!(:instructeur) { create(:instructeur) }
     let(:overview) { double('overview') }
@@ -16,7 +16,7 @@ RSpec.describe WeeklyOverviewJob, type: :job do
         before do
           expect_any_instance_of(Instructeur).to receive(:last_week_overview).and_return(overview)
           allow(InstructeurMailer).to receive(:last_week_overview).and_return(mailer_double)
-          WeeklyOverviewJob.new.perform
+          Cron::WeeklyOverviewJob.new.perform
         end
 
         it { expect(InstructeurMailer).to have_received(:last_week_overview).with(instructeur) }
@@ -27,7 +27,7 @@ RSpec.describe WeeklyOverviewJob, type: :job do
         before do
           expect_any_instance_of(Instructeur).to receive(:last_week_overview).and_return(nil)
           allow(InstructeurMailer).to receive(:last_week_overview)
-          WeeklyOverviewJob.new.perform
+          Cron::WeeklyOverviewJob.new.perform
         end
 
         it { expect(InstructeurMailer).not_to have_received(:last_week_overview) }
@@ -37,7 +37,7 @@ RSpec.describe WeeklyOverviewJob, type: :job do
     context 'if the feature is disabled' do
       before do
         allow(Instructeur).to receive(:all)
-        WeeklyOverviewJob.new.perform
+        Cron::WeeklyOverviewJob.new.perform
       end
 
       it { expect(Instructeur).not_to receive(:all) }

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -455,7 +455,7 @@ describe Instructeur, type: :model do
 
       before do
         procedure_to_assign.update(declarative_with_state: "en_instruction")
-        DeclarativeProceduresJob.new.perform
+        Cron::DeclarativeProceduresJob.new.perform
         dossier.reload
       end
 
@@ -480,7 +480,7 @@ describe Instructeur, type: :model do
 
       before do
         procedure_to_assign.update(declarative_with_state: "accepte")
-        DeclarativeProceduresJob.new.perform
+        Cron::DeclarativeProceduresJob.new.perform
         dossier.reload
       end
 
@@ -497,7 +497,7 @@ describe Instructeur, type: :model do
 
       before do
         procedure_to_assign.update(declarative_with_state: "accepte")
-        DeclarativeProceduresJob.new.perform
+        Cron::DeclarativeProceduresJob.new.perform
         dossier.traitements.last.update(processed_at: Time.zone.yesterday.beginning_of_day)
         dossier.reload
       end

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -51,7 +51,7 @@ describe NotificationService do
         let!(:dossier) { create(:dossier, :en_construction, procedure: procedure) }
         before do
           procedure.update(declarative_with_state: "en_instruction")
-          DeclarativeProceduresJob.new.perform
+          Cron::DeclarativeProceduresJob.new.perform
           dossier.reload
         end
 
@@ -65,7 +65,7 @@ describe NotificationService do
         let!(:dossier) { create(:dossier, :en_construction, procedure: procedure) }
         before do
           procedure.update(declarative_with_state: "accepte")
-          DeclarativeProceduresJob.new.perform
+          Cron::DeclarativeProceduresJob.new.perform
           dossier.traitements.last.update!(processed_at: Time.zone.yesterday.beginning_of_day)
           dossier.reload
         end
@@ -80,7 +80,7 @@ describe NotificationService do
         let!(:dossier) { create(:dossier, :en_construction, procedure: procedure) }
         before do
           procedure.update(declarative_with_state: "accepte")
-          DeclarativeProceduresJob.new.perform
+          Cron::DeclarativeProceduresJob.new.perform
           dossier.reload
         end
 


### PR DESCRIPTION
Réorganise les jobs de manière à ce que les crons soient dans un répertoire dédiés.

```bash
$ tree app/jobs
app/jobs
├── api_entreprise
│   ├── association_job.rb
│   ├── attestation_fiscale_job.rb
│   ├── attestation_sociale_job.rb
│   ├── bilans_bdf_job.rb
│   ├── effectifs_annuels_job.rb
│   ├── effectifs_job.rb
│   ├── entreprise_job.rb
│   ├── exercices_job.rb
│   └── job.rb
├── cron
│   ├── administrateur_activate_before_expiration_job.rb
│   ├── auto_archive_procedure_job.rb
│   ├── cron_job.rb
│   ├── declarative_procedures_job.rb
│   ├── discarded_dossiers_deletion_job.rb
│   ├── discarded_procedures_deletion_job.rb
│   ├── expired_dossiers_deletion_job.rb
│   ├── find_dubious_procedures_job.rb
│   ├── instructeur_email_notification_job.rb
│   ├── notify_draft_not_submitted_job.rb
│   ├── operations_signature_job.rb
│   ├── purge_stale_exports_job.rb
│   ├── purge_unattached_blobs_job.rb
│   ├── update_stats_job.rb
│   └── weekly_overview_job.rb
├── application_job.rb
├── etablissement_update_job.rb
├── export_job.rb
├── pipedrive_accepts_deals_job.rb
├── pipedrive_refuses_deals_job.rb
├── update_administrateur_usage_statistics_job.rb
├── virus_scanner_job.rb
└── web_hook_job.rb

```