### PR TITLE
Drop api entreprise job errors

### DIFF
--- a/app/jobs/api_entreprise/association_job.rb
+++ b/app/jobs/api_entreprise/association_job.rb
@@ -1,6 +1,6 @@
 class ApiEntreprise::AssociationJob < ApiEntreprise::Job
   def perform(etablissement_id, procedure_id)
-    etablissement = Etablissement.find(etablissement_id)
+    find_etablissement(etablissement_id)
     etablissement_params = ApiEntreprise::RNAAdapter.new(etablissement.siret, procedure_id).to_params
     etablissement.update!(etablissement_params)
   end

--- a/app/jobs/api_entreprise/attestation_fiscale_job.rb
+++ b/app/jobs/api_entreprise/attestation_fiscale_job.rb
@@ -1,6 +1,6 @@
 class ApiEntreprise::AttestationFiscaleJob < ApiEntreprise::Job
   def perform(etablissement_id, procedure_id, user_id)
-    etablissement = Etablissement.find(etablissement_id)
+    find_etablissement(etablissement_id)
     etablissement_params = ApiEntreprise::AttestationFiscaleAdapter.new(etablissement.siret, procedure_id, user_id).to_params
     attestation_fiscale_url = etablissement_params.delete(:entreprise_attestation_fiscale_url)
     etablissement.upload_attestation_fiscale(attestation_fiscale_url) if attestation_fiscale_url.present?

--- a/app/jobs/api_entreprise/attestation_sociale_job.rb
+++ b/app/jobs/api_entreprise/attestation_sociale_job.rb
@@ -1,6 +1,6 @@
 class ApiEntreprise::AttestationSocialeJob < ApiEntreprise::Job
   def perform(etablissement_id, procedure_id)
-    etablissement = Etablissement.find(etablissement_id)
+    find_etablissement(etablissement_id)
     etablissement_params = ApiEntreprise::AttestationSocialeAdapter.new(etablissement.siret, procedure_id).to_params
     attestation_sociale_url = etablissement_params.delete(:entreprise_attestation_sociale_url)
     etablissement.upload_attestation_sociale(attestation_sociale_url) if attestation_sociale_url.present?

--- a/app/jobs/api_entreprise/bilans_bdf_job.rb
+++ b/app/jobs/api_entreprise/bilans_bdf_job.rb
@@ -1,6 +1,6 @@
 class ApiEntreprise::BilansBdfJob < ApiEntreprise::Job
   def perform(etablissement_id, procedure_id)
-    etablissement = Etablissement.find(etablissement_id)
+    find_etablissement(etablissement_id)
     etablissement_params = ApiEntreprise::BilansBdfAdapter.new(etablissement.siret, procedure_id).to_params
     etablissement.update!(etablissement_params)
   end

--- a/app/jobs/api_entreprise/effectifs_annuels_job.rb
+++ b/app/jobs/api_entreprise/effectifs_annuels_job.rb
@@ -1,6 +1,6 @@
 class ApiEntreprise::EffectifsAnnuelsJob < ApiEntreprise::Job
   def perform(etablissement_id, procedure_id)
-    etablissement = Etablissement.find(etablissement_id)
+    find_etablissement(etablissement_id)
     etablissement_params = ApiEntreprise::EffectifsAnnuelsAdapter.new(etablissement.siret, procedure_id).to_params
     etablissement.update!(etablissement_params)
   end

--- a/app/jobs/api_entreprise/effectifs_job.rb
+++ b/app/jobs/api_entreprise/effectifs_job.rb
@@ -1,6 +1,6 @@
 class ApiEntreprise::EffectifsJob < ApiEntreprise::Job
   def perform(etablissement_id, procedure_id)
-    etablissement = Etablissement.find(etablissement_id)
+    find_etablissement(etablissement_id)
     # may 2020 is at the moment the most actual info for effectifs endpoint
     etablissement_params = ApiEntreprise::EffectifsAdapter.new(etablissement.siret, procedure_id, "2020", "05").to_params
     etablissement.update!(etablissement_params)

--- a/app/jobs/api_entreprise/entreprise_job.rb
+++ b/app/jobs/api_entreprise/entreprise_job.rb
@@ -1,6 +1,6 @@
 class ApiEntreprise::EntrepriseJob < ApiEntreprise::Job
   def perform(etablissement_id, procedure_id)
-    etablissement = Etablissement.find(etablissement_id)
+    find_etablissement(etablissement_id)
     etablissement_params = ApiEntreprise::EntrepriseAdapter.new(etablissement.siret, procedure_id).to_params
     etablissement.update!(etablissement_params)
   end

--- a/app/jobs/api_entreprise/exercices_job.rb
+++ b/app/jobs/api_entreprise/exercices_job.rb
@@ -3,7 +3,7 @@ class ApiEntreprise::ExercicesJob < ApiEntreprise::Job
   end
 
   def perform(etablissement_id, procedure_id)
