### PR TITLE
presente la civilité par ordre alphabétique

### DIFF
--- a/app/models/individual.rb
+++ b/app/models/individual.rb
@@ -19,8 +19,8 @@ class Individual < ApplicationRecord
   validates :nom, presence: true, allow_blank: false, allow_nil: false, on: :update
   validates :prenom, presence: true, allow_blank: false, allow_nil: false, on: :update
 
-  GENDER_MALE = 'M.'
-  GENDER_FEMALE = 'Mme'
+  GENDER_MALE = 'Monsieur'
+  GENDER_FEMALE = 'Madame'
 
   def self.from_france_connect(fc_information)
     new(

--- a/app/models/individual.rb
+++ b/app/models/individual.rb
@@ -19,8 +19,8 @@ class Individual < ApplicationRecord
   validates :nom, presence: true, allow_blank: false, allow_nil: false, on: :update
   validates :prenom, presence: true, allow_blank: false, allow_nil: false, on: :update
 
-  GENDER_MALE = 'Monsieur'
-  GENDER_FEMALE = 'Madame'
+  GENDER_MALE = "M."
+  GENDER_FEMALE = 'Mme'
 
   def self.from_france_connect(fc_information)
     new(

--- a/app/views/shared/dossiers/editable_champs/_civilite.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_civilite.html.haml
@@ -2,9 +2,9 @@
   %legend.mandatory-explanation
     Sélectionnez une des valeurs
   %label
-    = form.radio_button :value, Individual::GENDER_MALE
-    Monsieur
+    = form.radio_button :value, Individual::GENDER_FEMALE
+    = Individual::GENDER_FEMALE
 
   %label
-    = form.radio_button :value, Individual::GENDER_FEMALE
-    Madame
+    = form.radio_button :value, Individual::GENDER_MALE
+    = Individual::GENDER_MALE

--- a/app/views/shared/dossiers/editable_champs/_civilite.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_civilite.html.haml
@@ -3,8 +3,8 @@
     Sélectionnez une des valeurs
   %label
     = form.radio_button :value, Individual::GENDER_FEMALE
-    = Individual::GENDER_FEMALE
+    = t(Individual::GENDER_FEMALE, scope: 'activerecord.attributes.individual.gender_options')
 
   %label
     = form.radio_button :value, Individual::GENDER_MALE
-    = Individual::GENDER_MALE
+    = t('activerecord.attributes.individual.gender_options')[Individual::GENDER_MALE.to_sym] # GENDER_MALE contains a point letter

--- a/app/views/users/dossiers/identite.html.haml
+++ b/app/views/users/dossiers/identite.html.haml
@@ -13,11 +13,11 @@
         = f.label :gender
       .radios
         %label
-          = f.radio_button :gender, Individual::GENDER_MALE, required: true
-          = Individual::GENDER_MALE
-        %label
           = f.radio_button :gender, Individual::GENDER_FEMALE, required: true
           = Individual::GENDER_FEMALE
+        %label
+          = f.radio_button :gender, Individual::GENDER_MALE, required: true
+          = Individual::GENDER_MALE
 
     .flex
       .inline-champ

--- a/app/views/users/dossiers/identite.html.haml
+++ b/app/views/users/dossiers/identite.html.haml
@@ -14,10 +14,10 @@
       .radios
         %label
           = f.radio_button :gender, Individual::GENDER_FEMALE, required: true
-          = Individual::GENDER_FEMALE
+          = t(Individual::GENDER_FEMALE, scope: 'activerecord.attributes.individual.gender_options')
         %label
           = f.radio_button :gender, Individual::GENDER_MALE, required: true
-          = Individual::GENDER_MALE
+          = t('activerecord.attributes.individual.gender_options')[Individual::GENDER_MALE.to_sym] # GENDER_MALE contains a point letter
 
     .flex
       .inline-champ

--- a/config/locales/models/individual/fr.yml
+++ b/config/locales/models/individual/fr.yml
@@ -6,3 +6,6 @@ fr:
         nom: Nom
         prenom: Prénom
         birthdate: Date de naissance
+        gender_options:
+          "Mme": "Madame"
+          "M." : "Monsieur"

--- a/spec/factories/champ.rb
+++ b/spec/factories/champ.rb
@@ -57,7 +57,7 @@ FactoryBot.define do
 
     factory :champ_civilite, class: 'Champs::CiviliteChamp' do
       type_de_champ { association :type_de_champ_civilite, procedure: dossier.procedure }
-      value { 'M.' }
+      value { 'Monsieur' }
     end
 
     factory :champ_email, class: 'Champs::EmailChamp' do

--- a/spec/factories/individual.rb
+++ b/spec/factories/individual.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :individual do
-    gender { 'Monsieur' }
+    gender { 'M.' }
     nom { 'Julien' }
     prenom { 'Xavier' }
     birthdate { Date.new(1991, 11, 01) }

--- a/spec/factories/individual.rb
+++ b/spec/factories/individual.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :individual do
-    gender { 'M.' }
+    gender { 'Monsieur' }
     nom { 'Julien' }
     prenom { 'Xavier' }
     birthdate { Date.new(1991, 11, 01) }

--- a/spec/features/accessibilite/wcag_usager_spec.rb
+++ b/spec/features/accessibilite/wcag_usager_spec.rb
@@ -57,7 +57,7 @@ feature 'wcag rules for usager', js: true do
     scenario "dépot d'un dossier" do
       click_on 'Commencer la démarche'
 
-      choose 'M.'
+      choose 'Monsieur'
       fill_in('individual_prenom', with: 'prenom')
       fill_in('individual_nom', with: 'nom')
       click_on 'Continuer'

--- a/spec/features/routing/full_scenario_spec.rb
+++ b/spec/features/routing/full_scenario_spec.rb
@@ -185,7 +185,7 @@ feature 'The routing', js: true do
     visit commencer_path(path: procedure.reload.path)
     click_on 'Commencer la démarche'
 
-    choose 'M.'
+    choose 'Monsieur'
     fill_in 'individual_nom',    with: 'Nom'
     fill_in 'individual_prenom', with: 'Prenom'
     click_button('Continuer')

--- a/spec/features/users/brouillon_spec.rb
+++ b/spec/features/users/brouillon_spec.rb
@@ -51,7 +51,7 @@ feature 'The user' do
     expect(champ_value_for('datetime')).to eq('06/01/2030 07:05')
     expect(champ_value_for('number')).to eq('42')
     expect(champ_value_for('checkbox')).to eq('on')
-    expect(champ_value_for('civilite')).to eq('Madame')
+    expect(champ_value_for('civilite')).to eq('Mme')
     expect(champ_value_for('email')).to eq('loulou@yopmail.com')
     expect(champ_value_for('phone')).to eq('0123456789')
     expect(champ_value_for('yes_no')).to eq('false')

--- a/spec/features/users/brouillon_spec.rb
+++ b/spec/features/users/brouillon_spec.rb
@@ -51,7 +51,7 @@ feature 'The user' do
     expect(champ_value_for('datetime')).to eq('06/01/2030 07:05')
     expect(champ_value_for('number')).to eq('42')
     expect(champ_value_for('checkbox')).to eq('on')
-    expect(champ_value_for('civilite')).to eq('Mme')
+    expect(champ_value_for('civilite')).to eq('Madame')
     expect(champ_value_for('email')).to eq('loulou@yopmail.com')
     expect(champ_value_for('phone')).to eq('0123456789')
     expect(champ_value_for('yes_no')).to eq('false')
@@ -329,7 +329,7 @@ feature 'The user' do
   end
 
   def fill_individual
-    choose 'M.'
+    choose 'Monsieur'
     fill_in('individual_prenom', with: 'prenom')
     fill_in('individual_nom', with: 'nom')
     click_on 'Continuer'

--- a/spec/features/users/dossier_creation_spec.rb
+++ b/spec/features/users/dossier_creation_spec.rb
@@ -20,7 +20,7 @@ feature 'Creating a new dossier:' do
         expect(page).to have_current_path identite_dossier_path(user.reload.dossiers.last)
         expect(page).to have_procedure_description(procedure)
 
-        choose 'M.'
+        choose 'Monsieur'
         fill_in 'individual_nom',    with: 'Nom'
         fill_in 'individual_prenom', with: 'Prenom'
       end

--- a/spec/features/users/linked_dropdown_spec.rb
+++ b/spec/features/users/linked_dropdown_spec.rb
@@ -57,7 +57,7 @@ feature 'linked dropdown lists' do
   end
 
   def fill_individual
-    choose 'M.'
+    choose 'Monsieur'
     fill_in('individual_prenom', with: 'prenom')
     fill_in('individual_nom', with: 'nom')
     click_on 'Continuer'


### PR DESCRIPTION
Cette PR présente désormais les champs Civilité dans l'ordre suivant : **Mme** puis **M.** pour respecter l'ordre alphabétique.

![civilite](https://user-images.githubusercontent.com/1111966/101512580-73b5ff80-397b-11eb-8588-83f9ae00f214.png)
