### PR TITLE
ci: make linting check for zeitwerk errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,15 +55,16 @@ jobs:
     strategy:
       matrix:
         pattern:
-          - spec/controllers/*_spec.rb
-          - spec/controllers/[a-l]**/*_spec.rb
-          - spec/controllers/[m-z]**/*_spec.rb
-          - spec/features
-          - spec/helpers spec/lib spec/middlewares
-          - spec/mailers spec/jobs spec/policies
-          - spec/models
-          - spec/serializers spec/services
-          - spec/views
+          - bin/rake zeitwerk:check
+          - bin/rspec spec/controllers/*_spec.rb
+          - bin/rspec spec/controllers/[a-l]**/*_spec.rb
+          - bin/rspec spec/controllers/[m-z]**/*_spec.rb
+          - bin/rspec spec/features
+          - bin/rspec spec/helpers spec/lib spec/middlewares
+          - bin/rspec spec/mailers spec/jobs spec/policies
+          - bin/rspec spec/models
+          - bin/rspec spec/serializers spec/services
+          - bin/rspec spec/views
 
     steps:
       - name: Checkout code
@@ -99,5 +100,9 @@ jobs:
         run: |
           bundle exec rake db:create db:schema:load db:migrate
 
+      - name: Setup environment variables
+        run: |
+          cp config/env.example .env
+
       - name: Run tests
-        run: bundle exec rspec ${{ matrix.pattern }}
+        run: ${{ matrix.pattern }}

--- a/config/env.example
+++ b/config/env.example
@@ -99,7 +99,7 @@ SKYLIGHT_AUTHENTICATION_KEY=""
 LOGRAGE_ENABLED="disabled"
 
 # Service externe d'horodatage des changements de statut des dossiers (effectué quotidiennement)
-UNIVERSIGN_API_URL=""
+UNIVERSIGN_API_URL="https://ws.universign.eu/tsa/post/"
 UNIVERSIGN_USERPWD=""
 
 # API Geo / Adresse
@@ -112,4 +112,3 @@ API_EDUCATION_URL="https://data.education.gouv.fr/api/records/1.0"
 # Modifier le nb de tentatives de relance de job si echec
 # MAX_ATTEMPTS_JOBS=25
 # MAX_ATTEMPTS_API_ENTREPRISE_JOBS=5
-


### PR DESCRIPTION
If a zeitwerk-incompatible class is introduced, it won't break any test before reaching production.

Explicitely check for zeitwerk compatibility in the linter.