### PR TITLE
ETQ Administrateur, je peux voir la liste des experts invités sur tous les dossiers de ma démarche

### DIFF
--- a/app/controllers/new_administrateur/procedures_controller.rb
+++ b/app/controllers/new_administrateur/procedures_controller.rb
@@ -1,6 +1,6 @@
 module NewAdministrateur
   class ProceduresController < AdministrateurController
-    before_action :retrieve_procedure, only: [:champs, :annotations, :edit, :monavis, :update_monavis, :jeton, :update_jeton, :publication, :publish, :transfert, :allow_expert_review]
+    before_action :retrieve_procedure, only: [:champs, :annotations, :edit, :monavis, :update_monavis, :jeton, :update_jeton, :publication, :publish, :transfert, :allow_expert_review, :invited_expert_list]
     before_action :procedure_locked?, only: [:champs, :annotations]
 
     ITEMS_PER_PAGE = 25
@@ -183,6 +183,11 @@ module NewAdministrateur
         redirect_to admin_procedure_path(params[:procedure_id])
         flash.notice = "La démarche a correctement été clonée vers le nouvel administrateur."
       end
+    end
+
+    def invited_expert_list
+      @invited_expert_emails = Avis.invited_expert_emails(@procedure)
+      redirect_to admin_procedure_path(@procedure) if @invited_expert_emails.blank?
     end
 
     private

--- a/app/models/avis.rb
+++ b/app/models/avis.rb
@@ -56,6 +56,16 @@ class Avis < ApplicationRecord
     Avis.find_by(id: avis_id)&.email == email
   end
 
