### PR TITLE
/stats: Correction de l'affichage du nombre de dossiers

### DIFF
--- a/app/assets/stylesheets/stats.scss
+++ b/app/assets/stylesheets/stats.scss
@@ -125,7 +125,7 @@ $segmented-control-item-border-radius: 2 * $default-space;
 $big-number-card-padding: 2 * $segmented-control-item-border-radius;
 
 .big-number-card {
-  padding: $big-number-card-padding;
+  padding: $big-number-card-padding $segmented-control-item-horizontal-padding;
 }
 
 .big-number-card-title {


### PR DESCRIPTION
### Avant

<img width="473" alt="Capture d’écran 2021-02-04 à 11 56 43" src="https://user-images.githubusercontent.com/179923/106883534-664d9500-66e0-11eb-89db-00a660a5846a.png">

### Après

<img width="481" alt="Capture d’écran 2021-02-04 à 11 56 17" src="https://user-images.githubusercontent.com/179923/106883550-6a79b280-66e0-11eb-9fd3-12a9c157a195.png">
