### PR TITLE
#5764 - Allow logos (mail, webapp) and favicons to be configured in .env file

### DIFF
--- a/app/views/layouts/_new_header.haml
+++ b/app/views/layouts/_new_header.haml
@@ -20,7 +20,7 @@
       - else
         - root_profile_link, root_profile_libelle = root_path_info_for_profile(nav_bar_profile)
         = link_to root_profile_link, class: 'header-logo justify-center', title: root_profile_libelle do
-          = image_tag 'marianne.png', alt: 'Liberté, égalité, fraternité', width: '65', height: 56, loading: 'lazy'
+          = image_tag HEADER_LOGO_SRC, alt: HEADER_LOGO_ALT, width: HEADER_LOGO_WIDTH, height: HEADER_LOGO_HEIGHT, loading: 'lazy'
           %span.big.site-title>
             = APPLICATION_NAME
           %span.small.site-title>

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,9 +9,9 @@
     %title
       = content_for?(:title) ? "#{yield(:title)} · #{APPLICATION_NAME}" : APPLICATION_NAME
 
-    = favicon_link_tag(image_url("favicons/16x16.png"), type: "image/png", sizes: "16x16")
-    = favicon_link_tag(image_url("favicons/32x32.png"), type: "image/png", sizes: "32x32")
-    = favicon_link_tag(image_url("favicons/96x96.png"), type: "image/png", sizes: "96x96")
+    = favicon_link_tag(image_url("#{FAVICON_16PX_SRC}"), type: "image/png", sizes: "16x16")
+    = favicon_link_tag(image_url("#{FAVICON_32PX_SRC}"), type: "image/png", sizes: "32x32")
+    = favicon_link_tag(image_url("#{FAVICON_96PX_SRC}"), type: "image/png", sizes: "96x96")
 
     - packs = ['application', 'track', administrateur_signed_in? ? 'track-admin' : nil].compact
     = javascript_packs_with_chunks_tag *packs, defer: true

--- a/app/views/layouts/application_old.html.haml
+++ b/app/views/layouts/application_old.html.haml
@@ -5,9 +5,9 @@
       = t('dynamics.page_title')
     %meta{ 'http-equiv' => "X-UA-Compatible", :content => "IE=edge" }
 
-    = favicon_link_tag(image_url("favicons/16x16.png"), type: "image/png", sizes: "16x16")
-    = favicon_link_tag(image_url("favicons/32x32.png"), type: "image/png", sizes: "32x32")
-    = favicon_link_tag(image_url("favicons/96x96.png"), type: "image/png", sizes: "96x96")
+    = favicon_link_tag(image_url("#{FAVICON_16PX_SRC}"), type: "image/png", sizes: "16x16")
+    = favicon_link_tag(image_url("#{FAVICON_32PX_SRC}"), type: "image/png", sizes: "32x32")
+    = favicon_link_tag(image_url("#{FAVICON_96PX_SRC}"), type: "image/png", sizes: "96x96")
 
     = stylesheet_link_tag    'application', media: 'all'
     = stylesheet_link_tag    'print', media: 'print'

--- a/app/views/layouts/mailers/layout.html.erb
+++ b/app/views/layouts/mailers/layout.html.erb
@@ -50,7 +50,7 @@
                       <tr>
                         <td style="word-wrap:break-word;font-size:0px;padding:0;padding-top:0px;padding-bottom:0px;" align="left">
                           <div class="" style="cursor:auto;color:#55575d;font-family:Helvetica, Arial, sans-serif;font-size:11px;text-align:left;">
-                            <img align="middle" alt="Logo <%= "#{APPLICATION_NAME}" %>" src="<%= image_url('mailer/instructeur_mailer/logo.png') %>" style="max-width=600px; padding=30px 0; display=inline !important; vertical-align=bottom; border=0; height=auto; outline=none; text-decoration=none; -ms-interpolation-mode=bicubic;" />
+                            <img align="middle" alt="Logo <%= "#{APPLICATION_NAME}" %>" src="<%= image_url("#{MAILER_LOGO_SRC}") %>" style="max-width=600px; padding=30px 0; display=inline !important; vertical-align=bottom; border=0; height=auto; outline=none; text-decoration=none; -ms-interpolation-mode=bicubic;" />
                           </div>
                         </td>
                       </tr>

--- a/app/views/layouts/print.html.haml
+++ b/app/views/layouts/print.html.haml
@@ -8,9 +8,9 @@
     %title
       = t("dynamics.page_title")
 
