### PR TITLE
ci: update Github Action used to publish Sentry versions

### DIFF
--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Sentry Release
-      uses: getsentry/action-release@v1.0.0
+      uses: getsentry/action-release@v1
       env:
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         SENTRY_ORG: ${{ secrets.SENTRY_ORG }}


### PR DESCRIPTION
Attempts to fix the Sentry action failing after a deploy.