### PR TITLE
db: add last part of ActiveStorage::Blob migration

### DIFF
--- a/db/migrate/20210330112235_add_not_null_service_name_to_active_storage_blobs.rb
+++ b/db/migrate/20210330112235_add_not_null_service_name_to_active_storage_blobs.rb
@@ -1,0 +1,21 @@
+class AddNotNullServiceNameToActiveStorageBlobs < ActiveRecord::Migration[6.1]
+  def up
+    unless column_exists?(:active_storage_blobs, :service_name, null: false)
+      if (configured_service = ActiveStorage::Blob.service.name)
+        # First backfill the remaining data.
+        # (It should be fast, because the previous migration already backfilled almost all of it.)
+        say_with_time('fill missings ActiveStorage::Blob.service_name. This could take a while…') do
+          # rubocop:disable DS/Unscoped
+          ActiveStorage::Blob.unscoped.where(service_name: nil).update_all service_name: configured_service
+          # rubocop:enable DS/Unscoped
+        end
+      end
+
+      change_column :active_storage_blobs, :service_name, :string, null: false
+    end
+  end
+
+  def down
+    change_column :active_storage_blobs, :service_name, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_18_090001) do
+ActiveRecord::Schema.define(version: 2021_03_30_112235) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define(version: 2021_03_18_090001) do
     t.bigint "byte_size", null: false
     t.string "checksum", null: false
     t.datetime "created_at", null: false
-    t.string "service_name"
+    t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 


### PR DESCRIPTION
On DS, we split the ActiveStorage schema migration from Rails 6.1 into two migrations:
1. one for adding the column and filling the data asynchronousely
2. one for marking the column as non-null

This is the second part of this migration: it marks the column as non-null.