### PR TITLE
Simplify export unicity check and use create_or_find_by

### DIFF
--- a/db/migrate/20210331123709_add_cache_key_to_exports.rb
+++ b/db/migrate/20210331123709_add_cache_key_to_exports.rb
@@ -1,0 +1,6 @@
+class AddCacheKeyToExports < ActiveRecord::Migration[6.1]
+  def change
+    add_column :exports, :key, :text
+    add_index :exports, [:format, :key], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_30_112235) do
+ActiveRecord::Schema.define(version: 2021_03_31_123709) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -354,6 +354,8 @@ ActiveRecord::Schema.define(version: 2021_03_30_112235) do
     t.string "format", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "key"
+    t.index ["format", "key"], name: "index_exports_on_format_and_key", unique: true
   end
 
   create_table "exports_groupe_instructeurs", force: :cascade do |t|

--- a/spec/controllers/instructeurs/procedures_controller_spec.rb
+++ b/spec/controllers/instructeurs/procedures_controller_spec.rb
@@ -441,7 +441,7 @@ describe Instructeurs::ProceduresController, type: :controller do
 
     context 'when the export is not ready' do
       before do
-        Export.create(format: :csv, groupe_instructeurs: [gi_1])
+        create(:export, groupe_instructeurs: [gi_1])
       end
 
       it 'displays an notice' do
@@ -451,9 +451,7 @@ describe Instructeurs::ProceduresController, type: :controller do
     end
 
     context 'when the export is ready' do
-      let!(:export) do
-        Export.create(format: :csv, groupe_instructeurs: [gi_1])
-      end
+      let!(:export) { create(:export, groupe_instructeurs: [gi_1]) }
 
       before do
         export.file.attach(io: StringIO.new('export'), filename: 'file.csv')
@@ -466,9 +464,7 @@ describe Instructeurs::ProceduresController, type: :controller do
     end
 
     context 'when another export is ready' do
-      let!(:export) do
-        Export.create(format: :csv, groupe_instructeurs: [gi_0, gi_1])
-      end
+      let!(:export) { create(:export, groupe_instructeurs: [gi_0, gi_1]) }
 
       before do
         export.file.attach(io: StringIO.new('export'), filename: 'file.csv')

--- a/spec/factories/export.rb
+++ b/spec/factories/export.rb
@@ -2,5 +2,9 @@ FactoryBot.define do
   factory :export do
     format { :csv }
     groupe_instructeurs { [association(:groupe_instructeur)] }
+
+    after(:build) do |export, _evaluator|
+      export.key = Export.generate_cache_key(export.groupe_instructeurs)
+    end
   end
 end

--- a/spec/models/export_spec.rb
+++ b/spec/models/export_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Export, type: :model do
     let(:groupe_instructeur) { create(:groupe_instructeur) }
 
     context 'when everything is ok' do
-      let(:export) { build(:export) }
+      let(:export) { build(:export, groupe_instructeurs: [groupe_instructeur]) }
 
       it { expect(export.save).to be true }
     end
@@ -15,7 +15,7 @@ RSpec.describe Export, type: :model do
     end
 
     context 'when format is missing' do
-      let(:export) { build(:export, format: nil) }
+      let(:export) { build(:export, format: nil, groupe_instructeurs: [groupe_instructeur]) }
 
       it { expect(export.save).to be false }
     end
@@ -46,7 +46,7 @@ RSpec.describe Export, type: :model do
     let!(:gi_3) { create(:groupe_instructeur, procedure: procedure) }
 
     context 'when an export is made for one groupe instructeur' do
-      let!(:export) { Export.create(format: :csv, groupe_instructeurs: [gi_1, gi_2]) }
+      let!(:export) { create(:export, groupe_instructeurs: [gi_1, gi_2]) }
 
       it { expect(Export.find_for_format_and_groupe_instructeurs(:csv, [gi_1])).to eq(nil) }
       it { expect(Export.find_for_format_and_groupe_instructeurs(:csv, [gi_2, gi_1])).to eq(export) }


### PR DESCRIPTION
C'est une proposition. Je trouve que ça simplifie le code et réduit le risque de race conditions. Étant donné que nous avons beaucoup de problèmes mystérieux sur les exports je pense que ça vaut le coup d'essayer.