### PR TITLE
Manager : affichage et suppression des SuperAdmin

### DIFF
--- a/app/controllers/manager/super_admins_controller.rb
+++ b/app/controllers/manager/super_admins_controller.rb
@@ -1,0 +1,4 @@
+module Manager
+  class SuperAdminsController < Manager::ApplicationController
+  end
+end

--- a/app/dashboards/super_admin_dashboard.rb
+++ b/app/dashboards/super_admin_dashboard.rb
@@ -1,0 +1,39 @@
+require "administrate/base_dashboard"
+
+class SuperAdminDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    id: Field::Number,
+    email: Field::String,
+    encrypted_password: Field::String,
+    reset_password_sent_at: Field::DateTime,
+    remember_created_at: Field::DateTime,
+    sign_in_count: Field::Number,
+    current_sign_in_at: Field::DateTime,
+    last_sign_in_at: Field::DateTime,
+    current_sign_in_ip: Field::String,
+    last_sign_in_ip: Field::String,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+    failed_attempts: Field::Number,
+    locked_at: Field::DateTime
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = [:id, :email, :created_at, :updated_at, :reset_password_sent_at, :failed_attempts, :locked_at].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = [:id, :email, :created_at, :updated_at, :reset_password_sent_at, :failed_attempts, :locked_at].freeze
+
+  COLLECTION_FILTERS = {}.freeze
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,7 +52,7 @@ Rails.application.routes.draw do
 
     resources :services, only: [:index, :show]
 
-    resources :super_admins, only: [:index, :show]
+    resources :super_admins, only: [:index, :show, :destroy]
 
     post 'demandes/create_administrateur'
     post 'demandes/refuse_administrateur'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,8 @@ Rails.application.routes.draw do
 
     resources :services, only: [:index, :show]
 
+    resources :super_admins, only: [:index, :show]
+
     post 'demandes/create_administrateur'
     post 'demandes/refuse_administrateur'
 


### PR DESCRIPTION
Cette PR permet depuis le manager : 

- de lister les superadmins
- de supprimer un superadmin

![superadmin](https://user-images.githubusercontent.com/1111966/114565995-1fe15d00-9c72-11eb-8efd-d993289cf901.png)

close #6088 
close #6089 