### PR TITLE
Remove the link between commentaire and user

### DIFF
--- a/app/graphql/types/dossier_type.rb
+++ b/app/graphql/types/dossier_type.rb
@@ -80,10 +80,10 @@ module Types
     def messages(id: nil)
       if id.present?
         Loaders::Record
-          .for(Commentaire, where: { dossier: object }, includes: [:instructeur, :user], array: true)
+          .for(Commentaire, where: { dossier: object }, includes: [:instructeur, :expert], array: true)
           .load(ApplicationRecord.id_from_typed_id(id))
       else
-        Loaders::Association.for(object.class, commentaires: [:instructeur, :user]).load(object)
+        Loaders::Association.for(object.class, commentaires: [:instructeur, :expert]).load(object)
       end
     end
 

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -21,7 +21,6 @@ class Champ < ApplicationRecord
   belongs_to :dossier, -> { with_discarded }, inverse_of: false, touch: true, optional: false
   belongs_to :type_de_champ, inverse_of: :champ, optional: false
   belongs_to :parent, class_name: 'Champ', optional: true
-  has_many :commentaires
   has_one_attached :piece_justificative_file
 
   # We declare champ specific relationships (Champs::CarteChamp, Champs::SiretChamp and Champs::RepetitionChamp)

--- a/app/services/commentaire_service.rb
+++ b/app/services/commentaire_service.rb
@@ -2,10 +2,10 @@ class CommentaireService
   class << self
     def build(sender, dossier, params)
       case sender
-      when User
-        params[:user] = sender
       when Instructeur
         params[:instructeur] = sender
+      when Expert
+        params[:expert] = sender
       end
 
       build_with_email(sender.email, dossier, params)

--- a/db/migrate/20210422101149_add_expert_id_to_commentaires.rb
+++ b/db/migrate/20210422101149_add_expert_id_to_commentaires.rb
@@ -1,0 +1,5 @@
+class AddExpertIdToCommentaires < ActiveRecord::Migration[6.1]
+  def change
+    add_belongs_to :commentaires, :expert, type: :bigint, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_16_160721) do
+ActiveRecord::Schema.define(version: 2021_04_22_101149) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -175,7 +175,9 @@ ActiveRecord::Schema.define(version: 2021_04_16_160721) do
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.bigint "instructeur_id"
+    t.bigint "expert_id"
     t.index ["dossier_id"], name: "index_commentaires_on_dossier_id"
+    t.index ["expert_id"], name: "index_commentaires_on_expert_id"
     t.index ["instructeur_id"], name: "index_commentaires_on_instructeur_id"
     t.index ["user_id"], name: "index_commentaires_on_user_id"
   end
@@ -738,6 +740,7 @@ ActiveRecord::Schema.define(version: 2021_04_16_160721) do
   add_foreign_key "champs", "champs", column: "parent_id"
   add_foreign_key "closed_mails", "procedures"
   add_foreign_key "commentaires", "dossiers"
+  add_foreign_key "commentaires", "experts"
   add_foreign_key "dossier_operation_logs", "bill_signatures"
   add_foreign_key "dossier_operation_logs", "instructeurs"
   add_foreign_key "dossiers", "groupe_instructeurs"


### PR DESCRIPTION
La relation est très peu utilisée et n'apporte rien. Le fait de la retirer rend la suppression des usagers plus simple.