### PR TITLE
gems: update devise-two-factor to a released version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'delayed_job_web'
 gem 'devise' # Gestion des comptes utilisateurs
 gem 'devise-async'
 gem 'devise-i18n'
-gem 'devise-two-factor', github: 'jason-hobbs/devise-two-factor', branch: 'master' # Rails 6.1 compatibility: https://github.com/tinfoil/devise-two-factor/issues/183
+gem 'devise-two-factor'
 gem 'discard'
 gem 'dotenv-rails', require: 'dotenv/rails-now' # dotenv should always be loaded before rails
 gem 'flipper'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,4 @@
 GIT
-  remote: https://github.com/jason-hobbs/devise-two-factor.git
-  revision: e153f16ab86de01df034672dfffa321acd891c45
-  branch: master
-  specs:
-    devise-two-factor (3.1.0)
-      activesupport (< 7.0)
-      attr_encrypted (>= 1.3, < 4, != 2)
-      devise
-      railties (< 7.0)
-      rotp (~> 6)
-
-GIT
   remote: https://github.com/mina-deploy/mina.git
   revision: 84fa84c7f7f94f9518ef9b7099396ab6676b5881
   specs:
@@ -226,6 +214,12 @@ GEM
       devise (>= 4.0)
     devise-i18n (1.9.2)
       devise (>= 4.7.1)
+    devise-two-factor (4.0.0)
+      activesupport (< 6.2)
+      attr_encrypted (>= 1.3, < 4, != 2)
+      devise (~> 4.0)
+      railties (< 6.2)
+      rotp (~> 6.0)
     diff-lcs (1.4.4)
     discard (1.2.0)
       activerecord (>= 4.2, < 7)
@@ -403,7 +397,7 @@ GEM
       railties (>= 4)
       request_store (~> 1.0)
     logstash-event (1.2.02)
-    loofah (2.9.0)
+    loofah (2.9.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -430,7 +424,7 @@ GEM
       ruby2_keywords (~> 0.0.1)
     netrc (0.11.0)
     nio4r (2.5.7)
-    nokogiri (1.11.2)
+    nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     open4 (1.3.4)
@@ -803,7 +797,7 @@ DEPENDENCIES
   devise
   devise-async
   devise-i18n
-  devise-two-factor!
+  devise-two-factor
   discard
   dotenv-rails
   factory_bot


### PR DESCRIPTION
This is the first official release compatible with Rails 6.1.