### PR TITLE
Corrige l'affichage des emails envoyés dans le Manager

### DIFF
--- a/app/controllers/manager/users_controller.rb
+++ b/app/controllers/manager/users_controller.rb
@@ -49,14 +49,7 @@ module Manager
 
     def emails
       @user = User.find(params[:id])
-
-      transactionnal_api = ::SibApiV3Sdk::TransactionalEmailsApi.new
-
-      @transactionnal_emails = transactionnal_api.get_transac_emails_list(email: @user.email)
-      @events = transactionnal_api.get_email_event_report(email: @user.email, days: 30)
-
-    rescue ::SibApiV3Sdk::ApiError => e
-      flash.alert = "Impossible de récupérer les emails de cet utilisateur chez Sendinblue : #{e.message}"
+      @sent_mails = Sendinblue::API.new.sent_mails(@user.email)
     end
 
     def unblock_user

--- a/app/controllers/manager/users_controller.rb
+++ b/app/controllers/manager/users_controller.rb
@@ -52,14 +52,14 @@ module Manager
       @sent_mails = Sendinblue::API.new.sent_mails(@user.email)
     end
 
-    def unblock_user
-      @user = User.find(params[:id])
-
-      transactionnal_api = ::SibApiV3Sdk::TransactionalEmailsApi.new
-      transactionnal_api.smtp_blocked_contacts_email_delete(@user.email)
-
-    rescue ::SibApiV3Sdk::ApiError => e
-      flash.alert = "Impossible de débloquer cet email auprès de Sendinblue : #{e.message}"
+    def unblock_email
+      @user = User.find(params[:user_id])
+      if Sendinblue::API.new.unblock_user(@user.email)
+        flash.notice = "L'adresse email a été débloquée auprès de Sendinblue"
+      else
+        flash.alert = "Impossible de débloquer cette addresse email auprès de Sendinblue"
+      end
+      redirect_to emails_manager_user_path(@user)
     end
   end
 end

--- a/app/controllers/manager/users_controller.rb
+++ b/app/controllers/manager/users_controller.rb
@@ -49,7 +49,18 @@ module Manager
 
     def emails
       @user = User.find(params[:id])
-      @sent_mails = Sendinblue::API.new.sent_mails(@user.email)
+
+      email_services = [
+        Mailjet::API.new,
+        Sendinblue::API.new
+      ]
+
+      @sent_mails = email_services
+        .filter(&:properly_configured?)
+        .map { |api| api.sent_mails(@user.email) }
+        .flatten
+        .sort_by(&:delivered_at)
+        .reverse
     end
 
     def unblock_email

--- a/app/helpers/email_helper.rb
+++ b/app/helpers/email_helper.rb
@@ -1,9 +1,8 @@
 module EmailHelper
-  def event_color_code(email_events)
-    unique_events = email_events.map(&:event)
-    if unique_events.include?('delivered')
+  def status_color_code(status)
+    if status.include?('delivered')
       return 'email-sent'
-    elsif unique_events.include?('blocked') || unique_events.include?('hardBounces')
+    elsif status.include?('blocked') || status.include?('hardBounces')
       return 'email-blocked'
     else
       return ''

--- a/app/lib/mailjet/api.rb
+++ b/app/lib/mailjet/api.rb
@@ -1,0 +1,37 @@
+class Mailjet::API
+  def properly_configured?
+    [Mailjet.config.api_key, Mailjet.config.secret_key].all?(&:present?)
+  end
+
+  # Get messages sent to a user through SendInBlue.
+  #
+  # Returns an array of SentMail objects.
+  def sent_mails(email_address)
+    contact = Mailjet::Contact.find(email_address)
+    if contact.nil?
+      Rails.logger.info "Mailjet::API: no contact found for email address '#{email_address}'"
+      return []
+    end
+
+    messages = Mailjet::Message.all(
+      contact: contact.attributes['id'],
+      from_ts: 30.days.ago.to_datetime.rfc3339,
+      show_subject: true
+    )
+
+    messages.map do |message|
+      SentMail.new(
+        from: nil,
+        to: email_address,
+        subject: message.attributes['subject'],
+        delivered_at: message.attributes['arrived_at'],
+        status: message.attributes['status'],
+        service_name: 'Mailjet',
+        external_url: 'https://app.mailjet.com/contacts/subscribers/contact_list'
+      )
+    end
+  rescue Mailjet::ApiError => e
+    Rails.logger.error e.message
+    []
+  end
+end

--- a/app/lib/sendinblue/api.rb
+++ b/app/lib/sendinblue/api.rb
@@ -55,6 +55,15 @@ class Sendinblue::API
     []
   end
 
+  def unblock_user(email_address)
+    client = ::SibApiV3Sdk::TransactionalEmailsApi.new
+    client.smtp_blocked_contacts_email_delete(email_address)
+    true
+  rescue ::SibApiV3Sdk::ApiError => e
+    Rails.logger.error e.message
+    false
+  end
+
   def run
     hydra.run
     @hydra = nil

