### PR TITLE
ETQ Administrateur, je veux pouvoir facilement choisir si je veux gérer les experts sur mon interface

### DIFF
--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -60,7 +60,7 @@ module Instructeurs
     def avis
       @avis_seen_at = current_instructeur.follows.find_by(dossier: dossier)&.avis_seen_at
       @avis = Avis.new
-      if @dossier.procedure.feature_enabled?(:admin_affect_experts_to_avis)
+      if @dossier.procedure.experts_require_administrateur_invitation?
         @experts_emails = dossier.procedure.experts_procedures.where(revoked_at: nil).map(&:expert).map(&:email).sort
       end
     end

--- a/app/controllers/new_administrateur/procedures_controller.rb
+++ b/app/controllers/new_administrateur/procedures_controller.rb
@@ -1,6 +1,6 @@
 module NewAdministrateur
   class ProceduresController < AdministrateurController
-    before_action :retrieve_procedure, only: [:champs, :annotations, :edit, :monavis, :update_monavis, :jeton, :update_jeton, :publication, :publish, :transfert, :allow_expert_review]
+    before_action :retrieve_procedure, only: [:champs, :annotations, :edit, :monavis, :update_monavis, :jeton, :update_jeton, :publication, :publish, :transfert, :allow_expert_review, :experts_require_administrateur_invitation]
     before_action :procedure_locked?, only: [:champs, :annotations]
 
     ITEMS_PER_PAGE = 25
@@ -169,7 +169,7 @@ module NewAdministrateur
     def allow_expert_review
       @procedure.update!(allow_expert_review: !@procedure.allow_expert_review)
       flash.notice = @procedure.allow_expert_review? ? "Avis externes activés" : "Avis externes désactivés"
-      redirect_to admin_procedure_path(@procedure)
+      redirect_to admin_procedure_experts_path(@procedure)
     end
 
     def transfer
@@ -183,6 +183,12 @@ module NewAdministrateur
         redirect_to admin_procedure_path(params[:procedure_id])
         flash.notice = "La démarche a correctement été clonée vers le nouvel administrateur."
       end
+    end
+
+    def experts_require_administrateur_invitation
+      @procedure.update!(experts_require_administrateur_invitation: !@procedure.experts_require_administrateur_invitation)
+      flash.notice = @procedure.experts_require_administrateur_invitation? ? "Les experts sont gérés par les administrateurs de la démarche" : "Les experts sont gérés par les instructeurs"
+      redirect_to admin_procedure_experts_path(@procedure)
     end
 
     private

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -20,6 +20,7 @@
 #  durees_conservation_required        :boolean          default(TRUE)
 #  euro_flag                           :boolean          default(FALSE)
 #  for_individual                      :boolean          default(FALSE)
+#  experts_require_administrateur_invitation :boolean          default(FALSE)
 #  hidden_at                           :datetime
 #  juridique_required                  :boolean          default(TRUE)
 #  libelle                             :string

--- a/app/views/experts/shared/avis/_form.html.haml
+++ b/app/views/experts/shared/avis/_form.html.haml
@@ -1,4 +1,4 @@
-- if @dossier.procedure.feature_enabled?(:admin_affect_experts_to_avis).blank?
+- if !@dossier.procedure.experts_require_administrateur_invitation?
   %section.ask-avis
     %h1.tab-title Inviter des personnes à donner leur avis
     %p.avis-notice Les invités pourront consulter le dossier, donner un avis et contribuer au fil de messagerie. Ils ne pourront pas modifier le dossier.

--- a/app/views/instructeurs/shared/avis/_form.html.haml
+++ b/app/views/instructeurs/shared/avis/_form.html.haml
@@ -1,7 +1,7 @@
 %section.ask-avis
   %h1.tab-title Inviter des personnes à donner leur avis
   %p.avis-notice Les invités pourront consulter le dossier, donner un avis et contribuer au fil de messagerie. Ils ne pourront pas modifier le dossier.
-  - if @dossier.procedure.feature_enabled?(:admin_affect_experts_to_avis)
+  - if @dossier.procedure.experts_require_administrateur_invitation
     %p.avis-notice Choisissez des experts à qui vous souhaitez demander un avis parmi la liste prédéfinie par les administrateurs de la démarche
   - else
     %p.avis-notice Entrez les adresses email des experts à qui vous souhaitez demander un avis
