### PR TITLE
When procedure is reset delete only draft revision dossiers

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -266,7 +266,7 @@ class Procedure < ApplicationRecord
     if locked?
       raise "Can not reset a locked procedure."
     else
-      groupe_instructeurs.each { |gi| gi.dossiers.destroy_all }
+      draft_revision.dossiers.destroy_all
     end
   end
 


### PR DESCRIPTION
Dans l'immédiat, ça ne change rien. Les démarches en brouillon ne peuvent pas avoir de multiples revisions. Mais à l'avenir ce changement nous permettra de reposer des dossiers tests sur les revisions en cours de modification sur les démarches publiées.