-    = favicon_link_tag(image_url("favicons/16x16.png"), type: "image/png", sizes: "16x16")
-    = favicon_link_tag(image_url("favicons/32x32.png"), type: "image/png", sizes: "32x32")
-    = favicon_link_tag(image_url("favicons/96x96.png"), type: "image/png", sizes: "96x96")
+    = favicon_link_tag(image_url("#{FAVICON_16PX_SRC}"), type: "image/png", sizes: "16x16")
+    = favicon_link_tag(image_url("#{FAVICON_32PX_SRC}"), type: "image/png", sizes: "32x32")
+    = favicon_link_tag(image_url("#{FAVICON_96PX_SRC}"), type: "image/png", sizes: "96x96")
 
     = stylesheet_link_tag "new_design/print", media: "all"
 

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -24,5 +24,19 @@ APPLICATION_BASE_URL="https://www.demarches-simplifiees.fr"
 # Personnalisation d'instance - Page externe "Disponibilité" (status page)
 # STATUS_PAGE_URL=""
 
+# Personnalisation d'instance - Favicons ---> à placer dans "app/assets/images"
+# FAVICON_16PX_SRC="favicons/16x16.png"
+# FAVICON_32PX_SRC="favicons/32x32.png"
+# FAVICON_96PX_SRC="favicons/96x96.png"
+
+# Personnalisation d'instance - Logo de l'application ---> à placer dans "app/assets/images"
+# HEADER_LOGO_SRC="marianne.png"
+# HEADER_LOGO_ALT=""
+# HEADER_LOGO_WIDTH="65"
+# HEADER_LOGO_HEIGHT="56"
+
+# Personnalisation d'instance - Logo dans l'entête des emails ---> à placer dans "app/assets/images"
+# MAILER_LOGO_SRC="mailer/instructeur_mailer/logo.png"
+
 # Personnalisation d'instance - fichier utilisé pour poser un filigrane sur les pièces d'identité
 # WATERMARK_FILE=""

--- a/config/initializers/images.rb
+++ b/config/initializers/images.rb
@@ -1,0 +1,13 @@
+# Favicons
+FAVICON_16PX_SRC = ENV.fetch("FAVICON_16PX_SRC", "favicons/16x16.png")
+FAVICON_32PX_SRC = ENV.fetch("FAVICON_32PX_SRC", "favicons/32x32.png")
+FAVICON_96PX_SRC = ENV.fetch("FAVICON_96PX_SRC", "favicons/96x96.png")
+
+# Header logo
+HEADER_LOGO_SRC = ENV.fetch("HEADER_LOGO_SRC", "marianne.png")
+HEADER_LOGO_ALT = ENV.fetch("HEADER_LOGO_ALT", "Liberté, égalité, fraternité")
+HEADER_LOGO_WIDTH = ENV.fetch("HEADER_LOGO_WIDTH", "65")
+HEADER_LOGO_HEIGHT = ENV.fetch("HEADER_LOGO_HEIGHT", "56")
+
+# Mailer logo
+MAILER_LOGO_SRC = ENV.fetch("MAILER_LOGO_SRC", "mailer/instructeur_mailer/logo.png")


### PR DESCRIPTION
Fixed #5764 "ETQ Ops... personnaliser les images suivantes : favicons, logo du header et image d'entête des mails" / @adullact

##  Actuellement