@@ -10,13 +10,13 @@
     - hidden_field_id = SecureRandom.uuid
     = hidden_field_tag  'avis[emails]', nil, data: { uuid: hidden_field_id }
     = react_component("ComboMultipleDropdownList",
-        options: @dossier.procedure.feature_enabled?(:admin_affect_experts_to_avis) ? @experts_emails : [],
+        options: @dossier.procedure.experts_require_administrateur_invitation ? @experts_emails : [],
         selected: [],
         disabled: [],
         hiddenFieldId: hidden_field_id,
         label: 'avis_emails',
         id: 'avis_emails',
-        acceptNewValues: @dossier.procedure.feature_enabled?(:admin_affect_experts_to_avis).blank?)
+        acceptNewValues: !@dossier.procedure.experts_require_administrateur_invitation)
     = f.text_area :introduction, rows: 3, value: avis.introduction || 'Bonjour, merci de me donner votre avis sur ce dossier.', required: true
     %p.tab-title Ajouter une pièce jointe
     .form-group

--- a/app/views/new_administrateur/experts_procedures/index.html.haml
+++ b/app/views/new_administrateur/experts_procedures/index.html.haml
@@ -9,59 +9,88 @@
   .container.groupe-instructeur
 
     .card
-      .card-title Affecter des experts à la démarche
-      = form_for :experts_procedure,
-        url: admin_procedure_experts_path(@procedure),
-        html: { class: 'form' } do |f|
+      .card-title Autoriser les instructeurs à solliciter des experts invités
+      %p.notice Si cette fonctionnalité est désactivée, les instructeurs ne pourront plus solliciter d'experts
+      = form_for @procedure,
+        method: :put,
+        url: allow_expert_review_admin_procedure_path(@procedure),
+        html: { class: 'form procedure-form__column--form no-background' } do |f|
+        %label.toggle-switch
+          = f.check_box :allow_expert_review, class: 'toggle-switch-checkbox', onchange: 'this.form.submit()'
+          %span.toggle-switch-control.round
+          %span.toggle-switch-label.on
+          %span.toggle-switch-label.off
 
-        .instructeur-wrapper
-          %p.notice Pendant l'instruction d'un dossier, les instructeurs peuvent demander leur avis à un ou plusieurs experts.
-          %p.notice Entrez les adresses email des experts que vous souhaitez affecter à cette démarche
-          - hidden_field_id = SecureRandom.uuid
-          = hidden_field_tag :emails, nil, data: { uuid: hidden_field_id }
-          = react_component("ComboMultipleDropdownList",
-            options: [],
-            selected: [], disabled: [],
-            hiddenFieldId: hidden_field_id,
-            label: 'email expert',
-            acceptNewValues: true)
+    - if @procedure.allow_expert_review?
+      .card
+        .card-title Gérer les experts invités de la démarche
+        %p.notice Si cette fonctionnalité est activée, les instructeurs pourront uniquement inviter les experts de votre liste
+        = form_for @procedure,
+          method: :put,
+          url: experts_require_administrateur_invitation_admin_procedure_path(@procedure),
+          html: { class: 'form procedure-form__column--form no-background' } do |f|
+          %label.toggle-switch
+            = f.check_box :experts_require_administrateur_invitation, class: 'toggle-switch-checkbox', onchange: 'this.form.submit()'
+            %span.toggle-switch-control.round
+            %span.toggle-switch-label.on
+            %span.toggle-switch-label.off
 
