### PR TITLE
Improve UI of sign-in and password reset

### DIFF
--- a/app/assets/stylesheets/auth.scss
+++ b/app/assets/stylesheets/auth.scss
@@ -10,7 +10,7 @@
   // The procedure description can still be read from the /commencer
   // pages.
   @media (max-width: $two-columns-breakpoint) {
-    .procedure-description {
+    .procedure-preview {
       display: none;
     }
   }

--- a/app/assets/stylesheets/flex.scss
+++ b/app/assets/stylesheets/flex.scss
@@ -45,3 +45,7 @@
 .flex-grow {
   flex-grow: 1;
 }
+
+.flex-no-shrink {
+  flex-shrink: 0;
+}

--- a/app/views/instructeurs/passwords/new.html.haml
+++ b/app/views/instructeurs/passwords/new.html.haml
@@ -17,5 +17,5 @@
       %br
       %br
       .actions
-        = f.submit 'Réinitialiser', class: 'btn btn-primary'
+        = f.submit 'Demander un nouveau mot de passe', class: 'button large expand primary'
       %br

--- a/app/views/super_admins/passwords/new.html.haml
+++ b/app/views/super_admins/passwords/new.html.haml
@@ -14,4 +14,4 @@
       = f.label :email, 'Email'
       = f.email_field :email, autofocus: true
 
-      = f.submit 'Réinitialiser', class: 'button primary'
+      = f.submit 'Demander un nouveau mot de passe', class: 'button large expand primary'

--- a/app/views/users/passwords/new.html.haml
+++ b/app/views/users/passwords/new.html.haml
@@ -9,7 +9,9 @@
 
     = form_for(resource, as: resource_name, url: password_path(resource_name), html: { class: 'form' }) do |f|
 
-      %h1 Mot de passe oublié
+      %h1= t('devise.passwords.new.forgot_your_password')
+
+      %p.notice= t('views.passwords.new.send_me_reset_password_instructions')
 
       = f.label :email, 'Email'
       = f.email_field :email, autofocus: true

--- a/app/views/users/passwords/new.html.haml
+++ b/app/views/users/passwords/new.html.haml
@@ -14,4 +14,4 @@
       = f.label :email, 'Email'
       = f.email_field :email, autofocus: true
 
-      = f.submit 'Réinitialiser', class: 'button primary'
+      = f.submit 'Demander un nouveau mot de passe', class: 'button expand primary'

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -14,7 +14,7 @@
     = f.password_field :password, autocomplete: 'current-password'
 
     .auth-options
-      %div
+      .flex-no-shrink
         = f.check_box :remember_me
         = f.label :remember_me, t('views.sessions.new.remember_me'), class: 'remember-me'
 

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -2,7 +2,7 @@
 
 .auth-form.sign-in-form
 
-  = form_for User.new, url: user_session_path, html: { class: "form" } do |f|
+  = form_for resource, url: user_session_path, html: { class: "form" } do |f|
     %h1.huge-title= t('views.sessions.new.title')
 
     = render partial: 'shared/france_connect_login', locals: { url: france_connect_particulier_path }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,9 @@ en:
         ligne1: A simple tool
         ligne2: to manage dematerialized
         ligne3: administrative forms.
+    passwords:
+      new:
+        send_me_reset_password_instructions: "Fill-in your account's email, and we’ll send you instructions to reset your password."
   modal:
     publish:
       title:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,7 +49,7 @@ en:
       new:
         title: Sign in
         email: Email address (name@site.com)
-        password: Password (minimum length %{min_length} characters)
+        password: Password
         remember_me: Remember me
         reset_password: Forgot password?
         connection: Sign in
@@ -58,7 +58,7 @@ en:
     commencer:
       no_procedure:
         ligne1: A simple tool
-        ligne2: to manage dematerialized 
+        ligne2: to manage dematerialized
         ligne3: administrative forms.
   modal:
     publish:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -39,7 +39,7 @@ fr:
       new:
         title: Connectez-vous
         email: Email (nom@site.com)
-        password: Mot de passe (%{min_length} caractères minimum)
+        password: Mot de passe
         remember_me: Se souvenir de moi
         reset_password: Mot de passe oublié ?
         connection: Se connecter

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -41,7 +41,7 @@ fr:
         email: Email (nom@site.com)
         password: Mot de passe (%{min_length} caractères minimum)
         remember_me: Se souvenir de moi
-        reset_password: Mot de passe oublié ?
+        reset_password: Mot de passe oublié ?
         connection: Se connecter
         are_you_new: Vous êtes nouveau sur %{app_name} ?
         find_procedure: Trouvez votre démarche

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -50,6 +50,9 @@ fr:
         ligne1: Un outil simple
         ligne2: pour gérer les formulaires
         ligne3: administratifs dématérialisés.
+    passwords:
+      new:
+        send_me_reset_password_instructions: "Indiquez l’email de votre compte, et nous vous enverrons un lien pour créer un nouveau mot de passe."
   modal:
     publish:
       title:

--- a/spec/features/sessions/sign_in_spec.rb
+++ b/spec/features/sessions/sign_in_spec.rb
@@ -6,8 +6,11 @@ feature 'Signin in:' do
     visit root_path
     click_on 'Connexion'
 
-    sign_in_with user.email, password
+    sign_in_with user.email, 'invalid-password'
+    expect(page).to have_content 'Courriel ou mot de passe incorrect.'
+    expect(page).to have_field('Email', with: user.email)
 
+    sign_in_with user.email, password
     expect(page).to have_current_path dossiers_path
   end
 

--- a/spec/features/users/managing_password_spec.rb
+++ b/spec/features/users/managing_password_spec.rb
@@ -11,7 +11,7 @@ feature 'Managing password:' do
 
       fill_in 'Email', with: user.email
       perform_enqueued_jobs do
-        click_on 'Réinitialiser'
+        click_on 'Demander un nouveau mot de passe'
       end
       expect(page).to have_content('Si votre courriel existe dans notre base de données, vous recevrez un lien vous permettant de récupérer votre mot de passe.')
 
@@ -38,7 +38,7 @@ feature 'Managing password:' do
 
       fill_in 'Email', with: user.email
       perform_enqueued_jobs do
-        click_on 'Réinitialiser'
+        click_on 'Demander un nouveau mot de passe'
       end
       expect(page).to have_content('Si votre courriel existe dans notre base de données, vous recevrez un lien vous permettant de récupérer votre mot de passe.')
 

--- a/spec/features/users/managing_password_spec.rb
+++ b/spec/features/users/managing_password_spec.rb
@@ -6,7 +6,7 @@ feature 'Managing password:' do
     scenario 'a simple user can reset their password' do
       visit root_path
       click_on 'Connexion'
-      click_on 'Mot de passe oublié ?'
+      click_on 'Mot de passe oublié ?'
       expect(page).to have_current_path(new_user_password_path)
 
       fill_in 'Email', with: user.email
@@ -33,7 +33,7 @@ feature 'Managing password:' do
     scenario 'an admin can reset their password' do
       visit root_path
       click_on 'Connexion'
-      click_on 'Mot de passe oublié ?'
+      click_on 'Mot de passe oublié ?'
       expect(page).to have_current_path(new_user_password_path)
 
       fill_in 'Email', with: user.email

--- a/spec/views/users/sessions/new.html.haml_spec.rb
+++ b/spec/views/users/sessions/new.html.haml_spec.rb
@@ -3,7 +3,7 @@ describe 'users/sessions/new.html.haml', type: :view do
 
   before(:each) do
     allow(view).to receive(:devise_mapping).and_return(Devise.mappings[:user])
-    allow(view).to receive(:resource_name).and_return(:user)
+    allow(view).to receive(:resource).and_return(:user)
   end
 
   before do


### PR DESCRIPTION
I tried to reset my password on mobile, and it was painful. Here are a few tweaks and fixes to start improving this.

- app: retain user email on sign-in error
- password: make the "Reset password" button clearer
- sign_in: improve "Forgot password?" link appearance on mobile
- sign_in: remove password length advice (it is not useful on sign-in)
- sign_in: fix the procedure preview not being hidden on mobile
- password: add a small text with password reset instructions 