### PR TITLE
Use stable_id when replacing tags

### DIFF
--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -197,12 +197,12 @@ module TagsSubstitutionConcern
   end
 
   def champ_public_tags(dossier: nil)
-    types_de_champ = (dossier ? dossier : procedure.active_revision).types_de_champ
+    types_de_champ = (dossier || procedure.active_revision).types_de_champ
     types_de_champ_tags(types_de_champ, Dossier::SOUMIS)
   end
 
   def champ_private_tags(dossier: nil)
-    types_de_champ = (dossier ? dossier : procedure.active_revision).types_de_champ_private
+    types_de_champ = (dossier || procedure.active_revision).types_de_champ_private
     types_de_champ_tags(types_de_champ, Dossier::INSTRUCTION_COMMENCEE)
   end
 
@@ -246,7 +246,7 @@ module TagsSubstitutionConcern
   end
 
   def replace_tag(text, tag, data)
-    libelle = Regexp.quote(tag[:id] ? tag[:id] : tag[:libelle])
+    libelle = Regexp.quote(tag[:id].presence || tag[:libelle])
 
     # allow any kind of space (non-breaking or other) in the tag’s libellé to match any kind of space in the template
     # (the '\\ |' is there because plain ASCII spaces were escaped by preceding Regexp.quote)

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -87,6 +87,30 @@ class Procedure < ApplicationRecord
     brouillon? ? draft_types_de_champ_private : published_types_de_champ_private
   end
 
+  def types_de_champ_for_tags
+    if brouillon?
+      draft_types_de_champ
+    else
+      TypeDeChamp.root
+        .public_only
+        .where(revision: revisions - [draft_revision])
+        .order(:created_at)
+        .uniq
+    end
+  end
+
+  def types_de_champ_private_for_tags
+    if brouillon?
+      draft_types_de_champ_private
+    else
+      TypeDeChamp.root
+        .private_only
+        .where(revision: revisions - [draft_revision])
+        .order(:created_at)
+        .uniq
+    end
+  end
+
   def types_de_champ_for_export
     types_de_champ.reject(&:exclude_from_export?)
   end

--- a/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
@@ -6,26 +6,24 @@ class TypesDeChamp::LinkedDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBas
 
   def tags_for_template
     tags = super
-    tdc = @type_de_champ
+    stable_id = @type_de_champ.stable_id
     tags.push(
       {
         libelle: "#{libelle}/primaire",
+        id: "tdc#{stable_id}/primaire",
         description: "#{description} (menu primaire)",
         lambda: -> (champs) {
-          champs
-            .find { |champ| champ.type_de_champ == tdc }
-            &.primary_value
+          champs.find { |champ| champ.stable_id == stable_id }&.primary_value
         }
       }
     )
     tags.push(
       {
         libelle: "#{libelle}/secondaire",
+        id: "tdc#{stable_id}/secondaire",
         description: "#{description} (menu secondaire)",
         lambda: -> (champs) {
-          champs
-            .find { |champ| champ.type_de_champ == tdc }
-            &.secondary_value
+          champs.find { |champ| champ.stable_id == stable_id }&.secondary_value
         }
       }
     )

--- a/app/models/types_de_champ/type_de_champ_base.rb
+++ b/app/models/types_de_champ/type_de_champ_base.rb
@@ -8,13 +8,14 @@ class TypesDeChamp::TypeDeChampBase
   end
 
   def tags_for_template
-    tdc = @type_de_champ
+    stable_id = @type_de_champ.stable_id
     [
       {
         libelle: libelle,
+        id: "tdc#{stable_id}",
         description: description,
         lambda: -> (champs) {
-          champs.find { |champ| champ.type_de_champ == tdc }&.for_tag
+          champs.find { |champ| champ.stable_id == stable_id }&.for_tag
         }
       }
     ]

