### PR TITLE
active_storage: refactor concerns

### DIFF
--- a/app/jobs/virus_scanner_job.rb
+++ b/app/jobs/virus_scanner_job.rb
@@ -1,12 +1,20 @@
 class VirusScannerJob < ApplicationJob
+  class FileNotAnalyzedYetError < StandardError
+  end
+
   queue_as :active_storage_analysis
 
   # If by the time the job runs the blob has been deleted, ignore the error
   discard_on ActiveRecord::RecordNotFound
   # If the file is deleted during the scan, ignore the error
   discard_on ActiveStorage::FileNotFoundError
+  # If the file is not analyzed yet, retry later (to avoid clobbering metadata)
+  retry_on FileNotAnalyzedYetError
 
   def perform(blob)
+    raise FileNotAnalyzedYetError if !blob.analyzed?
+    return if blob.virus_scanner.done?
+
     metadata = extract_metadata_via_virus_scanner(blob)
     blob.update!(metadata: blob.metadata.merge(metadata))
   end

--- a/app/models/concerns/attachment_titre_identite_watermark_concern.rb
+++ b/app/models/concerns/attachment_titre_identite_watermark_concern.rb
@@ -1,0 +1,17 @@
+# Request a watermark on files attached to a `Champs::TitreIdentiteChamp`.
+#
+# We're using a class extension here, but we could as well have a periodic
+# job that watermarks relevant attachments.
+module AttachmentTitreIdentiteWatermarkConcern
+  extend ActiveSupport::Concern
+
+  included do
+    after_create_commit :watermark_later
+  end
+
+  private
+
+  def watermark_later
+    blob&.watermark_later
+  end
+end

--- a/app/models/concerns/attachment_virus_scanner_concern.rb
+++ b/app/models/concerns/attachment_virus_scanner_concern.rb
@@ -1,0 +1,20 @@
+# Run a virus scan on all attachments after they are analyzed.
+#
+# We're using a class extension to ensure that all attachments get scanned,
+# regardless on how they were created. This could be an ActiveStorage::Analyzer,
+# but as of Rails 6.1 only the first matching analyzer is ever run on
+# a blob (and we may want to analyze the dimension of a picture as well
+# as scanning it).
+module AttachmentVirusScannerConcern
+  extend ActiveSupport::Concern
+
+  included do
+    after_create_commit :scan_for_virus_later
+  end
+
+  private
+
+  def scan_for_virus_later
+    blob&.scan_for_virus_later
+  end
+end

--- a/app/models/concerns/blob_titre_identite_watermark_concern.rb
+++ b/app/models/concerns/blob_titre_identite_watermark_concern.rb
@@ -1,38 +1,21 @@
-# Request a watermark on blobs attached to a `Champs::TitreIdentiteChamp`
-# after the virus scan has run.
-#
-# We're using a class extension here, but we could as well have a periodic
-# job that watermarks relevant attachments.
-#
-# The `after_commit` hook is triggered, among other cases, when
-# the analyzer or virus scan updates the blob metadata. When both the analyzer
-# and the virus scan have run, it is now safe to start the watermarking,
-# without  risking to replace the picture while it is being scanned in a
-# concurrent job.
 module BlobTitreIdentiteWatermarkConcern
-  extend ActiveSupport::Concern
-
-  included do
-    after_commit :enqueue_watermark_job
-  end
-
   def watermark_pending?
     watermark_required? && !watermark_done?
-  end
-
-  private
-
-  def watermark_required?
-    attachments.any? { |attachment| attachment.record.class.name == 'Champs::TitreIdentiteChamp' }
   end
 
   def watermark_done?
     metadata[:watermark]
   end
 
-  def enqueue_watermark_job
-    if analyzed? && virus_scanner.done? && watermark_pending?
+  def watermark_later
+    if watermark_required?
       TitreIdentiteWatermarkJob.perform_later(self)
     end
+  end
+
+  private
+
+  def watermark_required?
+    attachments.any? { |attachment| attachment.record.class.name == 'Champs::TitreIdentiteChamp' }
   end
 end

