### PR TITLE
Compatibilité du passage d'argument nommés avec Ruby 2.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -792,9 +792,9 @@ GEM
     xray-rails (0.3.2)
       rails (>= 3.1.0)
     zeitwerk (2.4.2)
-    zip_tricks (5.3.1)
-    zipline (1.2.1)
-      rails (>= 3.2.1, < 6.1)
+    zip_tricks (5.5.0)
+    zipline (1.3.0)
+      actionpack (>= 3.2.1, < 7.0)
       zip_tricks (>= 4.2.1, < 6.0)
     zxcvbn-ruby (1.1.0)
 

--- a/app/mailers/dossier_mailer.rb
+++ b/app/mailers/dossier_mailer.rb
@@ -150,7 +150,7 @@ class DossierMailer < ApplicationMailer
     if interpolations[:state]
       mailer_scope = self.class.mailer_name.tr('/', '.')
       state = interpolations[:state].in?(Dossier::TERMINE) ? 'termine' : interpolations[:state]
-      I18n.t("subject_#{state}", interpolations.merge(scope: [mailer_scope, action_name]))
+      I18n.t("subject_#{state}", **interpolations.merge(scope: [mailer_scope, action_name]))
     else
       super
     end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -227,8 +227,8 @@ class Dossier < ApplicationRecord
       user: [])
   }
 
-  scope :with_notifiable_procedure, -> (notify_on_closed: false) do
-    states = notify_on_closed ? [:publiee, :close, :depubliee] : [:publiee, :depubliee]
+  scope :with_notifiable_procedure, -> (opts = { notify_on_closed: false }) do
+    states = opts[:notify_on_closed] ? [:publiee, :close, :depubliee] : [:publiee, :depubliee]
     joins(:procedure)
       .where(procedures: { aasm_state: states })
   end

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -71,7 +71,7 @@ module FeatureHelpers
 
   # Add a new type de champ in the procedure editor
   def add_champ(options = {})
-    add_champs(options)
+    add_champs(**options)
   end
 
   # Add several new type de champ in the procedure editor


### PR DESCRIPTION
Ruby 2.7 change légèrement la manière dont sont passés les arguments nommés d'une méthode (voir [article détaillé et clair ici](https://blog.saeloun.com/2019/10/07/ruby-2-7-keyword-arguments-redesign.html)).

Pour l'instant Ruby 2.7 n'affiche qu'un avertissement (visible quand on fait tourner les tests) – mais c'est une erreur dure dans Ruby 3.0.

Cette PR corrige tous les avertissements en question, en faisant en sorte que la distinction entre Dictionnaire et arguments nommés soit plus claire.

(NB: il manque encore une MàJ de smart_listing et de kaminari. Smart_listing n'est plus nécessaire et va être supprimé, mais pour kaminari faudra peut-être écrire du code upstream.)