--- a/spec/models/concern/tags_substitution_concern_spec.rb
+++ b/spec/models/concern/tags_substitution_concern_spec.rb
@@ -401,18 +401,18 @@ describe TagsSubstitutionConcern, type: :model do
         procedure.update!(draft_revision: procedure.create_new_revision, published_revision: procedure.draft_revision)
       end
 
-      context "replace by old label" do
+      context "when using the champ's original label" do
         let(:template) { '--mon tag--' }
 
-        it "should replace tag" do
+        it "replaces the tag" do
           is_expected.to eq('valeur')
         end
       end
 
-      context "replace by new label" do
+      context "when using the champ's revised label" do
         let(:template) { '--ton tag--' }
 
-        it "should replace tag" do
+        it "replaces the tag" do
           is_expected.to eq('valeur')
         end
       end

--- a/spec/models/concern/tags_substitution_concern_spec.rb
+++ b/spec/models/concern/tags_substitution_concern_spec.rb
@@ -392,17 +392,17 @@ describe TagsSubstitutionConcern, type: :model do
     end
 
     context 'when procedure has revisions' do
-      let(:types_de_champ) { [build(:type_de_champ, libelle: 'mon tag')] }
+      let(:types_de_champ) { [build(:type_de_champ, libelle: 'mon ancien libellé')] }
       let(:draft_type_de_champ) { procedure.draft_revision.find_or_clone_type_de_champ(types_de_champ[0].stable_id) }
 
       before do
-        draft_type_de_champ.update(libelle: 'ton tag')
+        draft_type_de_champ.update(libelle: 'mon nouveau libellé')
         dossier.champs.first.update(value: 'valeur')
         procedure.update!(draft_revision: procedure.create_new_revision, published_revision: procedure.draft_revision)
       end
 
       context "when using the champ's original label" do
-        let(:template) { '--mon tag--' }
+        let(:template) { '--mon ancien libellé--' }
 
         it "replaces the tag" do
           is_expected.to eq('valeur')
@@ -410,7 +410,7 @@ describe TagsSubstitutionConcern, type: :model do
       end
 
       context "when using the champ's revised label" do
-        let(:template) { '--ton tag--' }
+        let(:template) { '--mon nouveau libellé--' }
 
         it "replaces the tag" do
           is_expected.to eq('valeur')

--- a/spec/models/concern/tags_substitution_concern_spec.rb
+++ b/spec/models/concern/tags_substitution_concern_spec.rb
@@ -8,6 +8,7 @@ describe TagsSubstitutionConcern, type: :model do
 
   let(:procedure) do
     create(:procedure,
+      :published,
       libelle: 'Une magnifique démarche',
       types_de_champ: types_de_champ,
       types_de_champ_private: types_de_champ_private,
@@ -387,6 +388,33 @@ describe TagsSubstitutionConcern, type: :model do
 
       it "does not treat motivation or date de décision as tags" do
         is_expected.to eq('--motivation-- --date de décision--')
+      end
+    end
+
+    context 'when procedure has revisions' do
+      let(:types_de_champ) { [build(:type_de_champ, libelle: 'mon tag')] }
+      let(:draft_type_de_champ) { procedure.draft_revision.find_or_clone_type_de_champ(types_de_champ[0].stable_id) }
+
+      before do
+        draft_type_de_champ.update(libelle: 'ton tag')
+        dossier.champs.first.update(value: 'valeur')
+        procedure.update!(draft_revision: procedure.create_new_revision, published_revision: procedure.draft_revision)
+      end
+
+      context "replace by old label" do
+        let(:template) { '--mon tag--' }
+
+        it "should replace tag" do
+          is_expected.to eq('valeur')
+        end
+      end
+
+      context "replace by new label" do
+        let(:template) { '--ton tag--' }
+
+        it "should replace tag" do
+          is_expected.to eq('valeur')
+        end
       end
     end
   end


### PR DESCRIPTION
Cette PR fait en sorte que les tags soient remplacés par `stable_id` et donc résister aux renommages dans les revisions