### PR TITLE
Suppression et mise à jour de gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'delayed_job_web'
 gem 'devise' # Gestion des comptes utilisateurs
 gem 'devise-async'
 gem 'devise-i18n'
-gem 'devise-two-factor', github: 'bryanfagan/devise-two-factor'
+gem 'devise-two-factor', github: 'jason-hobbs/devise-two-factor', branch: 'master' # Rails 6.1 compatibility: https://github.com/tinfoil/devise-two-factor/issues/183
 gem 'discard'
 gem 'dotenv-rails', require: 'dotenv/rails-now' # dotenv should always be loaded before rails
 gem 'ffi-geos', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem 'image_processing'
 gem 'json_schemer'
 gem 'jwt'
 gem 'kaminari', '1.2.1' # Pagination
+gem 'listen' # Required by ActiveSupport::EventedFileUpdateChecker
 gem 'lograge'
 gem 'logstash-event'
 gem 'mailjet'
@@ -86,9 +87,6 @@ group :test do
   gem 'capybara-selenium'
   gem 'database_cleaner'
   gem 'factory_bot'
-  gem 'guard'
-  gem 'guard-livereload', require: false
-  gem 'guard-rspec', require: false
   gem 'launchy'
   gem 'rails-controller-testing'
   gem 'shoulda-matchers', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -117,7 +117,6 @@ group :development, :test do
   gem 'pry-byebug' # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'rspec_junit_formatter', require: false
   gem 'rspec-rails'
-  gem 'ruby-debug-ide', require: false
   gem 'simple_xlsx_reader'
   gem 'spring' # Spring speeds up development by keeping your application running in the background
   gem 'spring-commands-rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ gem 'devise-i18n'
 gem 'devise-two-factor', github: 'jason-hobbs/devise-two-factor', branch: 'master' # Rails 6.1 compatibility: https://github.com/tinfoil/devise-two-factor/issues/183
 gem 'discard'
 gem 'dotenv-rails', require: 'dotenv/rails-now' # dotenv should always be loaded before rails
-gem 'ffi-geos', require: false
 gem 'flipper'
 gem 'flipper-active_record'
 gem 'flipper-ui'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,9 +233,6 @@ GEM
     dumb_delegator (0.8.1)
     ecma-re-validator (0.3.0)
       regexp_parser (~> 2.0)
-    em-websocket (0.5.2)
-      eventmachine (>= 0.12.9)
-      http_parser.rb (~> 0.6.0)
     encryptor (3.0.0)
     equalizer (0.0.11)
     erubi (1.10.0)
@@ -244,7 +241,6 @@ GEM
       tzinfo
     ethon (0.12.0)
       ffi (>= 1.3.0)
-    eventmachine (1.2.7)
     excon (0.79.0)
     execjs (2.7.0)
     factory_bot (6.1.0)
@@ -306,25 +302,6 @@ GEM
       rails (>= 5.1.0)
     groupdate (5.2.2)
       activesupport (>= 5)
-    guard (2.16.2)
-      formatador (>= 0.2.4)
-      listen (>= 2.7, < 4.0)
-      lumberjack (>= 1.0.12, < 2.0)
-      nenv (~> 0.1)
-      notiffany (~> 0.0)
-      pry (>= 0.9.12)
-      shellany (~> 0.0)
-      thor (>= 0.18.1)
-    guard-compat (1.2.1)
-    guard-livereload (2.5.2)
-      em-websocket (~> 0.5)
-      guard (~> 2.8)
-      guard-compat (~> 1.0)
-      multi_json (~> 1.8)
-    guard-rspec (4.7.3)
-      guard (~> 2.1)
-      guard-compat (~> 1.1)
-      rspec (>= 2.99.0, < 4.0)
     haml (5.2.1)
       temple (>= 0.8.0)
       tilt
@@ -356,7 +333,6 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     http_accept_language (2.1.1)
-    http_parser.rb (0.6.0)
     httpclient (2.8.3)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