--- a/app/lib/sent_mail.rb
+++ b/app/lib/sent_mail.rb
@@ -1,0 +1,3 @@
+# Represent an email sent using an external API
+class SentMail < Struct.new(:from, :to, :subject, :delivered_at, :status, :service_name, :external_url, keyword_init: true)
+end

--- a/app/views/manager/users/emails.html.erb
+++ b/app/views/manager/users/emails.html.erb
@@ -18,9 +18,9 @@
 
 <section class="main-content__body">
   <h2>Historique des email</h2>
-<% if @transactionnal_emails.present? %>
+<% if @sent_mails.present? %>
   <p>
-  Cet historique contient les 30 derniers jours. Pour un recherche plus fine, il faut <a href="https://app-smtp.sendinblue.com/log">fouiller les logs</a>.
+  Cet historique contient les 30 derniers jours. Pour un recherche plus fine, il faut fouiller les <a href="https://app-smtp.sendinblue.com/log">logs de SendInblue</a> ou de Mailjet.
   </p>
   <table>
     <thead>
@@ -29,41 +29,44 @@
         Émetteur
       </th>
       <th class="cell-label cell-label--string cell-label--false" scope="col" role="columnheader" aria-sort="none">
-        Sujet
+        Objet
       </th>
       <th class="cell-label cell-label--string cell-label--false" scope="col" role="columnheader" aria-sort="none">
         Date
       </th>
+      <th class="cell-label cell-label--string cell-label--false" scope="col" role="columnheader" aria-sort="none">
+        Statut
+      </th>
+      <th class="cell-label cell-label--string cell-label--false" scope="col" role="columnheader" aria-sort="none">
+        Prestataire
+      </th>
     </tr>
     </thead>
     <tbody>
-      <% @transactionnal_emails&.transactional_emails&.reverse&.each do |email| %>
-        <% matching_events = @events&.events&.select { |e| e.message_id == email.message_id } %>
-      <tr class="<%= event_color_code(matching_events) %>">
+      <% @sent_mails.each do |email| %>
+      <tr class="<%= status_color_code(email.status) %>">
         <td class="cell-data cell-data--string" style="">
           <%= email.from %>
         </td>
         <td class="cell-data cell-data--string" style="">
-        <%= email.subject %>
+          <%= email.subject %>
         </td>
         <td class="cell-data cell-data--string" style="text-align: center;">
-        <%= l(email.date.is_a?(String) ? Time.zone.parse(email.date) : email.date, format: '%d/%m/%y à %H:%M') %>
+          <%= l(email.delivered_at, format: :long) %>
         </td>
         <td class="cell-data cell-data--string" style="text-align: center;">
-          <ul>
-
-          <% matching_events.each do |event|%>
-          <li><%= event.event %></li>
-          <% end %>
-          </ul>
+          <%= email.status %>
+        </td>
+        <td class="cell-data cell-data--string" style="">
+          <%= link_to email.service_name, email.external_url, style: 'text-decoration: underline' %>
         </td>
       </tr>
       <% end %>
     </tbody>
   </table>
 <% else %>
-  <p>Historique indisponible. Cet email n'existe pas chez Sendinblue, ou nous n'avons pas réussi à échanger.
-    Vous pouvez éventuellement <a href="https://app-smtp.sendinblue.com/log">fouiller leurs logs</a>.</p>
+  <p>Historique indisponible. Cette adresse email n'existe pas chez nos prestataires d'envoi, ou nous n'avons pas réussi à en charger des données.
+    Vous pouvez éventuellement fouiller les <a href="https://app-smtp.sendinblue.com/log">logs de SendInBlue</a> ou de Mailjet.</p>
 <% end %>
 
   <h2>Problèmes potentiel</h2>

--- a/app/views/manager/users/emails.html.erb
+++ b/app/views/manager/users/emails.html.erb
@@ -98,8 +98,12 @@ https://www.demarches-simplifiees.fr/users/password/new
 
 Cordialement</pre>
   <% end %>
-  <p><strong>Compte <a href="https://app-smtp.sendinblue.com/block">bloqué</a> chez Sendinblue ?</strong> Vous pouvez le <%= link_to('débloquer', manager_user_unblock_email_path(@user), method: :put, class: 'button', remote: true) %>  puis lui envoyer <button class="btn btn-secondary btn-small" onclick="reveal_email('#unblock_email')">le mail suivant</button></p>
-    <pre class="hidden" id="unblock_email">
+  <p>
+    <strong>Compte <a href="https://app-smtp.sendinblue.com/block">bloqué</a> chez Sendinblue ?</strong>
+    Vous pouvez le <%= link_to('débloquer', manager_user_unblock_email_path(@user), method: :put, class: 'button') %>
+    puis lui envoyer <button class="btn btn-secondary btn-small" onclick="reveal_email('#unblock_email')">le mail suivant</button>
+  </p>
+  <pre class="hidden" id="unblock_email">
 Bonjour,
 
 votre email était bloqué par notre prestataire.
