### PR TITLE
Show section numbers only if none of sections start with numbers

### DIFF
--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -45,6 +45,7 @@ class Champ < ApplicationRecord
     :repetition?,
     :dossier_link?,
     :titre_identite?,
+    :header_section?,
     to: :type_de_champ
 
   scope :updated_since?, -> (date) { where('champs.updated_at > ?', date) }
@@ -84,6 +85,10 @@ class Champ < ApplicationRecord
     else
       dossier&.champs_private
     end
+  end
+
+  def sections
+    siblings.filter(&:header_section?)
   end
 
   def mandatory_and_blank?

--- a/app/models/champs/header_section_champ.rb
+++ b/app/models/champs/header_section_champ.rb
@@ -23,22 +23,18 @@ class Champs::HeaderSectionChamp < Champ
   end
 
   def libelle_with_section_index
-    if libelle_with_section_index? || siblings.any?(&:libelle_with_section_index?)
-      libelle
-    else
+    if sections.none?(&:libelle_with_section_index?)
       "#{section_index}. #{libelle}"
+    else
+      libelle
     end
   end
-
-  private
 
   def libelle_with_section_index?
     libelle =~ /^\d/
   end
 
   def section_index
-    siblings
-      .filter { |c| c.type_champ == TypeDeChamp.type_champs.fetch(:header_section) }
-      .index(self) + 1
+    sections.index(self) + 1
   end
 end

--- a/app/models/champs/header_section_champ.rb
+++ b/app/models/champs/header_section_champ.rb
@@ -22,6 +22,20 @@ class Champs::HeaderSectionChamp < Champ
     # The user cannot enter any information here so it doesn’t make much sense to search
   end
 
+  def libelle_with_section_index
+    if libelle_with_section_index? || siblings.any?(&:libelle_with_section_index?)
+      libelle
+    else
+      "#{section_index}. #{libelle}"
+    end
+  end
+
+  private
+
+  def libelle_with_section_index?
+    libelle =~ /^\d/
+  end
+
   def section_index
     siblings
       .filter { |c| c.type_champ == TypeDeChamp.type_champs.fetch(:header_section) }

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -174,6 +174,10 @@ class TypeDeChamp < ApplicationRecord
     ])
   end
 
+  def header_section?
+    type_champ == TypeDeChamp.type_champs.fetch(:header_section)
+  end
+
   def linked_drop_down_list?
     type_champ == TypeDeChamp.type_champs.fetch(:linked_drop_down_list)
   end

--- a/app/views/shared/dossiers/editable_champs/_header_section.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_header_section.html.haml
@@ -1,5 +1,2 @@
 %h2.header-section
-  - libelle_starts_with_number = (champ.libelle =~ /^\d/)
-  - if !libelle_starts_with_number
-    = "#{champ.section_index}."
-  = champ.libelle
+  = champ.libelle_with_section_index


### PR DESCRIPTION
Suit à une discussion au support il me semble que c'est un changement plutôt raisonnable et qui évite des résultats "surprenants". J'ai sous les eux l'exemple d'un formulaire ou certaines sections ont des numéros et d'autres pas et le résultat est juste incompréhensible – quand on m’a envoyé le screenshot j'ai passé 20min à me creuser la tête sur ce qui se passait. Mais si vous avez de meilleures suggestions de comment gérer les edge cases je suis preneur.