--- a/app/models/concerns/blob_virus_scanner_concern.rb
+++ b/app/models/concerns/blob_virus_scanner_concern.rb
@@ -1,36 +1,21 @@
-# Run a virus scan on all blobs after they are analyzed.
-#
-# We're using a class extension to ensure that all blobs get scanned,
-# regardless on how they were created. This could be an ActiveStorage::Analyzer,
-# but as of Rails 6.1 only the first matching analyzer is ever run on
-# a blob (and we may want to analyze the dimension of a picture as well
-# as scanning it).
-#
-# The `after_commit` hook is triggered, among other cases, when
-# the analyzer updates the blob metadata. When the analyzer has run,
-# it is now safe to start our own scanning, without risking to have
-# two concurrent jobs overwriting the metadata of the blob.
 module BlobVirusScannerConcern
   extend ActiveSupport::Concern
 
   included do
     before_create :set_pending
-    after_commit :enqueue_virus_scan
   end
 
   def virus_scanner
     ActiveStorage::VirusScanner.new(self)
   end
 
+  def scan_for_virus_later
+    VirusScannerJob.perform_later(self)
+  end
+
   private
 
   def set_pending
-    self.metadata[:virus_scan_result] ||= ActiveStorage::VirusScanner::PENDING
-  end
-
-  def enqueue_virus_scan
-    if analyzed? && !virus_scanner.done?
-      VirusScannerJob.perform_later(self)
-    end
+    metadata[:virus_scan_result] ||= ActiveStorage::VirusScanner::PENDING
   end
 end

--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -4,9 +4,14 @@ Rails.application.config.active_storage.analyzers.delete ActiveStorage::Analyzer
 Rails.application.config.active_storage.analyzers.delete ActiveStorage::Analyzer::VideoAnalyzer
 
 ActiveSupport.on_load(:active_storage_blob) do
-  include BlobSignedIdConcern
-  include BlobVirusScannerConcern
   include BlobTitreIdentiteWatermarkConcern
+  include BlobVirusScannerConcern
+  include BlobSignedIdConcern
+end
+
+ActiveSupport.on_load(:active_storage_attachment) do
+  include AttachmentTitreIdentiteWatermarkConcern
+  include AttachmentVirusScannerConcern
 end
 
 # When an OpenStack service is initialized it makes a request to fetch

--- a/spec/models/champ_spec.rb
+++ b/spec/models/champ_spec.rb
@@ -458,7 +458,8 @@ describe Champ do
         end
 
         it 'marks the file as safe once the scan completes' do
-          perform_enqueued_jobs { subject }
+          subject
+          perform_enqueued_jobs
           expect(champ.reload.piece_justificative_file.virus_scanner.safe?).to be_truthy
         end
       end
@@ -480,13 +481,15 @@ describe Champ do
         champ
       end
 
-      it 'enqueues a watermark job on file attachment' do
+      it 'marks the file as needing watermarking' do
         expect(subject.piece_justificative_file.watermark_pending?).to be_truthy
       end
 
       it 'watermarks the file' do
-        perform_enqueued_jobs { subject }
-        expect(champ.reload.piece_justificative_file.blob.metadata[:watermark]).to be_truthy
+        subject
+        perform_enqueued_jobs
+        expect(champ.reload.piece_justificative_file.watermark_pending?).to be_falsy
+        expect(champ.reload.piece_justificative_file.blob.watermark_done?).to be_truthy
       end
     end
   end


### PR DESCRIPTION
Follow-up of #5953.

Refactor the concerns with two goals:

- Getting closer from the way ActiveStorage adds its own hooks.
  
  Usually ActiveStorage does this using an `Attachment#after_create` hook, which then delegates to the blob to enqueue the job.
- Enqueuing each job only once. By hooking on `Attachment#after_create`, we guarantee each job will be added only once.

We then let the jobs themselves check if they are relevant or not, and retry or discard themselves if necessary.