@@ -109,12 +113,18 @@ Cela peut arriver si vous, ou ceux qui gèrent vos emails, marquent nos emails c
 
 Nous vous invitons donc à autoriser les emails émis depuis demarches-simplifiees.fr
 
-Bien cordialement</pre>
-<p><strong>Problème chez Sendinblue ?</strong> Regardez leur <a href="https://status.sendinblue.com/">page de status</a>. <button class="btn btn-secondary btn-small" onclick="reveal_email('#pb-sendinblue')">Voir la suggestion d’email</button></p>
+Bien cordialement
+  </pre>
+  <p>
+    <strong>Problème chez Sendinblue ?</strong>
+    Regardez leur <a href="https://status.sendinblue.com/">page de status</a>.
+    <button class="btn btn-secondary btn-small" onclick="reveal_email('#pb-sendinblue')">Voir la suggestion d’email</button>
+  </p>
   <pre class="hidden" id="pb-sendinblue">
 Bonjour,
 Désolé, notre prestataire d'envoi d'email subit actuellement des soucis avec sa plateforme ;
 vous allez recevoir cet email sous peu.
 
-Bien cordialement,</pre>
+Bien cordialement,
+  </pre>
 </section>

--- a/app/views/manager/users/emails.html.erb
+++ b/app/views/manager/users/emails.html.erb
@@ -20,7 +20,11 @@
   <h2 style="font-size: 1.3em; margin: 24px 0 8px 0">Historique des email</h2>
 <% if @sent_mails.present? %>
   <p>
-  Cet historique contient les 30 derniers jours. Pour un recherche plus fine, il faut fouiller les <a href="https://app-smtp.sendinblue.com/log">logs de SendInblue</a> ou de Mailjet.
+  Cet historique contient les 30 derniers jours.
+    Pour un recherche plus fine, il faut fouiller les
+    <a href="https://app-smtp.sendinblue.com/log">logs de SendInblue</a>
+    ou
+    <a href="https://app.mailjet.com/contacts/subscribers/contact_list">de Mailjet</a>.
   </p>
   <table>
     <thead>
@@ -66,7 +70,11 @@
   </table>
 <% else %>
   <p>Historique indisponible. Cette adresse email n'existe pas chez nos prestataires d'envoi, ou nous n'avons pas réussi à en charger des données.
-    Vous pouvez éventuellement fouiller les <a href="https://app-smtp.sendinblue.com/log">logs de SendInBlue</a> ou de Mailjet.</p>
+    Vous pouvez éventuellement fouiller les
+    <a href="https://app-smtp.sendinblue.com/log">logs de SendInBlue</a>
+    ou
+    <a href="https://app.mailjet.com/contacts/subscribers/contact_list">de Mailjet</a>.
+  </p>
 <% end %>
 
   <h2 style="font-size: 1.3em; margin: 24px 0 8px 0">Problèmes potentiel</h2>

--- a/app/views/manager/users/emails.html.erb
+++ b/app/views/manager/users/emails.html.erb
@@ -17,7 +17,7 @@
 </header>
 
 <section class="main-content__body">
-  <h2>Historique des email</h2>
+  <h2 style="font-size: 1.3em; margin: 24px 0 8px 0">Historique des email</h2>
 <% if @sent_mails.present? %>
   <p>
   Cet historique contient les 30 derniers jours. Pour un recherche plus fine, il faut fouiller les <a href="https://app-smtp.sendinblue.com/log">logs de SendInblue</a> ou de Mailjet.
@@ -69,7 +69,7 @@
     Vous pouvez éventuellement fouiller les <a href="https://app-smtp.sendinblue.com/log">logs de SendInBlue</a> ou de Mailjet.</p>
 <% end %>
 
-  <h2>Problèmes potentiel</h2>
+  <h2 style="font-size: 1.3em; margin: 24px 0 8px 0">Problèmes potentiel</h2>
 
   <% if @user.confirmed? %>
     <p><strong>Compte activé, n'arrive pas à se connecter</strong> ? <button class="btn btn-secondary btn-small" onclick="reveal_email('#activated-cant-connect')">Voir la suggestion d’email</button></p>


### PR DESCRIPTION
## Avant

- La récupération des emails envoyés par SendInBlue était cassée
- Les emails envoyés par Mailjet n'étaient pas affichés

## Correction de SendInBlue

Pour récupérer les emails SendInBlue, on faisait deux appels : un pour récupérer les emails transactionnels, et un pour récupérer les évènements individuel (envoyé, bloqué, ouvert, ouvert, etc).

L'appel à transactional_emails ne fonctionne plus (renvoie une 200, mais pas de donnée). De fait cet appel n'est plus documenté.

Maintenant on fait un seul appel pour les évènements individuels, et on les group_by par message_id.

## Ajout de Mailjet

Les messages récupérés sont maintenant renvoyés comme un tableau de structures `SentMail`. Cela permet d'avoir une interface commune pour afficher les emails SendInBlue et Mailjet au même endroit.

## Notes

Il y a aussi du refactoring de SendInBlue (on fait passer plus de choses dans `Sendinblue::API`). Ça se relit bien commit-par-commit.