### PR TITLE
spec: fix rspec raise_error warning

### DIFF
--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -370,7 +370,7 @@ describe ProcedureExportService do
         end
 
         it 'should have valid sheet name' do
-          expect { subject }.not_to raise_error(ArgumentError)
+          expect { subject }.not_to raise_error
         end
       end
 


### PR DESCRIPTION
Rspec warns that if there is for example a SyntaxError, the test will pass (an error was raised, but it wasn't an ArgumentError, so this is fine).

Instead check that no error occurs whatsoever.