### PR TITLE
Renommage des constantes pour Zeitwerk

### DIFF
--- a/app/controllers/api/v2/graphql_controller.rb
+++ b/app/controllers/api/v2/graphql_controller.rb
@@ -2,7 +2,7 @@ class API::V2::GraphqlController < API::V2::BaseController
   def execute
     variables = ensure_hash(params[:variables])
 
-    result = Api::V2::Schema.execute(params[:query],
+    result = API::V2::Schema.execute(params[:query],
       variables: variables,
       context: context,
       operation_name: params[:operationName])

--- a/app/controllers/champs/carte_controller.rb
+++ b/app/controllers/champs/carte_controller.rb
@@ -11,7 +11,7 @@ class Champs::CarteController < ApplicationController
       @champ.geo_areas += GeoArea.from_feature_collection(cadastres_features_collection(@champ.to_feature_collection))
       @champ.save!
     end
-  rescue ApiCarto::API::ResourceNotFound
+  rescue APICarto::API::ResourceNotFound
     flash.alert = 'Les données cartographiques sont temporairement indisponibles. Réessayez dans un instant.'
     response.status = 503
   end
@@ -77,7 +77,7 @@ class Champs::CarteController < ApplicationController
     end
 
     if coordinates.present?
-      cadastres = ApiCartoService.generate_cadastre(coordinates)
+      cadastres = APICartoService.generate_cadastre(coordinates)
 
       {
         type: 'FeatureCollection',

--- a/app/controllers/champs/siret_controller.rb
+++ b/app/controllers/champs/siret_controller.rb
@@ -17,7 +17,7 @@ class Champs::SiretController < ApplicationController
 
     begin
       etablissement = find_etablissement_with_siret
-    rescue ApiEntreprise::API::Error::RequestFailed, ApiEntreprise::API::Error::ServiceUnavailable
+    rescue APIEntreprise::API::Error::RequestFailed, APIEntreprise::API::Error::ServiceUnavailable
       # i18n-tasks-use t('errors.siret_network_error')
       return siret_error(:network_error)
     end
@@ -53,7 +53,7 @@ class Champs::SiretController < ApplicationController
   end
 
   def find_etablissement_with_siret
-    ApiEntrepriseService.create_etablissement(@champ, @siret, current_user.id)
+    APIEntrepriseService.create_etablissement(@champ, @siret, current_user.id)
   end
 
   def clear_siret_and_etablissement

--- a/app/controllers/new_administrateur/procedures_controller.rb
+++ b/app/controllers/new_administrateur/procedures_controller.rb
@@ -129,7 +129,7 @@ module NewAdministrateur
       @procedure.api_entreprise_token = token
 
       if @procedure.valid? &&
-          ApiEntreprise::PrivilegesAdapter.new(token).valid? &&
+          APIEntreprise::PrivilegesAdapter.new(token).valid? &&
           @procedure.save
 
         redirect_to jeton_admin_procedure_path(procedure_id: params[:procedure_id]),

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -97,8 +97,8 @@ module Users
 
       sanitized_siret = siret_model.siret
       begin
-        etablissement = ApiEntrepriseService.create_etablissement(@dossier, sanitized_siret, current_user.id)
-      rescue ApiEntreprise::API::Error::RequestFailed, ApiEntreprise::API::Error::BadGateway, ApiEntreprise::API::Error::TimedOut
+        etablissement = APIEntrepriseService.create_etablissement(@dossier, sanitized_siret, current_user.id)
+      rescue APIEntreprise::API::Error::RequestFailed, APIEntreprise::API::Error::BadGateway, APIEntreprise::API::Error::TimedOut
         return render_siret_error(t('errors.messages.siret_network_error'))
       end
       if etablissement.nil?

--- a/app/graphql/api/v2/context.rb
+++ b/app/graphql/api/v2/context.rb
@@ -1,4 +1,4 @@
-class Api::V2::Context < GraphQL::Query::Context
+class API::V2::Context < GraphQL::Query::Context
   def has_fragment?(name)
     if self["has_fragment_#{name}"]
       true

--- a/app/graphql/api/v2/schema.rb
+++ b/app/graphql/api/v2/schema.rb
@@ -1,4 +1,4 @@
-class Api::V2::Schema < GraphQL::Schema
+class API::V2::Schema < GraphQL::Schema
   default_max_page_size 100
   max_complexity 300
   max_depth 15
@@ -6,7 +6,7 @@ class Api::V2::Schema < GraphQL::Schema
   query Types::QueryType
   mutation Types::MutationType
 
-  context_class Api::V2::Context
+  context_class API::V2::Context
 
   def self.id_from_object(object, type_definition, ctx)
     object.to_typed_id

--- a/app/helpers/notice_url_helper.rb
+++ b/app/helpers/notice_url_helper.rb
@@ -1,4 +1,4 @@
-module NoticeUrlHelper
+module NoticeURLHelper
   def notice_url(procedure)
     if procedure.notice.attached?
       url_for(procedure.notice)

--- a/app/jobs/annuaire_education_update_job.rb
+++ b/app/jobs/annuaire_education_update_job.rb
@@ -3,7 +3,7 @@ class AnnuaireEducationUpdateJob < ApplicationJob
     external_id = champ.external_id
 
     if external_id.present?
-      data = ApiEducation::AnnuaireEducationAdapter.new(external_id).to_params
+      data = APIEducation::AnnuaireEducationAdapter.new(external_id).to_params
 
       if data.present?
         champ.data = data

--- a/app/jobs/api_entreprise/association_job.rb
+++ b/app/jobs/api_entreprise/association_job.rb
@@ -1,7 +1,7 @@
-class ApiEntreprise::AssociationJob < ApiEntreprise::Job
+class APIEntreprise::AssociationJob < APIEntreprise::Job
   def perform(etablissement_id, procedure_id)
     find_etablissement(etablissement_id)
-    etablissement_params = ApiEntreprise::RNAAdapter.new(etablissement.siret, procedure_id).to_params
+    etablissement_params = APIEntreprise::RNAAdapter.new(etablissement.siret, procedure_id).to_params
     etablissement.update!(etablissement_params)
   end
 end

--- a/app/jobs/api_entreprise/attestation_fiscale_job.rb
+++ b/app/jobs/api_entreprise/attestation_fiscale_job.rb
@@ -1,7 +1,7 @@
-class ApiEntreprise::AttestationFiscaleJob < ApiEntreprise::Job
+class APIEntreprise::AttestationFiscaleJob < APIEntreprise::Job
   def perform(etablissement_id, procedure_id, user_id)
     find_etablissement(etablissement_id)
-    etablissement_params = ApiEntreprise::AttestationFiscaleAdapter.new(etablissement.siret, procedure_id, user_id).to_params
+    etablissement_params = APIEntreprise::AttestationFiscaleAdapter.new(etablissement.siret, procedure_id, user_id).to_params
     attestation_fiscale_url = etablissement_params.delete(:entreprise_attestation_fiscale_url)
     etablissement.upload_attestation_fiscale(attestation_fiscale_url) if attestation_fiscale_url.present?
   end

--- a/app/jobs/api_entreprise/attestation_sociale_job.rb
+++ b/app/jobs/api_entreprise/attestation_sociale_job.rb
@@ -1,7 +1,7 @@
-class ApiEntreprise::AttestationSocialeJob < ApiEntreprise::Job
+class APIEntreprise::AttestationSocialeJob < APIEntreprise::Job
   def perform(etablissement_id, procedure_id)
     find_etablissement(etablissement_id)
-    etablissement_params = ApiEntreprise::AttestationSocialeAdapter.new(etablissement.siret, procedure_id).to_params
+    etablissement_params = APIEntreprise::AttestationSocialeAdapter.new(etablissement.siret, procedure_id).to_params
     attestation_sociale_url = etablissement_params.delete(:entreprise_attestation_sociale_url)
     etablissement.upload_attestation_sociale(attestation_sociale_url) if attestation_sociale_url.present?
   end

--- a/app/jobs/api_entreprise/bilans_bdf_job.rb
+++ b/app/jobs/api_entreprise/bilans_bdf_job.rb
@@ -1,7 +1,7 @@
-class ApiEntreprise::BilansBdfJob < ApiEntreprise::Job
+class APIEntreprise::BilansBdfJob < APIEntreprise::Job
   def perform(etablissement_id, procedure_id)
     find_etablissement(etablissement_id)
-    etablissement_params = ApiEntreprise::BilansBdfAdapter.new(etablissement.siret, procedure_id).to_params
+    etablissement_params = APIEntreprise::BilansBdfAdapter.new(etablissement.siret, procedure_id).to_params
     etablissement.update!(etablissement_params)
   end
 end

--- a/app/jobs/api_entreprise/effectifs_annuels_job.rb
+++ b/app/jobs/api_entreprise/effectifs_annuels_job.rb
@@ -1,7 +1,7 @@
-class ApiEntreprise::EffectifsAnnuelsJob < ApiEntreprise::Job
+class APIEntreprise::EffectifsAnnuelsJob < APIEntreprise::Job
   def perform(etablissement_id, procedure_id)
     find_etablissement(etablissement_id)
-    etablissement_params = ApiEntreprise::EffectifsAnnuelsAdapter.new(etablissement.siret, procedure_id).to_params
+    etablissement_params = APIEntreprise::EffectifsAnnuelsAdapter.new(etablissement.siret, procedure_id).to_params
     etablissement.update!(etablissement_params)
   end
 end

--- a/app/jobs/api_entreprise/effectifs_job.rb
+++ b/app/jobs/api_entreprise/effectifs_job.rb
@@ -1,8 +1,8 @@
-class ApiEntreprise::EffectifsJob < ApiEntreprise::Job
+class APIEntreprise::EffectifsJob < APIEntreprise::Job
   def perform(etablissement_id, procedure_id)
     find_etablissement(etablissement_id)
     # may 2020 is at the moment the most actual info for effectifs endpoint
-    etablissement_params = ApiEntreprise::EffectifsAdapter.new(etablissement.siret, procedure_id, "2020", "05").to_params
+    etablissement_params = APIEntreprise::EffectifsAdapter.new(etablissement.siret, procedure_id, "2020", "05").to_params
     etablissement.update!(etablissement_params)
   end
 

--- a/app/jobs/api_entreprise/entreprise_job.rb
+++ b/app/jobs/api_entreprise/entreprise_job.rb
@@ -1,7 +1,7 @@
-class ApiEntreprise::EntrepriseJob < ApiEntreprise::Job
+class APIEntreprise::EntrepriseJob < APIEntreprise::Job
   def perform(etablissement_id, procedure_id)
     find_etablissement(etablissement_id)
-    etablissement_params = ApiEntreprise::EntrepriseAdapter.new(etablissement.siret, procedure_id).to_params
+    etablissement_params = APIEntreprise::EntrepriseAdapter.new(etablissement.siret, procedure_id).to_params
     etablissement.update!(etablissement_params)
   end
 end

--- a/app/jobs/api_entreprise/exercices_job.rb
+++ b/app/jobs/api_entreprise/exercices_job.rb
@@ -1,10 +1,10 @@
-class ApiEntreprise::ExercicesJob < ApiEntreprise::Job
-  rescue_from(ApiEntreprise::API::Error::BadFormatRequest) do |exception|
+class APIEntreprise::ExercicesJob < APIEntreprise::Job
+  rescue_from(APIEntreprise::API::Error::BadFormatRequest) do |exception|
   end
 
   def perform(etablissement_id, procedure_id)
     find_etablissement(etablissement_id)
-    etablissement_params = ApiEntreprise::ExercicesAdapter.new(etablissement.siret, procedure_id).to_params
+    etablissement_params = APIEntreprise::ExercicesAdapter.new(etablissement.siret, procedure_id).to_params
     etablissement.update!(etablissement_params)
   end
 end

--- a/app/jobs/api_entreprise/job.rb
+++ b/app/jobs/api_entreprise/job.rb
@@ -1,4 +1,4 @@
-class ApiEntreprise::Job < ApplicationJob
+class APIEntreprise::Job < ApplicationJob
   DEFAULT_MAX_ATTEMPTS_API_ENTREPRISE_JOBS = 5
 
   queue_as :api_entreprise
@@ -8,27 +8,27 @@ class ApiEntreprise::Job < ApplicationJob
   # - bdf: erreur interne
   # so we retry every day for 5 days
   # same logic for ServiceUnavailable
-  rescue_from(ApiEntreprise::API::Error::ServiceUnavailable) do |exception|
+  rescue_from(APIEntreprise::API::Error::ServiceUnavailable) do |exception|
     retry_or_discard(exception)
   end
-  rescue_from(ApiEntreprise::API::Error::BadGateway) do |exception|
+  rescue_from(APIEntreprise::API::Error::BadGateway) do |exception|
     retry_or_discard(exception)
   end
 
   # We guess the backend is slow but not broken
   # and the information we are looking for is available
   # so we retry few seconds later (exponentially to avoid overload)
-  retry_on ApiEntreprise::API::Error::TimedOut, wait: :exponentially_longer
+  retry_on APIEntreprise::API::Error::TimedOut, wait: :exponentially_longer
 
   # If by the time the job runs the Etablissement has been deleted
   # (it can happen through EtablissementUpdateJob for instance), ignore the job
   discard_on ActiveRecord::RecordNotFound
 
-  rescue_from(ApiEntreprise::API::Error::ResourceNotFound) do |exception|
+  rescue_from(APIEntreprise::API::Error::ResourceNotFound) do |exception|
     error(self, exception)
   end
 
-  rescue_from(ApiEntreprise::API::Error::BadFormatRequest) do |exception|
+  rescue_from(APIEntreprise::API::Error::BadFormatRequest) do |exception|
     error(self, exception)
   end
 

--- a/app/jobs/cron/fix_missing_antivirus_analysis_job.rb
+++ b/app/jobs/cron/fix_missing_antivirus_analysis_job.rb
@@ -1,4 +1,4 @@
-class Cron::FixMissingAntivirusAnalysis < Cron::CronJob
+class Cron::FixMissingAntivirusAnalysisJob < Cron::CronJob
   self.schedule_expression = "every day at 2 am"
 
   def perform

--- a/app/jobs/etablissement_update_job.rb
+++ b/app/jobs/etablissement_update_job.rb
@@ -1,7 +1,7 @@
 class EtablissementUpdateJob < ApplicationJob
   def perform(dossier, siret)
     begin
-      etablissement_attributes = ApiEntrepriseService.get_etablissement_params_for_siret(siret, dossier.procedure.id)
+      etablissement_attributes = APIEntrepriseService.get_etablissement_params_for_siret(siret, dossier.procedure.id)
     rescue
       return
     end

--- a/app/lib/api_carto/api.rb
+++ b/app/lib/api_carto/api.rb
@@ -1,4 +1,4 @@
-class ApiCarto::API
+class APICarto::API
   class ResourceNotFound < StandardError
   end
 
@@ -16,7 +16,7 @@ class ApiCarto::API
       response.body
     else
       message = response.code == 0 ? response.return_message : response.code.to_s
-      Rails.logger.error "[ApiCarto] Error on #{url}: #{message}"
+      Rails.logger.error "[APICarto] Error on #{url}: #{message}"
       raise ResourceNotFound
     end
   end

--- a/app/lib/api_carto/cadastre_adapter.rb
+++ b/app/lib/api_carto/cadastre_adapter.rb
@@ -1,10 +1,10 @@
-class ApiCarto::CadastreAdapter
+class APICarto::CadastreAdapter
   def initialize(coordinates)
     @coordinates = GeojsonService.to_json_polygon_for_cadastre(coordinates)
   end
 
   def data_source
-    @data_source ||= JSON.parse(ApiCarto::API.search_cadastre(@coordinates), symbolize_names: true)
+    @data_source ||= JSON.parse(APICarto::API.search_cadastre(@coordinates), symbolize_names: true)
   end
 
   def results

--- a/app/lib/api_education/annuaire_education_adapter.rb
+++ b/app/lib/api_education/annuaire_education_adapter.rb
@@ -1,6 +1,6 @@
 require 'json_schemer'
 
-class ApiEducation::AnnuaireEducationAdapter
+class APIEducation::AnnuaireEducationAdapter
   class InvalidSchemaError < ::StandardError
     def initialize(errors)
       super(errors.map(&:to_json).join("\n"))
@@ -27,7 +27,7 @@ class ApiEducation::AnnuaireEducationAdapter
   private
 
   def data_source
-    @data_source ||= JSON.parse(ApiEducation::API.get_annuaire_education(@id), symbolize_names: true)
+    @data_source ||= JSON.parse(APIEducation::API.get_annuaire_education(@id), symbolize_names: true)
   end
 
   def schemer

--- a/app/lib/api_education/api.rb
+++ b/app/lib/api_education/api.rb
@@ -1,4 +1,4 @@
-class ApiEducation::API
+class APIEducation::API
   class ResourceNotFound < StandardError
   end
 
@@ -15,7 +15,7 @@ class ApiEducation::API
       response.body
     else
       message = response.code == 0 ? response.return_message : response.code.to_s
-      Rails.logger.error "[ApiEducation] Error on #{url}: #{message}"
+      Rails.logger.error "[APIEducation] Error on #{url}: #{message}"
       raise ResourceNotFound
     end
   end

--- a/app/lib/api_entreprise/adapter.rb
+++ b/app/lib/api_entreprise/adapter.rb
@@ -1,4 +1,4 @@
-class ApiEntreprise::Adapter
+class APIEntreprise::Adapter
   UNAVAILABLE = 'Donnée indisponible'
 
   def initialize(siret, procedure_id)
@@ -9,7 +9,7 @@ class ApiEntreprise::Adapter
   def data_source
     begin
       @data_source ||= get_resource
-    rescue ApiEntreprise::API::Error::ResourceNotFound
+    rescue APIEntreprise::API::Error::ResourceNotFound
       @data_source = nil
     end
   end

--- a/app/lib/api_entreprise/api.rb
+++ b/app/lib/api_entreprise/api.rb
@@ -1,4 +1,4 @@
-class ApiEntreprise::API
+class APIEntreprise::API
   ENTREPRISE_RESOURCE_NAME = "entreprises"
   ETABLISSEMENT_RESOURCE_NAME = "etablissements"
   EXERCICES_RESOURCE_NAME = "exercices"
@@ -72,7 +72,7 @@ class ApiEntreprise::API
   end
 
   def self.call_with_siret(resource_name, siret_or_siren, procedure_id, user_id = nil)
-    return if ApiEntrepriseToken.new(token_for_procedure(procedure_id)).expired?
+    return if APIEntrepriseToken.new(token_for_procedure(procedure_id)).expired?
     url = url(resource_name, siret_or_siren)
     params = params(siret_or_siren, procedure_id, user_id)
 

--- a/app/lib/api_entreprise/api/error.rb
+++ b/app/lib/api_entreprise/api/error.rb
@@ -1,4 +1,4 @@
-class ApiEntreprise::API::Error < ::StandardError
+class APIEntreprise::API::Error < ::StandardError
   def initialize(response)
     # use uri to avoid sending token
     uri = URI.parse(response.effective_url)

--- a/app/lib/api_entreprise/api/error/bad_format_request.rb
+++ b/app/lib/api_entreprise/api/error/bad_format_request.rb
@@ -1,4 +1,2 @@
-class ApiEntreprise::API::Error
-  class BadFormatRequest < ApiEntreprise::API::Error
-  end
+class APIEntreprise::API::Error::BadFormatRequest < APIEntreprise::API::Error
 end

--- a/app/lib/api_entreprise/api/error/bad_gateway.rb
+++ b/app/lib/api_entreprise/api/error/bad_gateway.rb
@@ -1,4 +1,2 @@
-class ApiEntreprise::API::Error
-  class BadGateway < ApiEntreprise::API::Error
-  end
+class APIEntreprise::API::Error::BadGateway < APIEntreprise::API::Error
 end

--- a/app/lib/api_entreprise/api/error/request_failed.rb
+++ b/app/lib/api_entreprise/api/error/request_failed.rb
@@ -1,4 +1,2 @@
-class ApiEntreprise::API::Error
-  class RequestFailed < ApiEntreprise::API::Error
-  end
+class APIEntreprise::API::Error::RequestFailed < APIEntreprise::API::Error
 end

--- a/app/lib/api_entreprise/api/error/resource_not_found.rb
+++ b/app/lib/api_entreprise/api/error/resource_not_found.rb
@@ -1,4 +1,2 @@
-class ApiEntreprise::API::Error
-  class ResourceNotFound < ApiEntreprise::API::Error
-  end
+class APIEntreprise::API::Error::ResourceNotFound < APIEntreprise::API::Error
 end

--- a/app/lib/api_entreprise/api/error/service_unavailable.rb
+++ b/app/lib/api_entreprise/api/error/service_unavailable.rb
@@ -1,4 +1,2 @@
-class ApiEntreprise::API::Error
-  class ServiceUnavailable < ApiEntreprise::API::Error
-  end
+class APIEntreprise::API::Error::ServiceUnavailable < APIEntreprise::API::Error
 end

--- a/app/lib/api_entreprise/api/error/timed_out.rb
+++ b/app/lib/api_entreprise/api/error/timed_out.rb
@@ -1,4 +1,2 @@
-class ApiEntreprise::API::Error
-  class TimedOut < ApiEntreprise::API::Error
-  end
+class APIEntreprise::API::Error::TimedOut < APIEntreprise::API::Error
 end

--- a/app/lib/api_entreprise/attestation_fiscale_adapter.rb
+++ b/app/lib/api_entreprise/attestation_fiscale_adapter.rb
@@ -1,4 +1,4 @@
-class ApiEntreprise::AttestationFiscaleAdapter < ApiEntreprise::Adapter
+class APIEntreprise::AttestationFiscaleAdapter < APIEntreprise::Adapter
   def initialize(siret, procedure_id, user_id)
     @siret = siret
     @procedure_id = procedure_id
@@ -8,7 +8,7 @@ class ApiEntreprise::AttestationFiscaleAdapter < ApiEntreprise::Adapter
   private
 
   def get_resource
-    ApiEntreprise::API.attestation_fiscale(siren, @procedure_id, @user_id)
+    APIEntreprise::API.attestation_fiscale(siren, @procedure_id, @user_id)
   end
 
   def process_params

--- a/app/lib/api_entreprise/attestation_sociale_adapter.rb
+++ b/app/lib/api_entreprise/attestation_sociale_adapter.rb
@@ -1,4 +1,4 @@
-class ApiEntreprise::AttestationSocialeAdapter < ApiEntreprise::Adapter
+class APIEntreprise::AttestationSocialeAdapter < APIEntreprise::Adapter
   def initialize(siret, procedure_id)
     @siret = siret
     @procedure_id = procedure_id
@@ -7,7 +7,7 @@ class ApiEntreprise::AttestationSocialeAdapter < ApiEntreprise::Adapter
   private
 
   def get_resource
-    ApiEntreprise::API.attestation_sociale(siren, @procedure_id)
+    APIEntreprise::API.attestation_sociale(siren, @procedure_id)
   end
 
   def process_params

--- a/app/lib/api_entreprise/bilans_bdf_adapter.rb
+++ b/app/lib/api_entreprise/bilans_bdf_adapter.rb
@@ -1,4 +1,4 @@
-class ApiEntreprise::BilansBdfAdapter < ApiEntreprise::Adapter
+class APIEntreprise::BilansBdfAdapter < APIEntreprise::Adapter
   def initialize(siret, procedure_id)
     @siret = siret
     @procedure_id = procedure_id
@@ -7,7 +7,7 @@ class ApiEntreprise::BilansBdfAdapter < ApiEntreprise::Adapter
   private
 
   def get_resource
-    ApiEntreprise::API.bilans_bdf(siren, @procedure_id)
+    APIEntreprise::API.bilans_bdf(siren, @procedure_id)
   end
 
   def process_params

--- a/app/lib/api_entreprise/effectifs_adapter.rb
+++ b/app/lib/api_entreprise/effectifs_adapter.rb
@@ -1,4 +1,4 @@
-class ApiEntreprise::EffectifsAdapter < ApiEntreprise::Adapter
+class APIEntreprise::EffectifsAdapter < APIEntreprise::Adapter
   def initialize(siret, procedure_id, annee, mois)
     @siret = siret
     @procedure_id = procedure_id
@@ -9,7 +9,7 @@ class ApiEntreprise::EffectifsAdapter < ApiEntreprise::Adapter
   private
 
   def get_resource
-    ApiEntreprise::API.effectifs(siren, @procedure_id, @annee, @mois)
+    APIEntreprise::API.effectifs(siren, @procedure_id, @annee, @mois)
   end
 
   def process_params

--- a/app/lib/api_entreprise/effectifs_annuels_adapter.rb
+++ b/app/lib/api_entreprise/effectifs_annuels_adapter.rb
@@ -1,4 +1,4 @@
-class ApiEntreprise::EffectifsAnnuelsAdapter < ApiEntreprise::Adapter
+class APIEntreprise::EffectifsAnnuelsAdapter < APIEntreprise::Adapter
   def initialize(siret, procedure_id)
     @siret = siret
     @procedure_id = procedure_id
@@ -7,7 +7,7 @@ class ApiEntreprise::EffectifsAnnuelsAdapter < ApiEntreprise::Adapter
   private
 
   def get_resource
-    ApiEntreprise::API.effectifs_annuels(siren, @procedure_id)
+    APIEntreprise::API.effectifs_annuels(siren, @procedure_id)
   end
 
   def process_params

--- a/app/lib/api_entreprise/entreprise_adapter.rb
+++ b/app/lib/api_entreprise/entreprise_adapter.rb
@@ -1,8 +1,8 @@
-class ApiEntreprise::EntrepriseAdapter < ApiEntreprise::Adapter
+class APIEntreprise::EntrepriseAdapter < APIEntreprise::Adapter
   private
 
   def get_resource
-    ApiEntreprise::API.entreprise(siren, @procedure_id)
+    APIEntreprise::API.entreprise(siren, @procedure_id)
   end
 
   def process_params

--- a/app/lib/api_entreprise/etablissement_adapter.rb
+++ b/app/lib/api_entreprise/etablissement_adapter.rb
@@ -1,8 +1,8 @@
-class ApiEntreprise::EtablissementAdapter < ApiEntreprise::Adapter
+class APIEntreprise::EtablissementAdapter < APIEntreprise::Adapter
   private
 
   def get_resource
-    ApiEntreprise::API.etablissement(@siret, @procedure_id)
+    APIEntreprise::API.etablissement(@siret, @procedure_id)
   end
 
   def process_params

--- a/app/lib/api_entreprise/exercices_adapter.rb
+++ b/app/lib/api_entreprise/exercices_adapter.rb
@@ -1,8 +1,8 @@
-class ApiEntreprise::ExercicesAdapter < ApiEntreprise::Adapter
+class APIEntreprise::ExercicesAdapter < APIEntreprise::Adapter
   private
 
   def get_resource
-    ApiEntreprise::API.exercices(@siret, @procedure_id)
+    APIEntreprise::API.exercices(@siret, @procedure_id)
   end
 
   def process_params

--- a/app/lib/api_entreprise/privileges_adapter.rb
+++ b/app/lib/api_entreprise/privileges_adapter.rb
@@ -1,4 +1,4 @@
-class ApiEntreprise::PrivilegesAdapter < ApiEntreprise::Adapter
+class APIEntreprise::PrivilegesAdapter < APIEntreprise::Adapter
   def initialize(token)
     @token = token
   end
@@ -15,6 +15,6 @@ class ApiEntreprise::PrivilegesAdapter < ApiEntreprise::Adapter
   private
 
   def get_resource
-    ApiEntreprise::API.privileges(@token)
+    APIEntreprise::API.privileges(@token)
   end
 end

--- a/app/lib/api_entreprise/rna_adapter.rb
+++ b/app/lib/api_entreprise/rna_adapter.rb
@@ -1,8 +1,8 @@
-class ApiEntreprise::RNAAdapter < ApiEntreprise::Adapter
+class APIEntreprise::RNAAdapter < APIEntreprise::Adapter
   private
 
   def get_resource
-    ApiEntreprise::API.rna(@siret, @procedure_id)
+    APIEntreprise::API.rna(@siret, @procedure_id)
   end
 
   def process_params

--- a/app/lib/sendinblue/api.rb
+++ b/app/lib/sendinblue/api.rb
@@ -1,4 +1,4 @@
-class Sendinblue::Api
+class Sendinblue::API
   def self.new_properly_configured!
     api = self.new
     if !api.properly_configured?

--- a/app/models/api_entreprise_token.rb
+++ b/app/models/api_entreprise_token.rb
@@ -1,4 +1,4 @@
-class ApiEntrepriseToken
+class APIEntrepriseToken
   attr_reader :token
 
   def initialize(token)

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -625,7 +625,7 @@ class Procedure < ApplicationRecord
   end
 
   def api_entreprise_role?(role)
-    ApiEntrepriseToken.new(api_entreprise_token).role?(role)
+    APIEntrepriseToken.new(api_entreprise_token).role?(role)
   end
 
   def api_entreprise_token
@@ -633,7 +633,7 @@ class Procedure < ApplicationRecord
   end
 
   def api_entreprise_token_expired?
-    ApiEntrepriseToken.new(api_entreprise_token).expired?
+    APIEntrepriseToken.new(api_entreprise_token).expired?
   end
 
   def create_new_revision

--- a/app/serializers/module_api_carto_serializer.rb
+++ b/app/serializers/module_api_carto_serializer.rb
@@ -1,3 +1,3 @@
-class ModuleApiCartoSerializer < ActiveModel::Serializer
+class ModuleAPICartoSerializer < ActiveModel::Serializer
   attributes :use_api_carto, :cadastre
 end

--- a/app/serializers/procedure_serializer.rb
+++ b/app/serializers/procedure_serializer.rb
@@ -13,7 +13,7 @@ class ProcedureSerializer < ActiveModel::Serializer
     :link,
     :state
 
-  has_one :geographic_information, serializer: ModuleApiCartoSerializer
+  has_one :geographic_information, serializer: ModuleAPICartoSerializer
   has_many :types_de_champ, serializer: TypeDeChampSerializer
   has_many :types_de_champ_private, serializer: TypeDeChampSerializer
   has_many :types_de_piece_justificative

--- a/app/services/administrateur_usage_statistics_service.rb
+++ b/app/services/administrateur_usage_statistics_service.rb
@@ -18,7 +18,7 @@ class AdministrateurUsageStatisticsService
   private
 
   def api
-    @api ||= Sendinblue::Api.new_properly_configured!
+    @api ||= Sendinblue::API.new_properly_configured!
   end
 
   def administrateur_stats(administrateur)

--- a/app/services/api_carto_service.rb
+++ b/app/services/api_carto_service.rb
@@ -1,7 +1,7 @@
-class ApiCartoService
+class APICartoService
   def self.generate_qp(coordinates)
     coordinates.flat_map do |coordinate|
-      ApiCarto::QuartiersPrioritairesAdapter.new(
+      APICarto::QuartiersPrioritairesAdapter.new(
         coordinate.map { |element| [element['lng'], element['lat']] }
       ).results
     end
@@ -9,7 +9,7 @@ class ApiCartoService
 
   def self.generate_cadastre(coordinates)
     coordinates.flat_map do |coordinate|
-      ApiCarto::CadastreAdapter.new(
+      APICarto::CadastreAdapter.new(
         coordinate.map { |element| [element['lng'], element['lat']] }
       ).results
     end

--- a/app/services/api_entreprise_service.rb
+++ b/app/services/api_entreprise_service.rb
@@ -1,27 +1,27 @@
-class ApiEntrepriseService
+class APIEntrepriseService
   # create etablissement with EtablissementAdapter
   # enqueue api_entreprise jobs to retrieve
   # all informations we can get about a SIRET.
   #
   # Returns nil if the SIRET is unknown
   #
-  # Raises a ApiEntreprise::API::Error::RequestFailed exception on transient errors
+  # Raises a APIEntreprise::API::Error::RequestFailed exception on transient errors
   # (timeout, 5XX HTTP error code, etc.)
   def self.create_etablissement(dossier_or_champ, siret, user_id = nil)
-    etablissement_params = ApiEntreprise::EtablissementAdapter.new(siret, dossier_or_champ.procedure.id).to_params
+    etablissement_params = APIEntreprise::EtablissementAdapter.new(siret, dossier_or_champ.procedure.id).to_params
     return nil if etablissement_params.empty?
 
     etablissement = dossier_or_champ.build_etablissement(etablissement_params)
     etablissement.save!
 
     [
-      ApiEntreprise::EntrepriseJob, ApiEntreprise::AssociationJob, ApiEntreprise::ExercicesJob,
-      ApiEntreprise::EffectifsJob, ApiEntreprise::EffectifsAnnuelsJob, ApiEntreprise::AttestationSocialeJob,
-      ApiEntreprise::BilansBdfJob
+      APIEntreprise::EntrepriseJob, APIEntreprise::AssociationJob, APIEntreprise::ExercicesJob,
+      APIEntreprise::EffectifsJob, APIEntreprise::EffectifsAnnuelsJob, APIEntreprise::AttestationSocialeJob,
+      APIEntreprise::BilansBdfJob
     ].each do |job|
       job.perform_later(etablissement.id, dossier_or_champ.procedure.id)
     end
-    ApiEntreprise::AttestationFiscaleJob.perform_later(etablissement.id, dossier_or_champ.procedure.id, user_id)
+    APIEntreprise::AttestationFiscaleJob.perform_later(etablissement.id, dossier_or_champ.procedure.id, user_id)
 
     etablissement
   end

--- a/config/initializers/active_job_compatibility.rb
+++ b/config/initializers/active_job_compatibility.rb
@@ -1,0 +1,30 @@
+# The following jobs were renamed, but instances using the old name
+# were still scheduled to run on the job queue.
+#
+# To ensure the job queue can instantiate these jobs using the previous
+# names, this file defines retro-compatibility aliases.
+#
+# Once all jobs running using the previous name will have run, this
+# file can be safely deleted.
+#
+# (That probably means a few hours after deploying the rename in production
+# - but let's keep these for a while to make external integrators's life easier.
+# To keep some margin, let's say this file can be safely deleted in May 2021.)
+
+require 'excon'
+
+module ApiEntreprise
+  Job = APIEntreprise::Job
+  AssociationJob = APIEntreprise::AssociationJob
+  AttestationFiscaleJob = APIEntreprise::AttestationFiscaleJob
+  AttestationSocialeJob = APIEntreprise::AttestationSocialeJob
+  BilansBdfJob = APIEntreprise::BilansBdfJob
+  EffectifsAnnuelsJob = APIEntreprise::EffectifsAnnuelsJob
+  EffectifsJob = APIEntreprise::EffectifsJob
+  EntrepriseJob = APIEntreprise::EntrepriseJob
+  ExercicesJob = APIEntreprise::ExercicesJob
+end
+
+module Cron
+  FixMissingAntivirusAnalysis = FixMissingAntivirusAnalysisJob
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -9,6 +9,9 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   # inflect.irregular 'person', 'people'
   # inflect.uncountable %w( fish sheep )
   inflect.acronym 'API'
+  inflect.acronym 'ASN1'
+  inflect.acronym 'IP'
+  inflect.acronym 'JSON'
   inflect.acronym 'RNA'
   inflect.acronym 'URL'
   inflect.irregular 'type_de_champ', 'types_de_champ'

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -10,6 +10,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   # inflect.uncountable %w( fish sheep )
   inflect.acronym 'API'
   inflect.acronym 'RNA'
+  inflect.acronym 'URL'
   inflect.irregular 'type_de_champ', 'types_de_champ'
   inflect.irregular 'type_de_champ_private', 'types_de_champ_private'
   inflect.irregular 'procedure_revision_type_de_champ', 'procedure_revision_types_de_champ'

--- a/lib/tasks/deployment/20200527124112_fix_champ_etablissement.rake
+++ b/lib/tasks/deployment/20200527124112_fix_champ_etablissement.rake
@@ -24,12 +24,12 @@ namespace :after_party do
 
   def fetch_api_entreprise_infos(etablissement_id, procedure_id, user_id)
     [
-      ApiEntreprise::EntrepriseJob, ApiEntreprise::AssociationJob, ApiEntreprise::ExercicesJob,
-      ApiEntreprise::EffectifsJob, ApiEntreprise::EffectifsAnnuelsJob, ApiEntreprise::AttestationSocialeJob,
-      ApiEntreprise::BilansBdfJob
+      APIEntreprise::EntrepriseJob, APIEntreprise::AssociationJob, APIEntreprise::ExercicesJob,
+      APIEntreprise::EffectifsJob, APIEntreprise::EffectifsAnnuelsJob, APIEntreprise::AttestationSocialeJob,
+      APIEntreprise::BilansBdfJob
     ].each do |job|
       job.perform_later(etablissement_id, procedure_id)
     end
-    ApiEntreprise::AttestationFiscaleJob.perform_later(etablissement_id, procedure_id, user_id)
+    APIEntreprise::AttestationFiscaleJob.perform_later(etablissement_id, procedure_id, user_id)
   end
 end

--- a/lib/tasks/graphql.rake
+++ b/lib/tasks/graphql.rake
@@ -1,2 +1,2 @@
 require "graphql/rake_task"
-GraphQL::RakeTask.new(schema_name: "Api::V2::Schema", directory: 'app/graphql')
+GraphQL::RakeTask.new(schema_name: "API::V2::Schema", directory: 'app/graphql')

--- a/spec/controllers/champs/siret_controller_spec.rb
+++ b/spec/controllers/champs/siret_controller_spec.rb
@@ -32,9 +32,9 @@ describe Champs::SiretController, type: :controller do
         sign_in user
         stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/etablissements\/#{siret}/)
           .to_return(status: api_etablissement_status, body: api_etablissement_body)
-        allow_any_instance_of(ApiEntrepriseToken).to receive(:roles)
+        allow_any_instance_of(APIEntrepriseToken).to receive(:roles)
           .and_return(["attestations_fiscales", "attestations_sociales", "bilans_entreprise_bdf"])
-        allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(token_expired)
+        allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(token_expired)
       end
 
       context 'when the SIRET is empty' do

--- a/spec/controllers/new_administrateur/procedures_controller_spec.rb
+++ b/spec/controllers/new_administrateur/procedures_controller_spec.rb
@@ -338,7 +338,7 @@ describe NewAdministrateur::ProceduresController, type: :controller do
     subject { patch :update_jeton, params: { id: procedure.id, procedure: { api_entreprise_token: token } } }
 
     before do
-      allow_any_instance_of(ApiEntreprise::PrivilegesAdapter).to receive(:valid?).and_return(token_is_valid)
+      allow_any_instance_of(APIEntreprise::PrivilegesAdapter).to receive(:valid?).and_return(token_is_valid)
       subject
     end
 

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -208,9 +208,9 @@ describe Users::DossiersController, type: :controller do
       sign_in(user)
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/etablissements\/#{siret}/)
         .to_return(status: api_etablissement_status, body: api_etablissement_body)
-      allow_any_instance_of(ApiEntrepriseToken).to receive(:roles)
+      allow_any_instance_of(APIEntrepriseToken).to receive(:roles)
         .and_return(["attestations_fiscales", "attestations_sociales", "bilans_entreprise_bdf"])
-      allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(token_expired)
+      allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(token_expired)
     end
 
     subject! { post :update_siret, params: { id: dossier.id, user: { siret: params_siret } } }

--- a/spec/features/users/dossier_creation_spec.rb
+++ b/spec/features/users/dossier_creation_spec.rb
@@ -78,8 +78,8 @@ feature 'Creating a new dossier:' do
           .to_return(status: 404, body: '')
         stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/effectifs_annuels_acoss_covid\/#{siren}/)
           .to_return(status: 404, body: '')
-        allow_any_instance_of(ApiEntrepriseToken).to receive(:roles).and_return([])
-        allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+        allow_any_instance_of(APIEntrepriseToken).to receive(:roles).and_return([])
+        allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
       end
       before { Timecop.freeze(Time.zone.local(2020, 3, 14)) }
       after { Timecop.return }

--- a/spec/jobs/api_entreprise/association_job_spec.rb
+++ b/spec/jobs/api_entreprise/association_job_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ApiEntreprise::AssociationJob, type: :job do
+RSpec.describe APIEntreprise::AssociationJob, type: :job do
   let(:siret) { '50480511000013' }
   let(:etablissement) { create(:etablissement, siret: siret) }
   let(:procedure) { create(:procedure) }
@@ -9,10 +9,10 @@ RSpec.describe ApiEntreprise::AssociationJob, type: :job do
   before do
     stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/associations\//)
       .to_return(body: body, status: status)
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+    allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
   end
 
-  subject { ApiEntreprise::AssociationJob.new.perform(etablissement.id, procedure_id) }
+  subject { APIEntreprise::AssociationJob.new.perform(etablissement.id, procedure_id) }
 
   it 'updates etablissement' do
     subject

--- a/spec/jobs/api_entreprise/attestation_fiscale_job_spec.rb
+++ b/spec/jobs/api_entreprise/attestation_fiscale_job_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ApiEntreprise::AttestationFiscaleJob, type: :job do
+RSpec.describe APIEntreprise::AttestationFiscaleJob, type: :job do
   let(:etablissement) { create(:etablissement, siret: siret) }
   let(:siret) { '41816609600069' }
   let(:siren) { '418166096' }
@@ -12,11 +12,11 @@ RSpec.describe ApiEntreprise::AttestationFiscaleJob, type: :job do
       .to_return(body: body, status: status)
     stub_request(:get, "https://storage.entreprise.api.gouv.fr/siade/1569156756-f6b7779f99fa95cd60dc03c04fcb-attestation_fiscale_dgfip.pdf")
       .to_return(body: "body attestation", status: 200)
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:roles).and_return(["attestations_fiscales"])
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+    allow_any_instance_of(APIEntrepriseToken).to receive(:roles).and_return(["attestations_fiscales"])
+    allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
   end
 
-  subject { ApiEntreprise::AttestationFiscaleJob.new.perform(etablissement.id, procedure.id, user_id) }
+  subject { APIEntreprise::AttestationFiscaleJob.new.perform(etablissement.id, procedure.id, user_id) }
 
   it 'updates etablissement' do
     subject

--- a/spec/jobs/api_entreprise/attestation_sociale_job_spec.rb
+++ b/spec/jobs/api_entreprise/attestation_sociale_job_spec.rb
@@ -1,6 +1,6 @@
 include ActiveJob::TestHelper
 
-RSpec.describe ApiEntreprise::AttestationSocialeJob, type: :job do
+RSpec.describe APIEntreprise::AttestationSocialeJob, type: :job do
   let(:etablissement) { create(:etablissement, siret: siret) }
   let(:siret) { '41816609600069' }
   let(:siren) { '418166096' }
@@ -13,11 +13,11 @@ RSpec.describe ApiEntreprise::AttestationSocialeJob, type: :job do
       .to_return(body: body, status: status)
     stub_request(:get, "https://storage.entreprise.api.gouv.fr/siade/1569156881-f749d75e2bfd443316e2e02d59015f-attestation_vigilance_acoss.pdf")
       .to_return(body: "body attestation", status: 200)
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:roles).and_return(["attestations_sociales"])
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+    allow_any_instance_of(APIEntrepriseToken).to receive(:roles).and_return(["attestations_sociales"])
+    allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
   end
 
-  subject { ApiEntreprise::AttestationSocialeJob.new.perform(etablissement.id, procedure.id) }
+  subject { APIEntreprise::AttestationSocialeJob.new.perform(etablissement.id, procedure.id) }
 
   it 'updates etablissement' do
     subject

--- a/spec/jobs/api_entreprise/bilans_bdf_job_spec.rb
+++ b/spec/jobs/api_entreprise/bilans_bdf_job_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ApiEntreprise::BilansBdfJob, type: :job do
+RSpec.describe APIEntreprise::BilansBdfJob, type: :job do
   let(:etablissement) { create(:etablissement, siret: siret) }
   let(:siret) { '41816609600069' }
   let(:siren) { '418166096' }
@@ -11,11 +11,11 @@ RSpec.describe ApiEntreprise::BilansBdfJob, type: :job do
   before do
     stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/bilans_entreprises_bdf\/#{siren}/)
       .to_return(body: body, status: status)
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:roles).and_return(["bilans_entreprise_bdf"])
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+    allow_any_instance_of(APIEntrepriseToken).to receive(:roles).and_return(["bilans_entreprise_bdf"])
+    allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
   end
 
-  subject { ApiEntreprise::BilansBdfJob.new.perform(etablissement.id, procedure_id) }
+  subject { APIEntreprise::BilansBdfJob.new.perform(etablissement.id, procedure_id) }
 
   it 'updates etablissement' do
     subject

--- a/spec/jobs/api_entreprise/effectifs_annuels_job_spec.rb
+++ b/spec/jobs/api_entreprise/effectifs_annuels_job_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ApiEntreprise::EffectifsAnnuelsJob, type: :job do
+RSpec.describe APIEntreprise::EffectifsAnnuelsJob, type: :job do
   let(:etablissement) { create(:etablissement, siret: siret) }
   let(:siret) { '41816609600069' }
   let(:siren) { '418166096' }
@@ -10,10 +10,10 @@ RSpec.describe ApiEntreprise::EffectifsAnnuelsJob, type: :job do
   before do
     stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/effectifs_annuels_acoss_covid\/#{siren}/)
       .to_return(body: body, status: status)
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+    allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
   end
 
-  subject { ApiEntreprise::EffectifsAnnuelsJob.new.perform(etablissement.id, procedure_id) }
+  subject { APIEntreprise::EffectifsAnnuelsJob.new.perform(etablissement.id, procedure_id) }
 
   it 'updates etablissement' do
     subject

--- a/spec/jobs/api_entreprise/effectifs_job_spec.rb
+++ b/spec/jobs/api_entreprise/effectifs_job_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ApiEntreprise::EffectifsJob, type: :job do
+RSpec.describe APIEntreprise::EffectifsJob, type: :job do
   let(:siret) { '41816609600069' }
   let(:siren) { '418166096' }
   let(:etablissement) { create(:etablissement, siret: siret) }
@@ -13,13 +13,13 @@ RSpec.describe ApiEntreprise::EffectifsJob, type: :job do
   before do
     stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/effectifs_mensuels_acoss_covid\/#{annee}\/#{mois}\/entreprise\/#{siren}/)
       .to_return(body: body, status: status)
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+    allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
   end
 
   before { Timecop.freeze(now) }
   after { Timecop.return }
 
-  subject { ApiEntreprise::EffectifsJob.new.perform(etablissement.id, procedure_id) }
+  subject { APIEntreprise::EffectifsJob.new.perform(etablissement.id, procedure_id) }
 
   it 'updates etablissement' do
     subject

--- a/spec/jobs/api_entreprise/entreprise_job_spec.rb
+++ b/spec/jobs/api_entreprise/entreprise_job_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ApiEntreprise::EntrepriseJob, type: :job do
+RSpec.describe APIEntreprise::EntrepriseJob, type: :job do
   let(:siret) { '41816609600051' }
   let(:siren) { '418166096' }
   let(:etablissement) { create(:etablissement, siret: siret) }
@@ -10,10 +10,10 @@ RSpec.describe ApiEntreprise::EntrepriseJob, type: :job do
   before do
     stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/entreprises\/#{siren}/)
       .to_return(body: body, status: status)
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+    allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
   end
 
-  subject { ApiEntreprise::EntrepriseJob.new.perform(etablissement.id, procedure_id) }
+  subject { APIEntreprise::EntrepriseJob.new.perform(etablissement.id, procedure_id) }
 
   it 'updates etablissement' do
     subject

--- a/spec/jobs/api_entreprise/exercices_job_spec.rb
+++ b/spec/jobs/api_entreprise/exercices_job_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe ApiEntreprise::ExercicesJob, type: :job do
+RSpec.describe APIEntreprise::ExercicesJob, type: :job do
   let(:siret) { '41816609600051' }
   let(:procedure) { create(:procedure) }
   let(:etablissement) { create(:etablissement, siret: siret) }
@@ -8,10 +8,10 @@ RSpec.describe ApiEntreprise::ExercicesJob, type: :job do
   before do
     stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/exercices\//)
       .to_return(body: body, status: status)
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+    allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
   end
 
-  subject { ApiEntreprise::ExercicesJob.new.perform(etablissement.id, procedure.id) }
+  subject { APIEntreprise::ExercicesJob.new.perform(etablissement.id, procedure.id) }
 
   it 'updates etablissement' do
     subject

--- a/spec/jobs/api_entreprise/job_spec.rb
+++ b/spec/jobs/api_entreprise/job_spec.rb
@@ -1,6 +1,6 @@
 include ActiveJob::TestHelper
 
-RSpec.describe ApiEntreprise::Job, type: :job do
+RSpec.describe APIEntreprise::Job, type: :job do
   # https://api.rubyonrails.org/classes/ActiveJob/Exceptions/ClassMethods.html
   # #method-i-retry_on
   describe '#perform' do
@@ -19,7 +19,7 @@ RSpec.describe ApiEntreprise::Job, type: :job do
 
       it 'retries 5 times' do
         ensure_errors_force_n_retry(errors, 5)
-        expect(dossier.reload.api_entreprise_job_exceptions.first).to match('ApiEntreprise::API::Error::ServiceUnavailable')
+        expect(dossier.reload.api_entreprise_job_exceptions.first).to match('APIEntreprise::API::Error::ServiceUnavailable')
       end
     end
 
@@ -34,7 +34,7 @@ RSpec.describe ApiEntreprise::Job, type: :job do
     end
   end
 
-  class ErrorJob < ApiEntreprise::Job
+  class ErrorJob < APIEntreprise::Job
     def perform(error, etablissement)
       @etablissement = etablissement
 
@@ -50,11 +50,11 @@ RSpec.describe ApiEntreprise::Job, type: :job do
 
       case error
       when :service_unavaible
-        raise ApiEntreprise::API::Error::ServiceUnavailable.new(response)
+        raise APIEntreprise::API::Error::ServiceUnavailable.new(response)
       when :bad_gateway
-        raise ApiEntreprise::API::Error::BadGateway.new(response)
+        raise APIEntreprise::API::Error::BadGateway.new(response)
       when :timed_out
-        raise ApiEntreprise::API::Error::TimedOut.new(response)
+        raise APIEntreprise::API::Error::TimedOut.new(response)
       else
         raise StandardError
       end

--- a/spec/lib/api_carto/api_spec.rb
+++ b/spec/lib/api_carto/api_spec.rb
@@ -1,4 +1,4 @@
-describe ApiCarto::API do
+describe APICarto::API do
   describe '.search_cadastre' do
     subject { described_class.search_cadastre(geojson) }
 
@@ -13,8 +13,8 @@ describe ApiCarto::API do
       let(:status) { 404 }
       let(:body) { '' }
 
-      it 'raises ApiCarto::API::ResourceNotFound' do
-        expect { subject }.to raise_error(ApiCarto::API::ResourceNotFound)
+      it 'raises APICarto::API::ResourceNotFound' do
+        expect { subject }.to raise_error(APICarto::API::ResourceNotFound)
       end
     end
 

--- a/spec/lib/api_carto/cadastre_adapter_spec.rb
+++ b/spec/lib/api_carto/cadastre_adapter_spec.rb
@@ -1,4 +1,4 @@
-describe ApiCarto::CadastreAdapter do
+describe APICarto::CadastreAdapter do
   subject { described_class.new(coordinates).results }
 
   before do
@@ -58,6 +58,6 @@ describe ApiCarto::CadastreAdapter do
     let(:status) { 404 }
     let(:body) { '' }
 
-    it { expect { subject }.to raise_error(ApiCarto::API::ResourceNotFound) }
+    it { expect { subject }.to raise_error(APICarto::API::ResourceNotFound) }
   end
 end

--- a/spec/lib/api_education/annuaire_education_adapter_spec.rb
+++ b/spec/lib/api_education/annuaire_education_adapter_spec.rb
@@ -1,4 +1,4 @@
-describe ApiEducation::AnnuaireEducationAdapter do
+describe APIEducation::AnnuaireEducationAdapter do
   let(:search_term) { '0050009H' }
   let(:adapter) { described_class.new(search_term) }
   subject { adapter.to_params }
@@ -23,7 +23,7 @@ describe ApiEducation::AnnuaireEducationAdapter do
     let(:status) { 200 }
 
     it '#to_params raise exception' do
-      expect { subject }.to raise_exception(ApiEducation::AnnuaireEducationAdapter::InvalidSchemaError)
+      expect { subject }.to raise_exception(APIEducation::AnnuaireEducationAdapter::InvalidSchemaError)
     end
   end
 end

--- a/spec/lib/api_entreprise/api_spec.rb
+++ b/spec/lib/api_entreprise/api_spec.rb
@@ -1,4 +1,4 @@
-describe ApiEntreprise::API do
+describe APIEntreprise::API do
   let(:procedure) { create(:procedure) }
   let(:procedure_id) { procedure.id }
   let(:token) { Rails.application.secrets.api_entreprise[:key] }
@@ -9,7 +9,7 @@ describe ApiEntreprise::API do
     before do
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/entreprises\/#{siren}/)
         .to_return(status: status, body: body)
-      allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+      allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
     end
 
     context 'when the service throws a bad gateaway exception' do
@@ -17,8 +17,8 @@ describe ApiEntreprise::API do
       let(:status) { 502 }
       let(:body) { File.read('spec/fixtures/files/api_entreprise/entreprises_unavailable.json') }
 
-      it 'raises ApiEntreprise::API::Error::RequestFailed' do
-        expect { subject }.to raise_error(ApiEntreprise::API::Error::BadGateway)
+      it 'raises APIEntreprise::API::Error::RequestFailed' do
+        expect { subject }.to raise_error(APIEntreprise::API::Error::BadGateway)
       end
     end
 
@@ -27,8 +27,8 @@ describe ApiEntreprise::API do
       let(:status) { 404 }
       let(:body) { File.read('spec/fixtures/files/api_entreprise/entreprises_not_found.json') }
 
-      it 'raises ApiEntreprise::API::Error::ResourceNotFound' do
-        expect { subject }.to raise_error(ApiEntreprise::API::Error::ResourceNotFound)
+      it 'raises APIEntreprise::API::Error::ResourceNotFound' do
+        expect { subject }.to raise_error(APIEntreprise::API::Error::ResourceNotFound)
       end
     end
 
@@ -37,8 +37,8 @@ describe ApiEntreprise::API do
       let(:status) { 400 }
       let(:body) { File.read('spec/fixtures/files/api_entreprise/entreprises_not_found.json') }
 
-      it 'raises ApiEntreprise::API::Error::BadFormatRequest' do
-        expect { subject }.to raise_error(ApiEntreprise::API::Error::BadFormatRequest)
+      it 'raises APIEntreprise::API::Error::BadFormatRequest' do
+        expect { subject }.to raise_error(APIEntreprise::API::Error::BadFormatRequest)
       end
     end
 
@@ -47,8 +47,8 @@ describe ApiEntreprise::API do
       let(:status) { 403 }
       let(:body) { File.read('spec/fixtures/files/api_entreprise/entreprises_private.json') }
 
-      it 'raises ApiEntreprise::API::Error::ResourceNotFound' do
-        expect { subject }.to raise_error(ApiEntreprise::API::Error::ResourceNotFound)
+      it 'raises APIEntreprise::API::Error::ResourceNotFound' do
+        expect { subject }.to raise_error(APIEntreprise::API::Error::ResourceNotFound)
       end
     end
 
@@ -89,7 +89,7 @@ describe ApiEntreprise::API do
     before do
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/etablissements\/#{siret}?.*non_diffusables=true/)
         .to_return(status: status, body: body)
-      allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+      allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
     end
 
     context 'when siret does not exist' do
@@ -97,8 +97,8 @@ describe ApiEntreprise::API do
       let(:status) { 404 }
       let(:body) { '' }
 
-      it 'raises ApiEntreprise::API::Error::ResourceNotFound' do
-        expect { subject }.to raise_error(ApiEntreprise::API::Error::ResourceNotFound)
+      it 'raises APIEntreprise::API::Error::ResourceNotFound' do
+        expect { subject }.to raise_error(APIEntreprise::API::Error::ResourceNotFound)
       end
     end
 
@@ -117,7 +117,7 @@ describe ApiEntreprise::API do
     before do
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/exercices\//)
         .to_return(status: status, body: body)
-      allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+      allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
     end
 
     context 'when siret does not exist' do
@@ -127,8 +127,8 @@ describe ApiEntreprise::API do
       let(:status) { 404 }
       let(:body) { '' }
 
-      it 'raises ApiEntreprise::API::Error::ResourceNotFound' do
-        expect { subject }.to raise_error(ApiEntreprise::API::Error::ResourceNotFound)
+      it 'raises APIEntreprise::API::Error::ResourceNotFound' do
+        expect { subject }.to raise_error(APIEntreprise::API::Error::ResourceNotFound)
       end
     end
 
@@ -149,7 +149,7 @@ describe ApiEntreprise::API do
     before do
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/associations\//)
         .to_return(status: status, body: body)
-      allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+      allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
     end
 
     subject { described_class.rna(siren, procedure_id) }
@@ -159,8 +159,8 @@ describe ApiEntreprise::API do
       let(:status) { 404 }
       let(:body) { '' }
 
-      it 'raises ApiEntreprise::API::Error::ResourceNotFound' do
-        expect { subject }.to raise_error(ApiEntreprise::API::Error::ResourceNotFound)
+      it 'raises APIEntreprise::API::Error::ResourceNotFound' do
+        expect { subject }.to raise_error(APIEntreprise::API::Error::ResourceNotFound)
       end
     end
 
@@ -180,8 +180,8 @@ describe ApiEntreprise::API do
     let(:body) { File.read('spec/fixtures/files/api_entreprise/attestation_sociale.json') }
 
     before do
-      allow_any_instance_of(ApiEntrepriseToken).to receive(:roles).and_return(roles)
-      allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+      allow_any_instance_of(APIEntrepriseToken).to receive(:roles).and_return(roles)
+      allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/attestations_sociales_acoss\/#{siren}/)
         .to_return(body: body, status: status)
     end
@@ -209,8 +209,8 @@ describe ApiEntreprise::API do
     let(:body) { File.read('spec/fixtures/files/api_entreprise/attestation_fiscale.json') }
 
     before do
-      allow_any_instance_of(ApiEntrepriseToken).to receive(:roles).and_return(roles)
-      allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+      allow_any_instance_of(APIEntrepriseToken).to receive(:roles).and_return(roles)
+      allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/attestations_fiscales_dgfip\/#{siren}/)
         .to_return(body: body, status: status)
     end
@@ -237,8 +237,8 @@ describe ApiEntreprise::API do
     let(:body) { File.read('spec/fixtures/files/api_entreprise/bilans_entreprise_bdf.json') }
 
     before do
-      allow_any_instance_of(ApiEntrepriseToken).to receive(:roles).and_return(roles)
-      allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+      allow_any_instance_of(APIEntrepriseToken).to receive(:roles).and_return(roles)
+      allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/bilans_entreprises_bdf\/#{siren}/)
         .to_return(body: body, status: status)
     end
@@ -263,7 +263,7 @@ describe ApiEntreprise::API do
     subject { described_class.entreprise(siren, procedure_id) }
 
     before do
-      allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(true)
+      allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(true)
     end
 
     it 'makes no call to api-entreprise' do

--- a/spec/lib/api_entreprise/attestation_fiscale_adapter_spec.rb
+++ b/spec/lib/api_entreprise/attestation_fiscale_adapter_spec.rb
@@ -1,4 +1,4 @@
-describe ApiEntreprise::AttestationFiscaleAdapter do
+describe APIEntreprise::AttestationFiscaleAdapter do
   let(:siret) { '41816609600069' }
   let(:siren) { '418166096' }
   let(:procedure) { create(:procedure) }
@@ -9,8 +9,8 @@ describe ApiEntreprise::AttestationFiscaleAdapter do
   before do
     stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/attestations_fiscales_dgfip\/#{siren}/)
       .to_return(body: body, status: status)
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:roles).and_return(["attestations_fiscales"])
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+    allow_any_instance_of(APIEntrepriseToken).to receive(:roles).and_return(["attestations_fiscales"])
+    allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
   end
 
   context "when the SIREN is valid" do

