### PR TITLE
#6092 - Test: use APPLICATION_NAME to deal nicely with custom configuration

### DIFF
--- a/spec/features/users/sign_up_spec.rb
+++ b/spec/features/users/sign_up_spec.rb
@@ -19,7 +19,7 @@ feature 'Signing up:' do
 
     before do
       visit commencer_path(path: procedure.path)
-      click_on 'Créer un compte demarches-simplifiees.fr'
+      click_on "Créer un compte #{APPLICATION_NAME}"
       expect(page).to have_selector('.suspect-email', visible: false)
       fill_in 'Email', with: 'bidou@yahoo.rf'
       fill_in 'Mot de passe', with: '12345'
@@ -49,7 +49,7 @@ feature 'Signing up:' do
 
   scenario 'a new user can’t sign-up with too short password when visiting a procedure' do
     visit commencer_path(path: procedure.path)
-    click_on 'Créer un compte demarches-simplifiees.fr'
+    click_on "Créer un compte #{APPLICATION_NAME}"
 
     expect(page).to have_current_path new_user_registration_path
     sign_up_with user_email, '1234567'

--- a/spec/helpers/conservation_de_donnees_helper_spec.rb
+++ b/spec/helpers/conservation_de_donnees_helper_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe ConservationDeDonneesHelper, type: :helper do
       let(:dans_ds) { 3 }
       let(:hors_ds) { 6 }
 
-      it { is_expected.to eq(["Dans demarches-simplifiees.fr : 3 mois", "Par l’administration : 6 mois"]) }
+      it { is_expected.to eq(["Dans #{APPLICATION_NAME} : 3 mois", "Par l’administration : 6 mois"]) }
     end
 
     context "when only in-app retention time is set" do
       let(:dans_ds) { 3 }
       let(:hors_ds) { nil }
 
-      it { is_expected.to eq(["Dans demarches-simplifiees.fr : 3 mois"]) }
+      it { is_expected.to eq(["Dans #{APPLICATION_NAME} : 3 mois"]) }
     end
 
     context "when only out of app retention time is set" do


### PR DESCRIPTION
Fixed #6092 "ETQ developpeur, ... utiliser la variable d'env optionnelle `APPLICATION_NAME` et lancer les tests" / @adullact

-----------------------------

## Résumé 

Lorsque la variable d'environnement `APPLICATION_NAME` est personnalisée 
avec une valeur différente de `demarches-simplifiees.fr`, certains tests ne passent plus.

##  Actuellement

Depuis la PR #5405  _"Rendre le nom d'application paramétrable"_, il est possible de configurer le nom de l'application via  une variable d'environnement optionnelle `APPLICATION_NAME` à rajouter dans le fichier `.env`.

En ce basant sur le fichier [config/env.example.optional](https://github.com/betagouv/demarches-simplifiees.fr/blob/main/config/env.example.optional), nous avons rajouté dans notre fichier `.env` les 2 lignes suivantes :

```bash
# Les paramètres pour l'affichage du nom l'application, et pour la génération des liens
APPLICATION_NAME="ds.exemple.com"
APPLICATION_BASE_URL="http://ds.exemple.com"
```

Avec cette configuration, 6 tests sont en erreurs dans les fichiers suivants : 
- `spec/helpers/conservation_de_donnees_helper_spec.rb`
- `spec/features/users/sign_up_spec.rb`

```ruby
bin/rspec spec/helpers/conservation_de_donnees_helper_spec.rb
#############################################################
Failures:

  1) ConservationDeDonneesHelper politiques_conservation_de_donnees when both retention times are set is expected to eq ["Dans demarches-simplifiees.fr : 3 mois", "Par l’administration : 6 mois"]
     Failure/Error: it { is_expected.to eq(["Dans demarches-simplifiees.fr : 3 mois", "Par l’administration : 6 mois"]) }
       expected: ["Dans demarches-simplifiees.fr : 3 mois", "Par l’administration : 6 mois"]
            got: ["Dans ds.exemple.com : 3 mois", "Par l’administration : 6 mois"]     
       (compared using ==)
     # ./spec/helpers/conservation_de_donnees_helper_spec.rb:11:in `block (4 levels) in <main>'

  2) ConservationDeDonneesHelper politiques_conservation_de_donnees when only in-app retention time is set is expected to eq ["Dans demarches-simplifiees.fr : 3 mois"]
     Failure/Error: it { is_expected.to eq(["Dans demarches-simplifiees.fr : 3 mois"]) }     
       expected: ["Dans demarches-simplifiees.fr : 3 mois"]
            got: ["Dans ds.exemple.com : 3 mois"]     
       (compared using ==)
     # ./spec/helpers/conservation_de_donnees_helper_spec.rb:18:in `block (4 levels) in <main>'

4 examples, 2 failures


bin/rspec spec/features/users/sign_up_spec.rb
#############################################
Failures:
  1) Signing up: a new user can’t sign-up with too short password when visiting a procedure
     Failure/Error: click_on 'Créer un compte demarches-simplifiees.fr'     
     Capybara::ElementNotFound:
       Unable to find link or button "Créer un compte demarches-simplifiees.fr"
     # ./spec/features/users/sign_up_spec.rb:52:in `block (2 levels) in <main>'

  2) Signing up: when the user makes a typo in their email address they can accept the suggestion
     Failure/Error: click_on 'Créer un compte demarches-simplifiees.fr'     
     Capybara::ElementNotFound:
       Unable to find link or button "Créer un compte demarches-simplifiees.fr"
     # ./spec/features/users/sign_up_spec.rb:22:in `block (3 levels) in <main>'

  3) Signing up: when the user makes a typo in their email address they can discard the suggestion
     Failure/Error: click_on 'Créer un compte demarches-simplifiees.fr'     
     Capybara::ElementNotFound:
       Unable to find link or button "Créer un compte demarches-simplifiees.fr"
     # ./spec/features/users/sign_up_spec.rb:22:in `block (3 levels) in <main>'

  4) Signing up: when the user makes a typo in their email address they can fix the typo themselves
     Failure/Error: click_on 'Créer un compte demarches-simplifiees.fr'     
     Capybara::ElementNotFound:
       Unable to find link or button "Créer un compte demarches-simplifiees.fr"
     # ./spec/features/users/sign_up_spec.rb:22:in `block (3 levels) in <main>'

8 examples, 4 failures
```

## Comportement attendu

Lorsque la variable d'environnement `APPLICATION_NAME` est personnalisée 
avec une valeur différente de `demarches-simplifiees.fr`, tous les tests des fichiers suivants passent sans erreur :
- `spec/helpers/conservation_de_donnees_helper_spec.rb`
- `spec/features/users/sign_up_spec.rb`

## Correctif proposé

Utiliser la variable d'environnement dans les tests, plutôt qu'une valeur fixe, résout le problème.

Exemple :
```diff
- it { is_expected.to eq(["Dans demarches-simplifiees.fr : 3 mois", "Par l’administration : 6 mois"]) }
+ it { is_expected.to eq(["Dans #{APPLICATION_NAME} : 3 mois", "Par l’administration : 6 mois"]) }
```

--------------

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe betagouv sur le ticket et sur la PR (répondre aux commentaires, pousser des commits, ...).