### PR TITLE
#5795 - Allow default logo of a procedure to be configured in .env file

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -568,7 +568,7 @@ class Procedure < ApplicationRecord
     if logo.attached?
       Rails.application.routes.url_helpers.url_for(logo)
     else
-      ActionController::Base.helpers.image_url("republique-francaise-logo.svg")
+      ActionController::Base.helpers.image_url(PROCEDURE_DEFAULT_LOGO_SRC)
     end
   end
 

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -41,5 +41,8 @@ APPLICATION_BASE_URL="https://www.demarches-simplifiees.fr"
 # Personnalisation d'instance - Logo dans l'entête des emails ---> à placer dans "app/assets/images"
 # MAILER_LOGO_SRC="mailer/instructeur_mailer/logo.png"
 
+# Personnalisation d'instance - Logo par défaut d'une procédure  ---> à placer dans "app/assets/images"
+# PROCEDURE_DEFAULT_LOGO_SRC="republique-francaise-logo.svg"
+
 # Personnalisation d'instance - fichier utilisé pour poser un filigrane sur les pièces d'identité
 # WATERMARK_FILE=""

--- a/config/initializers/images.rb
+++ b/config/initializers/images.rb
@@ -11,3 +11,6 @@ HEADER_LOGO_HEIGHT = ENV.fetch("HEADER_LOGO_HEIGHT", "56")
 
 # Mailer logo
 MAILER_LOGO_SRC = ENV.fetch("MAILER_LOGO_SRC", "mailer/instructeur_mailer/logo.png")
+
+# Default logo of a procedure
+PROCEDURE_DEFAULT_LOGO_SRC = ENV.fetch("PROCEDURE_DEFAULT_LOGO_SRC", "republique-francaise-logo.svg")


### PR DESCRIPTION
Fixed #5795 "ETQ Ops, je souhaite personnaliser l'image par défaut d'une démarche" / @adullact

##  Actuellement

Lorsqu'on installe sa propre instance DS sans modifier le code source,
l'image par défaut d'une démarche n'est pas personnalisable :

Visible sur la page de création ou de modification d'une démarche avant l'ajout d'un logo via le formulaire :
```html
<div class="procedure-preview">
<!--XRAY START 151 /shared_dev/app/views/shared/_procedure_description.html.haml-->
<div class="procedure-logos">
    <img alt="" src="/assets/republique-francaise-logo-(...).svg">
</div>
```

Visible sur la page d'une démarche dont le logo n'a pas été personnalisé (usage de l'image par défaut) :
```html
<div class="column procedure-preview">
<!--XRAY START 208 /shared_dev/app/views/shared/_procedure_description.html.haml-->
<div class="procedure-logos">
    <img alt="Service − Organisme" src="/assets/republique-francaise-logo-(...).svg">
</div>
```

![Screenshot_2020-12-14 ds local](https://user-images.githubusercontent.com/6709977/102039990-b6d50000-3dcb-11eb-9957-e51fbabf10d9.png)



## Comportement attendu

Rendre configurable l'image par défaut d'une démarche, via une variables d'environnements optionnelle :
```env
# Personnalisation d'instance - Logo par défaut d'une procédure  ---> à placer dans "app/assets/images"
PROCEDURE_DEFAULT_LOGO_SRC="custom/procedure-default-logo.svg"
```

Visible sur la page de création ou de modification d'une démarche avant l'ajout d'un logo via le formulaire :
```html
<div class="procedure-preview">
<!--XRAY START 151 /shared_dev/app/views/shared/_procedure_description.html.haml-->
<div class="procedure-logos">
    <img alt="" src="/assets/custom/procedure-default-logo-(...).svg">
</div>
```

Visible sur la page d'une démarche dont le logo n'a pas été personnalisé (usage de l'image par défaut) :
```html
<div class="column procedure-preview">
<!--XRAY START 208 /shared_dev/app/views/shared/_procedure_description.html.haml-->
<div class="procedure-logos">
    <img alt="Service − Organisme" src="/assets/custom/procedure-default-logo-(...).svg">
</div>
```
![Screenshot_2020-12-14 ds local(1)](https://user-images.githubusercontent.com/6709977/102040228-7924a700-3dcc-11eb-95a3-1eff8c3cb71c.png)


## Implémentation

Ajouter au fichier [`config/initializers/images.rb`](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/config/initializers/images.rb), une variables d'environnements optionnelle pour cette image et la documenter dans le fichier  [`env.example.optional`](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/config/env.example.optional).

Fichier `config/initializers/images.rb` :
```ruby
# Default logo of a procedure
PROCEDURE_DEFAULT_LOGO_SRC = ENV.fetch("PROCEDURE_DEFAULT_LOGO_SRC", "republique-francaise-logo.svg")
```


## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur BetaGouv pour faire le rebase directement sur notre dépôt.