### PR TITLE
Adjust sentry sample rate

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -3,5 +3,5 @@ Sentry.init do |config|
   config.send_default_pii = false
   config.enabled_environments = ['production']
   config.breadcrumbs_logger = [:active_support_logger]
-  config.traces_sample_rate = 0.01
+  config.traces_sample_rate = 0.001
 end


### PR DESCRIPTION
Après avoir observé les chiffres sur deux jours, avec le sampling actuel de 1% nous enregistrons en journée près de 30 transactions/minute. Si l’on veut rester dans les clous des 100000 transactions inclus avec notre plan, il faut redire ça à 2 transactions/minute.