### PR TITLE
Improuve export UI

### DIFF
--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -169,6 +169,11 @@ module Instructeurs
 
       export = Export.find_or_create_export(export_format, groupe_instructeurs)
 
+      if export.ready? && export.old? && params[:force_export]
+        export.destroy
+        export = Export.find_or_create_export(export_format, groupe_instructeurs)
+      end
+
       if export.ready?
         respond_to do |format|
           format.js do

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -9,7 +9,7 @@
 #  updated_at :datetime         not null
 #
 class Export < ApplicationRecord
-  MAX_DUREE_CONSERVATION_EXPORT = 1.hour
+  MAX_DUREE_CONSERVATION_EXPORT = 3.hours
 
   enum format: {
     csv: 'csv',
@@ -43,6 +43,10 @@ class Export < ApplicationRecord
 
   def ready?
     file.attached?
+  end
+
+  def old?
+    updated_at < 20.minutes.ago
   end
 
   def self.find_or_create_export(format, groupe_instructeurs)

--- a/app/views/instructeurs/procedures/_download_dossiers.html.haml
+++ b/app/views/instructeurs/procedures/_download_dossiers.html.haml
@@ -7,11 +7,12 @@
         - [[xlsx_export, :xlsx], [ods_export, :ods], [csv_export, :csv]].each do |(export, format)|
           %li
             - if export.nil?
-              - export_text = "Demander un export au format .#{format}"
-              - if format == :csv
-                - export_text = "Demander un export au format .#{format}<br/>(uniquement les dossiers, sans les champs répétables)".html_safe
-              = link_to export_text, download_export_instructeur_procedure_path(procedure, export_format: format), remote: true
+              = link_to t("#{format}_html", scope: [:instructeurs, :procedure, :export_stale]), download_export_instructeur_procedure_path(procedure, export_format: format), remote: true
             - elsif export.ready?
-              = link_to "Télécharger l'export au format .#{format}", export.file.service_url, target: "_blank", rel: "noopener"
+              = link_to t(:export_ready_html, export_time: time_ago_in_words(export.updated_at), export_format: ".#{format}", scope: [:instructeurs, :procedure]), export.file.service_url, target: "_blank", rel: "noopener"
+              - if export.old?
+                = button_to download_export_instructeur_procedure_path(procedure, export_format: format, force_export: true), class: "button small", style: "padding-right: 2px", title: t(:short, export_format: ".#{format}", scope: [:instructeurs, :procedure, :export_stale]), remote: true, method: :get, params: { export_format: format, force_export: true } do
+                  .icon.retry
             - else
               %span{ 'data-export-poll-url': download_export_instructeur_procedure_path(procedure, export_format: format, no_progress_notification: true) }
+                = t(:export_pending_html, export_time: time_ago_in_words(export.created_at), export_format: ".#{format}", scope: [:instructeurs, :procedure])

--- a/config/locales/views/instructeurs/fr.yml
+++ b/config/locales/views/instructeurs/fr.yml
@@ -1,0 +1,10 @@
+fr:
+  instructeurs:
+    procedure:
+      export_stale:
+        short: Demander un export au format %{export_format}
+        csv_html: Demander un export au format .csv<br>(uniquement les dossiers, sans les champs répétables)
+        xlsx_html: Demander un export au format .xlsx
+        ods_html: Demander un export au format .ods
+      export_ready_html: Télécharger l’export au format %{export_format}<br>(généré il y a %{export_time})
+      export_pending_html: Un export au format %{export_format} est en train d’être généré<br>(demandé il y a %{export_time})


### PR DESCRIPTION
- Afficher un message clair lorsqu’un export est en train d’être généré et depuis combien de temps
- Afficher le moment de la création de l’export
- Permettre de relancer les exports générés il y a plus de 20 minutes
- Augmenter la durée de vie d’un export – aujourd’hui c’est 1 heure ce qui fait que pour les exports qui mettent 30min à se générer il reste très peu de temps pour consulter l’export. Sachant que maintenant il est possible de redemander un export si l’instructeur considère qu’il est trop vieux je pense que cette augmentation ne posera pas de problèmes

![CleanShot 2021-04-08 at 12 24 21](https://user-images.githubusercontent.com/12428/114018696-6fd0b600-9865-11eb-89c1-50cb3aa5c848.png)