### PR TITLE
rend plus compréhensible le mail quotidien des nouveautés

### DIFF
--- a/app/views/instructeur_mailer/send_notifications.html.haml
+++ b/app/views/instructeur_mailer/send_notifications.html.haml
@@ -4,7 +4,7 @@
   Bonjour,
 
 %p
-  Vous avez du nouveau sur #{APPLICATION_NAME}.
+  Vous avez du nouveau sur #{APPLICATION_NAME} depuis hier.
 
 %ul
   - @data.each do |datum|
@@ -18,10 +18,10 @@
         #{datum[:nb_notification]} #{'notification'.pluralize(datum[:nb_notification])}
       - if datum[:nb_en_instruction] > 0
         %br
-        #{datum[:nb_en_instruction]} #{'dossier'.pluralize(datum[:nb_en_instruction])}
+        #{datum[:nb_en_instruction]} #{'dossier'.pluralize(datum[:nb_en_instruction])} en instruction
       - if datum[:nb_accepted] > 0
         %br
-        #{datum[:nb_accepted]} #{'dossier'.pluralize(datum[:nb_accepted])}
+        #{datum[:nb_accepted]} #{'dossier'.pluralize(datum[:nb_accepted])} #{'accepté'.pluralize(datum[:nb_accepted])}
 
 
 = render partial: "layouts/mailers/signature"

--- a/app/views/instructeur_mailer/send_notifications.html.haml
+++ b/app/views/instructeur_mailer/send_notifications.html.haml
@@ -4,7 +4,8 @@
   Bonjour,
 
 %p
-  Vous avez du nouveau sur #{APPLICATION_NAME} depuis hier.
+  Vous avez du nouveau sur #{APPLICATION_NAME} depuis
+  = Date.today.monday? ? "vendredi dernier" : "hier"
 
 %ul
   - @data.each do |datum|


### PR DESCRIPTION
Le mail quotidien adressé aux instructeurs n'est pas très compréhensible. Cette PR vise à le rendre plus compréhensible.