--- a/spec/lib/api_entreprise/attestation_sociale_adapter_spec.rb
+++ b/spec/lib/api_entreprise/attestation_sociale_adapter_spec.rb
@@ -1,4 +1,4 @@
-describe ApiEntreprise::AttestationSocialeAdapter do
+describe APIEntreprise::AttestationSocialeAdapter do
   let(:siret) { '41816609600069' }
   let(:siren) { '418166096' }
   let(:procedure) { create(:procedure) }
@@ -8,8 +8,8 @@ describe ApiEntreprise::AttestationSocialeAdapter do
   before do
     stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/attestations_sociales_acoss\/#{siren}/)
       .to_return(body: body, status: status)
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:roles).and_return(["attestations_sociales"])
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+    allow_any_instance_of(APIEntrepriseToken).to receive(:roles).and_return(["attestations_sociales"])
+    allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
   end
 
   context "when the SIREN is valid" do

--- a/spec/lib/api_entreprise/bilans_bdf_adapter_spec.rb
+++ b/spec/lib/api_entreprise/bilans_bdf_adapter_spec.rb
@@ -1,4 +1,4 @@
-describe ApiEntreprise::BilansBdfAdapter do
+describe APIEntreprise::BilansBdfAdapter do
   let(:siret) { '41816609600069' }
   let(:siren) { '418166096' }
   let(:procedure) { create(:procedure) }