Lorsqu'on installe sa propre instance DS sans modifier le code source, les images suivantes ne sont pas personnalisables :
- [favicons/*.png](https://github.com/betagouv/demarches-simplifiees.fr/tree/dev/app/assets/images/favicons)
- [app/assets/images/marianne.png](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/app/assets/images/marianne.png)
- [mailer/instructeur_mailer/logo.png](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/app/assets/images/mailer/instructeur_mailer/logo.png)

Visible dans la page HTML :
```html
<link rel="shortcut icon" type="image/png" href="(...)/assets/favicons/16x16-(...).png" sizes="16x16" />
<link rel="shortcut icon" type="image/png" href="(...)/assets/favicons/32x32-(...).png" sizes="32x32" />
<link rel="shortcut icon" type="image/png" href="(...)r/assets/favicons/96x96-(...).png" sizes="96x96" />
...
<header class='new-header' role='banner'>
     <a class="header-logo justify-center" title="Aller à la page d&#39;accueil" href="/">
           <img alt="..." width="65" height="56" loading="lazy" src="/assets/marianne-(...).png" />
          <span class='big site-title'>demarches-simplifiees.fr</span>
```

Visible dans certains emails  :
```html
<img align="middle" alt="Logo demarches-simplifiees.fr" src="/assets/mailer/instructeur_mailer/logo-(...).png"  (...)>
```

## Comportement attendu

Rendre configurable les images suivantes  :
- [favicons/*.png](https://github.com/betagouv/demarches-simplifiees.fr/tree/dev/app/assets/images/favicons)
- [app/assets/images/marianne.png](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/app/assets/images/marianne.png)
- [mailer/instructeur_mailer/logo.png](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/app/assets/images/mailer/instructeur_mailer/logo.png)

Visible dans la page HTML :
```html
<link rel="shortcut icon" type="image/png" href="(...)/assets/custom/favicons/16x16-(...).png" sizes="16x16" />
<link rel="shortcut icon" type="image/png" href="(...)/assets/custom/favicons/32x32-(...).png" sizes="32x32" />
<link rel="shortcut icon" type="image/png" href="(...)r/assets/custom/favicons/96x96-(...).png" sizes="96x96" />
...
<header class='new-header' role='banner'>
     <a class="header-logo justify-center" title="Aller à la page d&#39;accueil" href="/">
           <img alt="..." width="65" height="56" loading="lazy" src="/assets/custom/logo-webapage-header-(...).png" />
```

Visible dans certains emails  :
```html
<img align="middle" alt="Logo demarches-simplifiees.fr" src="/assets/custom/mailer/instructeur_mailer/mail-header-(...).png"  (...)>
```

## Implémentation

Ajout d'un fichier `config/initializers/images.rb`, pour utiliser des variables d'environnements optionnelles pour ces images et les documenter dans le fichier  [`env.example.optional`](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/config/env.example.optional).

Fichier `config/initializers/images.rb` :
```ruby
# Favicons
FAVICON_16PX_SRC = ENV.fetch("FAVICON_16PX_SRC", "favicons/16x16.png")
FAVICON_32PX_SRC = ENV.fetch("FAVICON_32PX_SRC", "favicons/32x32.png")
FAVICON_96PX_SRC = ENV.fetch("FAVICON_96PX_SRC", "favicons/96x96.png")

# Header logo
HEADER_LOGO_SRC = ENV.fetch("HEADER_LOGO_SRC", "marianne.png")
HEADER_LOGO_ALT = ENV.fetch("HEADER_LOGO_ALT", "Liberté, égalité, fraternité")
HEADER_LOGO_WIDTH = ENV.fetch("HEADER_LOGO_WIDTH", "65")
HEADER_LOGO_HEIGHT = ENV.fetch("HEADER_LOGO_HEIGHT", "56")

# Mailer logo
MAILER_LOGO_SRC = ENV.fetch("MAILER_LOGO_SRC", "mailer/instructeur_mailer/logo.png")
```

## Exemple 

### Ajout des images pour la personnalisation

```
app/assets/images/
├── adullact
│   ├── favicons
│   │   ├── 16x16.png
│   │   ├── 32x32.png
│   │   └── 96x96.png
│   ├── logo-header-adullact_65x56.png
│   └── mailer
│       └── instructeur_mailer
│           └── logo-mail-header-adullact_600x63.png
│ ..
```

### Ajout des variables optionnelles dans le fichier `.env` 

```env
# Personnalisation d'instance - Favicons ---> à placer dans "app/assets/images"
FAVICON_16PX_SRC="adullact/favicons/16x16.png"
FAVICON_32PX_SRC="adullact/favicons/32x32.png"
FAVICON_96PX_SRC="adullact/favicons/96x96.png"

# Personnalisation d'instance - Logo de l'application ---> à placer dans "app/assets/images"
HEADER_LOGO_SRC="adullact/logo-header-adullact_65x56.png"
HEADER_LOGO_ALT=""
HEADER_LOGO_WIDTH="65"
HEADER_LOGO_HEIGHT="56"

# Personnalisation d'instance - Logo dans l'entête des emails ---> à placer dans "app/assets/images"
MAILER_LOGO_SRC="adullact/mailer/instructeur_mailer/logo-mail-header-adullact_600x63.png"
```

### Affichages

![Sélection_005](https://user-images.githubusercontent.com/6709977/100402553-d692c700-305c-11eb-8b4c-4066437c6743.png)

----------

![Sélection_006](https://user-images.githubusercontent.com/6709977/100402550-d5619a00-305c-11eb-9085-9bbecdfa13d0.png)

