### PR TITLE
config: reload compatibility aliases on classes reload

### DIFF
--- a/config/initializers/active_job_compatibility.rb
+++ b/config/initializers/active_job_compatibility.rb
@@ -13,18 +13,20 @@
 
 require 'excon'
 
-module ApiEntreprise
-  Job = APIEntreprise::Job
-  AssociationJob = APIEntreprise::AssociationJob
-  AttestationFiscaleJob = APIEntreprise::AttestationFiscaleJob
-  AttestationSocialeJob = APIEntreprise::AttestationSocialeJob
-  BilansBdfJob = APIEntreprise::BilansBdfJob
-  EffectifsAnnuelsJob = APIEntreprise::EffectifsAnnuelsJob
-  EffectifsJob = APIEntreprise::EffectifsJob
-  EntrepriseJob = APIEntreprise::EntrepriseJob
-  ExercicesJob = APIEntreprise::ExercicesJob
-end
+Rails.application.reloader.to_prepare do
+  module ApiEntreprise
+    Job = APIEntreprise::Job
+    AssociationJob = APIEntreprise::AssociationJob
+    AttestationFiscaleJob = APIEntreprise::AttestationFiscaleJob
+    AttestationSocialeJob = APIEntreprise::AttestationSocialeJob
+    BilansBdfJob = APIEntreprise::BilansBdfJob
+    EffectifsAnnuelsJob = APIEntreprise::EffectifsAnnuelsJob
+    EffectifsJob = APIEntreprise::EffectifsJob
+    EntrepriseJob = APIEntreprise::EntrepriseJob
+    ExercicesJob = APIEntreprise::ExercicesJob
+  end
 
-module Cron
-  FixMissingAntivirusAnalysis = FixMissingAntivirusAnalysisJob
+  module Cron
+    FixMissingAntivirusAnalysis = FixMissingAntivirusAnalysisJob
+  end
 end


### PR DESCRIPTION
Fixes zeitwerk complaining that the compatibility aliases loaded in an initializer will never be reloaded. The suggested fix is to instruct Rails to re-execute the code when classes are reloaded.

In our case it doesn't matter that much, but it will reduce the console spam.