### PR TITLE
Add DateTime champ to GraphQL

### DIFF
--- a/app/graphql/api/v2/context.rb
+++ b/app/graphql/api/v2/context.rb
@@ -1,0 +1,30 @@
+class Api::V2::Context < GraphQL::Query::Context
+  def has_fragment?(name)
+    if self["has_fragment_#{name}"]
+      true
+    else
+      visitor = HasFragment.new(self.query.selected_operation, name)
+      visitor.visit
+      self["has_fragment_#{name}"] = visitor.found
+      self["has_fragment_#{name}"]
+    end
+  end
+
+  class HasFragment < GraphQL::Language::Visitor
+    def initialize(document, name)
+      super(document)
+      @name = name.to_s
+      @found = false
+    end
+
+    attr_reader :found
+
+    def on_inline_fragment(node, parent)
+      if node.type.name == @name
+        @found = true
+      end
+
+      super
+    end
+  end
+end

--- a/app/graphql/api/v2/schema.rb
+++ b/app/graphql/api/v2/schema.rb
@@ -43,6 +43,7 @@ class Api::V2::Schema < GraphQL::Schema
     Types::Champs::CheckboxChampType,
     Types::Champs::CiviliteChampType,
     Types::Champs::DateChampType,
+    Types::Champs::DatetimeChampType,
     Types::Champs::DecimalNumberChampType,
     Types::Champs::DossierLinkChampType,
     Types::Champs::IntegerNumberChampType,

--- a/app/graphql/api/v2/schema.rb
+++ b/app/graphql/api/v2/schema.rb
@@ -6,6 +6,8 @@ class Api::V2::Schema < GraphQL::Schema
   query Types::QueryType
   mutation Types::MutationType
 
+  context_class Api::V2::Context
+
   def self.id_from_object(object, type_definition, ctx)
     object.to_typed_id
   end

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -180,6 +180,10 @@ type CreateDirectUploadPayload {
 }
 
 type DateChamp implements Champ {
+  """
+  La valeur du champ formaté en ISO8601 (Date).
+  """
+  date: ISO8601Date
   id: ID!
 
   """
@@ -191,7 +195,29 @@ type DateChamp implements Champ {
   La valeur du champ sous forme texte.
   """
   stringValue: String
-  value: ISO8601DateTime
+
+  """
+  La valeur du champ formaté en ISO8601 (DateTime).
+  """
+  value: ISO8601DateTime @deprecated(reason: "Utilisez le champ 'date' ou le fragment 'DatetimeChamp' à la place.")
+}
+
+type DatetimeChamp implements Champ {
+  """
+  La valeur du champ formaté en ISO8601 (DateTime).
+  """
+  datetime: ISO8601DateTime
+  id: ID!
+
+  """
+  Libellé du champ.
+  """
+  label: String!
+
+  """
+  La valeur du champ sous forme texte.
+  """
+  stringValue: String
 }
 
 type DecimalNumberChamp implements Champ {

--- a/app/graphql/types/champ_type.rb
+++ b/app/graphql/types/champ_type.rb
@@ -11,8 +11,14 @@ module Types
         case object
         when ::Champs::EngagementChamp, ::Champs::YesNoChamp, ::Champs::CheckboxChamp
           Types::Champs::CheckboxChampType
-        when ::Champs::DateChamp, ::Champs::DatetimeChamp
+        when ::Champs::DateChamp
           Types::Champs::DateChampType
+        when ::Champs::DatetimeChamp
+          if context.has_fragment?(:DatetimeChamp)
+            Types::Champs::DatetimeChampType
+          else
+            Types::Champs::DateChampType
+          end
         when ::Champs::DossierLinkChamp
           Types::Champs::DossierLinkChampType
         when ::Champs::PieceJustificativeChamp

--- a/app/graphql/types/champs/date_champ_type.rb
+++ b/app/graphql/types/champs/date_champ_type.rb
@@ -2,11 +2,18 @@ module Types::Champs
   class DateChampType < Types::BaseObject
     implements Types::ChampType
 
-    field :value, GraphQL::Types::ISO8601DateTime, null: true
+    field :value, GraphQL::Types::ISO8601DateTime, "La valeur du champ formaté en ISO8601 (DateTime).", null: true, deprecation_reason: "Utilisez le champ 'date' ou le fragment 'DatetimeChamp' à la place."
+    field :date, GraphQL::Types::ISO8601Date, "La valeur du champ formaté en ISO8601 (Date).", null: true
 
     def value
       if object.value.present?
         Time.zone.parse(object.value)
+      end
+    end
+
+    def date
+      if object.value.present?
+        Date.parse(object.value)
       end
     end
   end

--- a/app/graphql/types/champs/datetime_champ_type.rb
+++ b/app/graphql/types/champs/datetime_champ_type.rb
@@ -1,0 +1,13 @@
+module Types::Champs
+  class DatetimeChampType < Types::BaseObject
+    implements Types::ChampType
+
+    field :datetime, GraphQL::Types::ISO8601DateTime, "La valeur du champ formaté en ISO8601 (DateTime).", null: true
+
+    def datetime
+      if object.value.present?
+        Time.zone.parse(object.value)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Cette PR ajoute la méthode `has_fragment?(name)` au context. Elle permet de déterminer si un certain fragment est utilisé dans une query. L'objectif c'est de pouvoir ajouter ou modifier des types de champs à l'API sans casser les queries existants.

Exemple :
```graphql
query getDossierLegacy {
    dossier(number: 1) {
    champs {
      ... on DateChamp {
        value
      }
    }
  }
}

query getDossierDatetime {
  dossier(number: 1) {
    champs {
      ... on DateChamp {
        date
      }
      ... on DatetimeChamp {
        datetime
      }
    }
  }
}
```

Dans le premier cas, le champ `DateChamp` est utilisé pour les champs de type `DateTime` et `Date`. Dans le deuxième cas, on détecte l'usage du fragment `DatetimeChamp` et l’on utilise ce fragment pour les champs `DateTime` plutôt que `Date`. Toutes les anciennes queries gardent le comportement d'origine. Cette technique sera utilisée dans le futur pour raffiner les types des autres champs qui aujourd'hui utilisent `TextChamp`. Par exemple, les champs `Adresse` ou `Region`.