### PR TITLE
add specific totp label for dev env

### DIFF
--- a/app/controllers/super_admins_controller.rb
+++ b/app/controllers/super_admins_controller.rb
@@ -22,6 +22,7 @@ class SuperAdminsController < ApplicationController
 
   def generate_qr_code
     issuer = 'DSManager'
+    issuer += "-dev" if Rails.env.development?
     label = "#{issuer}:#{current_super_admin.email}"
     RQRCode::QRCode.new(current_super_admin.otp_provisioning_uri(label, issuer: issuer))
   end


### PR DESCRIPTION
Cette PR permet de distinguer dans son application 2FA le code totp de production de celui pour l'environnement de dev.