### PR TITLE
dossier pdf: display form fields in two columns (instead of 2 lines)

### DIFF
--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -93,9 +93,9 @@ def render_single_champ(pdf, champ)
     end
     pdf.text "\n"
   when 'Champs::ExplicationChamp'
-    format_in_2_lines(pdf, champ.libelle, champ.description)
+    format_in_2_columns(pdf, champ.libelle, champ.description)
   when 'Champs::CarteChamp'
-    format_in_2_lines(pdf, champ.libelle, champ.to_feature_collection.to_json)
+    format_in_2_columns(pdf, champ.libelle, champ.to_feature_collection.to_json)
   when 'Champs::SiretChamp'
     pdf.font 'marianne', style: :bold, size: 9 do
       pdf.text champ.libelle
@@ -105,10 +105,10 @@ def render_single_champ(pdf, champ)
     pdf.text "\n"
   when 'Champs::NumberChamp'
     value = number_with_delimiter(champ.to_s)
-    format_in_2_lines(pdf, champ.libelle, value)
+    format_in_2_columns(pdf, champ.libelle, value)
   else
     value = champ.to_s.empty? ? 'Non communiqué' : champ.to_s
-    format_in_2_lines(pdf, champ.libelle, value)
+    format_in_2_columns(pdf, champ.libelle, value)
   end
 end
 
@@ -181,7 +181,7 @@ prawn_document(page_size: "A4") do |pdf|
   pdf.text "Ce dossier est <b>#{dossier_display_state(@dossier, lower: true)}</b>.", inline_format: true
   pdf.text "\n"
   if @dossier.motivation.present?
-    format_in_2_lines(pdf, "Motif de la décision", @dossier.motivation)
+    format_in_2_columns(pdf, "Motif de la décision", @dossier.motivation)
   end
   add_title(pdf, 'Historique')
   add_etats_dossier(pdf, @dossier)


### PR DESCRIPTION
Extracted from #5700: Currently Identity fields are displayed on two columns, but Dossier fields were displayed on two lines.

This was because of a bug in format_in_2_columns, where the multiple- lines fields were not handled properly.

This has been fixed a while back by @maatinito, so we can now enable two-columns formatting even for Dossier fields.

![Screenshot of the fields on two lines](https://user-images.githubusercontent.com/15379878/96657996-4637c880-12df-11eb-8ed8-f915096c082f.png)

/cc @maatinito 