-    etablissement = Etablissement.find(etablissement_id)
+    find_etablissement(etablissement_id)
     etablissement_params = ApiEntreprise::ExercicesAdapter.new(etablissement.siret, procedure_id).to_params
     etablissement.update!(etablissement_params)
   end

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champ < ApplicationRecord
   belongs_to :dossier, -> { with_discarded }, inverse_of: :champs, touch: true, optional: false

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -137,6 +137,12 @@ class Champ < ApplicationRecord
     type_de_champ.stable_id
   end
 
+  def log_fetch_external_data_exception(exception)
+    exceptions = self.fetch_external_data_exceptions ||= []
+    exceptions << exception.inspect
+    update_column(:fetch_external_data_exceptions, exceptions)
+  end
+
   private
 
   def needs_dossier_id?

--- a/app/models/champs/address_champ.rb
+++ b/app/models/champs/address_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::AddressChamp < Champs::TextChamp
 end

--- a/app/models/champs/annuaire_education_champ.rb
+++ b/app/models/champs/annuaire_education_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::AnnuaireEducationChamp < Champs::TextChamp
   before_save :cleanup_if_empty

--- a/app/models/champs/carte_champ.rb
+++ b/app/models/champs/carte_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::CarteChamp < Champ
   # Default map location. Center of the World, ahm, France...

--- a/app/models/champs/checkbox_champ.rb
+++ b/app/models/champs/checkbox_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::CheckboxChamp < Champs::YesNoChamp
   def true?

--- a/app/models/champs/civilite_champ.rb
+++ b/app/models/champs/civilite_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::CiviliteChamp < Champ
   def html_label?

--- a/app/models/champs/commune_champ.rb
+++ b/app/models/champs/commune_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::CommuneChamp < Champs::TextChamp
 end

--- a/app/models/champs/date_champ.rb
+++ b/app/models/champs/date_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::DateChamp < Champ
   before_save :format_before_save

--- a/app/models/champs/datetime_champ.rb
+++ b/app/models/champs/datetime_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::DatetimeChamp < Champ
   before_save :format_before_save

--- a/app/models/champs/decimal_number_champ.rb
+++ b/app/models/champs/decimal_number_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::DecimalNumberChamp < Champ
   validates :value, numericality: {

--- a/app/models/champs/departement_champ.rb
+++ b/app/models/champs/departement_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::DepartementChamp < Champs::TextChamp
 end

--- a/app/models/champs/dossier_link_champ.rb
+++ b/app/models/champs/dossier_link_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::DossierLinkChamp < Champ
 end

--- a/app/models/champs/drop_down_list_champ.rb
+++ b/app/models/champs/drop_down_list_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::DropDownListChamp < Champ
   THRESHOLD_NB_OPTIONS_AS_RADIO = 5

--- a/app/models/champs/email_champ.rb
+++ b/app/models/champs/email_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::EmailChamp < Champs::TextChamp
 end

--- a/app/models/champs/engagement_champ.rb
+++ b/app/models/champs/engagement_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::EngagementChamp < Champs::CheckboxChamp
 end

--- a/app/models/champs/explication_champ.rb
+++ b/app/models/champs/explication_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::ExplicationChamp < Champs::TextChamp
   def search_terms

--- a/app/models/champs/header_section_champ.rb
+++ b/app/models/champs/header_section_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::HeaderSectionChamp < Champ
   def search_terms

--- a/app/models/champs/iban_champ.rb
+++ b/app/models/champs/iban_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::IbanChamp < Champ
   validates_with IbanValidator

--- a/app/models/champs/integer_number_champ.rb
+++ b/app/models/champs/integer_number_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::IntegerNumberChamp < Champ
   validates :value, numericality: {

--- a/app/models/champs/linked_drop_down_list_champ.rb
+++ b/app/models/champs/linked_drop_down_list_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::LinkedDropDownListChamp < Champ
   delegate :primary_options, :secondary_options, to: 'type_de_champ.dynamic_type'

--- a/app/models/champs/multiple_drop_down_list_champ.rb
+++ b/app/models/champs/multiple_drop_down_list_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::MultipleDropDownListChamp < Champ
   before_save :format_before_save

--- a/app/models/champs/number_champ.rb
+++ b/app/models/champs/number_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::NumberChamp < Champ
 end

--- a/app/models/champs/pays_champ.rb
+++ b/app/models/champs/pays_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::PaysChamp < Champs::TextChamp
 end

--- a/app/models/champs/phone_champ.rb
+++ b/app/models/champs/phone_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::PhoneChamp < Champs::TextChamp
   validates :value,

--- a/app/models/champs/piece_justificative_champ.rb
+++ b/app/models/champs/piece_justificative_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::PieceJustificativeChamp < Champ
   MAX_SIZE = 200.megabytes

--- a/app/models/champs/region_champ.rb
+++ b/app/models/champs/region_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::RegionChamp < Champs::TextChamp
 end

--- a/app/models/champs/repetition_champ.rb
+++ b/app/models/champs/repetition_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::RepetitionChamp < Champ
   accepts_nested_attributes_for :champs, allow_destroy: true

--- a/app/models/champs/siret_champ.rb
+++ b/app/models/champs/siret_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::SiretChamp < Champ
   def search_terms

--- a/app/models/champs/text_champ.rb
+++ b/app/models/champs/text_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::TextChamp < Champ
 end

--- a/app/models/champs/textarea_champ.rb
+++ b/app/models/champs/textarea_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::TextareaChamp < Champs::TextChamp
   def for_export

--- a/app/models/champs/titre_identite_champ.rb
+++ b/app/models/champs/titre_identite_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::TitreIdentiteChamp < Champ
   MAX_SIZE = 20.megabytes

--- a/app/models/champs/yes_no_champ.rb
+++ b/app/models/champs/yes_no_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: champs
 #
-#  id               :integer          not null, primary key
-#  data             :jsonb
-#  private          :boolean          default(FALSE), not null
-#  row              :integer
-#  type             :string
-#  value            :string
-#  created_at       :datetime
-#  updated_at       :datetime
-#  dossier_id       :integer
-#  etablissement_id :integer
-#  external_id      :string
-#  parent_id        :bigint
-#  type_de_champ_id :integer
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
 #
 class Champs::YesNoChamp < Champ
   def search_terms

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -820,6 +820,12 @@ class Dossier < ApplicationRecord
     }
   end
 
+  def log_api_entreprise_job_exception(exception)
+    exceptions = self.api_entreprise_job_exceptions ||= []
+    exceptions << exception.inspect
+    update_column(:api_entreprise_job_exceptions, exceptions)
+  end
+
   private
 
   def geo_areas

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -3,6 +3,7 @@
 # Table name: dossiers
 #
 #  id                                                 :integer          not null, primary key
+#  api_entreprise_job_exceptions                      :string           is an Array
 #  archived                                           :boolean          default(FALSE)
 #  autorisation_donnees                               :boolean
 #  brouillon_close_to_expiration_notice_sent_at       :datetime

--- a/db/migrate/20210204180955_add_job_exception_logs.rb
+++ b/db/migrate/20210204180955_add_job_exception_logs.rb
@@ -1,0 +1,6 @@
+class AddJobExceptionLogs < ActiveRecord::Migration[6.0]
+  def change
+    add_column :dossiers, :api_entreprise_job_exceptions, :string, array: true
+    add_column :champs, :fetch_external_data_exceptions, :string, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_21_134435) do
+ActiveRecord::Schema.define(version: 2021_02_04_180955) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -147,6 +147,7 @@ ActiveRecord::Schema.define(version: 2021_01_21_134435) do
     t.integer "row"
     t.jsonb "data"
     t.string "external_id"
