### PR TITLE
#5765 - Fix db/seeds.rb (replace "Administration" by "SuperAdmin")

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,7 @@ default_user = "test@exemple.fr"
 default_password = "this is a very complicated password !"
 
 puts "Create test user '#{default_user}'"
-Administration.create!(email: default_user, password: default_password)
+SuperAdmin.create!(email: default_user, password: default_password)
 user = User.create!(
   email: default_user,
   password: default_password,


### PR DESCRIPTION
Fixed #5765   "bin/rails db:seed" ne fonctionne plus  / @adullact

**Bug**

Depuis le commit [5562e65 - refacto: rename administration to super_admin](https://github.com/betagouv/demarches-simplifiees.fr/commit/5562e65bf371b733b76c889d1cad243b856ec514),
la commande `bin/rails db:seed` ne fonctionne  plus.

**Reproduction**
```ruby
bin/rails db:seed

      Create test user 'test@exemple.fr'
      rails aborted!
      NameError: uninitialized constant Administration
      /shared_dev/db/seeds.rb:12:in `<top (required)>'
      == Command ["bin/rails db:seed"] failed ==
```

**Comportement attendu**
```ruby
bin/rails db:seed

      Create test user 'test@exemple.fr'
```

**Correctif proposé**

dans [db/seeds.rb](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/db/seeds.rb#L12)
```diff
-Administration.create!(email: default_user, password: default_password)
+SuperAdmin.create!(email: default_user, password: default_password)
```
