### PR TITLE
detect staging env

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -110,7 +110,7 @@ module ApplicationHelper
   end
 
   def staging?
-    ENV['APP_NAME'] == 'tps_dev'
+    Rails.application.config.ds_env == 'staging'
   end
 
   def contact_link(title, options = {})

--- a/config/application.rb
+++ b/config/application.rb
@@ -73,7 +73,9 @@ module TPS
     config.middleware.use Rack::Attack
     config.middleware.use Flipper::Middleware::Memoizer, preload_all: true
 
-    config.ds_weekly_overview = ENV['APP_NAME'] == 'tps'
+    config.ds_env = ENV.fetch('DS_ENV', Rails.env)
+
+    config.ds_weekly_overview = Rails.env.production? && config.ds_env != 'staging'
 
     config.ds_autosave = {
       debounce_delay: 3000,

--- a/config/env.example
+++ b/config/env.example
@@ -1,9 +1,3 @@
-# 3 valeurs:
-#   * tps: environnement de production
-#   * tps_dev: environnement de pre-production
-#   * tps_local: machine de développeur
-APP_NAME="tps_local"
-
 # Nom d'hôte de l'appli
 #   * Pour du dev local: localhost:3000
 #   * pour de la preprod: preprod.ds.organisme.fr (par exemple)

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -6,6 +6,8 @@ APPLICATION_NAME="demarches-simplifiees.fr"
 APPLICATION_SHORTNAME="d-s.fr"
 APPLICATION_BASE_URL="https://www.demarches-simplifiees.fr"
 
+DS_ENV="staging"
+
 # Utilisation de France Connect
 # FRANCE_CONNECT_ENABLED="disabled" # "enabled" par défaut
 


### PR DESCRIPTION
close #5493 

Cette PR permet de détecter si l'environnement courant est un environnement de staging.

Pour indiquer que l'environnement courant est un environnement de staging, positioner la variable d'environnement `DS_ENV`à `staging`
Si `DS_ENV` n'est pas valorisé, il prend la valeur par défaut de `Rails.env`

- ajout de la variable DS_ENV
- suppression de la variable d'environnement APP_NAME