-          = f.submit 'Affecter à la démarche', class: 'button primary send'
-  - if @experts_procedure.present?
-    %table.table.mt-2
-      %thead
-        %tr
-          %th Liste des experts
-          %th Nombre d'avis
-          - if @procedure.feature_enabled?(:admin_affect_experts_to_avis)
-            %th Notifier des décisions sur les dossiers
-      %tbody
-        - @experts_procedure.each do |expert_procedure|
-          %tr
-            %td
-              %span.icon.person
-              = expert_procedure.expert.email
-            %td.text-center
-              = expert_procedure.avis.count
-            - if @procedure.feature_enabled?(:admin_affect_experts_to_avis)
-              %td.text-center
-                = form_for expert_procedure,
-                  url: admin_procedure_expert_path(id: expert_procedure),
-                  remote: true,
-                  method: :put,
-                  authenticity_token: true,
-                  html: { class: 'form procedure-form__column--form no-background' } do |f|
-                  %label.toggle-switch
-                    = f.check_box :allow_decision_access, class: 'toggle-switch-checkbox', onchange: 'this.form.submit()'
-                    %span.toggle-switch-control.round
-                    %span.toggle-switch-label.on
-                    %span.toggle-switch-label.off
-            %td.actions= button_to 'retirer',
-              admin_procedure_expert_path(id: expert_procedure, procedure: @procedure),
-              method: :delete,
-              data: { confirm: "Êtes-vous sûr de vouloir révoquer l'expert « #{expert_procedure.expert.email} » de la démarche #{expert_procedure.procedure.libelle} ? Les instructeurs ne pourront plus lui demander d'avis" },
-              class: 'button'
-  - else
-    .blank-tab
-      %h2.empty-text Aucun expert invité pour le moment.
-      %p.empty-text-details Les instructeurs de cette démarche n'ont pas encore fait appel aux experts.
+      - if @procedure.experts_require_administrateur_invitation?
+        .card
+          .card-title Affecter des experts à la démarche
+          = form_for :experts_procedure,
+            url: admin_procedure_experts_path(@procedure),
+            html: { class: 'form' } do |f|
+
+            .instructeur-wrapper
+              %p.notice Pendant l'instruction d'un dossier, les instructeurs peuvent demander leur avis à un ou plusieurs experts.
+              %p.notice Entrez les adresses email des experts que vous souhaitez affecter à cette démarche
+              - hidden_field_id = SecureRandom.uuid
+              = hidden_field_tag :emails, nil, data: { uuid: hidden_field_id }
+              = react_component("ComboMultipleDropdownList",
+                options: [],
+                selected: [], disabled: [],
+                hiddenFieldId: hidden_field_id,
+                label: 'email expert',
+                acceptNewValues: true)
+
+              = f.submit 'Affecter à la démarche', class: 'button primary send'
+      - if @experts_procedure.present?
+        %table.table.mt-2
+          %thead
+            %tr
+              %th Liste des experts
+              %th Nombre d'avis
+              - if @procedure.experts_require_administrateur_invitation
+                %th Notifier des décisions sur les dossiers
+          %tbody
+            - @experts_procedure.each do |expert_procedure|
+              %tr
+                %td
+                  %span.icon.person
+                  = expert_procedure.expert.email
+                %td.text-center
+                  = expert_procedure.avis.count
+                - if @procedure.experts_require_administrateur_invitation
+                  %td.text-center
+                    = form_for expert_procedure,
+                      url: admin_procedure_expert_path(id: expert_procedure),
+                      remote: true,
+                      method: :put,
+                      authenticity_token: true,
+                      html: { class: 'form procedure-form__column--form no-background' } do |f|
+                      %label.toggle-switch
+                        = f.check_box :allow_decision_access, class: 'toggle-switch-checkbox', onchange: 'this.form.submit()'
+                        %span.toggle-switch-control.round
+                        %span.toggle-switch-label.on
+                        %span.toggle-switch-label.off
+                - if @procedure.experts_require_administrateur_invitation
+                  %td.actions= button_to 'retirer',
+                    admin_procedure_expert_path(id: expert_procedure, procedure: @procedure),
+                    method: :delete,
+                    data: { confirm: "Êtes-vous sûr de vouloir révoquer l'expert « #{expert_procedure.expert.email} » de la démarche #{expert_procedure.procedure.libelle} ? Les instructeurs ne pourront plus lui demander d'avis" },
+                    class: 'button'
+      - else
+        .blank-tab
+          %h2.empty-text Aucun expert invité pour le moment.
+          %p.empty-text-details Les instructeurs de cette démarche n'ont pas encore fait appel aux experts.

--- a/app/views/new_administrateur/procedures/show.html.haml
+++ b/app/views/new_administrateur/procedures/show.html.haml
@@ -142,32 +142,16 @@
         = link_to 'Modifier', edit_admin_procedure_attestation_template_path(@procedure), class: 'button'
 
     .card-admin
-      - if @procedure.allow_expert_review?
-        %div
-          %span.icon.accept
-          %p.card-admin-status-accept Activé
-      - else
-        %div
-          %span.icon.clock
-          %p.card-admin-status-todo Désactivée
+      %div
+        %span.icon.preview
+        %p.card-admin-status-todo À configurer
+
       %div
         %p.card-admin-title Avis externes
-        %p.card-admin-subtitle Demander des avis aux experts invités
+        %p.card-admin-subtitle Gérer les avis des experts invités
+
       .card-admin-action
