### PR TITLE
feat/5731- list-expert-visible

### DIFF
--- a/app/controllers/new_administrateur/procedures_controller.rb
+++ b/app/controllers/new_administrateur/procedures_controller.rb
@@ -186,9 +186,16 @@ module NewAdministrateur
     end
 
     def expert_list
-      redirect_to admin_procedure_path(@procedure) if !@procedure.allow_expert_review?
-      avis_list = @procedure.dossiers.includes(:avis).map(&:avis).reject(&:empty?)
-      @experts = avis_list.map { |avis| Instructeur.find(avis[0].instructeur_id).user }.uniq
+      if @procedure.allow_expert_review?
+        @expert_emails = Avis
+          .joins(dossier: :procedure)
+          .left_joins(instructeur: :user)
+          .where(dossiers: { revision: @procedure.revisions })
+          .map(&:email_to_display)
+          .uniq
+      else
+        redirect_to admin_procedure_path(@procedure)
+      end
     end
 
     private

--- a/app/controllers/new_administrateur/procedures_controller.rb
+++ b/app/controllers/new_administrateur/procedures_controller.rb
@@ -1,6 +1,6 @@
 module NewAdministrateur
   class ProceduresController < AdministrateurController
-    before_action :retrieve_procedure, only: [:champs, :annotations, :edit, :monavis, :update_monavis, :jeton, :update_jeton, :publication, :publish, :transfert, :allow_expert_review]
+    before_action :retrieve_procedure, only: [:champs, :annotations, :edit, :monavis, :update_monavis, :jeton, :update_jeton, :publication, :publish, :transfert, :allow_expert_review, :expert_list]
     before_action :procedure_locked?, only: [:champs, :annotations]
 
     ITEMS_PER_PAGE = 25
@@ -183,6 +183,12 @@ module NewAdministrateur
         redirect_to admin_procedure_path(params[:procedure_id])
         flash.notice = "La démarche a correctement été clonée vers le nouvel administrateur."
       end
+    end
+
+    def expert_list
+      redirect_to admin_procedure_path(@procedure) if !@procedure.allow_expert_review?
+      avis_list = @procedure.dossiers.includes(:avis).map(&:avis).reject(&:empty?)
+      @experts = avis_list.map { |avis| Instructeur.find(avis[0].instructeur_id).user }.uniq
     end
 
     private

--- a/app/views/new_administrateur/procedures/expert_list.html.haml
+++ b/app/views/new_administrateur/procedures/expert_list.html.haml
@@ -1,0 +1,10 @@
+.container
+  %h1.mt-2 Experts invités sur #{@procedure.libelle}
+  %table.table.mt-2
+    %thead
+      %tr
+        %th{ colspan: 2 } Liste des experts
+    %tbody
+      - @experts.each do |expert|
+        %tr
+          %td= expert.email

--- a/app/views/new_administrateur/procedures/expert_list.html.haml
+++ b/app/views/new_administrateur/procedures/expert_list.html.haml
@@ -3,8 +3,8 @@
   %table.table.mt-2
     %thead
       %tr
-        %th{ colspan: 2 } Liste des experts
+        %th Liste des experts
     %tbody
-      - @experts.each do |expert|
+      - @expert_emails.each do |expert|
         %tr
-          %td= expert.email
+          %td= expert

--- a/app/views/new_administrateur/procedures/show.html.haml
+++ b/app/views/new_administrateur/procedures/show.html.haml
@@ -156,6 +156,19 @@
       .card-admin-action
         = link_to "#{@procedure.allow_expert_review? ? 'Désactiver' : 'Activer'}", allow_expert_review_admin_procedure_path(@procedure), method: :put,  class: 'button'
 
+    - if @procedure.allow_expert_review?
+      .card-admin
+        %div
+          %span.icon.preview
+          %p.card-admin-status-todo À voir
+
+        %div
+          %p.card-admin-title Liste des experts
+          %p.card-admin-subtitle Liste des experts invités par les instructeurs
+
+        .card-admin-action
+          = link_to "Voir", expert_list_admin_procedure_path(@procedure), class: 'button'
+
     .card-admin
       %div
         %span.icon.clock

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -374,6 +374,7 @@ Rails.application.routes.draw do
         get 'jeton'
         patch 'update_jeton'
         put :allow_expert_review
+        get 'expert_list'
       end
 
       get 'publication' => 'procedures#publication', as: :publication

