### PR TITLE
#5793 - Fix(.gitignore): exclude /public/assets directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-debug.log*
 .yarn-integrity
 /.vscode
 /.idea
+/public/assets
 /public/packs
 /public/packs-test
 /node_modules


### PR DESCRIPTION
Fixed #5793 _"ETQ developpeur, exclure le répertoire /public/assets via .gitignore"_ / @adullact

Quand on utilise `rails assets:precompile`, le répertoire `/public/assets` est créé avec beaucoup de fichier, mais il n'est pas exclu par le `.gitignore`.

**Reproduction**
```ruby
RAILS_ENV=production rails assets:precompile
git status
        Fichiers non suivis:
	public/assets/
```

**Comportement attendu**
```ruby
RAILS_ENV=production rails assets:precompile
git status
        rien à valider, la copie de travail est propre
```

**Correctif proposé**

Correctif proposé pour le fichier [.gitignore](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/.gitignore#L30)

```diff
+/public/assets
 /public/packs
 /public/packs-test
```

**Rebase du code** (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur BetaGouv pour faire le rebase directement sur notre dépôt.