### PR TITLE
app: enable Bootsnap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'administrate'
 gem 'after_party'
 gem 'anchored'
 gem 'bcrypt'
+gem 'bootsnap', '>= 1.4.4', require: false # Reduces boot times through caching; required in config/boot.rb
 gem 'browser'
 gem 'chartkick'
 gem 'chunky_png'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,8 @@ GEM
     bcrypt (3.1.16)
     bindata (2.4.8)
     bindex (0.8.1)
+    bootsnap (1.7.2)
+      msgpack (~> 1.0)
     brakeman (5.0.0)
     browser (5.3.0)
     builder (3.2.4)
@@ -419,6 +421,7 @@ GEM
     minitest (5.14.4)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
+    msgpack (1.4.2)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     mustermann (1.1.1)
@@ -781,6 +784,7 @@ DEPENDENCIES
   annotate
   axe-matchers
   bcrypt
+  bootsnap (>= 1.4.4)
   brakeman
   browser
   capybara

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
+require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap/setup" # Speed up boot time by caching expensive operations.


### PR DESCRIPTION
Bootsnap speeds up the initial loading of the Rails app by:

- Optimizing the LOAD_PATH dynamically
- Caching the result of Ruby bytecode compilation

Cached data are written to `tmp/cache/bootsnap*`.

This is enabled in the default Rails app template.

## Benchmark

> ➜  tps git:(main) ✗ time bin/rake environment
> bin/rake environment  7,90s user 7,67s system 90% cpu 17,216 total

> ➜  tps git:(bootsnap) ✗ time bin/rake environment
> bin/rake environment  3,59s user 1,90s system 65% cpu 8,382 total