### PR TITLE
suppression de la colonne obsolete procedure_id de la table assign_to

### DIFF
--- a/app/models/assign_to.rb
+++ b/app/models/assign_to.rb
@@ -11,7 +11,6 @@
 #  updated_at                                  :datetime
 #  groupe_instructeur_id                       :bigint
 #  instructeur_id                              :integer
-#  procedure_id                                :integer
 #
 class AssignTo < ApplicationRecord
   self.ignored_columns = [:procedure_id]

--- a/db/migrate/20210409075105_remove_procedure_id_from_assign_tos.rb
+++ b/db/migrate/20210409075105_remove_procedure_id_from_assign_tos.rb
@@ -1,0 +1,5 @@
+class RemoveProcedureIdFromAssignTos < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :assign_tos, :procedure_id, :number
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_07_174523) do
+ActiveRecord::Schema.define(version: 2021_04_09_075105) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,7 +83,6 @@ ActiveRecord::Schema.define(version: 2021_04_07_174523) do
 
   create_table "assign_tos", id: :serial, force: :cascade do |t|
     t.integer "instructeur_id"
-    t.integer "procedure_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.bigint "groupe_instructeur_id"
@@ -93,9 +92,7 @@ ActiveRecord::Schema.define(version: 2021_04_07_174523) do
     t.boolean "instant_email_dossier_notifications_enabled", default: false, null: false
     t.index ["groupe_instructeur_id", "instructeur_id"], name: "unique_couple_groupe_instructeur_instructeur", unique: true
     t.index ["groupe_instructeur_id"], name: "index_assign_tos_on_groupe_instructeur_id"
-    t.index ["instructeur_id", "procedure_id"], name: "index_assign_tos_on_instructeur_id_and_procedure_id", unique: true
     t.index ["instructeur_id"], name: "index_assign_tos_on_instructeur_id"
-    t.index ["procedure_id"], name: "index_assign_tos_on_procedure_id"
   end
 
   create_table "attestation_templates", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
la liaison se fait grâce au groupe instructeur