### PR TITLE
#5869 - Allow logo in PDF export to be configured in .env file

### DIFF
--- a/app/views/dossiers/dossier_vide.pdf.prawn
+++ b/app/views/dossiers/dossier_vide.pdf.prawn
@@ -181,7 +181,7 @@ prawn_document(page_size: "A4") do |pdf|
       italic: Rails.root.join('lib/prawn/fonts/marianne/marianne-thin.ttf' ),
   })
   pdf.font 'marianne'
-  pdf.svg IO.read("app/assets/images/header/logo-ds-wide.svg"), width: 300, position: :center
+  pdf.svg IO.read(DOSSIER_PDF_EXPORT_LOGO_SRC), width: 300, position: :center
   pdf.move_down(40)
 
   render_in_2_columns(pdf, 'Démarche', @dossier.procedure.libelle)

--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -170,7 +170,7 @@ prawn_document(page_size: "A4") do |pdf|
   })
   pdf.font 'marianne'
 
-  pdf.svg IO.read("app/assets/images/header/logo-ds-wide.svg"), width: 300, position: :center
+  pdf.svg IO.read(DOSSIER_PDF_EXPORT_LOGO_SRC), width: 300, position: :center
   pdf.move_down(40)
 
   format_in_2_columns(pdf, 'Dossier Nº', @dossier.id.to_s)

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -50,5 +50,9 @@ APPLICATION_BASE_URL="https://www.demarches-simplifiees.fr"
 # Personnalisation d'instance - Logo par défaut d'une procédure  ---> à placer dans "app/assets/images"
 # PROCEDURE_DEFAULT_LOGO_SRC="republique-francaise-logo.svg"
 
+# Personnalisation d'instance - Logo dans le PDF d'export d'un dossier  ---> à placer dans "app/assets/images"
+# DOSSIER_PDF_EXPORT_LOGO_SRC="app/assets/images/header/logo-ds-wide.svg"
+
 # Personnalisation d'instance - fichier utilisé pour poser un filigrane sur les pièces d'identité
 # WATERMARK_FILE=""
+

--- a/config/initializers/images.rb
+++ b/config/initializers/images.rb
@@ -14,3 +14,6 @@ MAILER_LOGO_SRC = ENV.fetch("MAILER_LOGO_SRC", "mailer/instructeur_mailer/logo.p
 
 # Default logo of a procedure
 PROCEDURE_DEFAULT_LOGO_SRC = ENV.fetch("PROCEDURE_DEFAULT_LOGO_SRC", "republique-francaise-logo.svg")
+
+# Logo in PDF export of a "Dossier"
+DOSSIER_PDF_EXPORT_LOGO_SRC = ENV.fetch("DOSSIER_PDF_EXPORT_LOGO_SRC", "app/assets/images/header/logo-ds-wide.svg")


### PR DESCRIPTION
Fixed #5869 "ETQ Ops, je souhaite personnaliser l'image utilisé dans les PDF d'export d'un dossier" / @adullact

##  Actuellement

Lorsqu'on installe sa propre instance DS sans modifier le code source,
l'image SVG utilisé dans le PDF d'export d'un dossier n'est pas personnalisable.

Cette image [ `app/assets/images/header/logo-ds-wide.svg`](https://raw.githubusercontent.com/betagouv/demarches-simplifiees.fr/dev/app/assets/images/header/logo-ds-wide.svg) contient le logo Marianne et le texte "demarches-simplifiees.fr"

![image](https://raw.githubusercontent.com/betagouv/demarches-simplifiees.fr/dev/app/assets/images/header/logo-ds-wide.svg)



### Reproduction

- remplir un dossier d'une démarche
- consulter son dossier
- utiliser l’icône "imprimante" pour télécharger le dossier

![Screenshot_2021-01-06_Résumé___Dossier_nº_18__Formulaire_de_saisine_Mairie_d__39_Orvault____demarches-preprod_adullact_org](https://user-images.githubusercontent.com/6709977/106464143-88ed6d00-6498-11eb-975f-4cdf52e586dd.png)

### PDF généré sur une instance DS déjà personnalisée
![Screenshot_2021-01-30 3 pdf(1)](https://user-images.githubusercontent.com/6709977/106464305-c520cd80-6498-11eb-856d-6f85cf4a1769.png)

## Comportement attendu

Rendre configurable l'image SVG utilisé dans le PDF d'export d'un dossier, via une variable d'environnement optionnelle :
```env
# Personnalisation d'instance - Logo dans le PDF d'export d'un dossier  ---> à placer dans "app/assets/images"
DOSSIER_PDF_EXPORT_LOGO_SRC="app/assets/images/custom/logo-pdf-export.svg"
```

![Screenshot_2021-01-30 3 pdf](https://user-images.githubusercontent.com/6709977/106464385-dec21500-6498-11eb-8f9a-53c4fbef6780.png)


## Implémentation

Ajouter au fichier [`config/initializers/images.rb`](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/config/initializers/images.rb), une variable d'environnement optionnelle pour cette image et la documenter dans le fichier  [`env.example.optional`](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/config/env.example.optional).

Fichier `config/initializers/images.rb` :
```ruby
# Logo in PDF export of a "Dossier"
DOSSIER_PDF_EXPORT_LOGO_SRC = ENV.fetch("DOSSIER_PDF_EXPORT_LOGO_SRC", "app/assets/images/header/logo-ds-wide.svg")
```


## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur BetaGouv pour faire le rebase directement sur notre dépôt.

