### PR TITLE
#5873 - Allow email footer logo to be configured in .env file

### DIFF
--- a/app/views/layouts/mailers/layout.html.erb
+++ b/app/views/layouts/mailers/layout.html.erb
@@ -167,7 +167,7 @@
                       <tr>
                         <td style="word-wrap:break-word;font-size:0px;padding:0px 20px 0px 20px;padding-top:0px;padding-bottom:0px;" align="center">
                           <div class="" style="cursor:auto;color:#55575d;font-family:Helvetica, Arial, sans-serif;font-size:11px;line-height:22px;text-align:center;">
-                            <img align="middle" alt="Logo Beta Gouv Fr" src="<%= image_url('mailer/instructeur_mailer/logo-beta-gouv-fr.png') %>" style="max-width=125px; padding=30px 0; display=inline !important; vertical-align=bottom; border=0; height=auto; outline=none; text-decoration=none; -ms-interpolation-mode=bicubic;" />
+                            <img align="middle" alt="Logo <%= "#{APPLICATION_NAME}" %>" src="<%= image_url("#{MAILER_FOOTER_LOGO_SRC}") %>" style="max-width=125px; padding=30px 0; display=inline !important; vertical-align=bottom; border=0; height=auto; outline=none; text-decoration=none; -ms-interpolation-mode=bicubic;" />
                           </div>
                         </td>
                       </tr>

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -50,6 +50,9 @@ APPLICATION_BASE_URL="https://www.demarches-simplifiees.fr"
 # Personnalisation d'instance - Logo dans l'entête des emails ---> à placer dans "app/assets/images"
 # MAILER_LOGO_SRC="mailer/instructeur_mailer/logo.png"
 
+# Personnalisation d'instance - Logo dans le pied de page des emails ---> à placer dans "app/assets/images"
+# MAILER_FOOTER_LOGO_SRC="mailer/instructeur_mailer/logo-beta-gouv-fr.png"
+
 # Personnalisation d'instance - Logo par défaut d'une procédure  ---> à placer dans "app/assets/images"
 # PROCEDURE_DEFAULT_LOGO_SRC="republique-francaise-logo.svg"
 

--- a/config/initializers/images.rb
+++ b/config/initializers/images.rb
@@ -9,8 +9,9 @@ HEADER_LOGO_ALT = ENV.fetch("HEADER_LOGO_ALT", "Liberté, égalité, fraternité
 HEADER_LOGO_WIDTH = ENV.fetch("HEADER_LOGO_WIDTH", "65")
 HEADER_LOGO_HEIGHT = ENV.fetch("HEADER_LOGO_HEIGHT", "56")
 
-# Mailer logo
+# Mailer logos
 MAILER_LOGO_SRC = ENV.fetch("MAILER_LOGO_SRC", "mailer/instructeur_mailer/logo.png")
+MAILER_FOOTER_LOGO_SRC = ENV.fetch("MAILER_FOOTER_LOGO_SRC", "mailer/instructeur_mailer/logo-beta-gouv-fr.png")
 
 # Default logo of a procedure
 PROCEDURE_DEFAULT_LOGO_SRC = ENV.fetch("PROCEDURE_DEFAULT_LOGO_SRC", "republique-francaise-logo.svg")


### PR DESCRIPTION
Fixed #5873 "ETQ Ops, je souhaite personnaliser le logo de pied de page des emails" / @adullact

##  Actuellement

Lorsqu'on installe sa propre instance DS sans modifier le code source,
l'image utilisé dans pied de page des emails n'est pas personnalisable.

L'image [ `app/assets/images/mailer/instructeur_mailer/logo-beta-gouv-fr.png`](https://raw.githubusercontent.com/betagouv/demarches-simplifiees.fr/dev/app/assets/images/mailer/instructeur_mailer/logo-beta-gouv-fr.png) 
est écrite en dur dans le fichier [`app/views/layouts/mailers/layout.html.erb`](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/app/views/layouts/mailers/layout.html.erb#L170)

> ![image](https://raw.githubusercontent.com/betagouv/demarches-simplifiees.fr/dev/app/assets/images/mailer/instructeur_mailer/logo-beta-gouv-fr.png)

### Reproduction

- à partir d'une instance DS personnalisée
- utiliser le formulaire "Mot de passe oublié"
- consulter le message "Instructions pour changer le mot de passe" qui affiche l'image `logo-beta-gouv-fr.png`

![Sélection_025](https://user-images.githubusercontent.com/6709977/106557515-47a19f80-6522-11eb-9c12-4bc7baf8bbfc.png)

## Comportement attendu

Rendre configurable l'image utilisée dans pied de page des emails, via une variable d'environnement optionnelle :
```env
# Personnalisation d'instance - Logo dans le pied de page des emails ---> à placer dans "app/assets/images"
MAILER_FOOTER_LOGO_SRC="custom/logo-mail-footer.png"
MAILER_FOOTER_LOGO_ALT="Adulllact"
```

![Sélection_024](https://user-images.githubusercontent.com/6709977/106557551-5ab46f80-6522-11eb-8db5-70daebdaf09a.png)


## Implémentation

Ajouter au fichier [`config/initializers/images.rb`](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/config/initializers/images.rb), deux variables d'environnements optionnelles pour cette image et les documenter dans le fichier  [`env.example.optional`](https://github.com/betagouv/demarches-simplifiees.fr/blob/dev/config/env.example.optional).

Fichier `config/initializers/images.rb` :
```ruby
# Mailer logos
...
MAILER_FOOTER_LOGO_SRC = ENV.fetch("MAILER_FOOTER_LOGO_SRC", "mailer/instructeur_mailer/logo-beta-gouv-fr.png")
MAILER_FOOTER_LOGO_ALT = ENV.fetch("MAILER_FOOTER_LOGO_ALT", "Logo Beta Gouv Fr")
```


## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur BetaGouv pour faire le rebase directement sur notre dépôt.

