### PR TITLE
update entreprise annuaire link

### DIFF
--- a/app/views/shared/dossiers/_identite_entreprise.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise.html.haml
@@ -145,6 +145,6 @@
           %td= try_format_date(etablissement.association_date_declaration)
 
 %p
-  = link_to "➡ Autres informations sur l’organisme sur « entreprise.data.gouv.fr » (ex: fiche d'immatriculation RNCS)",
-  "https://entreprise.data.gouv.fr/etablissement/#{etablissement.siret}",
+  = link_to "➡ Autres informations sur l’organisme sur « annuaire-entreprises.data.gouv.fr » (ex: fiche d'immatriculation RNCS)",
+  "https://annuaire-entreprises.data.gouv.fr/entreprise/#{etablissement.siren}",
   target: "_blank"

--- a/app/views/users/dossiers/etablissement/_infos_entreprise.html.haml
+++ b/app/views/users/dossiers/etablissement/_infos_entreprise.html.haml
@@ -30,6 +30,6 @@
   - if procedure.api_entreprise_role?("bilans_bdf")
     %p.etablissement-exercices Les 3 derniers bilans connus de votre entreprise par la Banque de France ont été joints à votre dossier.
 %p
-  = link_to '➡ Autres informations sur l’organisme sur « entreprise.data.gouv.fr »',
-  "https://entreprise.data.gouv.fr/etablissement/#{etablissement.siret}",
+  = link_to "➡ Autres informations sur l’organisme sur « annuaire-entreprises.data.gouv.fr »",
+  "https://annuaire-entreprises.data.gouv.fr/entreprise/#{etablissement.siren}",
   target: "_blank"

--- a/app/views/users/dossiers/siret.html.haml
+++ b/app/views/users/dossiers/siret.html.haml
@@ -12,8 +12,8 @@
 
     %p.mb-4
       Pour trouver votre numéro SIRET, utilisez
-      %a{ href: 'https://entreprise.data.gouv.fr/', target: '_blank', rel: 'noopener' }
-        entreprise.data.gouv.fr
+      %a{ href: "https://annuaire-entreprises.data.gouv.fr" , target: '_blank', rel: 'noopener' }
+        annuaire-entreprises.data.gouv.fr
       ou renseignez-vous auprès de votre service comptable.
 
     = f.submit "Valider", class: "button large primary expand mt-1", data: { disable_with: "Récupération des informations…" }


### PR DESCRIPTION
Le site entreprise.data.gouv.fr va être décomissionné. Il est remplacé par https://annuaire-entreprises.data.gouv.fr