### PR TITLE
#6094 - Enable rspec only failures support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /log/*
 !/log/.keep
 /tmp
+failing_specs.txt
 
 public/uploads
 public/downloads

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Pour exécuter les tests de l'application, plusieurs possibilités :
         bin/rake spec SPEC=file_path/file_name_spec.rb
         bin/rspec file_path/file_name_spec.rb
 
+- Relancer uniquement les tests qui ont échoué précédemment
+
+        bin/rspec --only-failures
+
 ### Ajout de taches à exécuter au déploiement
 
         rails generate after_party:task task_name

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,7 @@ RSpec.configure do |config|
   config.color = true
   config.tty = true
 
+  config.example_status_persistence_file_path = 'failing_specs.txt'
   config.run_all_when_everything_filtered = true
   config.filter_run :focus => true
 


### PR DESCRIPTION
Fixed #6094 "ETQ developpeur, je souhaite utiliser les options --only-failures et --next-failure de RSpec" / @adullact

-----------------------------------------------------------

## Résumé 

L'exécution de l'ensemble des tests prend un certain temps. 
RSpec propose les options `--only-failures` et `--next-failure`
permettant de garder trace des tests ayant échoué pour ne rejouer que ceux-ci.

Documentation : https://relishapp.com/rspec/rspec-core/docs/command-line/only-failures

##  Actuellement

Les  options `--only-failures` et `--next-failure` de RSpec ne peuvent pas être utilisées, 
car la directive de configuration de RSpec `config.example_status_persistence_file_path` n'est pas déclarée.

```ruby
bin/rspec --only-failures
   # To use `--only-failures`, you must first set `config.example_status_persistence_file_path`.
   
bin/rspec --next-failure
bin/rspec --only-failures --fail-fast --order
   # To use `--only-failures`, you must first set `config.example_status_persistence_file_path`.
```

## Comportement attendu

Les  options `--only-failures` et `--next-failure` de RSpec peuvent être utilisées.

```ruby
  bin/rspec                                               # lancer tous les tests
  bin/rspec --only-failures                               # relancer uniquement tous les tests en échec
  bin/rspec --next-failure                                # relancer uniquement le 1er test en échec
  bin/rspec --only-failures file_path/file_name_spec.rb   # relancer uniquement les tests en échec d'un fichier
  bin/rspec --next-failure  file_path/file_name_spec.rb   # relancer uniquement le 1er test en échec d'un fichier
```

## Correctif proposé

Ajouter la directive de configuration  `config.example_status_persistence_file_path`
au fichier [`spec/spec_helper.rb`](https://github.com/betagouv/demarches-simplifiees.fr/blob/main/spec/spec_helper.rb)

```diff
 RSpec.configure do |config|
   config.filter_run_excluding disable: true
   config.color = true
   config.tty = true

+  config.example_status_persistence_file_path = 'failing_specs.txt'
   config.run_all_when_everything_filtered = true
```

--------------

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe betagouv sur le ticket et sur cette PR (répondre aux commentaires, pousser des commits, ...).


## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur BetaGouv pour faire le rebase directement sur notre dépôt.

