### PR TITLE
config: make Sentry ignore rescued ActiveJob exceptions

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -4,4 +4,13 @@ Sentry.init do |config|
   config.enabled_environments = ['production']
   config.breadcrumbs_logger = [:active_support_logger]
   config.traces_sample_rate = ENV['SENTRY_ENABLED'] == 'enabled' ? 0.001 : nil
+  config.excluded_exceptions += [
+    # Ignore exceptions caught by ActiveJob.retry_on
+    # https://github.com/getsentry/sentry-ruby/issues/1347
+    'Excon::Error::BadRequest',
+    'ActiveStorage::IntegrityError',
+    'VirusScannerJob::FileNotAnalyzedYetError',
+    'TitreIdentiteWatermarkJob::WatermarkFileNotScannedYetError',
+    'APIEntreprise::API::Error::TimedOut'
+  ]
 end


### PR DESCRIPTION
For now the Sentry delayed_job integration reports errors that are rescued with `retry_on`.

Ignore these errors manually for now.

See https://github.com/getsentry/sentry-ruby/issues/1347

Fix https://sentry.io/organizations/demarches-simplifiees/issues/2278141668/?project=1429550&referrer=slack