### PR TITLE
Implementer le feature flag pour permettre le routage via l'API

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,10 +67,6 @@ class ApplicationController < ActionController::Base
     Flipper.enabled?(feature_name, current_user)
   end
 
-  def feature_enabled_for?(feature_name, item)
-    Flipper.enabled?(feature_name, item)
-  end
-
   def authenticate_logged_user!
     if instructeur_signed_in?
       authenticate_instructeur!

--- a/app/controllers/instructeurs/avis_controller.rb
+++ b/app/controllers/instructeurs/avis_controller.rb
@@ -72,7 +72,7 @@ module Instructeurs
 
     def create_avis
       @procedure = Procedure.find(params[:procedure_id])
-      if !feature_enabled_for?(:expert_not_allowed_to_invite, @procedure)
+      if !@procedure.feature_enabled?(:expert_not_allowed_to_invite)
         @new_avis = create_avis_from_params(avis.dossier, avis.confidentiel)
 
         if @new_avis.nil?

--- a/app/helpers/flipper_helper.rb
+++ b/app/helpers/flipper_helper.rb
@@ -2,8 +2,4 @@ module FlipperHelper
   def feature_enabled?(feature_name)
     Flipper.enabled?(feature_name, current_user)
   end
-
-  def feature_enabled_for?(feature_name, item)
-    Flipper.enabled?(feature_name, item)
-  end
 end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -418,6 +418,14 @@ class Dossier < ApplicationRecord
     Dossier.en_construction_close_to_expiration.where(id: self).present?
   end
 
+  def show_groupe_instructeur_details?
+    procedure.routee? && (!procedure.feature_enabled?(:procedure_routage_api) || !defaut_groupe_instructeur?)
+  end
+
+  def show_groupe_instructeur_selector?
+    procedure.routee? && !procedure.feature_enabled?(:procedure_routage_api)
+  end
+
   def assign_to_groupe_instructeur(groupe_instructeur, author = nil)
     if groupe_instructeur.procedure == procedure && groupe_instructeur != self.groupe_instructeur
       if update(groupe_instructeur: groupe_instructeur, groupe_instructeur_updated_at: Time.zone.now)
@@ -831,6 +839,10 @@ class Dossier < ApplicationRecord
   end
 
   private
+
+  def defaut_groupe_instructeur?
+    groupe_instructeur == procedure.defaut_groupe_instructeur
+  end
 
   def geo_areas
     champs.includes(:geo_areas).flat_map(&:geo_areas) + champs_private.includes(:geo_areas).flat_map(&:geo_areas)

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -342,6 +342,10 @@ class Procedure < ApplicationRecord
     end
   end
 
+  def feature_enabled?(feature)
+    Flipper.enabled?(feature, self)
+  end
+
   # Warning: dossier after_save build_default_champs must be removed
   # to save a dossier created from this method
   def new_dossier

--- a/app/views/commencer/show.html.haml
+++ b/app/views/commencer/show.html.haml
@@ -41,7 +41,7 @@
       = link_to 'Voir mes dossiers en cours', dossiers_path, class: ['button large expand primary']
       = link_to 'Commencer un nouveau dossier', url_for_new_dossier(@procedure), class: ['button large expand']
 
-  - if feature_enabled_for?(:dossier_pdf_vide, @procedure)
+  - if @procedure.feature_enabled?(:dossier_pdf_vide)
     - pdf_link = commencer_dossier_vide_path(path: @procedure.path)
     - if @procedure.brouillon?
       - pdf_link = commencer_dossier_vide_test_path(path: @procedure.path)

--- a/app/views/instructeurs/avis/instruction.html.haml
+++ b/app/views/instructeurs/avis/instruction.html.haml
@@ -31,7 +31,7 @@
         .send-wrapper
           = f.submit 'Envoyer votre avis', class: 'button send'
 
