### PR TITLE
ajoute l'export pdf du dossier aux pieces justificatives

### DIFF
--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -210,6 +210,7 @@ module Instructeurs
     def telecharger_pjs
       return head(:forbidden) if !dossier.attachments_downloadable?
 
+      generate_pdf_for_instructeur_export
       files = ActiveStorage::DownloadableFile.create_list_from_dossier(dossier)
 
       zipline(files, "dossier-#{dossier.id}.zip")
@@ -230,6 +231,12 @@ module Instructeurs
 
     def dossier
       @dossier ||= current_instructeur.dossiers.find(params[:dossier_id])
+    end
+
+    def generate_pdf_for_instructeur_export
+      @include_infos_administration = true
+      pdf = render_to_string(file: 'dossiers/show', formats: [:pdf])
+      dossier.pdf_export_for_instructeur.attach(io: StringIO.open(pdf), filename: "export-#{dossier.id}.pdf", content_type: 'application/pdf')
     end
 
     def commentaire_params

--- a/app/lib/active_storage/downloadable_file.rb
+++ b/app/lib/active_storage/downloadable_file.rb
@@ -1,16 +1,4 @@
 class ActiveStorage::DownloadableFile
-  def initialize(attached)
-    if using_local_backend?
-      @url = 'file://' + ActiveStorage::Blob.service.path_for(attached.key)
-    else
-      @url = attached.service_url
-    end
-  end
-
-  def url
-    @url
-  end
-
   def self.create_list_from_dossier(dossier)
     pjs = PiecesJustificativesService.liste_pieces_justificatives(dossier)
     files = pjs.map do |piece_justificative|

--- a/app/lib/active_storage/downloadable_file.rb
+++ b/app/lib/active_storage/downloadable_file.rb
@@ -13,12 +13,14 @@ class ActiveStorage::DownloadableFile
 
   def self.create_list_from_dossier(dossier)
     pjs = PiecesJustificativesService.liste_pieces_justificatives(dossier)
-    pjs.map do |piece_justificative|
+    files = pjs.map do |piece_justificative|
       [
         piece_justificative,
         self.timestamped_filename(piece_justificative)
       ]
     end
+    files << [dossier.pdf_export_for_instructeur, self.timestamped_filename(dossier.pdf_export_for_instructeur)]
+    files
   end
 
   private

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -63,6 +63,7 @@ class Dossier < ApplicationRecord
   has_one :france_connect_information, through: :user
 
   has_one_attached :justificatif_motivation
+  has_one_attached :pdf_export_for_instructeur
 
   has_many :champs, -> { root.public_ordered }, inverse_of: :dossier, dependent: :destroy
   has_many :champs_private, -> { root.private_ordered }, class_name: 'Champ', inverse_of: :dossier, dependent: :destroy

--- a/app/views/instructeurs/dossiers/_header_actions.html.haml
+++ b/app/views/instructeurs/dossiers/_header_actions.html.haml
@@ -19,7 +19,7 @@
     %ul#print-pj-menu.print-menu.dropdown-content
       %li
         - if PiecesJustificativesService.pieces_justificatives_total_size(dossier) < Dossier::TAILLE_MAX_ZIP
-          = link_to "Télécharger toutes les pièces jointes", telecharger_pjs_instructeur_dossier_path(dossier.procedure, dossier), target: "_blank", rel: "noopener", class: "menu-item menu-link"
+          = link_to "Télécharger le dossier et toutes ses pièces jointes", telecharger_pjs_instructeur_dossier_path(dossier.procedure, dossier), target: "_blank", rel: "noopener", class: "menu-item menu-link"
         - else
           %p.menu-item Le téléchargement des pièces jointes est désactivé pour les dossiers de plus de #{number_to_human_size Dossier::TAILLE_MAX_ZIP}.
 

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -201,6 +201,15 @@ FactoryBot.define do
       end
     end
 
