### PR TITLE
#5871 - Allow mailers/_bizdev_signature to be configured in .env file

### DIFF
--- a/app/views/layouts/mailers/_bizdev_signature.html.haml
+++ b/app/views/layouts/mailers/_bizdev_signature.html.haml
@@ -9,6 +9,4 @@ Cordialement,
 Téléphone (standard) :
 = CONTACT_PHONE
 %br
-Incubateur de Services Numériques / beta.gouv.fr
-%br
-Services du Premier Ministre, 20 avenue de Ségur, 75007 Paris
+= safe_join(CONTACT_ADDRESS.split("\n"), raw('<br>'))

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -21,6 +21,9 @@ APPLICATION_BASE_URL="https://www.demarches-simplifiees.fr"
 # OLD_CONTACT_EMAIL=""
 # CONTACT_PHONE=""
 
+# Personnalisation d'instance - Adresses postale de l'opérateur de l'instance
+# CONTACT_ADDRESS="Incubateur de Services Numériques / beta.gouv.fr\nServices du Premier Ministre, 20 avenue de Ségur, 75007 Paris"
+
 # Personnalisation d'instance - URL pour la création de compte administrateur sur l'instance
 # DEMANDE_INSCRIPTION_ADMIN_PAGE_URL=""
 

--- a/config/initializers/contacts.rb
+++ b/config/initializers/contacts.rb
@@ -8,5 +8,6 @@ if !defined?(CONTACT_EMAIL)
   CONTACT_PHONE = ENV.fetch("CONTACT_PHONE", "01 76 42 02 87")
 
   OLD_CONTACT_EMAIL = ENV.fetch("OLD_CONTACT_EMAIL", "contact@tps.apientreprise.fr")
+  CONTACT_ADDRESS = ENV.fetch("CONTACT_ADDRESS", "Incubateur de Services Numériques / beta.gouv.fr\nServices du Premier Ministre, 20 avenue de Ségur, 75007 Paris")
 end
 # rubocop:enable DS/ApplicationName


### PR DESCRIPTION
Fixed #5871 "ETQ Ops, je souhaite personnaliser l'adresse postale du mail "Activez votre compte administrateur"" / @adullact

##  Actuellement

Lorsqu'on installe sa propre instance DS sans modifier le code source,
l'adresse postale du mail "**Activez votre compte administrateur**" n'est pas personnalisable.

Le mail "**Activez votre compte administrateur**" contient les 2 lignes suivantes 
qu'ils seraient souhaitables de pouvoir configurer :
```
Incubateur de Services Numériques / beta.gouv.fr
Services du Premier Ministre, 20 avenue de Ségur, 75007 Paris 
```

Ces 2 lignes sont écrites en dur dans le fichier [`app/views/layouts/mailers/_bizdev_signature.html.haml`](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/app/views/layouts/mailers/_bizdev_signature.html.haml). 

### Reproduction

- à partir d'un compte `super-admin` d'une instance DS personnalisée
- ajouter un nouveau compte **Administrateur**
- consulter le message "Activez votre compte administrateur"

![Sélection_025](https://user-images.githubusercontent.com/6709977/106485027-7848f100-64b0-11eb-938d-71073e626dbf.png)


## Comportement attendu

Rendre configurable l'adresse postale du mail "**Activez votre compte administrateur**" , via des variables d'environnements optionnelles :
```env
# Personnalisation d'instance - Adresses postale de l'opérateur de l'instance
CONTACT_ADRESS_LINE1="Association Adullact"
CONTACT_ADRESS_LINE2="5 rue du Plan du Palais, 34000 Montpellier"
```

![Sélection_026](https://user-images.githubusercontent.com/6709977/106485055-7e3ed200-64b0-11eb-9ab8-6dad035aff4b.png)



## Implémentation

Ajouter au fichier  [`config/initializers/contacts.rb`](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/config/initializers/contacts.rb), deux variables d'environnements optionnelles pour l'adresse postale utilisée dans le mail "**Activez votre compte administrateur**" et les documenter dans le fichier  [`env.example.optional`](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/config/env.example.optional).

Fichier `config/initializers/contacts.rb` :
```ruby
CONTACT_ADRESS_LINE1 = ENV.fetch("CONTACT_ADRESS_LINE1", "Incubateur de Services Numériques / beta.gouv.fr")
CONTACT_ADRESS_LINE2 = ENV.fetch("CONTACT_ADRESS_LINE2", "Services du Premier Ministre, 20 avenue de Ségur, 75007 Paris")
```


## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur BetaGouv pour faire le rebase directement sur notre dépôt.

