### PR TITLE
Don't cache classes during tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that


### PR DESCRIPTION
When running several individual tests in succession using Spring, we get an error message:

> zeitwerk error: reloading is disabled because config.cache_classes is true

Rails 6 now recommends to disable the classes cache during tests (when using Spring), because:

- Spring takes care of the caching for us,
- It makes zeitwerk happy.

See discussion in https://github.com/rails/rails/commit/65344f254cde87950c7f176cb7aa09c002a6f882

(A potential downside used to be that when running system tests using Capybara, each web request would reload the classes, which invalidated the model objects of the test case. But it seems to be fixed now.)