-        = link_to "#{@procedure.allow_expert_review? ? 'Désactiver' : 'Activer'}", allow_expert_review_admin_procedure_path(@procedure), method: :put,  class: 'button'
-
-    - if @procedure.allow_expert_review?
-      .card-admin
-        %div
-          %span.icon.preview
-          %p.card-admin-status-todo À voir
-
-        %div
-          %p.card-admin-title Liste des experts
-          %p.card-admin-subtitle Liste des experts invités par les instructeurs
-
-        .card-admin-action
-          = link_to "Voir", admin_procedure_experts_path(@procedure), class: 'button'
+        = link_to "Modifier", admin_procedure_experts_path(@procedure), class: 'button'
 
 
     .card-admin

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -402,6 +402,7 @@ Rails.application.routes.draw do
         get 'jeton'
         patch 'update_jeton'
         put :allow_expert_review
+        put :experts_require_administrateur_invitation
       end
 
       get 'publication' => 'procedures#publication', as: :publication

--- a/db/migrate/20210416074049_add_experts_require_administrateur_invitation_to_procedures.rb
+++ b/db/migrate/20210416074049_add_experts_require_administrateur_invitation_to_procedures.rb
@@ -1,0 +1,5 @@
+class AddExpertsRequireAdministrateurInvitationToProcedures < ActiveRecord::Migration[6.1]
+  def change
+    add_column :procedures, :experts_require_administrateur_invitation, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_12_092710) do
+ActiveRecord::Schema.define(version: 2021_04_16_074049) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -551,6 +551,7 @@ ActiveRecord::Schema.define(version: 2021_04_12_092710) do
     t.bigint "draft_revision_id"
     t.bigint "published_revision_id"
     t.boolean "allow_expert_review", default: true, null: false
+    t.boolean "experts_require_administrateur_invitation", default: false
     t.index ["declarative_with_state"], name: "index_procedures_on_declarative_with_state"
     t.index ["draft_revision_id"], name: "index_procedures_on_draft_revision_id"
     t.index ["hidden_at"], name: "index_procedures_on_hidden_at"

--- a/spec/views/new_administrateur/experts_procedures/index.html.haml_spec.rb
+++ b/spec/views/new_administrateur/experts_procedures/index.html.haml_spec.rb
@@ -37,4 +37,20 @@ describe 'new_administrateur/experts_procedures/index.html.haml', type: :view do
       expect(@invited_experts).to match_array([avis.experts_procedure, avis2.experts_procedure])
     end
   end
+
+  context 'when the experts_require_administrateur_invitation is false' do
+    it 'authorize instructors to invite any expert' do
+      expect(rendered).not_to have_content "Affecter des experts à la démarche"
+    end
+  end
+
+  context 'when the experts_require_administrateur_invitation is true' do
+    let!(:procedure) { create(:procedure, :published, experts_require_administrateur_invitation: true) }
+    before do
+      subject
+    end
+    it 'does not authorize instructors to invite any expert but only those presents in admin list' do
+      expect(rendered).to have_content "Affecter des experts à la démarche"
+    end
+  end
 end

--- a/spec/views/new_administrateur/procedures/show.html.haml_spec.rb
+++ b/spec/views/new_administrateur/procedures/show.html.haml_spec.rb
@@ -55,24 +55,5 @@ describe 'new_administrateur/procedures/show.html.haml', type: :view do
       it { expect(rendered).to have_css('#publish-procedure-link') }
       it { expect(rendered).to have_content('Réactiver') }
     end
-
-    describe 'When procedure.allow_expert_review is true, the expert list card must be visible' do
-      before do
-        render
-      end
-      it { expect(procedure.allow_expert_review).to be_truthy }
-      it { expect(rendered).to have_content('Liste des experts invités par les instructeurs') }
-    end
-
-    describe 'When procedure.allow_expert_review is false, the expert list card must not be visible' do
-      before do
-        procedure.update!(allow_expert_review: false)
-        procedure.reload
-        render
-      end
-
-      it { expect(procedure.allow_expert_review).to be_falsy }
-      it { expect(rendered).not_to have_content('Liste des experts invités par les instructeurs') }
-    end
   end
 end


### PR DESCRIPTION
**Le tableau de bord admin a désormais une seule case pour gérer les avis externes** 
![image](https://user-images.githubusercontent.com/21340608/115011693-37f1f000-9eaf-11eb-95d4-cf2abc9542c6.png)

**Lorsque les dossiers de la démarche n'ont pas encore reçu d'avis et que l'admin n'a pas activé la possibilité d'ajouter une liste d'experts**

![image](https://user-images.githubusercontent.com/21340608/115204754-20a64300-a0f9-11eb-9c40-6a4161fa0601.png)


**Lorsque l'admin active la fonctionnalité de création de liste experts**

![image](https://user-images.githubusercontent.com/21340608/115204806-2dc33200-a0f9-11eb-901f-e03cf399dbf1.png)