@@ -9,8 +9,8 @@ describe ApiEntreprise::BilansBdfAdapter do
   before do
     stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/bilans_entreprises_bdf\/#{siren}/)
       .to_return(body: body, status: status)
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:roles).and_return(["bilans_entreprise_bdf"])
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+    allow_any_instance_of(APIEntrepriseToken).to receive(:roles).and_return(["bilans_entreprise_bdf"])
+    allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
   end
 
   context "when the SIREN is valid" do

--- a/spec/lib/api_entreprise/effectifs_adapter_spec.rb
+++ b/spec/lib/api_entreprise/effectifs_adapter_spec.rb
@@ -1,4 +1,4 @@
-describe ApiEntreprise::EffectifsAdapter do
+describe APIEntreprise::EffectifsAdapter do
   let(:siret) { '41816609600069' }
   let(:siren) { '418166096' }
   let(:procedure) { create(:procedure) }
@@ -11,7 +11,7 @@ describe ApiEntreprise::EffectifsAdapter do
   before do
     stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/effectifs_mensuels_acoss_covid\/#{annee}\/#{mois}\/entreprise\/#{siren}/)
       .to_return(body: body, status: status)
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+    allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
   end
 
   context "when the SIREN is valid" do

--- a/spec/lib/api_entreprise/effectifs_annuels_adapter_spec.rb
+++ b/spec/lib/api_entreprise/effectifs_annuels_adapter_spec.rb
@@ -1,4 +1,4 @@
-describe ApiEntreprise::EffectifsAnnuelsAdapter do
+describe APIEntreprise::EffectifsAnnuelsAdapter do
   let(:siret) { '41816609600069' }
   let(:siren) { '418166096' }
   let(:procedure) { create(:procedure) }
