### PR TITLE
amélioration des temps de réponse instructeur procedure show

### DIFF
--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -16,6 +16,12 @@ class ProcedurePresentation < ApplicationRecord
     'self' => ['id', 'state']
   }
 
+  TABLE = 'table'
+  COLUMN = 'column'
+  SLASH = '/'
+  TYPE_DE_CHAMP = 'type_de_champ'
+  TYPE_DE_CHAMP_PRIVATE = 'type_de_champ_private'
+
   belongs_to :assign_to, optional: false
 
   delegate :procedure, to: :assign_to
@@ -66,13 +72,13 @@ class ProcedurePresentation < ApplicationRecord
       .where.not(type_champ: explanatory_types_de_champ)
       .order(:id)
       .pluck(:libelle, :stable_id)
-      .map { |(libelle, stable_id)| field_hash(libelle, 'type_de_champ', stable_id.to_s) }
+      .map { |(libelle, stable_id)| field_hash(libelle, TYPE_DE_CHAMP, stable_id.to_s) }
 
     fields.concat procedure.types_de_champ_private
       .where.not(type_champ: explanatory_types_de_champ)
       .order(:id)
       .pluck(:libelle, :stable_id)
-      .map { |(libelle, stable_id)| field_hash(libelle, 'type_de_champ_private', stable_id.to_s) }
+      .map { |(libelle, stable_id)| field_hash(libelle, TYPE_DE_CHAMP_PRIVATE, stable_id.to_s) }
 
     fields
   end
@@ -85,11 +91,11 @@ class ProcedurePresentation < ApplicationRecord
   end
 
   def displayed_fields_values(dossier)
-    displayed_fields.map { |field| get_value(dossier, field['table'], field['column']) }
+    displayed_fields.map { |field| get_value(dossier, field[TABLE], field[COLUMN]) }
   end
 
   def sorted_ids(dossiers, instructeur)
-    table, column, order = sort.values_at('table', 'column', 'order')
+    table, column, order = sort.values_at(TABLE, COLUMN, 'order')
 
     case table
     when 'notifications'
@@ -101,12 +107,12 @@ class ProcedurePresentation < ApplicationRecord
         (dossiers.order('dossiers.updated_at asc').ids - dossiers_id_with_notification) +
             dossiers_id_with_notification
       end
-    when 'type_de_champ'
+    when TYPE_DE_CHAMP
       dossiers
         .with_type_de_champ(column)
         .order("champs.value #{order}")
         .pluck(:id)
-    when 'type_de_champ_private'
+    when TYPE_DE_CHAMP_PRIVATE
       dossiers
         .with_type_de_champ_private(column)
         .order("champs.value #{order}")
@@ -127,7 +133,7 @@ class ProcedurePresentation < ApplicationRecord
   end
 
   def filtered_ids(dossiers, statut)
-    filters[statut].group_by { |filter| filter.values_at('table', 'column') } .map do |(table, column), filters|
+    filters[statut].group_by { |filter| filter.values_at(TABLE, COLUMN) } .map do |(table, column), filters|
       values = filters.pluck('value')
       case table
       when 'self'
@@ -135,10 +141,10 @@ class ProcedurePresentation < ApplicationRecord
           .map { |v| Time.zone.parse(v).beginning_of_day rescue nil }
           .compact
         dossiers.filter_by_datetimes(column, dates)
-      when 'type_de_champ'
+      when TYPE_DE_CHAMP
         dossiers.with_type_de_champ(column)
           .filter_ilike(:champs, :value, values)
-      when 'type_de_champ_private'
+      when TYPE_DE_CHAMP_PRIVATE
         dossiers.with_type_de_champ_private(column)
           .filter_ilike(:champs_private, :value, values)
       when 'etablissement'
@@ -174,13 +180,13 @@ class ProcedurePresentation < ApplicationRecord
 
   def eager_load_displayed_fields(dossiers)
     relations_to_include = displayed_fields
-      .pluck('table')
+      .pluck(TABLE)
       .reject { |table| table == 'self' }
       .map do |table|
         case table
-        when 'type_de_champ'
+        when TYPE_DE_CHAMP
           { champs: :type_de_champ }
-        when 'type_de_champ_private'
+        when TYPE_DE_CHAMP_PRIVATE
           { champs_private: :type_de_champ }
         else
           table
@@ -192,9 +198,9 @@ class ProcedurePresentation < ApplicationRecord
   end
 
   def human_value_for_filter(filter)
-    case filter['table']
-    when 'type_de_champ', 'type_de_champ_private'
-      find_type_de_champ(filter['column']).dynamic_type.filter_to_human(filter['value'])
+    case filter[TABLE]
+    when TYPE_DE_CHAMP, TYPE_DE_CHAMP_PRIVATE
+      find_type_de_champ(filter[COLUMN]).dynamic_type.filter_to_human(filter['value'])
     else
       filter['value']
     end
@@ -202,19 +208,19 @@ class ProcedurePresentation < ApplicationRecord
 
   def add_filter(statut, field, value)
     if value.present?
-      table, column = field.split('/')
+      table, column = field.split(SLASH)
       label = find_field(table, column)['label']
 
       case table
-      when 'type_de_champ', 'type_de_champ_private'
+      when TYPE_DE_CHAMP, TYPE_DE_CHAMP_PRIVATE
         value = find_type_de_champ(column).dynamic_type.human_to_filter(value)
       end
 
       updated_filters = filters.dup
       updated_filters[statut] << {
         'label' => label,
-        'table' => table,
-        'column' => column,
+        TABLE => table,
+        COLUMN => column,
         'value' => value
       }
 
