### PR TITLE
Claimant type to avis table

### DIFF
--- a/app/controllers/concerns/create_avis_concern.rb
+++ b/app/controllers/concerns/create_avis_concern.rb
@@ -27,6 +27,7 @@ module CreateAvisConcern
             introduction: create_avis_params[:introduction],
             introduction_file: create_avis_params[:introduction_file],
             claimant: current_instructeur,
+            claimant_type: current_instructeur.dossiers.present? ? 'Instructeur' : 'Expert',
             dossier: dossier,
             confidentiel: confidentiel,
             experts_procedure: experts_procedure

--- a/app/models/avis.rb
+++ b/app/models/avis.rb
@@ -4,6 +4,7 @@
 #
 #  id                   :integer          not null, primary key
 #  answer               :text
+#  claimant_type        :string
 #  confidentiel         :boolean          default(FALSE), not null
 #  email                :string
 #  introduction         :text

--- a/db/migrate/20210307143807_add_claimant_type_to_avis.rb
+++ b/db/migrate/20210307143807_add_claimant_type_to_avis.rb
@@ -1,0 +1,6 @@
+class AddClaimantTypeToAvis < ActiveRecord::Migration[6.0]
+  def change
+    add_column :avis, :claimant_type, :string
+    remove_foreign_key :avis, :instructeurs, column: "claimant_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_04_180955) do
+ActiveRecord::Schema.define(version: 2021_03_07_143807) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -122,6 +122,7 @@ ActiveRecord::Schema.define(version: 2021_02_04_180955) do
     t.boolean "confidentiel", default: false, null: false
     t.datetime "revoked_at"
     t.bigint "experts_procedure_id"
+    t.string "claimant_type"
     t.index ["claimant_id"], name: "index_avis_on_claimant_id"
     t.index ["dossier_id"], name: "index_avis_on_dossier_id"
     t.index ["experts_procedure_id"], name: "index_avis_on_experts_procedure_id"
@@ -729,7 +730,6 @@ ActiveRecord::Schema.define(version: 2021_02_04_180955) do
   add_foreign_key "attestation_templates", "procedures"
   add_foreign_key "attestations", "dossiers"
   add_foreign_key "avis", "experts_procedures"
-  add_foreign_key "avis", "instructeurs", column: "claimant_id"
   add_foreign_key "champs", "champs", column: "parent_id"
   add_foreign_key "closed_mails", "procedures"
   add_foreign_key "commentaires", "dossiers"

--- a/lib/tasks/deployment/20210307144755_backfill_claimant_type_on_avis_table.rake
+++ b/lib/tasks/deployment/20210307144755_backfill_claimant_type_on_avis_table.rake
@@ -1,0 +1,39 @@
+namespace :after_party do
+  desc 'Deployment task: backfill_claimant_type_on_avis_table'
+  task backfill_claimant_type_on_avis_table: :environment do
+    puts "Running deploy task 'backfill_claimant_type_on_avis_table'"
+
+    with_dossiers = Avis.where(claimant_type: nil).includes(claimant: :assign_to).where.not(claimant: { assign_tos: { id: nil } })
+    with_dossiers.update_all(claimant_type: 'Instructeur')
+
+    without_dossiers = Avis.where(claimant_type: nil).includes(claimant: :assign_to).where(claimant: { assign_tos: { id: nil } })
+    without_dossiers.find_each do |avis|
+      claimant = Instructeur.find(avis.claimant_id).user
+      instructeur = Instructeur.find(avis.instructeur) if avis.instructeur
+
+      if instructeur && avis.experts_procedure_id.blank?
+        User.create_or_promote_to_expert(instructeur.user.email, SecureRandom.hex)
+        instructeur.user.reload
+        experts_procedure = ExpertsProcedure.find_or_create_by(procedure: avis.procedure, expert: instructeur.user.expert)
+        avis.update_columns(claimant_type: 'Expert', experts_procedure_id: experts_procedure.id)
+
+      elsif instructeur.blank? && avis.experts_procedure_id.blank?
+        expert = User.create_or_promote_to_expert(avis.email, SecureRandom.hex).expert
+        expert.reload
+        experts_procedure = ExpertsProcedure.find_or_create_by(procedure: avis.procedure, expert: expert)
+        avis.update_columns(claimant_type: 'Expert', experts_procedure_id: experts_procedure.id)
+
+      elsif avis.experts_procedure_id.present?
+        avis.update_column(:claimant_type, 'Expert')
+
+      elsif claimant.blank?
+        avis.destroy
+      end
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
On ajoute la colonne`claimant_type` sur la table avis car un demandeur peut être soit Instructeur, soit Expert.

La tâche after_party va remplir le champ `claimant_type` des avis déjà existants. Le souci, c'est que pour un même avis le `claimant_type` peut être `Expert` et `claimant_id` est de classe Instructeur.

Dans une prochaine PR je vais donc isoler tous les avis ayant un `claimant_type` à `Expert` et modifier le `claimant_id` pour qu'il soit de classe Expert.

Je ne l'ai pas fait ici car pour dissocier les experts des instructeurs, on vérifie l'association Instructeur <> AssignTo : Un instructeur qui n'a pas de assign_to est en réalité un expert. Cette association n'existe pas entre Expert <> AssignTo

