### PR TITLE
ci: split controller tests into 3 groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,9 @@ jobs:
     strategy:
       matrix:
         pattern:
-          - spec/controllers
+          - spec/controllers/*_spec.rb
+          - spec/controllers/[a-l]**/*_spec.rb
+          - spec/controllers/[m-z]**/*_spec.rb
           - spec/features
           - spec/helpers spec/lib spec/middlewares
           - spec/mailers spec/jobs spec/policies


### PR DESCRIPTION
On github actions, controller specs are the slowest; split them up.

Ideally we'd like:

- One group with `spec/controllers/api/**/*_spec.rb` files
- One group with everything else

But due to the way globbing works (and doesn't allow to say "Files NOT
starting with `api`"), this looks like a sensible and future-proof
configuration.