--- a/spec/views/new_administrateur/procedures/expert_list.html.haml.spec.rb
+++ b/spec/views/new_administrateur/procedures/expert_list.html.haml.spec.rb
@@ -1,0 +1,53 @@
+describe 'new_administrateur/procedures/expert_list.html.haml', type: :view do
+  let(:claimant) { create(:instructeur) }
+  let(:instructeur) { create(:instructeur) }
+  let(:instructeur2) { create(:instructeur) }
+  let(:procedure) { create(:procedure, :published, instructeurs: [claimant]) }
+  let(:dossier) { create(:dossier, :en_construction, procedure: procedure) }
+  let!(:avis_with_answer) { Avis.create(dossier: dossier, claimant: claimant, instructeur: instructeur, answer: 'yop') }
+  let!(:avis_with_answer2) { Avis.create(dossier: dossier, claimant: claimant, instructeur: instructeur, answer: 'yop') }
+  let!(:avis_with_answer3) { Avis.create(dossier: dossier, claimant: claimant, instructeur: instructeur2, answer: 'yop') }
+
+  before do
+    assign(:procedure, procedure)
+    assign(:procedure_lien, commencer_url(path: procedure.path))
+    allow(view).to receive(:current_administrateur).and_return(procedure.administrateurs.first)
+  end
+
+  def expert_list
+    if procedure.allow_expert_review?
+      expert_emails = Avis
+        .joins(dossier: :procedure)
+        .left_joins(instructeur: :user)
+        .where(dossiers: { revision: procedure.revisions })
+        .map(&:email_to_display)
+        .uniq
+    end
+  end
+
+  context 'when allow expert review is true' do
+    before do
+      expert_list
+      render
+    end
+
+    it 'has 2 experts' do
+      puts expert_list
+      expect(expert_list.count).to eq(2)
+    end
+  end
+
+  context 'when allow expert review is false' do
+    before do
+      procedure.update!(allow_expert_review: false)
+      procedure.reload
+      expert_list
+      render
+    end
+
+    it 'has 0 experts' do
+      puts expert_list
+      expect(expert_list).to eq(nil)
+    end
+  end
+end

--- a/spec/views/new_administrateur/procedures/show.html.haml_spec.rb
+++ b/spec/views/new_administrateur/procedures/show.html.haml_spec.rb
@@ -44,16 +44,20 @@ describe 'new_administrateur/procedures/show.html.haml', type: :view do
       procedure.publish!
       procedure.close!
       procedure.reload
-      render
     end
 
     describe 'Re-enable button is visible' do
+
+      before do
+        render
+      end
+
       it { expect(rendered).not_to have_css('#close-procedure-link') }
       it { expect(rendered).to have_css('#publish-procedure-link') }
       it { expect(rendered).to have_content('Réactiver') }
     end
 
-    describe 'The expert list card is visible' do
+    describe 'When procedure.allow_expert_review is true, the expert list card must be visible' do
       before do
         render
       end
@@ -61,11 +65,10 @@ describe 'new_administrateur/procedures/show.html.haml', type: :view do
       it { expect(rendered).to have_content('Liste des experts invités par les instructeurs') }
     end
 
-    describe 'when allow expert review is false, the expert list card must not be visible' do
+    describe 'When procedure.allow_expert_review is false, the expert list card must not be visible' do
       before do
         procedure.update!(allow_expert_review: false)
         procedure.reload
-        byebug
         render
       end
 

--- a/spec/views/new_administrateur/procedures/show.html.haml_spec.rb
+++ b/spec/views/new_administrateur/procedures/show.html.haml_spec.rb
@@ -52,5 +52,25 @@ describe 'new_administrateur/procedures/show.html.haml', type: :view do
       it { expect(rendered).to have_css('#publish-procedure-link') }
       it { expect(rendered).to have_content('Réactiver') }
     end
+
+    describe 'The expert list card is visible' do
+      before do
+        render
+      end
+      it { expect(procedure.allow_expert_review).to be_truthy }
+      it { expect(rendered).to have_content('Liste des experts invités par les instructeurs') }
+    end
+
+    describe 'when allow expert review is false, the expert list card must not be visible' do
+      before do
+        procedure.update!(allow_expert_review: false)
+        procedure.reload
+        byebug
+        render
+      end
+
+      it { expect(procedure.allow_expert_review).to be_falsy }
+      it { expect(rendered).not_to have_content('Liste des experts invités par les instructeurs') }
+    end
   end
 end


### PR DESCRIPTION
**Si l'administrateur active la fonction d'appel à experts, alors il peut voir les experts associés à sa démarche**

![image](https://user-images.githubusercontent.com/21340608/102354696-3967e600-3fab-11eb-90fc-6c5ab3a3943a.png)

**Affichage des experts coté administrateur**

![image](https://user-images.githubusercontent.com/21340608/102354793-56041e00-3fab-11eb-898a-8578beb8834a.png)

Tests en cours
