### PR TITLE
Groupe instructeur order

### DIFF
--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -9,7 +9,7 @@
 #  procedure_id :bigint           not null
 #
 class GroupeInstructeur < ApplicationRecord
-  DEFAULT_LABEL = 'défaut'
+  DEFAUT_LABEL = 'défaut'
   belongs_to :procedure, -> { with_discarded }, inverse_of: :groupe_instructeurs, optional: false
   has_many :assign_tos, dependent: :destroy
   has_many :instructeurs, through: :assign_tos

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -135,7 +135,7 @@ class Procedure < ApplicationRecord
   has_one :refused_mail, class_name: "Mails::RefusedMail", dependent: :destroy
   has_one :without_continuation_mail, class_name: "Mails::WithoutContinuationMail", dependent: :destroy
 
-  has_one :defaut_groupe_instructeur, -> { order(:id) }, class_name: 'GroupeInstructeur', inverse_of: :procedure
+  has_one :defaut_groupe_instructeur, -> { order(:label) }, class_name: 'GroupeInstructeur', inverse_of: :procedure
 
   has_one_attached :logo
   has_one_attached :notice

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -221,7 +221,7 @@ class Procedure < ApplicationRecord
   before_save :update_juridique_required
   after_initialize :ensure_path_exists
   before_save :ensure_path_exists
-  after_create :ensure_default_groupe_instructeur
+  after_create :ensure_defaut_groupe_instructeur
 
   include AASM
 
@@ -715,9 +715,9 @@ class Procedure < ApplicationRecord
     end
   end
 
-  def ensure_default_groupe_instructeur
+  def ensure_defaut_groupe_instructeur
     if self.groupe_instructeurs.empty?
-      groupe_instructeurs.create(label: GroupeInstructeur::DEFAULT_LABEL)
+      groupe_instructeurs.create(label: GroupeInstructeur::DEFAUT_LABEL)
     end
   end
 end

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -101,7 +101,7 @@ FactoryBot.define do
 
     trait :routee do
       after(:create) do |procedure, _evaluator|
-        procedure.groupe_instructeurs.create(label: '2nd groupe')
+        procedure.groupe_instructeurs.create(label: 'deuxième groupe')
       end
     end
 

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -529,7 +529,7 @@ describe Instructeur, type: :model do
     let(:instructeur_a) { create(:instructeur, groupe_instructeurs: [procedure_a.defaut_groupe_instructeur]) }
 
     before do
-      gi2 = procedure_a.groupe_instructeurs.create(label: '2')
+      gi2 = procedure_a.groupe_instructeurs.create(label: 'gi2')
 
       instructeur_a.groupe_instructeurs << gi2
     end

--- a/spec/models/procedure_presentation_spec.rb
+++ b/spec/models/procedure_presentation_spec.rb
@@ -730,8 +730,8 @@ describe ProcedurePresentation do
     context 'for groupe_instructeur table' do
       let(:filter) { [{ 'table' => 'groupe_instructeur', 'column' => 'label', 'value' => 'défaut' }] }
 
-      let!(:gi_2) { procedure.groupe_instructeurs.create(label: '2') }
-      let!(:gi_3) { procedure.groupe_instructeurs.create(label: '3') }
+      let!(:gi_2) { procedure.groupe_instructeurs.create(label: 'gi2') }
+      let!(:gi_3) { procedure.groupe_instructeurs.create(label: 'gi3') }
 
       let!(:kept_dossier) { create(:dossier, procedure: procedure) }
       let!(:discarded_dossier) { create(:dossier, procedure: procedure, groupe_instructeur: gi_2) }
@@ -742,7 +742,7 @@ describe ProcedurePresentation do
         let(:filter) do
           [
             { 'table' => 'groupe_instructeur', 'column' => 'label', 'value' => 'défaut' },
-            { 'table' => 'groupe_instructeur', 'column' => 'label', 'value' => '3' }
+            { 'table' => 'groupe_instructeur', 'column' => 'label', 'value' => 'gi3' }
           ]
         end
 

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -466,7 +466,7 @@ describe Procedure do
 
       it 'should have a default groupe instructeur' do
         expect(subject.groupe_instructeurs.size).to eq(1)
-        expect(subject.groupe_instructeurs.first.label).to eq(GroupeInstructeur::DEFAULT_LABEL)
+        expect(subject.groupe_instructeurs.first.label).to eq(GroupeInstructeur::DEFAUT_LABEL)
         expect(subject.groupe_instructeurs.first.instructeurs.size).to eq(0)
       end
     end
@@ -1011,7 +1011,7 @@ describe Procedure do
     let!(:procedure) { create(:procedure) }
 
     it { expect(procedure.groupe_instructeurs.count).to eq(1) }
-    it { expect(procedure.groupe_instructeurs.first.label).to eq(GroupeInstructeur::DEFAULT_LABEL) }
+    it { expect(procedure.groupe_instructeurs.first.label).to eq(GroupeInstructeur::DEFAUT_LABEL) }
   end
 
   describe '.missing_instructeurs?' do


### PR DESCRIPTION
`defaut_groupe_instructeur` est utilisé pour assigner un groupe instructeur aux nouveaux dossiers. Partout dans l'application on affiche les `groupe instructeur` par ordre alphabétique de leur label. Ce qui veut dire que pour les nouveaux dossiers le groupe instructeur choisi par défaut n'est potentiellement pas le premier dans la liste. Ce changement est essentiellement motivé par le changement qui arrivera par la suite à savoir la possibilité de cacher le sélecteur de groupes instructeur pour gérer l'assignation via l'API. Dans ce cas, le dossier sera affecté au premier groupe dans la liste qui devrait être un groupe buffer. Il est important que ce groupe soit stable du point de vue de l'administrateur.

J'ai dû reprendre quelques tests, mais dans la vraie vie ça ne sera jamais un problème.