@@ -223,11 +229,11 @@ class ProcedurePresentation < ApplicationRecord
   end
 
   def remove_filter(statut, field, value)
-    table, column = field.split('/')
+    table, column = field.split(SLASH)
 
     updated_filters = filters.dup
     updated_filters[statut] = filters[statut].reject do |filter|
-      filter.values_at('table', 'column', 'value') == [table, column, value]
+      filter.values_at(TABLE, COLUMN, 'value') == [table, column, value]
     end
 
     update!(filters: updated_filters)
@@ -238,7 +244,7 @@ class ProcedurePresentation < ApplicationRecord
       values = []
     end
 
-    fields = values.map { |value| find_field(*value.split('/')) }
+    fields = values.map { |value| find_field(*value.split(SLASH)) }
 
     update!(displayed_fields: fields)
 
@@ -248,15 +254,15 @@ class ProcedurePresentation < ApplicationRecord
   end
 
   def update_sort(table, column)
-    order = if sort.values_at('table', 'column') == [table, column]
+    order = if sort.values_at(TABLE, COLUMN) == [table, column]
       sort['order'] == 'asc' ? 'desc' : 'asc'
     else
       'asc'
     end
 
     update!(sort: {
-      'table' => table,
-      'column' => column,
+      TABLE => table,
+      COLUMN => column,
       'order' => order
     })
   end
@@ -264,11 +270,11 @@ class ProcedurePresentation < ApplicationRecord
   private
 
   def field_id(field)
-    field.values_at('table', 'column').join('/')
+    field.values_at(TABLE, COLUMN).join(SLASH)
   end
 
   def find_field(table, column)
-    fields.find { |field| field.values_at('table', 'column') == [table, column] }
+    fields.find { |field| field.values_at(TABLE, COLUMN) == [table, column] }
   end
 
   def find_type_de_champ(column)
@@ -302,7 +308,7 @@ class ProcedurePresentation < ApplicationRecord
   end
 
   def check_allowed_field(kind, field, extra_columns = {})
-    table, column = field.values_at('table', 'column')
+    table, column = field.values_at(TABLE, COLUMN)
     if !valid_column?(table, column, extra_columns)
       errors.add(kind, "#{table}.#{column} n’est pas une colonne permise")
     end
@@ -316,9 +322,9 @@ class ProcedurePresentation < ApplicationRecord
       dossier.send(table)&.send(column)
     when 'followers_instructeurs'
       dossier.send(table)&.map { |g| g.send(column) }&.join(', ')
-    when 'type_de_champ'
+    when TYPE_DE_CHAMP
       dossier.champs.find { |c| c.stable_id == column.to_i }.to_s
-    when 'type_de_champ_private'
+    when TYPE_DE_CHAMP_PRIVATE
       dossier.champs_private.find { |c| c.stable_id == column.to_i }.to_s
     when 'groupe_instructeur'
       dossier.groupe_instructeur.label
@@ -328,8 +334,8 @@ class ProcedurePresentation < ApplicationRecord
   def field_hash(label, table, column)
     {
       'label' => label,
-      'table' => table,
-      'column' => column
+      TABLE => table,
+      COLUMN => column
     }
   end
 
@@ -340,8 +346,8 @@ class ProcedurePresentation < ApplicationRecord
 
   def valid_columns_for_table(table)
     @column_whitelist ||= fields
-      .group_by { |field| field['table'] }
-      .transform_values { |fields| Set.new(fields.pluck('column')) }
+      .group_by { |field| field[TABLE] }
+      .transform_values { |fields| Set.new(fields.pluck(COLUMN)) }
 
     @column_whitelist[table] || []
   end

--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -177,9 +177,9 @@ class ProcedurePresentation < ApplicationRecord
       .map do |table|
         case table
         when 'type_de_champ'
-          :champs
+          { champs: :type_de_champ }
         when 'type_de_champ_private'
-          :champs_private
+          { champs_private: :type_de_champ }
         else
           table
         end

--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -65,12 +65,14 @@ class ProcedurePresentation < ApplicationRecord
     fields.concat procedure.types_de_champ
       .where.not(type_champ: explanatory_types_de_champ)
       .order(:id)
-      .map { |type_de_champ| field_hash(type_de_champ.libelle, 'type_de_champ', type_de_champ.stable_id.to_s) }
+      .pluck(:libelle, :stable_id)
+      .map { |(libelle, stable_id)| field_hash(libelle, 'type_de_champ', stable_id.to_s) }
 
     fields.concat procedure.types_de_champ_private
       .where.not(type_champ: explanatory_types_de_champ)
       .order(:id)
-      .map { |type_de_champ| field_hash(type_de_champ.libelle, 'type_de_champ_private', type_de_champ.stable_id.to_s) }
+      .pluck(:libelle, :stable_id)
+      .map { |(libelle, stable_id)| field_hash(libelle, 'type_de_champ_private', stable_id.to_s) }
 
     fields
   end


### PR DESCRIPTION
- évite un n+1 du au filtrage de champ par stable_id qui est porté par type de champ
- évite une dé sérialisation inutile des types de champs alors que l'on ne charge que sont libelle et stable_id
- évite la récréation de string lors de boucle en les passants en constantes