### PR TITLE
expert mailer instead of avis mailer

### DIFF
--- a/spec/mailers/previews/expert_mailer_preview.rb
+++ b/spec/mailers/previews/expert_mailer_preview.rb
@@ -1,4 +1,4 @@
-class AvisMailerPreview < ActionMailer::Preview
+class ExpertMailerPreview < ActionMailer::Preview
   def send_dossier_decision
     procedure = Procedure.new(libelle: 'Démarche pour faire des marches')
     dossier = Dossier.new(id: 1, procedure: procedure)


### PR DESCRIPTION
Fix an error in production:

> expected file /var/www/ds/releases/94/spec/mailers/previews/expert_mailer_preview.rb to define constant ExpertMailerPreview, but didn't (Zeitwerk::NameError)

