### PR TITLE
Return empty strings for incomplete api entreprise adresses

### DIFF
--- a/app/graphql/types/personne_morale_type.rb
+++ b/app/graphql/types/personne_morale_type.rb
@@ -108,9 +108,9 @@ module Types
         street_number: object.numero_voie,
         street_name: object.nom_voie,
         street_address: object.nom_voie.present? ? [object.numero_voie, object.type_voie, object.nom_voie].compact.join(' ') : nil,
-        postal_code: object.code_postal,
-        city_name: object.localite,
-        city_code: object.code_insee_localite
+        postal_code: object.code_postal.presence || '',
+        city_name: object.localite.presence || '',
+        city_code: object.code_insee_localite.presence || ''
       }
     end
 


### PR DESCRIPTION
Certaines adresses sur l'API entreprise sont incomplètes. C'est un petit nombre (quelques dizaines). Je n'ai pas envie de relaxer le type `Address` sur l'API, je préfère renvoyer des strings vides pour ces cas marginaux.

https://sentry.io/organizations/demarches-simplifiees/discover/results/?field=title&field=release&field=environment&field=user&field=timestamp&name=RuntimeError%3A+Cannot+return+null+for+non-nullable+field+SelectionUtilisateur.geometry&project=1429550&query=issue.id%3A2251578477+postalCode&sort=-timestamp&statsPeriod=14d&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1