### PR TITLE
fix order of types de champ on procedure

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -62,13 +62,13 @@ class Procedure < ApplicationRecord
   belongs_to :published_revision, class_name: 'ProcedureRevision', optional: true
   has_many :deleted_dossiers, dependent: :destroy
 
-  has_many :published_types_de_champ, -> { ordered }, through: :published_revision, source: :types_de_champ
-  has_many :published_types_de_champ_private, -> { ordered }, through: :published_revision, source: :types_de_champ_private
-  has_many :draft_types_de_champ, -> { ordered }, through: :draft_revision, source: :types_de_champ
-  has_many :draft_types_de_champ_private, -> { ordered }, through: :draft_revision, source: :types_de_champ_private
+  has_many :published_types_de_champ, through: :published_revision, source: :types_de_champ
+  has_many :published_types_de_champ_private, through: :published_revision, source: :types_de_champ_private
+  has_many :draft_types_de_champ, through: :draft_revision, source: :types_de_champ
+  has_many :draft_types_de_champ_private, through: :draft_revision, source: :types_de_champ_private
 
-  has_many :all_types_de_champ, -> { joins(:procedure).where('types_de_champ.revision_id != procedures.draft_revision_id').ordered }, through: :revisions, source: :types_de_champ
-  has_many :all_types_de_champ_private, -> { joins(:procedure).where('types_de_champ.revision_id != procedures.draft_revision_id').ordered }, through: :revisions, source: :types_de_champ_private
+  has_many :all_types_de_champ, -> { joins(:procedure).where('types_de_champ.revision_id != procedures.draft_revision_id') }, through: :revisions, source: :types_de_champ
+  has_many :all_types_de_champ_private, -> { joins(:procedure).where('types_de_champ.revision_id != procedures.draft_revision_id') }, through: :revisions, source: :types_de_champ_private
 
   has_many :experts_procedures, dependent: :destroy
   has_many :experts, through: :experts_procedures

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -51,16 +51,22 @@ describe ProcedureRevision do
 
     it 'move down' do
       expect(revision.types_de_champ.index(type_de_champ)).to eq(0)
+      type_de_champ.update(order_place: nil)
       revision.move_type_de_champ(type_de_champ.stable_id, 2)
       revision.reload
       expect(revision.types_de_champ.index(type_de_champ)).to eq(2)
+      expect(revision.procedure.types_de_champ.index(type_de_champ)).to eq(2)
+      expect(revision.procedure.types_de_champ_for_export.index(type_de_champ)).to eq(2)
     end
 
     it 'move up' do
       expect(revision.types_de_champ.index(last_type_de_champ)).to eq(3)
+      last_type_de_champ.update(order_place: nil)
       revision.move_type_de_champ(last_type_de_champ.stable_id, 0)
       revision.reload
       expect(revision.types_de_champ.index(last_type_de_champ)).to eq(0)
+      expect(revision.procedure.types_de_champ.index(last_type_de_champ)).to eq(0)
+      expect(revision.procedure.types_de_champ_for_export.index(last_type_de_champ)).to eq(0)
     end
 
     context 'repetition' do


### PR DESCRIPTION
L'ordre des types de champ sur la démarche doit être porté par `procedure_revisions.position` et non plus par `type_de_champ.order_place` qui est utilisé uniquement sur les champs à l'intérieur des blocs répétables

HS https://secure.helpscout.net/conversation/1352886863/72316?folderId=1784050