-  - if !@dossier.termine? && !feature_enabled_for?(:expert_not_allowed_to_invite, @avis.procedure)
+  - if !@dossier.termine? && !@avis.procedure.feature_enabled?(:expert_not_allowed_to_invite)
     = render partial: "instructeurs/shared/avis/form", locals: { url: avis_instructeur_avis_path(@avis.procedure, @avis), linked_dossiers: @dossier.linked_dossiers_for(current_instructeur), must_be_confidentiel: @avis.confidentiel?, avis: @new_avis }
 
   - if @dossier.avis_for(current_instructeur).present?

--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -5,10 +5,10 @@
 
 -# only display the coronavirus to usagers (instructeurs know there are delays) when they are logged in, or on the public pages.
 - if user_signed_in?
-  - if dossier.present? && feature_enabled_for?(:coronavirus_banner, dossier.procedure)
+  - if dossier.present? && dossier.procedure.feature_enabled?(:coronavirus_banner)
     = render partial: 'layouts/coronavirus_banner'
 - else
-  - if procedure.present? && feature_enabled_for?(:coronavirus_banner, procedure)
+  - if procedure.present? && procedure.feature_enabled?(:coronavirus_banner)
     = render partial: 'layouts/coronavirus_banner'
 
 %header.new-header{ class: current_page?(root_path) ? nil : "new-header-with-border", role: 'banner' }

--- a/app/views/new_administrateur/procedures/invited_expert_list.html.haml
+++ b/app/views/new_administrateur/procedures/invited_expert_list.html.haml
@@ -10,7 +10,7 @@
       %thead
         %tr
           %th Liste des experts
-          - if feature_enabled_for?(:make_experts_notifiable, @procedure)
+          - if @procedure.feature_enabled?(:make_experts_notifiable)
             %th Notifier des décisions sur les dossiers
       %tbody
         - @experts_procedure.each do |expert_procedure|
@@ -18,7 +18,7 @@
             %td
               %span.icon.person
               = expert_procedure.expert.email
-            - if feature_enabled_for?(:make_experts_notifiable, @procedure)
+            - if @procedure.feature_enabled?(:make_experts_notifiable)
               %td
                 = form_for expert_procedure,
                   url: admin_procedure_update_allow_decision_access_path(expert_procedure: expert_procedure),

--- a/app/views/shared/dossiers/_champs.html.haml
+++ b/app/views/shared/dossiers/_champs.html.haml
@@ -1,6 +1,6 @@
 %table.table.vertical.dossier-champs
   %tbody
-    - if dossier.procedure.routee?
+    - if dossier.show_groupe_instructeur_details?
       %th= dossier.procedure.routing_criteria_name
       %td{ class: highlight_if_unseen_class(demande_seen_at, dossier.groupe_instructeur_updated_at) }= dossier.groupe_instructeur.label
       %td.updated-at

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -30,7 +30,7 @@
 
     %hr
 
-    - if dossier.procedure.routee?
+    - if dossier.show_groupe_instructeur_selector?
       = f.label :groupe_instructeur_id do
         = dossier.procedure.routing_criteria_name
         %span.mandatory *

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -25,14 +25,20 @@ end
 
 # A list of features to be deployed on first push
 features = [
+  :administrateur_routage,
   :administrateur_web_hook,
+  :carte_ign,
+  :coronavirus_banner,
+  :dossier_pdf_vide,
+  :expert_not_allowed_to_invite,
+  :hide_instructeur_email,
   :insee_api_v3,
   :instructeur_bypass_email_login_token,
+  :localization,
   :maintenance_mode,
+  :make_experts_notifiable,
   :mini_profiler,
-  :xray,
-  :carte_ign,
-  :localization
+  :xray
 ]
 
 def database_exists?

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -38,6 +38,7 @@ features = [
   :maintenance_mode,
   :make_experts_notifiable,
   :mini_profiler,
+  :procedure_routage_api,
   :xray
 ]
 


### PR DESCRIPTION
Implémenter la demande de Initiative France. Le feature flag permet de cacher le sélecteur du groupe instructeur pour donner la main a l'administration de gérer l'attribution aux groupes via l'API