### PR TITLE
Diminue l'impact de flipper sur les temps de réponses

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -309,7 +309,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_locale
-    if feature_enabled?(:localization)
+    if ENV.fetch('LOCALIZATION_ENABLED', 'false') == 'true'
       I18n.locale = http_accept_language.compatible_language_from(I18n.available_locales)
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
   before_action :set_current_roles
   before_action :set_sentry_user
   before_action :redirect_if_untrusted
-  before_action :reject, if: -> { feature_enabled?(:maintenance_mode) }
+  before_action :reject, if: -> { ENV.fetch("MAINTENANCE_MODE", 'false') == 'true' }
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   before_action :staging_authenticate

--- a/app/lib/api_entreprise/api.rb
+++ b/app/lib/api_entreprise/api.rb
@@ -113,13 +113,7 @@ class APIEntreprise::API
   end
 
   def self.url(resource_name, siret_or_siren)
-    base_url = [API_ENTREPRISE_URL, resource_name, siret_or_siren].join("/")
-
-    if Flipper.enabled?(:insee_api_v3)
-      base_url += "?with_insee_v3=true"
-    end
-
-    base_url
+    [API_ENTREPRISE_URL, resource_name, siret_or_siren].join("/")
   end
 
   def self.params(siret_or_siren, procedure_id, user_id)

--- a/app/views/layouts/_coronavirus_banner.html.haml
+++ b/app/views/layouts/_coronavirus_banner.html.haml
@@ -1,8 +1,0 @@
-#strike-banner.site-banner
-  .container
-    .site-banner-icon ⚠️
-    .site-banner-text
-      %strong
-        En raison de l’épidémie du coronavirus, les services fonctionnent en mode dégradé.
-      %br
-      Les délais de prise en charge des dossiers ou de réponses aux questions pourront être perturbés durant cette période.

--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -3,14 +3,6 @@
 - dossier = controller.try(:dossier_for_help)
 - procedure = controller.try(:procedure_for_help)
 
--# only display the coronavirus to usagers (instructeurs know there are delays) when they are logged in, or on the public pages.
-- if user_signed_in?
-  - if dossier.present? && dossier.procedure.feature_enabled?(:coronavirus_banner)
-    = render partial: 'layouts/coronavirus_banner'
-- else
-  - if procedure.present? && procedure.feature_enabled?(:coronavirus_banner)
-    = render partial: 'layouts/coronavirus_banner'
-
 %header.new-header{ class: current_page?(root_path) ? nil : "new-header-with-border", role: 'banner' }
   .header-inner-content
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -23,9 +23,6 @@
 
     = Gon::Base.render_data(camel_case: true, init: true, nonce:  request.content_security_policy_nonce)
 
-    - if Rails.env.development? && feature_enabled?(:xray)
-      = stylesheet_link_tag :xray
-
   %body{ id: content_for(:page_id), class: browser.platform.ios? ? 'ios' : nil }
     .page-wrapper
       = render partial: "layouts/outdated_browser_banner"
@@ -42,8 +39,5 @@
 
       - if content_for?(:footer)
         = content_for(:footer)
-
-      - if Rails.env.development? && feature_enabled?(:xray)
-        = javascript_include_tag :xray
 
       = yield :charts_js

--- a/config/application.rb
+++ b/config/application.rb
@@ -77,7 +77,8 @@ module TPS
     end
 
     config.middleware.use Rack::Attack
-    config.middleware.use Flipper::Middleware::Memoizer, preload_all: true
+    config.middleware.use Flipper::Middleware::Memoizer,
+      preload: [:instructeur_bypass_email_login_token]
 
     config.ds_env = ENV.fetch('DS_ENV', Rails.env)
 

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -67,3 +67,5 @@ DS_ENV="staging"
 # Personnalisation d'instance - fichier utilisé pour poser un filigrane sur les pièces d'identité
 # WATERMARK_FILE=""
 
+# Active le mode maintenance
+# MAINTENANCE_MODE="true"

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -69,3 +69,6 @@ DS_ENV="staging"
 
 # Active le mode maintenance
 # MAINTENANCE_MODE="true"
+
+# Active la localisation
+# LOCALIZATION_ENABLED="true"

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -35,7 +35,6 @@ features = [
   :instructeur_bypass_email_login_token,
   :localization,
   :make_experts_notifiable,
-  :mini_profiler,
   :procedure_routage_api,
   :xray
 ]

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -34,7 +34,6 @@ features = [
   :insee_api_v3,
   :instructeur_bypass_email_login_token,
   :localization,
-  :maintenance_mode,
   :make_experts_notifiable,
   :mini_profiler,
   :procedure_routage_api,

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -32,7 +32,6 @@ features = [
   :expert_not_allowed_to_invite,
   :hide_instructeur_email,
   :instructeur_bypass_email_login_token,
-  :localization,
   :make_experts_notifiable,
   :procedure_routage_api
 ]

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -35,8 +35,7 @@ features = [
   :instructeur_bypass_email_login_token,
   :localization,
   :make_experts_notifiable,
-  :procedure_routage_api,
-  :xray
+  :procedure_routage_api
 ]
 
 def database_exists?

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -28,7 +28,6 @@ features = [
   :administrateur_routage,
   :administrateur_web_hook,
   :carte_ign,
-  :coronavirus_banner,
   :dossier_pdf_vide,
   :expert_not_allowed_to_invite,
   :hide_instructeur_email,

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -31,7 +31,6 @@ features = [
   :dossier_pdf_vide,
   :expert_not_allowed_to_invite,
   :hide_instructeur_email,
-  :insee_api_v3,
   :instructeur_bypass_email_login_token,
   :localization,
   :make_experts_notifiable,


### PR DESCRIPTION
- supprime les clés inutilisées
- utilise une variable d'env quand l'activation est en tout ou rien
- ne précharge que ce qui est nécessaire sur la plupart des pages