### PR TITLE
Stop crashing when removed repetition row is submitted

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -346,6 +346,11 @@ module Users
 
       if champs_params[:dossier]
         @dossier.assign_attributes(champs_params[:dossier])
+        # FIXME in some cases a removed repetition bloc row is submitted.
+        # In this case it will be trated as a new records and action will fail.
+        @dossier.champs.filter(&:repetition?).each do |champ|
+          champ.champs = champ.champs.filter(&:persisted?)
+        end
         if @dossier.champs.any?(&:changed?)
           @dossier.last_champ_updated_at = Time.zone.now
         end


### PR DESCRIPTION
fix https://sentry.io/organizations/demarches-simplifiees/issues/2009997742/?environment=production&project=1429550&query=is%3Aunresolved+assigned%3Ame&statsPeriod=14d