+    t.string "fetch_external_data_exceptions", array: true
     t.index ["dossier_id"], name: "index_champs_on_dossier_id"
     t.index ["parent_id"], name: "index_champs_on_parent_id"
     t.index ["private"], name: "index_champs_on_private"
@@ -250,6 +251,7 @@ ActiveRecord::Schema.define(version: 2021_01_21_134435) do
     t.datetime "last_commentaire_updated_at"
     t.index "to_tsvector('french'::regconfig, (search_terms || private_search_terms))", name: "index_dossiers_on_search_terms_private_search_terms", using: :gin
     t.index "to_tsvector('french'::regconfig, search_terms)", name: "index_dossiers_on_search_terms", using: :gin
+    t.string "api_entreprise_job_exceptions", array: true
     t.index ["archived"], name: "index_dossiers_on_archived"
     t.index ["groupe_instructeur_id"], name: "index_dossiers_on_groupe_instructeur_id"
     t.index ["hidden_at"], name: "index_dossiers_on_hidden_at"

--- a/spec/models/champ_spec.rb
+++ b/spec/models/champ_spec.rb
@@ -510,4 +510,16 @@ describe Champ do
       end
     end
   end
+
+  describe '#log_fetch_external_data_exception' do
+    let(:champ) { create(:champ_siret) }
+
+    context "add execption to the log" do
+      before do
+        champ.log_fetch_external_data_exception(StandardError.new('My special exception!'))
+      end
+
+      it { expect(champ.fetch_external_data_exceptions).to eq(['#<StandardError: My special exception!>']) }
+    end
+  end
 end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1424,4 +1424,16 @@ describe Dossier do
       end
     end
   end
+
+  describe '#log_api_entreprise_job_exception' do
+    let(:dossier) { create(:dossier) }
+
+    context "add execption to the log" do
+      before do
+        dossier.log_api_entreprise_job_exception(StandardError.new('My special exception!'))
+      end
+
+      it { expect(dossier.api_entreprise_job_exceptions).to eq(['#<StandardError: My special exception!>']) }
+    end
+  end
 end


### PR DESCRIPTION
Je ne vois pas de moyen de combiner `retry_on` et `discard_on` donc j'ai utilisé `presque_from` pour implémenter la même logique de retry que nous avons déjà en place, mais j'ai aussi ajouté le log dans une colonne sur le dossier et sur le champ. La colonne sur le dossier est vouée à disparaitre avec la disparition de l'établissement sur le dossier. Sur le champ j'ai utilisé un nom plus générique aligné avec la nouvelle infrastructure de fetch de référentiels extérieurs que je suis en train de mettre en place. J'aimerais bien généraliser cette logique de retry / discard sur tous les jobs qui communiquent avec les API externes.