### PR TITLE
Cleanup Dossier ↔︎ Champs inverse relationships

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -365,7 +365,7 @@ module Users
         @dossier.champs.filter(&:repetition?).each do |champ|
           champ.champs = champ.champs.filter(&:persisted?)
         end
-        if @dossier.champs.any?(&:changed?)
+        if @dossier.champs.any?(&:changed_for_autosave?)
           @dossier.last_champ_updated_at = Time.zone.now
         end
         if !@dossier.save

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -360,8 +360,8 @@ module Users
 
       if champs_params[:dossier]
         @dossier.assign_attributes(champs_params[:dossier])
-        # FIXME in some cases a removed repetition bloc row is submitted.
-        # In this case it will be trated as a new records and action will fail.
+        # FIXME: in some cases a removed repetition bloc row is submitted.
+        # In this case it will be treated as a new record, and the action will fail.
         @dossier.champs.filter(&:repetition?).each do |champ|
           champ.champs = champ.champs.filter(&:persisted?)
         end

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -18,7 +18,7 @@
 #  type_de_champ_id               :integer
 #
 class Champ < ApplicationRecord
-  belongs_to :dossier, -> { with_discarded }, inverse_of: :champs, touch: true, optional: false
+  belongs_to :dossier, -> { with_discarded }, inverse_of: false, touch: true, optional: false
   belongs_to :type_de_champ, inverse_of: :champ, optional: false
   belongs_to :parent, class_name: 'Champ', optional: true
   has_many :commentaires

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -65,8 +65,8 @@ class Dossier < ApplicationRecord
   has_one_attached :justificatif_motivation
   has_one_attached :pdf_export_for_instructeur
 
-  has_many :champs, -> { root.public_ordered }, inverse_of: :dossier, dependent: :destroy
-  has_many :champs_private, -> { root.private_ordered }, class_name: 'Champ', inverse_of: :dossier, dependent: :destroy
+  has_many :champs, -> { root.public_ordered }, inverse_of: false, dependent: :destroy
+  has_many :champs_private, -> { root.private_ordered }, class_name: 'Champ', inverse_of: false, dependent: :destroy
   has_many :commentaires, inverse_of: :dossier, dependent: :destroy
   has_many :invites, dependent: :destroy
   has_many :follows, -> { active }, inverse_of: :dossier


### PR DESCRIPTION
This PR ensures the Dossier <-> Champs inverse relationship is not wrong. (For now this works, but it breaks under Rails 6.1 when `has_many_inversed` is enabled).

The issue is that `Dossier.champs` is not really an inverse of `Champs.dossier`: when a Champ record is created, it should not always be added to dossier.champs (for instance if the champ is private).

The issue is fixed by removing the inverse relationship.

