### PR TITLE
Suppression des requetes cross origin pour les pjs

### DIFF
--- a/config/env.example
+++ b/config/env.example
@@ -44,7 +44,6 @@ FOG_OPENSTACK_USERNAME=""
 FOG_OPENSTACK_URL=""
 FOG_OPENSTACK_REGION=""
 FOG_ENABLED="" # valeur attendue: enabled
-DS_PROXY_URL=""
 
 # Service externe: authentification France Connect
 FC_PARTICULIER_ID=""

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -15,30 +15,6 @@ end
 # are performed through DS_Proxy.
 #
 # https://github.com/fog/fog-openstack/blob/37621bb1d5ca78d037b3c56bd307f93bba022ae1/lib/fog/openstack/auth/catalog/v2.rb#L16
-require 'fog/openstack/auth/catalog/v2'
-
-module Fog::OpenStack::Auth::Catalog
-  class V2
-    def endpoint_url(endpoint, interface)
-      url = endpoint["#{interface}URL"]
-
-      if interface == 'public'
-        publicize(url)
-      else
-        url
-      end
-    end
-
-    private
-
-    def publicize(url)
-      search = %r{^https://[^/]+/}
-      replace = "#{ENV['DS_PROXY_URL']}/"
-      url.gsub(search, replace)
-    end
-  end
-end
-
 require 'fog/openstack/auth/catalog/v3'
 module Fog::OpenStack::Auth::Catalog
   class V3

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -32,7 +32,7 @@ module Fog::OpenStack::Auth::Catalog
 
     def publicize(url)
       search = %r{^https://[^/]+/}
-      replace = "#{ENV['DS_PROXY_URL']}/"
+      replace = "#{ENV['APPLICATION_BASE_URL']}/storage/"
       url.gsub(search, replace)
     end
   end

--- a/config/initializers/urls.rb
+++ b/config/initializers/urls.rb
@@ -9,9 +9,6 @@ SENDINBLUE_API_V3_URL = ENV.fetch("SENDINBLUE_API_V3_URL", "https://api.sendinbl
 UNIVERSIGN_API_URL = ENV.fetch("UNIVERSIGN_API_URL", "https://ws.universign.eu/tsa/post/")
 FEATURE_UPVOTE_URL = ENV.fetch("FEATURE_UPVOTE_URL", "https://demarches-simplifiees.featureupvote.com")
 
-# Internal URLs
-FOG_BASE_URL = "https://static.demarches-simplifiees.fr"
-
 # External services URLs
 WEBINAIRE_URL = "https://app.livestorm.co/demarches-simplifiees"
 CALENDLY_URL = "https://calendly.com/demarches-simplifiees/accompagnement-administrateur-demarches-simplifiees-fr"

--- a/spec/initializers/active_storage_spec.rb
+++ b/spec/initializers/active_storage_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'active_storage initializer' do
   describe '#endpoint_url' do
     let(:url) { 'https://default.fr/toto' }
 
-    before { ENV['DS_PROXY_URL'] = 'https://proxy.fr' }
+    before { ENV['APPLICATION_BASE_URL'] = 'https://www.ds.fr' }
 
     subject { catalogue.endpoint_url({ "url" => url }, interface) }
 
@@ -17,7 +17,7 @@ RSpec.describe 'active_storage initializer' do
     context 'when the interface is public' do
       let(:interface) { 'public' }
 
-      it { is_expected.to eq('https://proxy.fr/toto') }
+      it { is_expected.to eq('https://www.ds.fr/storage/toto') }
     end
   end
 end

--- a/spec/initializers/active_storage_spec.rb
+++ b/spec/initializers/active_storage_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe 'active_storage initializer' do
+  let(:catalogue) { Fog::OpenStack::Auth::Catalog::V3.new({}) }
+
+  describe '#endpoint_url' do
+    let(:url) { 'https://default.fr/toto' }
+
+    before { ENV['DS_PROXY_URL'] = 'https://proxy.fr' }
+
+    subject { catalogue.endpoint_url({ "url" => url }, interface) }
+
+    context 'when the interface is not public' do
+      let(:interface) { 'private' }
+
+      it { is_expected.to eq(url) }
+    end
+
+    context 'when the interface is public' do
+      let(:interface) { 'public' }
+
+      it { is_expected.to eq('https://proxy.fr/toto') }
+    end
+  end
+end


### PR DESCRIPTION
Pb: des usagers nous indique régulièrement avoir des pbs avec des pièces jointes. J'ai pu constater avec l'un d'entre eux travaillant dans un réseau d'entreprise une erreurs CORS sur un navigateur moderne.

```
Access to XMLHttpRequest at 'https://static.demarches-simplifiees.fr/...' 
from origin 'https://www.demarches-simplifiees.fr' 
has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

Je suppose que leur firewall est trop restrictif et empêche certains headers de passer, la littérature donne des exemples : (https://superuser.com/questions/1140943/cors-policy-enforced-on-some-networks , https://stackoverflow.com/questions/16859122/cors-access-control-allow-origin-header-stripped-by-watchguard  (note cela suppose que leur firewall réalise la terminaison ssl et inspecte les headers).

Pour contre ce pb, je propose de changer la route vers les pjs de `static.demarches-simplifiees.fr` à `www.demarches-simplifiees.fr/storage/` et de refaire le dispatch au niveau de notre load balancer.

Side effect, on enlève par la même occasion une pre flight requête avant chaque upload.

A faire avant :

- [ ] configurer le loadbalancer
- [ ] prévenir les utilisateur de l'api
- [ ] prévenir les forks