### PR TITLE
#6050 - Doc: add ACCESSIBILITE_URL to env.example.optional file

### DIFF
--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -35,6 +35,9 @@ DS_ENV="staging"
 # Personnalisation d'instance - URL du site web FAQ
 # FAQ_URL="https://faq.demarches-simplifiees.fr"
 
+# Personnalisation d'instance - URL de la déclaration d'accessibilité
+# ACCESSIBILITE_URL=""
+
 # Personnalisation d'instance - Page externe "Disponibilité" (status page)
 # STATUS_PAGE_URL=""
 


### PR DESCRIPTION
Fixed #6050 "Documentation pour la variable d'environnement optionnelle ACCESSIBILITE_URL" / @adullact

-----------------------------

##  Actuellement

Une variable d'environnement optionnelle `ACCESSIBILITE_URL` a été récemment ajoutée :

- ajout via la PR #6039 et le commit [d89dc785](https://github.com/betagouv/demarches-simplifiees.fr/commit/d89dc785f0d6ecab646b094fd62ae8a2209ee6f3#diff-9b2c01427881eb6769cb5337e8f910257f13923e6335386ce21e176f1f03b1b0)
- disponible depuis le tag [2021-04-02-01](https://github.com/betagouv/demarches-simplifiees.fr/releases/tag/2021-04-02-01)
- code source: [config/initializers/urls.rb](https://github.com/betagouv/demarches-simplifiees.fr/blob/main/config/initializers/urls.rb#L28)
```ruby
ACCESSIBILITE_URL = ENV.fetch("ACCESSIBILITE_URL", [DOC_URL, "declaration-daccessibilite"].join("/"))
```

Actuellement, cette variable d'environnement optionnelle `ACCESSIBILITE_URL`   ne semble pas présente dans le fichier [`config/env.example`](https://github.com/betagouv/demarches-simplifiees.fr/blob/main/config/env.example) ou le fichier  [`env.example.optional`](https://github.com/betagouv/demarches-simplifiees.fr/blob/main/config/env.example.optional).

L'ajout cette variable d'environnement optionnelle  dans le fichier `.env` d'une instance DS fonctionne très bien et permet facilement de modifier l'URL par défaut du lien "**Accessibilité**".

Le lien est visible dans le pied de page de toutes les pages et pointe par défaut vers la [déclaration d'accessibilité](https://doc.demarches-simplifiees.fr/declaration-daccessibilite) sur le site `doc.demarches-simplifiees.fr`

| Pied de page sur la page d'accueil | Pied de page sur une démarche |
|---|----|
| ![Screenshot_2021-04-05 demarches-simplifiees fr](https://user-images.githubusercontent.com/6709977/113581686-c5b81a80-9627-11eb-8f84-7275d488d26a.png)|![Screenshot_2021-04-05 demarches-simplifiees fr(1)](https://user-images.githubusercontent.com/6709977/113581685-c51f8400-9627-11eb-8d73-bf8faf3f8610.png)|



## Correctif proposé

Compléter la documentation sur les variables d'environnements en ajoutant cette  variable d'environnement optionnelle `ACCESSIBILITE_URL`  dans le fichier [`env.example.optional`](https://github.com/betagouv/demarches-simplifiees.fr/blob/main/config/env.example.optional)
```diff
+# Personnalisation d'instance - URL de la déclaration d'accessibilité
+# ACCESSIBILITE_URL=""
+
 # Personnalisation d'instance - Page externe "Disponibilité" (status page)
 # STATUS_PAGE_URL=""
```
