### PR TITLE
jobs: retry on ActiveStorage::IntegrityError during virus scan

### DIFF
--- a/app/jobs/virus_scanner_job.rb
+++ b/app/jobs/virus_scanner_job.rb
@@ -6,6 +6,9 @@ class VirusScannerJob < ApplicationJob
   # If the file is deleted during the scan, ignore the error
   discard_on ActiveStorage::FileNotFoundError
 
+  # If for some reason the file appears invalid, retry for a while
+  retry_on ActiveStorage::IntegrityError, attempts: 10, wait: 5.seconds
+
   def perform(blob)
     metadata = extract_metadata_via_virus_scanner(blob)
     blob.update!(metadata: blob.metadata.merge(metadata))


### PR DESCRIPTION
This is the same setting than what ActiveStorage::AnalyzeJob uses.

Fix https://sentry.io/organizations/demarches-simplifiees/issues/2223383265/?project=1429550&query=integrity&statsPeriod=14d