### PR TITLE
gems: use a zeitwerk-compatible version of byebug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,10 +115,9 @@ end
 
 group :development, :test do
   gem 'axe-matchers' # accessibility rspec matchers
-  gem 'byebug' # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'graphql-schema_comparator'
   gem 'mina', git: 'https://github.com/mina-deploy/mina.git', require: false # Deploy
-  gem 'pry-byebug'
+  gem 'pry-byebug' # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'rspec_junit_formatter', require: false
   gem 'rspec-rails'
   gem 'ruby-debug-ide', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -802,7 +802,6 @@ DEPENDENCIES
   bcrypt
   brakeman
   browser
-  byebug
   capybara
   capybara-email
   capybara-screenshot


### PR DESCRIPTION
It seems byebug is not compatible with the zeitwerk autoloader, but
byebug-pry is.