@@ -9,7 +9,7 @@ describe ApiEntreprise::EffectifsAnnuelsAdapter do
   before do
     stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/effectifs_annuels_acoss_covid\/#{siren}/)
       .to_return(body: body, status: status)
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+    allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
   end
 
   context "when the SIREN is valid" do

--- a/spec/lib/api_entreprise/entreprise_adapter_spec.rb
+++ b/spec/lib/api_entreprise/entreprise_adapter_spec.rb
@@ -1,4 +1,4 @@
-describe ApiEntreprise::EntrepriseAdapter do
+describe APIEntreprise::EntrepriseAdapter do
   let(:siren) { '418166096' }
   let(:procedure) { create(:procedure) }
   let(:procedure_id) { procedure.id }
@@ -8,7 +8,7 @@ describe ApiEntreprise::EntrepriseAdapter do
   before do
     stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/entreprises\/#{siren}/)
       .to_return(body: body, status: status)
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+    allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
   end
 
   context "when the SIRET is valid" do
@@ -84,7 +84,7 @@ describe ApiEntreprise::EntrepriseAdapter do
     let(:status) { 500 }
 
     it 'raises an exception' do
-      expect { subject }.to raise_error(ApiEntreprise::API::Error::RequestFailed)
+      expect { subject }.to raise_error(APIEntreprise::API::Error::RequestFailed)
     end
   end
 end