@@ -424,7 +400,6 @@ GEM
     loofah (2.9.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    lumberjack (1.2.8)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     mailjet (1.6.0)
@@ -448,15 +423,11 @@ GEM
     multipart-post (2.1.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    nenv (0.3.0)
     netrc (0.11.0)
     nio4r (2.5.5)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    notiffany (0.1.3)
-      nenv (~> 0.1)
-      shellany (~> 0.0)
     open4 (1.3.4)
     openid_connect (1.2.0)
       activemodel
@@ -600,10 +571,6 @@ GEM
       chunky_png (~> 1.0)
       rqrcode_core (~> 0.2)
     rqrcode_core (0.2.0)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.1)
@@ -698,7 +665,6 @@ GEM
       concurrent-ruby
       faraday
     sexp_processor (4.15.2)
-    shellany (0.0.1)
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
     sib-api-v3-sdk (7.4.0)
@@ -854,9 +820,6 @@ DEPENDENCIES
   graphql-schema_comparator
   graphql_playground-rails
   groupdate
-  guard
-  guard-livereload
-  guard-rspec
   haml-lint
   haml-rails
   hashie
@@ -869,6 +832,7 @@ DEPENDENCIES
   kaminari (= 1.2.1)
   launchy
   letter_opener_web
+  listen
   lograge
   logstash-event
   mailjet

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,14 @@
 GIT
-  remote: https://github.com/bryanfagan/devise-two-factor.git
-  revision: 60038a699b1847266f6ce0a3457fdc2cd24715be
+  remote: https://github.com/jason-hobbs/devise-two-factor.git
+  revision: e153f16ab86de01df034672dfffa321acd891c45
+  branch: master
   specs:
-    devise-two-factor (3.1.1)
-      activesupport (< 6.1)
+    devise-two-factor (3.1.0)
+      activesupport (< 7.0)
       attr_encrypted (>= 1.3, < 4, != 2)
-      devise (~> 4.0)
-      railties (< 6.1)
-      rotp (~> 4.0)
+      devise
+      railties (< 7.0)
+      rotp (~> 6)
 
 GIT
   remote: https://github.com/mina-deploy/mina.git
@@ -595,8 +596,7 @@ GEM
       builder (>= 3.0)
       dry-inflector (~> 0.1)
       rubyzip (>= 1.0)
-    rotp (4.1.0)
-      addressable (~> 2.5)
+    rotp (6.2.0)
     rouge (3.26.0)
     rqrcode (1.2.0)
       chunky_png (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,8 +255,6 @@ GEM
       ruby2_keywords
     faraday-net_http (1.0.1)
     ffi (1.14.2)
-    ffi-geos (2.1.0)
-      ffi (>= 1.0.0)
     flipper (0.20.3)
     flipper-active_record (0.20.3)
       activerecord (>= 5.0, < 7)
@@ -843,7 +841,6 @@ DEPENDENCIES
   discard
   dotenv-rails
   factory_bot
-  ffi-geos
   flipper
   flipper-active_record
   flipper-ui

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -619,8 +619,6 @@ GEM
       rubocop-rails (~> 2.0)
     rubocop-rspec-focused (1.0.0)
       rubocop (>= 0.51)
-    ruby-debug-ide (0.7.2)
-      rake (>= 0.8.1)
     ruby-graphviz (1.2.5)
       rexml
     ruby-progressbar (1.11.0)
@@ -861,7 +859,6 @@ DEPENDENCIES
   rubocop
   rubocop-rails_config
   rubocop-rspec-focused
-  ruby-debug-ide
   ruby-saml-idp
   sanitize-url
   sassc-rails

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,6 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
-require 'rspec'
 require 'capybara/rspec'
 require 'capybara-screenshot/rspec'
 require 'capybara/email/rspec'


### PR DESCRIPTION
Pour le passage à Rails 6.1 (#5886), cette PR supprime un certain nombre de gems incompatibles et peu utilisées :

- guard (peu utilisé et incompatible)
- ruby-debug-ide (cause des soucis à chaque `bundle update`, et à priori inutile avec les dernières version de Rubymine)
- ffi-geos (inutile depuis le passage à du code geo en Ruby)

Elle met aussi à jour :

- devise-two-factors (avec un fork compatible Rails 6.1, en attendant que les problèmes légaux autour du merge de PRs dans le dépôt principal soient résolus…)