### PR TITLE
views: fix warning message about incomplete fields for attestation

### DIFF
--- a/app/views/instructeurs/dossiers/_state_button_motivation.html.haml
+++ b/app/views/instructeurs/dossiers/_state_button_motivation.html.haml
@@ -16,7 +16,7 @@
       - if unspecified_attestation_champs.present?
         .warning
           Attention, les valeurs suivantes n'ont pas été renseignées mais sont nécessaires pour pouvoir envoyer une attestation valide :
-          - unspecified_champs, unspecified_annotations_privees = unspecified_attestation_champs.partition(&:private)
+          - unspecified_annotations_privees, unspecified_champs = unspecified_attestation_champs.partition(&:private)
 
           - if unspecified_champs.present?
             %h4 Champs de la demande

--- a/spec/views/instructeur/dossiers/_state_button_motivation.html.haml_spec.rb
+++ b/spec/views/instructeur/dossiers/_state_button_motivation.html.haml_spec.rb
@@ -1,7 +1,7 @@
 describe 'instructeurs/dossiers/state_button_motivation.html.haml', type: :view do
   let(:dossier) { create(:dossier, :en_instruction) }
 
-  subject! do
+  subject do
     render(
       'instructeurs/dossiers/state_button_motivation.html.haml',
       dossier: dossier,
@@ -14,12 +14,15 @@ describe 'instructeurs/dossiers/state_button_motivation.html.haml', type: :view 
     )
   end
 
-  context 'with an attestation preview' do
-    let(:dossier) { create :dossier, :accepte, :with_attestation }
-    it { expect(rendered).to have_link(href: apercu_attestation_instructeur_dossier_path(dossier.procedure, dossier)) }
+  context 'without attestation' do
+    it { expect(subject).not_to have_link(href: apercu_attestation_instructeur_dossier_path(dossier.procedure, dossier)) }
   end
 
-  context 'without an attestation preview' do
-    it { expect(rendered).not_to have_link(href: apercu_attestation_instructeur_dossier_path(dossier.procedure, dossier)) }
+  context 'with an attestation' do
+    let(:dossier) { create :dossier, :accepte, :with_attestation }
+
+    it 'includes a link to preview the attestation' do
+      expect(subject).to have_link(href: apercu_attestation_instructeur_dossier_path(dossier.procedure, dossier))
+    end
   end
 end


### PR DESCRIPTION
Extracted from #5700: The labels for the champs and private champs were inverted.

![Screenshot of the resolved issue](https://user-images.githubusercontent.com/15379878/96661049-e5ac8980-12e6-11eb-9f9b-dc5771c5acec.png)

/cc @maatinito 