--- a/spec/lib/api_entreprise/etablissement_adapter_spec.rb
+++ b/spec/lib/api_entreprise/etablissement_adapter_spec.rb
@@ -1,9 +1,9 @@
-describe ApiEntreprise::EtablissementAdapter do
+describe APIEntreprise::EtablissementAdapter do
   let(:procedure) { create(:procedure) }
   let(:procedure_id) { procedure.id }
 
   before do
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+    allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
   end
 
   context 'SIRET valide avec infos diffusables' do

--- a/spec/lib/api_entreprise/exercices_adapter_spec.rb
+++ b/spec/lib/api_entreprise/exercices_adapter_spec.rb
@@ -1,4 +1,4 @@
-describe ApiEntreprise::ExercicesAdapter do
+describe APIEntreprise::ExercicesAdapter do
   let(:siret) { '41816609600051' }
   let(:procedure) { create(:procedure) }
   subject { described_class.new(siret, procedure.id).to_params }
@@ -6,7 +6,7 @@ describe ApiEntreprise::ExercicesAdapter do
   before do
     stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/exercices\//)
       .to_return(body: File.read('spec/fixtures/files/api_entreprise/exercices.json', status: 200))
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+    allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
   end
 
   it { is_expected.to be_an_instance_of(Hash) }

