### PR TITLE
Correction de messages d'avertissement liés à Zeitwerk

### DIFF
--- a/app/models/dynamic_smtp_settings_interceptor.rb
+++ b/app/models/dynamic_smtp_settings_interceptor.rb
@@ -1,3 +1,9 @@
+# Note: this class is instanciated when being added as an interceptor
+# during the app initialization.
+#
+# If you edit this file in development env, you will need to restart
+# the app to see the changes.
+
 class DynamicSmtpSettingsInterceptor
   def self.delivering_email(message)
     if ENV['SENDINBLUE_BALANCING'] == 'enabled'

--- a/config/initializers/active_job_compatibility.rb
+++ b/config/initializers/active_job_compatibility.rb
@@ -11,22 +11,24 @@
 # - but let's keep these for a while to make external integrators's life easier.
 # To keep some margin, let's say this file can be safely deleted in May 2021.)
 
-require 'excon'
-
 Rails.application.reloader.to_prepare do
-  module ApiEntreprise
-    Job = APIEntreprise::Job
-    AssociationJob = APIEntreprise::AssociationJob
-    AttestationFiscaleJob = APIEntreprise::AttestationFiscaleJob
-    AttestationSocialeJob = APIEntreprise::AttestationSocialeJob
-    BilansBdfJob = APIEntreprise::BilansBdfJob
-    EffectifsAnnuelsJob = APIEntreprise::EffectifsAnnuelsJob
-    EffectifsJob = APIEntreprise::EffectifsJob
-    EntrepriseJob = APIEntreprise::EntrepriseJob
-    ExercicesJob = APIEntreprise::ExercicesJob
-  end
+  if !defined?(ApiEntreprise)
+    require 'excon'
 
-  module Cron
-    FixMissingAntivirusAnalysis = FixMissingAntivirusAnalysisJob
+    module ApiEntreprise
+      Job = APIEntreprise::Job
+      AssociationJob = APIEntreprise::AssociationJob
+      AttestationFiscaleJob = APIEntreprise::AttestationFiscaleJob
+      AttestationSocialeJob = APIEntreprise::AttestationSocialeJob
+      BilansBdfJob = APIEntreprise::BilansBdfJob
+      EffectifsAnnuelsJob = APIEntreprise::EffectifsAnnuelsJob
+      EffectifsJob = APIEntreprise::EffectifsJob
+      EntrepriseJob = APIEntreprise::EntrepriseJob
+      ExercicesJob = APIEntreprise::ExercicesJob
+    end
+
+    module Cron
+      FixMissingAntivirusAnalysis = FixMissingAntivirusAnalysisJob
+    end
   end
 end

--- a/config/initializers/dynamic_smtp_settings_interceptor.rb
+++ b/config/initializers/dynamic_smtp_settings_interceptor.rb
@@ -1,1 +1,3 @@
-ActionMailer::Base.register_interceptor "DynamicSmtpSettingsInterceptor"
+ActiveSupport.on_load(:action_mailer) do
+  ActionMailer::Base.register_interceptor "DynamicSmtpSettingsInterceptor"
+end


### PR DESCRIPTION
- Correction d'un message d'avertissement lié au DynamicSmtpSettingsInterceptor (qui apparaissait lors du chargement initial de l'app) ;
- Correction d'un message d'avertissement lié aux alias de compatibilité des jobs (qui apparaissait lors du re-chargement des classes).

Voir les messages de commit pour plus de détails.