### PR TITLE
5608 upload accessible

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -79,6 +79,12 @@ module ApplicationHelper
     # rubocop:enable Rails/OutputSafety
   end
 
+  def focus_element(selector)
+    # rubocop:disable Rails/OutputSafety
+    raw("document.querySelector('#{selector}').focus();")
+    # rubocop:enable Rails/OutputSafety
+  end
+
   def disable_element(selector)
     # rubocop:disable Rails/OutputSafety
     raw("document.querySelector('#{selector}').disabled = true;")

--- a/app/javascript/shared/activestorage/progress-bar.js
+++ b/app/javascript/shared/activestorage/progress-bar.js
@@ -32,6 +32,7 @@ export default class ProgressBar {
     const element = getDirectUploadProgressElement(id);
     if (element) {
       element.style.width = `${progress}%`;
+      element.setAttribute('aria-valuenow', progress);
     }
   }
 
@@ -52,7 +53,7 @@ export default class ProgressBar {
 
   static render(id, filename) {
     return `<div id="direct-upload-${id}" class="direct-upload ${PENDING_CLASS}" data-direct-upload-id="${id}">
-      <div class="direct-upload__progress" style="width: 0%"></div>
+      <div role="progressbar" aria-valuemin="0" aria-valuemax="100" class="direct-upload__progress" style="width: 0%"></div>
       <span class="direct-upload__filename">${filename}</span>
     </div>`;
   }

--- a/app/javascript/shared/activestorage/progress-bar.js
+++ b/app/javascript/shared/activestorage/progress-bar.js
@@ -25,6 +25,7 @@ export default class ProgressBar {
     const element = getDirectUploadElement(id);
     if (element) {
       element.classList.remove(PENDING_CLASS);
+      element.focus();
     }
   }
 

--- a/app/javascript/shared/toggle-target.js
+++ b/app/javascript/shared/toggle-target.js
@@ -16,5 +16,6 @@ delegate('click', TOGGLE_SOURCE_SELECTOR, (evt) => {
   const targetElements = document.querySelectorAll(targetSelector);
   for (let target of targetElements) {
     toggle(target);
+    target.focus();
   }
 });

--- a/app/views/champs/piece_justificative/show.js.erb
+++ b/app/views/champs/piece_justificative/show.js.erb
@@ -4,3 +4,5 @@
 <% if attachment.virus_scanner.pending? %>
   <%= fire_event('attachment:update', { url: attachment_url(attachment.id, { signed_id: attachment.blob.signed_id, user_can_upload: true }) }.to_json ) %>
 <% end %>
+
+<%= focus_element("button[data-toggle-target=\".attachment-input-#{attachment.id}\"]") %>

--- a/app/views/shared/attachment/_edit.html.haml
+++ b/app/views/shared/attachment/_edit.html.haml
@@ -19,7 +19,7 @@
         = render partial: "shared/attachment/show", locals: { attachment: attachment, user_can_upload: true }
       - if user_can_destroy
         .attachment-action
-          = link_to 'Supprimer', attachment_url(attachment.id, { signed_id: attachment.blob.signed_id }), remote: true, method: :delete, class: 'button small danger', data: { disable: true }
+          = link_to 'Supprimer', attachment_url(attachment.id, { signed_id: attachment.blob.signed_id }), remote: true, method: :delete, class: 'button small danger', data: { disable: true }, role: 'button'
       .attachment-action
         = button_tag 'Remplacer', type: 'button', class: 'button small', data: { 'toggle-target': ".attachment-input-#{attachment_id}" }
 


### PR DESCRIPTION
close #5608 

Cette PR rend accessible le champ Pièce justificative.

Plus précisément, voici ce qui est implémenté : 

- Implémentation du modèle de conception "progressbar"  (avec les propriétés aria-valuemin, aria-valuemax et aria-valuenow)
- A l'affichage de la barre de progression, le focus est donné sur la barre de progression
- Lorsque l'upload est terminé, le focus est donné au bouton permettant de remplacer le téléchargement.
- Lorsqu'un utilisateur clique sur le bouton "remplacer", le focus est donné au bouton permettant de choisir un fichier de remplacement.
- le lien "Supprimer" a désormais le rôle `button` (il n'était pas possible d'en faire un bouton de formulaire, étant donné que cela aurait eu pour conséquence de créer un formulaire dans un formulaire, ce qui n'est pas possible)