--- a/spec/lib/api_entreprise/rna_adapter_spec.rb
+++ b/spec/lib/api_entreprise/rna_adapter_spec.rb
@@ -1,4 +1,4 @@
-describe ApiEntreprise::RNAAdapter do
+describe APIEntreprise::RNAAdapter do
   let(:siret) { '50480511000013' }
   let(:procedure) { create(:procedure) }
   let(:procedure_id) { procedure.id }
@@ -11,7 +11,7 @@ describe ApiEntreprise::RNAAdapter do
   before do
     stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/associations\//)
       .to_return(body: body, status: status)
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+    allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
   end
 
   context 'when siret is not valid' do

--- a/spec/lib/tasks/graphql_spec.rb
+++ b/spec/lib/tasks/graphql_spec.rb
@@ -1,5 +1,5 @@
 describe 'graphql' do
-  let(:current_defn) { Api::V2::Schema.to_definition }
+  let(:current_defn) { API::V2::Schema.to_definition }
   let(:printout_defn) { File.read(Rails.root.join('app', 'graphql', 'schema.graphql')) }
 
   it "update the printed schema with `bin/rake graphql:schema:idl`" do

--- a/spec/services/api_entreprise_service_spec.rb
+++ b/spec/services/api_entreprise_service_spec.rb
@@ -1,4 +1,4 @@
-describe ApiEntrepriseService do
+describe APIEntrepriseService do
   describe '#create_etablissement' do
     before do
       stub_request(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/etablissements\/#{siret}/)
@@ -11,11 +11,11 @@ describe ApiEntrepriseService do
     let(:valid_token) { "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c" }
     let(:procedure) { create(:procedure, api_entreprise_token: valid_token) }
     let(:dossier) { create(:dossier, procedure: procedure) }
-    let(:subject) { ApiEntrepriseService.create_etablissement(dossier, siret, procedure.id) }
+    let(:subject) { APIEntrepriseService.create_etablissement(dossier, siret, procedure.id) }
 
     before do
-      allow_any_instance_of(ApiEntrepriseToken).to receive(:roles).and_return([])
-      allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+      allow_any_instance_of(APIEntrepriseToken).to receive(:roles).and_return([])
+      allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
     end
 
     context 'when service is up' do
@@ -24,9 +24,9 @@ describe ApiEntrepriseService do
       end
 
       [
-        ApiEntreprise::EntrepriseJob, ApiEntreprise::AssociationJob, ApiEntreprise::ExercicesJob,
-        ApiEntreprise::EffectifsJob, ApiEntreprise::EffectifsAnnuelsJob, ApiEntreprise::AttestationSocialeJob,
-        ApiEntreprise::BilansBdfJob
+        APIEntreprise::EntrepriseJob, APIEntreprise::AssociationJob, APIEntreprise::ExercicesJob,
+        APIEntreprise::EffectifsJob, APIEntreprise::EffectifsAnnuelsJob, APIEntreprise::AttestationSocialeJob,
+        APIEntreprise::BilansBdfJob
       ].each do |job|
         it "should enqueue #{job.class.name}" do
           expect { subject }.to have_enqueued_job(job)
@@ -38,8 +38,8 @@ describe ApiEntrepriseService do
       let(:etablissements_status) { 504 }
       let(:etablissements_body) { '' }
 
-      it 'should raise ApiEntreprise::API::Error::RequestFailed' do
-        expect { subject }.to raise_error(ApiEntreprise::API::Error::RequestFailed)
+      it 'should raise APIEntreprise::API::Error::RequestFailed' do
+        expect { subject }.to raise_error(APIEntreprise::API::Error::RequestFailed)
       end
     end
 

--- a/spec/views/users/dossiers/etablissement.html.haml_spec.rb
+++ b/spec/views/users/dossiers/etablissement.html.haml_spec.rb
@@ -6,8 +6,8 @@ describe 'users/dossiers/etablissement.html.haml', type: :view do
   before do
     sign_in dossier.user
     assign(:dossier, dossier)
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:roles).and_return([])
-    allow_any_instance_of(ApiEntrepriseToken).to receive(:expired?).and_return(false)
+    allow_any_instance_of(APIEntrepriseToken).to receive(:roles).and_return([])
+    allow_any_instance_of(APIEntrepriseToken).to receive(:expired?).and_return(false)
   end
 
   subject! { render }


### PR DESCRIPTION
Zeitwerk, le nouvel autoloader de classes de Rails 6, est moins bogué que l'autoloader "classique" – mais il est aussi plus strict.

Notamment il s'attend à ce que `notice_url_helper.rb` contienne une classe `NoticeUrlHelper` (sans majuscules) – sauf si on déclare que `URL` est un acronyme, et dans ce cas il veut `NoticeURLHelper` (avec majuscules).

Cette PR n'active pas encore zeitwerk. Mais elle prépare le terrain en harmonisant le nommage et le namespace des classes d'une manière qui plait à zeitwerk.

Ça fait aussi changer le nom de certains jobs ; pour ça on définit des alias de rétro-compatibilité le temps que les jobs actuels soient dépilés de la file.