### PR TITLE
Fix discarded destruction

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -62,6 +62,9 @@ class Dossier < ApplicationRecord
   has_one :attestation, dependent: :destroy
   has_one :france_connect_information, through: :user
 
+  # FIXME: some dossiers have more than one attestation
+  has_many :attestations, dependent: :destroy
+
   has_one_attached :justificatif_motivation
   has_one_attached :pdf_export_for_instructeur
 

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -18,6 +18,10 @@ class ProcedureRevision < ApplicationRecord
   has_many :types_de_champ, through: :revision_types_de_champ, source: :type_de_champ
   has_many :types_de_champ_private, through: :revision_types_de_champ_private, source: :type_de_champ
 
+  has_many :owned_types_de_champ, class_name: 'TypeDeChamp', foreign_key: :revision_id, dependent: :destroy, inverse_of: :revision
+  has_one :draft_procedure, class_name: 'Procedure', foreign_key: :draft_revision_id, dependent: :nullify, inverse_of: :draft_revision
+  has_one :published_procedure, class_name: 'Procedure', foreign_key: :published_revision_id, dependent: :nullify, inverse_of: :published_revision
+
   def build_champs
     types_de_champ.map(&:build_champ)
   end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1422,4 +1422,16 @@ describe Dossier do
       it { expect(dossier.api_entreprise_job_exceptions).to eq(['#<StandardError: My special exception!>']) }
     end
   end
+
+  describe "#destroy" do
+    let(:dossier) { create(:dossier) }
+    before do
+      create(:attestation, dossier: dossier)
+      create(:attestation, dossier: dossier)
+    end
+
+    it "can destroy dossier with two attestations" do
+      expect(dossier.destroy).to be_truthy
+    end
+  end
 end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -1030,4 +1030,12 @@ describe Procedure do
       it { is_expected.to be false }
     end
   end
+
+  describe "#destroy" do
+    let(:procedure) { create(:procedure, :with_type_de_champ) }
+
+    it "can destroy procedure" do
+      expect(procedure.destroy).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
Les dossiers et démarches en attente de suppression ne sont plus supprimés depuis un moment à cause des foreign key. Nous avons accumulé quelques milliers de dossiers et démarches discarded.

https://sentry.io/organizations/demarches-simplifiees/issues/?project=1429550&query=is%3Aunresolved+discarded&statsPeriod=14d