### PR TITLE
Add proper external data API errors handling

### DIFF
--- a/app/javascript/components/shared/queryClient.js
+++ b/app/javascript/components/shared/queryClient.js
@@ -14,7 +14,7 @@ export const queryClient = new QueryClient({
 });
 
 function buildURL(scope, term) {
-  term = encodeURIComponent(term);
+  term = encodeURIComponent(term.replace(/\(|\)/g, ''));
   if (scope === 'adresse') {
     return `${api_adresse_url}/search?q=${term}&limit=5`;
   } else if (scope === 'annuaire-education') {
@@ -42,7 +42,12 @@ async function defaultQueryFn({ queryKey: [scope, term] }) {
 
   const url = buildURL(scope, term);
   const [options, controller] = buildOptions();
-  const promise = fetch(url, options).then((response) => response.json());
+  const promise = fetch(url, options).then((response) => {
+    if (response.ok) {
+      return response.json();
+    }
+    throw new Error(`Error fetching from "${scope}" API`);
+  });
   promise.cancel = () => controller && controller.abort();
   return promise;
 }


### PR DESCRIPTION
Avec l'implémentation actuelle on retourne le payload de l'erreur au champ et il crash misérablement. Avec ce changement on laisse ReactQuery gérer l'erreur.

Et API education n'aime pas les ( dans le search text 🤷‍♂️ 