### PR TITLE
Improuve annuaire education

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -323,8 +323,8 @@ module Users
     def champs_params
       params.permit(dossier: {
         champs_attributes: [
-          :id, :value, :primary_value, :secondary_value, :piece_justificative_file, value: [],
-          champs_attributes: [:id, :_destroy, :value, :primary_value, :secondary_value, :piece_justificative_file, value: []]
+          :id, :value, :external_id, :primary_value, :secondary_value, :piece_justificative_file, value: [],
+          champs_attributes: [:id, :_destroy, :value, :external_id, :primary_value, :secondary_value, :piece_justificative_file, value: []]
         ]
       })
     end

--- a/app/javascript/components/ComboSearch.js
+++ b/app/javascript/components/ComboSearch.js
@@ -28,22 +28,38 @@ function ComboSearch({
   transformResults = defaultTransformResults
 }) {
   const label = scope;
-  const hiddenField = useMemo(
+  const hiddenValueField = useMemo(
     () => document.querySelector(`input[data-uuid="${hiddenFieldId}"]`),
     [hiddenFieldId]
   );
-  const initialValue = hiddenField && hiddenField.value;
+  const hiddenIdField = useMemo(
+    () =>
+      document.querySelector(
+        `input[data-uuid="${hiddenFieldId}"] + input[data-reference]`
+      ),
+    [hiddenFieldId]
+  );
+  const initialValue = hiddenValueField && hiddenValueField.value;
   const [searchTerm, setSearchTerm] = useState('');
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('');
   const [value, setValue] = useState(initialValue);
   const resultsMap = useRef({});
   const setExternalValue = useCallback((value) => {
-    if (hiddenField) {
-      hiddenField.setAttribute('value', value);
-      fire(hiddenField, 'autosave:trigger');
+    if (hiddenValueField) {
+      hiddenValueField.setAttribute('value', value);
+      fire(hiddenValueField, 'autosave:trigger');
     }
+  });
+  const setExternalId = useCallback((key) => {
+    if (hiddenIdField) {
+      hiddenIdField.setAttribute('value', key);
+    }
+  });
+  const setExternalValueAndId = useCallback((value) => {
+    const [key, result] = resultsMap.current[value];
+    setExternalId(key);
+    setExternalValue(value);
     if (onChange) {
-      const result = resultsMap.current[value];
       onChange(value, result);
     }
   });
@@ -62,6 +78,7 @@ function ComboSearch({
       if (value.length >= minimumInputLength) {
         setSearchTerm(value.trim());
         if (allowInputValues) {
+          setExternalId('');
           setExternalValue(value);
         }
       }
@@ -70,7 +87,7 @@ function ComboSearch({
   );
 
   const handleOnSelect = useCallback((value) => {
-    setExternalValue(value);
+    setExternalValueAndId(value);
     setValue(value);
   });
 
@@ -95,7 +112,7 @@ function ComboSearch({
             <ComboboxList>
               {results.map((result) => {
                 const [key, str] = transformResult(result);
-                resultsMap.current[str] = result;
+                resultsMap.current[str] = [key, result];
                 return (
                   <ComboboxOption
                     key={key}

--- a/app/jobs/annuaire_education_update_job.rb
+++ b/app/jobs/annuaire_education_update_job.rb
@@ -1,14 +1,14 @@
 class AnnuaireEducationUpdateJob < ApplicationJob
   def perform(champ)
-    search_term = champ.value
+    external_id = champ.external_id
 
-    if search_term.present?
-      data = ApiEducation::AnnuaireEducationAdapter.new(search_term).to_params
+    if external_id.present?
+      data = ApiEducation::AnnuaireEducationAdapter.new(external_id).to_params
 
       if data.present?
         champ.data = data
       else
-        champ.value = nil
+        champ.external_id = nil
       end
       champ.save!
     end

--- a/app/lib/api_education/annuaire_education_adapter.rb
+++ b/app/lib/api_education/annuaire_education_adapter.rb
@@ -7,8 +7,8 @@ class ApiEducation::AnnuaireEducationAdapter
     end
   end
 
-  def initialize(search_term)
-    @search_term = search_term
+  def initialize(id)
+    @id = id
   end
 
   def to_params
@@ -27,7 +27,7 @@ class ApiEducation::AnnuaireEducationAdapter
   private
 
   def data_source
-    @data_source ||= JSON.parse(ApiEducation::API.search_annuaire_education(@search_term), symbolize_names: true)
+    @data_source ||= JSON.parse(ApiEducation::API.get_annuaire_education(@id), symbolize_names: true)
   end
 
   def schemer

--- a/app/lib/api_education/api.rb
+++ b/app/lib/api_education/api.rb
@@ -2,8 +2,8 @@ class ApiEducation::API
   class ResourceNotFound < StandardError
   end
 
-  def self.search_annuaire_education(search_term)
-    call([API_EDUCATION_URL, 'search'].join('/'), 'fr-en-annuaire-education', { q: search_term })
+  def self.get_annuaire_education(id)
+    call([API_EDUCATION_URL, 'search'].join('/'), 'fr-en-annuaire-education', { 'refine.identifiant_de_l_etablissement': id })
   end
 
   private

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/address_champ.rb
+++ b/app/models/champs/address_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/annuaire_education_champ.rb
+++ b/app/models/champs/annuaire_education_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/annuaire_education_champ.rb
+++ b/app/models/champs/annuaire_education_champ.rb
@@ -23,13 +23,13 @@ class Champs::AnnuaireEducationChamp < Champs::TextChamp
   private
 
   def cleanup_if_empty
-    if value_changed?
+    if external_id_changed?
       self.data = nil
     end
   end
 
   def fetch_data
-    if value.present? && data.nil?
+    if external_id.present? && data.nil?
       AnnuaireEducationUpdateJob.perform_later(self)
     end
   end

--- a/app/models/champs/carte_champ.rb
+++ b/app/models/champs/carte_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/checkbox_champ.rb
+++ b/app/models/champs/checkbox_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/civilite_champ.rb
+++ b/app/models/champs/civilite_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/commune_champ.rb
+++ b/app/models/champs/commune_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/date_champ.rb
+++ b/app/models/champs/date_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/datetime_champ.rb
+++ b/app/models/champs/datetime_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/decimal_number_champ.rb
+++ b/app/models/champs/decimal_number_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/departement_champ.rb
+++ b/app/models/champs/departement_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/dossier_link_champ.rb
+++ b/app/models/champs/dossier_link_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/drop_down_list_champ.rb
+++ b/app/models/champs/drop_down_list_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/email_champ.rb
+++ b/app/models/champs/email_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/engagement_champ.rb
+++ b/app/models/champs/engagement_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/explication_champ.rb
+++ b/app/models/champs/explication_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/header_section_champ.rb
+++ b/app/models/champs/header_section_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/iban_champ.rb
+++ b/app/models/champs/iban_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/integer_number_champ.rb
+++ b/app/models/champs/integer_number_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/linked_drop_down_list_champ.rb
+++ b/app/models/champs/linked_drop_down_list_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/multiple_drop_down_list_champ.rb
+++ b/app/models/champs/multiple_drop_down_list_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/number_champ.rb
+++ b/app/models/champs/number_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/pays_champ.rb
+++ b/app/models/champs/pays_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/phone_champ.rb
+++ b/app/models/champs/phone_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/piece_justificative_champ.rb
+++ b/app/models/champs/piece_justificative_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/region_champ.rb
+++ b/app/models/champs/region_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/repetition_champ.rb
+++ b/app/models/champs/repetition_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/siret_champ.rb
+++ b/app/models/champs/siret_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/text_champ.rb
+++ b/app/models/champs/text_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/textarea_champ.rb
+++ b/app/models/champs/textarea_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/titre_identite_champ.rb
+++ b/app/models/champs/titre_identite_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/models/champs/yes_no_champ.rb
+++ b/app/models/champs/yes_no_champ.rb
@@ -12,6 +12,7 @@
 #  updated_at       :datetime
 #  dossier_id       :integer
 #  etablissement_id :integer
+#  external_id      :string
 #  parent_id        :bigint
 #  type_de_champ_id :integer
 #

--- a/app/views/shared/dossiers/editable_champs/_address.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_address.html.haml
@@ -1,3 +1,4 @@
 - hidden_field_id = SecureRandom.uuid
 = form.hidden_field :value, { data: { uuid: hidden_field_id } }
+= form.hidden_field :external_id, { data: { reference: true } }
 = react_component("ComboAdresseSearch", mandatory: champ.mandatory?, hiddenFieldId: hidden_field_id)

--- a/app/views/shared/dossiers/editable_champs/_annuaire_education.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_annuaire_education.html.haml
@@ -1,3 +1,4 @@
 - hidden_field_id = SecureRandom.uuid
 = form.hidden_field :value, { data: { uuid: hidden_field_id } }
+= form.hidden_field :external_id, { data: { reference: true } }
 = react_component("ComboAnnuaireEducationSearch", mandatory: champ.mandatory?, hiddenFieldId: hidden_field_id )

--- a/app/views/shared/dossiers/editable_champs/_communes.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_communes.html.haml
@@ -1,3 +1,4 @@
 - hidden_field_id = SecureRandom.uuid
 = form.hidden_field :value, { data: { uuid: hidden_field_id } }
+= form.hidden_field :external_id, { data: { reference: true } }
 = react_component("ComboCommunesSearch", mandatory: champ.mandatory?, hiddenFieldId: hidden_field_id)

--- a/app/views/shared/dossiers/editable_champs/_departements.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_departements.html.haml
@@ -1,3 +1,4 @@
 - hidden_field_id = SecureRandom.uuid
 = form.hidden_field :value, { data: { uuid: hidden_field_id } }
+= form.hidden_field :external_id, { data: { reference: true } }
 = react_component("ComboDepartementsSearch", mandatory: champ.mandatory?, hiddenFieldId: hidden_field_id)

--- a/app/views/shared/dossiers/editable_champs/_regions.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_regions.html.haml
@@ -1,3 +1,4 @@
 - hidden_field_id = SecureRandom.uuid
 = form.hidden_field :value, { data: { uuid: hidden_field_id } }
+= form.hidden_field :external_id, { data: { reference: true } }
 = react_component("ComboRegionsSearch", mandatory: champ.mandatory?, hiddenFieldId: hidden_field_id)

--- a/db/migrate/20210114224721_add_external_id_to_champs.rb
+++ b/db/migrate/20210114224721_add_external_id_to_champs.rb
@@ -1,0 +1,5 @@
+class AddExternalIdToChamps < ActiveRecord::Migration[6.0]
+  def change
+    add_column :champs, :external_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_13_150013) do
+ActiveRecord::Schema.define(version: 2021_01_14_224721) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -144,6 +144,7 @@ ActiveRecord::Schema.define(version: 2021_01_13_150013) do
     t.bigint "parent_id"
     t.integer "row"
     t.jsonb "data"
+    t.string "external_id"
     t.index ["dossier_id"], name: "index_champs_on_dossier_id"
     t.index ["parent_id"], name: "index_champs_on_parent_id"
     t.index ["private"], name: "index_champs_on_private"


### PR DESCRIPTION
Dans la version que nous avons déjà margée, j’utilise la `value` du champ pour récupérer plus d'informations. C'est une stratégie qui fonctionne par ce que l'API éducation dispose de full “text search”. Ça reste une solution un peu bancale. Je pense qu’enregistrer une "clé" en plus de la valeur est une stratégie bien plus robuste. Ce mécanisme, on l'utilisera pour d'autres API. Séparer la valeur humainement lisible de la "reference" est une bonne idée, je pense. J'ai donc ajouté sur le champ une colonne `reference_value`. Certains types de champ ont déjà `secondary_value` et `primary_value`. Donc j'ai continué avec un nomade similaire. Pour résumer : nous avons `value` qui est texte possiblement lisible par l'humain et utilisable comme un placeholder en attendant plus de data. Nous avons `reference_value` qui contient une clé de référence qui peut servir à récupérer plus d'informations. Et nous avons `data` qui est une colonne `jsonb` qui peut contenir toute information complémentaire.