### PR TITLE
#5801 - Allow configuration of the URLs of FAQ and documentation websites in .env file

### DIFF
--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -24,6 +24,12 @@ APPLICATION_BASE_URL="https://www.demarches-simplifiees.fr"
 # Personnalisation d'instance - URL pour la création de compte administrateur sur l'instance
 # DEMANDE_INSCRIPTION_ADMIN_PAGE_URL=""
 
+# Personnalisation d'instance - URL du site web de documentation
+# DOC_URL="https://doc.demarches-simplifiees.fr"
+
+# Personnalisation d'instance - URL du site web FAQ
+# FAQ_URL="https://faq.demarches-simplifiees.fr"
+
 # Personnalisation d'instance - Page externe "Disponibilité" (status page)
 # STATUS_PAGE_URL=""
 

--- a/config/initializers/urls.rb
+++ b/config/initializers/urls.rb
@@ -16,7 +16,7 @@ FOG_BASE_URL = "https://static.demarches-simplifiees.fr"
 WEBINAIRE_URL = "https://app.livestorm.co/demarches-simplifiees"
 CALENDLY_URL = "https://calendly.com/demarches-simplifiees/accompagnement-administrateur-demarches-simplifiees-fr"
 
-DOC_URL = "https://doc.demarches-simplifiees.fr"
+DOC_URL = ENV.fetch("DOC_URL", "https://doc.demarches-simplifiees.fr")
 DOC_NOUVEAUTES_URL = [DOC_URL, "nouveautes"].join("/")
 ADMINISTRATEUR_TUTORIAL_URL = [DOC_URL, "tutoriels", "tutoriel-administrateur"].join("/")
 INSTRUCTEUR_TUTORIAL_URL = [DOC_URL, "tutoriels", "tutoriel-accompagnateur"].join("/")
@@ -29,7 +29,7 @@ WEBHOOK_DOC_URL = [DOC_URL, "pour-aller-plus-loin", "webhook"].join("/")
 ARCHIVAGE_DOC_URL = [DOC_URL, "pour-aller-plus-loin", "archivage-longue-duree-des-demarches"].join("/")
 DOC_INTEGRATION_MONAVIS_URL = [DOC_URL, "tutoriels", "integration-du-bouton-mon-avis"].join("/")
 
-FAQ_URL = "https://faq.demarches-simplifiees.fr"
+FAQ_URL = ENV.fetch("FAQ_URL", "https://faq.demarches-simplifiees.fr")
 FAQ_ADMIN_URL = [FAQ_URL, "collection", "1-administrateur-creation-dun-formulaire"].join("/")
 FAQ_AUTOSAVE_URL = [FAQ_URL, "article", "77-enregistrer-mon-formulaire-pour-le-reprendre-plus-tard?preview=5ec28ca1042863474d1aee00"].join("/")
 COMMENT_TROUVER_MA_DEMARCHE_URL = [FAQ_URL, "article", "59-comment-trouver-ma-demarche"].join("/")


### PR DESCRIPTION
Fixed #5801 "ETQ Ops, je souhaite changer les URL des sites web FAQ et documentation" / @adullact

##  Actuellement

Les URL des sites web **FAQ** et **documentation** sont déclarées dans le fichier [`config/initializers/urls.rb`](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/config/initializers/urls.rb#L19). Ce n'est pas configurable sans modifier le code source.

Lorsqu'on installe sa propre instance DS (par exemple celle de l'Adullact) sans modifier le code source, il serait utile de pouvoir configurer l'URL des sites web FAQ et documentation.

```html
<!-- Page d’accueil, utilisateur non connecté --> 
<a class="button primary" href="https://faq.demarches-simplifiees.fr">Aide</a>
...
<a class="role-panel-button-primary" href="https://faq.demarches-simplifiees.fr/article/59-comment-trouver-ma-demarche">Comment trouver ma démarche ?</a>
...
<ul class="footer-links">
    <li class="footer-link"><a href="https://doc.demarches-simplifiees.fr">Documentation</a></li>
   <li class="footer-link"><a href="https://doc.demarches-simplifiees.fr/pour-aller-plus-loin/api">Documentation de l'API</a></li>
   <li class="footer-link"><a href="https://faq.demarches-simplifiees.fr">FAQ</a></li>
   ...

<!-- Page du formulaire de création d'une démarche --> 
<a href="https://doc.demarches-simplifiees.fr/tutoriels/video-le-cadre-juridique">En savoir plus avec cette vidéo de 5 minutes</a>
```

## Comportement attendu

Rendre configurable les URL des sites web **FAQ** et **documentation** avec des variables d'environnements optionnelles.

```html
<!-- Page d’accueil, utilisateur non connecté --> 
<a class="button primary" href="https://faq.example.com">Aide</a>
...
<a class="role-panel-button-primary" href="https://faq.example.com/article/59-comment-trouver-ma-demarche">Comment trouver ma démarche ?</a>
...
<ul class="footer-links">
    <li class="footer-link"><a href="https://doc.example.com">Documentation</a></li>
   <li class="footer-link"><a href="https://doc.example.com/pour-aller-plus-loin/api">Documentation de l'API</a></li>
   <li class="footer-link"><a href="https://faq.example.com">FAQ</a></li>
   ...

<!-- Page du formulaire de création d'une démarche --> 
<a href="https://doc.example.com/tutoriels/video-le-cadre-juridique">En savoir plus avec cette vidéo de 5 minutes</a>
```

## Proposition 

Modifier le fichier [`config/initializers/urls.rb`](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/config/initializers/urls.rb#L19), pour utiliser des variables d'environnements optionnelles `DOC_URL` et `FAQ_URL` et les documenter dans le fichier  [`env.example.optional`](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/config/env.example.optional).

```diff
-DOC_URL = "https://doc.demarches-simplifiees.fr"
+DOC_URL = ENV.fetch("DOC_URL", "https://doc.demarches-simplifiees.fr")
...
-FAQ_URL = "https://faq.demarches-simplifiees.fr"
+FAQ_URL = ENV.fetch("FAQ_URL", "https://faq.demarches-simplifiees.fr")
```


## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur BetaGouv pour faire le rebase directement sur notre dépôt.