+    trait :with_pdf_export do
+      after(:create) do |dossier, _evaluator|
+        dossier.pdf_export_for_instructeur.attach(
+          io: StringIO.new('Hello World'),
+          filename: 'export.pdf'
+        )
+      end
+    end
+
     trait :with_justificatif do
       after(:create) do |dossier, _evaluator|
         dossier.justificatif_motivation.attach(

--- a/spec/features/instructeurs/instruction_spec.rb
+++ b/spec/features/instructeurs/instruction_spec.rb
@@ -162,10 +162,11 @@ feature 'Instructing a dossier:' do
       files = ZipTricks::FileReader.read_zip_structure(io: File.open(DownloadHelpers.download))
 
       expect(DownloadHelpers.download).to include "dossier-#{dossier.id}.zip"
-      expect(files.size).to be 2
+      expect(files.size).to be 3
       expect(files[0].filename.include?('piece_justificative_0')).to be_truthy
       expect(files[0].uncompressed_size).to be File.size(path)
       expect(files[1].filename.include?('horodatage/operation')).to be_truthy
+      expect(files[2].filename.include?('dossier/export')).to be_truthy
     end
 
     scenario 'A instructeur can download an archive containing several identical attachments' do
@@ -176,13 +177,14 @@ feature 'Instructing a dossier:' do
       files = ZipTricks::FileReader.read_zip_structure(io: File.open(DownloadHelpers.download))
 
       expect(DownloadHelpers.download).to include "dossier-#{dossier.id}.zip"
-      expect(files.size).to be 3
+      expect(files.size).to be 4
       expect(files[0].filename.include?('piece_justificative_0')).to be_truthy
       expect(files[1].filename.include?('piece_justificative_0')).to be_truthy
       expect(files[0].filename).not_to eq files[1].filename
       expect(files[0].uncompressed_size).to be File.size(path)
       expect(files[1].uncompressed_size).to be File.size(path)
       expect(files[2].filename.include?('horodatage/operation')).to be_truthy
+      expect(files[3].filename.include?('dossier/export')).to be_truthy
     end
 
     before { DownloadHelpers.clear_downloads }

--- a/spec/features/instructeurs/instruction_spec.rb
+++ b/spec/features/instructeurs/instruction_spec.rb
@@ -153,7 +153,7 @@ feature 'Instructing a dossier:' do
 
     scenario 'A instructeur can download an archive containing a single attachment' do
       find(:css, '.attached').click
-      click_on 'Télécharger toutes les pièces jointes'
+      click_on 'Télécharger le dossier et toutes ses pièces jointes'
       # For some reason, clicking the download link does not trigger the download in the headless browser ;
       # So we need to go to the download link directly
       visit telecharger_pjs_instructeur_dossier_path(procedure, dossier)

--- a/spec/lib/active_storage/downloadable_file_spec.rb
+++ b/spec/lib/active_storage/downloadable_file_spec.rb
@@ -1,11 +1,12 @@
 describe ActiveStorage::DownloadableFile do
-  let(:dossier) { create(:dossier, :en_construction) }
+  let(:dossier) { create(:dossier, :en_construction, :with_pdf_export) }
 
   subject(:list) { ActiveStorage::DownloadableFile.create_list_from_dossier(dossier) }
 
   describe 'create_list_from_dossier' do
     context 'when no piece_justificative is present' do
-      it { expect(list).to match([]) }
+      it { expect(list.length).to eq 1 }
+      it { expect(list.first[0].record_type).to eq "Dossier" }
     end
 
     context 'when there is a piece_justificative' do
@@ -13,7 +14,7 @@ describe ActiveStorage::DownloadableFile do
         dossier.champs << create(:champ_piece_justificative, :with_piece_justificative_file, dossier: dossier)
       end
 
-      it { expect(list.length).to eq 1 }
+      it { expect(list.length).to eq 2 }
     end
 
     context 'when there is a private piece_justificative' do
@@ -21,7 +22,7 @@ describe ActiveStorage::DownloadableFile do
         dossier.champs_private << create(:champ_piece_justificative, :with_piece_justificative_file, private: true, dossier: dossier)
       end
 
-      it { expect(list.length).to eq 1 }
+      it { expect(list.length).to eq 2 }
     end
 
     context 'when there is a repetition bloc' do
@@ -30,7 +31,7 @@ describe ActiveStorage::DownloadableFile do
       end
 
       it 'should have 4 piece_justificatives' do
-        expect(list.size).to eq 4
+        expect(list.size).to eq 5
       end
     end
 
@@ -39,7 +40,7 @@ describe ActiveStorage::DownloadableFile do
         dossier.commentaires << create(:commentaire, dossier: dossier)
       end
 
-      it { expect(list.length).to eq 0 }
+      it { expect(list.length).to eq 1 }
     end
 
     context 'when there is a message with an attachment' do
@@ -47,7 +48,7 @@ describe ActiveStorage::DownloadableFile do
         dossier.commentaires << create(:commentaire, :with_file, dossier: dossier)
       end
 
-      it { expect(list.length).to eq 1 }
+      it { expect(list.length).to eq 2 }
     end
   end
 end


### PR DESCRIPTION
close #5885 

Cette PR

- ajoute l'export pdf du dossier dans le zip contenant les pj
- supprime du code mort
- renomme en conséquence le lien
![Capture d’écran du 2021-03-08 14-02-46](https://user-images.githubusercontent.com/1111966/110324993-0ca9f480-8017-11eb-9df0-655c42ad44c1.png)
 pour télécharger toutes les pièces jointes