+  def self.invited_expert_emails(procedure)
+    Avis
+      .joins(dossier: :revision)
+      .left_joins(instructeur: :user)
+      .where(procedure_revisions: { procedure_id: procedure })
+      .map(&:email_to_display)
+      .uniq
+      .sort
+  end
+
   def spreadsheet_columns
     [
       ['Dossier ID', dossier_id.to_s],

--- a/app/views/new_administrateur/procedures/invited_expert_list.html.haml
+++ b/app/views/new_administrateur/procedures/invited_expert_list.html.haml
@@ -1,0 +1,10 @@
+.container
+  %h1.mt-2 Experts invités sur #{@procedure.libelle}
+  %table.table.mt-2
+    %thead
+      %tr
+        %th Liste des experts
+    %tbody
+      - @invited_expert_emails.each do |expert|
+        %tr
+          %td= expert

--- a/app/views/new_administrateur/procedures/show.html.haml
+++ b/app/views/new_administrateur/procedures/show.html.haml
@@ -156,6 +156,20 @@
       .card-admin-action
         = link_to "#{@procedure.allow_expert_review? ? 'Désactiver' : 'Activer'}", allow_expert_review_admin_procedure_path(@procedure), method: :put,  class: 'button'
 
+    - if @procedure.allow_expert_review?
+      .card-admin
+        %div
+          %span.icon.preview
+          %p.card-admin-status-todo À voir
+
+        %div
+          %p.card-admin-title Liste des experts
+          %p.card-admin-subtitle Liste des experts invités par les instructeurs
+
+        .card-admin-action
+          = link_to "Voir", invited_expert_list_admin_procedure_path(@procedure), class: 'button'
+
+
     .card-admin
       %div
         %span.icon.clock

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -379,6 +379,7 @@ Rails.application.routes.draw do
         get 'jeton'
         patch 'update_jeton'
         put :allow_expert_review
+        get 'invited_expert_list'
       end
 
       get 'publication' => 'procedures#publication', as: :publication

--- a/spec/models/avis_spec.rb
+++ b/spec/models/avis_spec.rb
@@ -200,4 +200,46 @@ RSpec.describe Avis, type: :model do
       end
     end
   end
+
+  describe '#invited_expert_emails' do
+    let!(:procedure) { create(:procedure, :published) }
+
+    subject { Avis.invited_expert_emails(procedure) }
+
+    context 'when there is one dossier' do
+      let!(:dossier) { create(:dossier, procedure: procedure) }
+
+      context 'when a procedure has one avis and unknown instructeur' do
+        let!(:avis) { create(:avis, dossier: dossier, email: 'expert@expert.com') }
+
+        it { is_expected.to eq(['expert@expert.com']) }
+      end
+
+      context 'when a procedure has one avis and known instructeur' do
+        let!(:avis) { create(:avis, dossier: dossier, instructeur: create(:instructeur, email: 'expert@expert.com')) }
+
+        it { is_expected.to eq(['expert@expert.com']) }
+      end
+
+      context 'when a dossier has 2 avis from the same expert' do
+        let!(:avis) { create(:avis, dossier: dossier, email: 'expert@expert.com') }
+        let!(:avis2) { create(:avis, dossier: dossier, email: 'expert@expert.com') }
+
+        it { is_expected.to eq(['expert@expert.com']) }
+      end
+    end
+
+    context 'when there are two dossiers' do
+      let!(:dossier) { create(:dossier, procedure: procedure) }
+      let!(:dossier2) { create(:dossier, procedure: procedure) }
+
+      context 'and each one has an avis from 3 different experts' do
+        let!(:avis) { create(:avis, dossier: dossier, instructeur: create(:instructeur, email: '2_expert@expert.com')) }
+        let!(:unaffected_avis) { create(:avis, dossier: dossier2, email: '3_expert@expert.com') }
+        let!(:unaffected_avis2) { create(:avis, dossier: dossier2, email: '1_expert@expert.com') }
+
+        it { is_expected.to eq(['1_expert@expert.com', '2_expert@expert.com', '3_expert@expert.com']) }
+      end
+    end
+  end
 end

--- a/spec/views/new_administrateur/procedures/invited_expert_list.html.haml_spec.rb
+++ b/spec/views/new_administrateur/procedures/invited_expert_list.html.haml_spec.rb
@@ -1,0 +1,41 @@
+describe 'new_administrateur/procedures/invited_expert_list.html.haml', type: :view do
+  let!(:procedure) { create(:procedure, :published) }
+
+  before do
+    assign(:procedure, procedure)
+    assign(:procedure_lien, commencer_url(path: procedure.path))
+    allow(view).to receive(:current_administrateur).and_return(procedure.administrateurs.first)
+  end
+
+  subject { render }
+
+  context 'when the procedure has 0 avis' do
+    let!(:dossier) { create(:dossier, procedure: procedure) }
+    before do
+      @invited_expert_emails = Avis.invited_expert_emails(procedure)
+      subject
+    end
+
+    it 'has 0 experts into the page' do
+      expect(@invited_expert_emails.count).to eq(0)
+      expect(@invited_expert_emails).to eq([])
+    end
+  end
+
+  context 'when the procedure has 3 avis from 2 experts and 1 unasigned' do
+    let!(:dossier) { create(:dossier, procedure: procedure) }
+    let!(:avis) { create(:avis, dossier: dossier, instructeur: create(:instructeur, email: '1_expert@expert.com')) }
+    let!(:avis2) { create(:avis, dossier: dossier, instructeur: create(:instructeur, email: '2_expert@expert.com')) }
+    let!(:unasigned_avis) { create(:avis, dossier: dossier, email: 'expert@expert.com') }
+
+    before do
+      @invited_expert_emails = Avis.invited_expert_emails(procedure)
+      subject
+    end
+
+    it 'has 3 experts and match array' do
+      expect(@invited_expert_emails.count).to eq(3)
+      expect(@invited_expert_emails).to eq(['1_expert@expert.com', '2_expert@expert.com', 'expert@expert.com'])
+    end
+  end
+end

--- a/spec/views/new_administrateur/procedures/show.html.haml_spec.rb
+++ b/spec/views/new_administrateur/procedures/show.html.haml_spec.rb
@@ -44,13 +44,35 @@ describe 'new_administrateur/procedures/show.html.haml', type: :view do
       procedure.publish!
       procedure.close!
       procedure.reload
-      render
     end
 
     describe 'Re-enable button is visible' do
+      before do
+        render
+      end
+
       it { expect(rendered).not_to have_css('#close-procedure-link') }
       it { expect(rendered).to have_css('#publish-procedure-link') }
       it { expect(rendered).to have_content('Réactiver') }
+    end
+
+    describe 'When procedure.allow_expert_review is true, the expert list card must be visible' do
+      before do
+        render
+      end
+      it { expect(procedure.allow_expert_review).to be_truthy }
+      it { expect(rendered).to have_content('Liste des experts invités par les instructeurs') }
+    end
+
+    describe 'When procedure.allow_expert_review is false, the expert list card must not be visible' do
+      before do
+        procedure.update!(allow_expert_review: false)
+        procedure.reload
+        render
+      end
+
+      it { expect(procedure.allow_expert_review).to be_falsy }
+      it { expect(rendered).not_to have_content('Liste des experts invités par les instructeurs') }
     end
   end
 end


### PR DESCRIPTION
#5811 

**L'admin peut voir la liste des experts si l'appel aux experts est autorisé dans la démarche** 
![image](https://user-images.githubusercontent.com/21340608/102592294-8ebf0700-4113-11eb-9c94-4895a59c945d.png)

**Affichage de la liste des experts**
![image](https://user-images.githubusercontent.com/21340608/102592390-b1512000-4113-11eb-9d45-4a35b63e0d84.png)
