### PR TITLE
5911 allonge conservation dossiers

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -188,7 +188,7 @@ class Procedure < ApplicationRecord
   validate :check_juridique
   validates :path, presence: true, format: { with: /\A[a-z0-9_\-]{3,200}\z/ }, uniqueness: { scope: [:path, :closed_at, :hidden_at, :unpublished_at], case_sensitive: false }
   validates :duree_conservation_dossiers_dans_ds, allow_nil: false, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: MAX_DUREE_CONSERVATION }
-  validates :duree_conservation_dossiers_hors_ds, allow_nil: false, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :duree_conservation_dossiers_hors_ds, allow_nil: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates_with MonAvisEmbedValidator
   validates :notice, content_type: [
     "application/msword",

--- a/app/views/new_administrateur/procedures/_informations.html.haml
+++ b/app/views/new_administrateur/procedures/_informations.html.haml
@@ -16,14 +16,15 @@
 %h3.header-subsection Logo de la démarche
 = image_upload_and_render f, @procedure.logo
 
-- if !@procedure.locked?
-  %h3.header-subsection Conservation des données
-  = f.label :duree_conservation_dossiers_dans_ds do
-    Sur #{APPLICATION_NAME}
-    %span.mandatory *
+%h3.header-subsection Conservation des données
+= f.label :duree_conservation_dossiers_dans_ds do
+  Sur #{APPLICATION_NAME}
+  %span.mandatory *
+
   %p.notice (durée en mois après le début de l’instruction)
   = f.number_field :duree_conservation_dossiers_dans_ds, class: 'form-control', placeholder: '6', required: true
 
+- if !@procedure.locked?
   = f.label :duree_conservation_dossiers_hors_ds do
     Hors #{APPLICATION_NAME}
     %span.mandatory *

--- a/app/views/new_administrateur/procedures/_informations.html.haml
+++ b/app/views/new_administrateur/procedures/_informations.html.haml
@@ -21,8 +21,8 @@
   Sur #{APPLICATION_NAME}
   %span.mandatory *
 
-  %p.notice (durée en mois après le début de l’instruction)
-  = f.number_field :duree_conservation_dossiers_dans_ds, class: 'form-control', placeholder: '6', required: true
+%p.notice (durée en mois après le début de l’instruction)
+= f.number_field :duree_conservation_dossiers_dans_ds, class: 'form-control', placeholder: '6', required: true
 
 - if @procedure.created_at.present?
   = f.label :lien_site_web do

--- a/app/views/new_administrateur/procedures/_informations.html.haml
+++ b/app/views/new_administrateur/procedures/_informations.html.haml
@@ -24,13 +24,6 @@
   %p.notice (durée en mois après le début de l’instruction)
   = f.number_field :duree_conservation_dossiers_dans_ds, class: 'form-control', placeholder: '6', required: true
 
-- if !@procedure.locked?
-  = f.label :duree_conservation_dossiers_hors_ds do
-    Hors #{APPLICATION_NAME}
-    %span.mandatory *
-  %p.notice (durée en mois après la fin de l'instruction)
-  = f.number_field :duree_conservation_dossiers_hors_ds, class: 'form-control', placeholder: '6', required: true
-
 - if @procedure.created_at.present?
   = f.label :lien_site_web do
     Où les usagers trouveront-ils le lien vers la démarche ?

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -8,7 +8,6 @@ FactoryBot.define do
     cadre_juridique { "un cadre juridique important" }
     published_at { nil }
     duree_conservation_dossiers_dans_ds { 3 }
-    duree_conservation_dossiers_hors_ds { 6 }
     ask_birthday { false }
     lien_site_web { "https://mon-site.gouv" }
     path { SecureRandom.uuid }

--- a/spec/features/admin/procedure_creation_spec.rb
+++ b/spec/features/admin/procedure_creation_spec.rb
@@ -38,7 +38,6 @@ feature 'As an administrateur I wanna create a new procedure', js: true do
         expect(find('#procedure_for_individual_true')).to be_checked
         expect(find('#procedure_for_individual_false')).not_to be_checked
         fill_in 'procedure_duree_conservation_dossiers_dans_ds', with: '3'
-        fill_in 'procedure_duree_conservation_dossiers_hors_ds', with: '6'
         click_on 'Créer la démarche'
 
         expect(page).to have_text('Libelle doit être rempli')

--- a/spec/features/admin/procedure_spec_helper.rb
+++ b/spec/features/admin/procedure_spec_helper.rb
@@ -4,6 +4,5 @@ module ProcedureSpecHelper
     fill_in 'procedure_description', with: 'description de la procedure'
     fill_in 'procedure_cadre_juridique', with: 'cadre juridique'
     fill_in 'procedure_duree_conservation_dossiers_dans_ds', with: '3'
-    fill_in 'procedure_duree_conservation_dossiers_hors_ds', with: '6'
   end
 end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -271,12 +271,6 @@ describe Procedure do
 
       it_behaves_like 'duree de conservation'
     end
-
-    describe 'duree de conservation hors ds' do
-      let(:field_name) { :duree_conservation_dossiers_hors_ds }
-
-      it_behaves_like 'duree de conservation'
-    end
   end
 
   describe 'active' do


### PR DESCRIPTION
close #5911 

Cette PR permet à un administrateur de modifier la durée de conservation des données dans DS.
Elle  ne demande plus à un administrateur d'indiquer la durée de conservation des données hors DS (mais le champ `duree_conservation_dossiers_hors_ds` n'est pas supprimé)