### PR TITLE
[GraphQL] fix attachment upload

### DIFF
--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -5,6 +5,7 @@ module Mutations
         begin
           blob = ActiveStorage::Blob.find_signed(blob_id)
           blob.identify
+          nil
         rescue ActiveStorage::FileNotFoundError
           return { errors: ['Le fichier n’a pas été correctement téléversé sur le serveur de stockage'] }
         rescue ActiveSupport::MessageVerifier::InvalidSignature

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -37,7 +37,7 @@ describe API::V2::GraphqlController do
     }
   end
   let(:blob) do
-    blob = ActiveStorage::Blob.create_before_direct_upload!(blob_info)
+    blob = ActiveStorage::Blob.create_before_direct_upload!(**blob_info)
     blob.upload(file)
     blob
   end


### PR DESCRIPTION
Mon commit qui ajoute de la gestion d'erreur pète complètement l'upload. Le plus triste c'est que c'est passé malgré la présence du test – l'upload n'est pas fait pareille que en conditions réelles et du coup le résultat de `identify` n'est pas le même en prod qu’en test...