### PR TITLE
Correction de DossiersController#avis_for_expert

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -497,7 +497,6 @@ class Dossier < ApplicationRecord
         .where(confidentiel: false)
         .or(avis.where(claimant_id: expert.id, claimant_type: 'Expert', tmp_expert_migrated: true))
         .or(avis.where(claimant_id: instructeur, claimant_type: 'Instructeur', tmp_expert_migrated: false))
-        .or(avis.where(expert: expert))
         .order(created_at: :asc)
     end
   end


### PR DESCRIPTION
This line causes an error on Rails 6.1.

And it isn't even necessary: this line is supposed to query avis where the expert advice has been requested – but this is handled by the `if expert.dossiers.include?(self)` condition just above.