### PR TITLE
i18n: traduction dossiers/edition

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -51,7 +51,7 @@ module Users
       if dossier.attestation&.pdf&.attached?
         redirect_to dossier.attestation.pdf.service_url
       else
-        flash.notice = "L'attestation n’est plus disponible sur ce dossier."
+        flash.notice = t('.no_longer_available')
         redirect_to dossier_path(dossier)
       end
     end
@@ -66,7 +66,7 @@ module Users
 
       if @dossier.individual.update(individual_params)
         @dossier.update!(autorisation_donnees: true)
-        flash.notice = "Identité enregistrée"
+        flash.notice = t('.identity_saved')
 
         redirect_to brouillon_dossier_path(@dossier)
       else
@@ -116,7 +116,7 @@ module Users
 
       # Redirect if the user attempts to access the page URL directly
       if !@dossier.etablissement
-        flash.alert = 'Aucun établissement n’est associé à ce dossier'
+        flash.alert = t('.no_establishment')
         return redirect_to siret_dossier_path(@dossier)
       end
     end
@@ -151,7 +151,7 @@ module Users
       elsif errors.present?
         flash.now.alert = errors
       else
-        flash.now.notice = 'Votre brouillon a bien été sauvegardé.'
+        flash.now.notice = t('.draft_saved')
       end
 
       respond_to do |format|
@@ -162,7 +162,7 @@ module Users
 
     def extend_conservation
       dossier.update(conservation_extension: dossier.conservation_extension + 1.month)
-      flash[:notice] = 'Votre dossier sera conservé un mois supplémentaire'
+      flash[:notice] = t('.archived_dossier')
       redirect_to dossier_path(@dossier)
     end
 
@@ -197,7 +197,7 @@ module Users
           .each do |instructeur|
           DossierMailer.notify_new_commentaire_to_instructeur(dossier, instructeur.email).deliver_later
         end
-        flash.notice = "Votre message a bien été envoyé à l’instructeur en charge de votre dossier."
+        flash.notice = t('.message_send')
         redirect_to messagerie_dossier_path(dossier)
       else
         flash.now.alert = @commentaire.errors.full_messages
@@ -210,10 +210,10 @@ module Users
 
       if dossier.can_be_deleted_by_user?
         dossier.discard_and_keep_track!(current_user, :user_request)
-        flash.notice = 'Votre dossier a bien été supprimé.'
+        flash.notice = t('.deleted_dossier')
         redirect_to dossiers_path
       else
-        flash.notice = "L’instruction de votre dossier a commencé, il n’est plus possible de supprimer votre dossier. Si vous souhaitez annuler l’instruction contactez votre administration par la messagerie de votre dossier."
+        flash.notice = t('.undergoingreview')
         redirect_to dossier_path(dossier)
       end
     end
@@ -304,13 +304,13 @@ module Users
 
     def show_demarche_en_test_banner
       if @dossier.present? && @dossier.revision.draft?
-        flash.now.alert = "Ce dossier est déposé sur une démarche en test. Toute modification de la démarche par l'administrateur (ajout d’un champ, publication de la démarche...) entraînera sa suppression."
+        flash.now.alert = t('.test_procedure')
       end
     end
 
     def ensure_dossier_can_be_updated
       if !dossier.can_be_updated_by_user?
-        flash.alert = 'Votre dossier ne peut plus être modifié'
+        flash.alert = t('.no_longer_editable')
         redirect_to dossiers_path
       end
     end
@@ -411,7 +411,7 @@ module Users
     end
 
     def forbidden!
-      flash[:alert] = "Vous n’avez pas accès à ce dossier"
+      flash[:alert] = t('.no_access')
       redirect_to root_path
     end
 

--- a/app/helpers/commentaire_helper.rb
+++ b/app/helpers/commentaire_helper.rb
@@ -7,9 +7,9 @@ module CommentaireHelper
 
   def commentaire_answer_action(commentaire, connected_user)
     if commentaire.sent_by?(connected_user)
-      "Envoyer un message à l’instructeur"
+      I18n.t('helpers.commentaire.send_message_to_instructeur')
     else
-      "Répondre dans la messagerie"
+      I18n.t('helpers.commentaire.reply_in_mailbox')
     end
   end
 

--- a/app/helpers/procedure_helper.rb
+++ b/app/helpers/procedure_helper.rb
@@ -8,7 +8,7 @@ module ProcedureHelper
   end
 
   def procedure_libelle(procedure)
-    parts = procedure.brouillon? ? [tag.span('démarche en test', class: 'badge')] : []
+    parts = procedure.brouillon? ? [tag.span(t('helpers.procedure.testing_procedure'), class: 'badge')] : []
     parts << procedure.libelle
     safe_join(parts, ' ')
   end

--- a/app/views/commencer/show.html.haml
+++ b/app/views/commencer/show.html.haml
@@ -16,7 +16,7 @@
     - not_drafts = dossiers.merge(Dossier.state_not_brouillon)
 
     - if dossiers.count == 0
-      = link_to 'Commencer la démarche', url_for_new_dossier(@revision), class: ['button large expand primary']
+      = link_to t('views.commencer.show.start_procedure'), url_for_new_dossier(@revision), class: ['button large expand primary']
 
     - elsif drafts.count == 1 && not_drafts.count == 0
       - dossier = drafts.first
@@ -37,9 +37,9 @@
       = link_to 'Commencer un nouveau dossier', url_for_new_dossier(@revision), class: ['button large expand']
 
     - else
-      %h2.huge-title Vous avez déjà des dossiers pour cette démarche
-      = link_to 'Voir mes dossiers en cours', dossiers_path, class: ['button large expand primary']
-      = link_to 'Commencer un nouveau dossier', url_for_new_dossier(@revision), class: ['button large expand']
+      %h2.huge-title= t('views.commencer.show.existing_dossiers')
+      = link_to t('views.commencer.show.show_dossiers'), dossiers_path, class: ['button large expand primary']
+      = link_to t('views.commencer.show.start_new_dossier'), url_for_new_dossier(@revision), class: ['button large expand']
 
   - if @procedure.feature_enabled?(:dossier_pdf_vide)
     - pdf_link = @revision.draft? ? commencer_dossier_vide_test_path(path: @procedure.path) : commencer_dossier_vide_path(path: @procedure.path)

--- a/app/views/invites/_dropdown.html.haml
+++ b/app/views/invites/_dropdown.html.haml
@@ -2,13 +2,13 @@
   %button.button.dropdown-button{ 'aria-expanded' => 'false', 'aria-controls' => 'invite-content' }
     %span.icon.person
     - if dossier.invites.count > 0
-      Voir les personnes invitées
+      = t('views.invites.dropdown.view_invited_people')
       %span.badge= dossier.invites.count
     - else
       - if dossier.read_only?
-        Inviter une personne à consulter ce dossier
+        = t('views.invites.dropdown.invite_to_view')
       - else
-        Inviter une personne à modifier ce dossier
+        = t('views.invites.dropdown.invite_to_edit')
 
   #invite-content.dropdown-content.fade-in-down
     = render partial: "invites/form", locals: { dossier: dossier }

--- a/app/views/invites/_form.html.haml
+++ b/app/views/invites/_form.html.haml
@@ -1,28 +1,28 @@
 #invites-form
   - if dossier.invites.present?
-    %h4 Personnes invitées à participer à ce dossier
+    %h4= t('views.invites.form.invite_to_participate')
     %ul
       - dossier.invites.each do |invite|
         %li
           = invite.email
-          %small= link_to("Révoquer l'autorisation", invite_path(invite), data: { confirm: "Souhaitez-vous supprimer l'autorisation ?" }, method: :delete, remote: true)
-    %p Ces personnes peuvent modifier ce dossier.
+          %small= link_to(t('views.invites.form.withdraw_permission'), invite_path(invite), data: { confirm: t('views.invites.form.want_to_withdraw_permission') }, method: :delete, remote: true)
+    %p= t('views.invites.form.edit_dossier')
     - if dossier.brouillon?
-      %p Une fois le dossier complet, vous devez le déposer vous-même.
+      %p= t('views.invites.form.submit_dossier_yourself')
 
   - else
-    %p Vous pouvez inviter quelqu’un à remplir ce dossier avec vous.
-    %p Cette personne aura le droit de modifier votre dossier.
+    %p= t('views.invites.form.invite_to_edit_line1')
+    %p= t('views.invites.form.invite_to_edit_line2')
 
   = form_tag dossier_invites_path(dossier), remote: true, method: :post, class: 'form' do
     .row
       .col
         %span
-          = label_tag :invite_email, "Adresse email"
-        = email_field_tag :invite_email, '', class: 'small', placeholder: 'Adresse email', required: true
+          = label_tag :invite_email, t('views.invites.form.email')
+        = email_field_tag :invite_email, '', class: 'small', placeholder: t('views.invites.form.email'), required: true
       .col
         %span
-          = label_tag :invite_message, "Ajouter un message à la personne invitée (optionnel)"
-        = text_area_tag :invite_message, '', class: 'small', placeholder: 'Ajouter un message à la personne invitée (optionnel)'
+          = label_tag :invite_message, t('views.invites.form.invite_message')
+        = text_area_tag :invite_message, '', class: 'small', placeholder: t('views.invites.form.invite_message')
       .col
-        = submit_tag 'Envoyer une invitation', class: 'button accepted'
+        = submit_tag t('views.invites.form.send_invitation'), class: 'button accepted'

--- a/app/views/layouts/commencer/_no_procedure.html.haml
+++ b/app/views/layouts/commencer/_no_procedure.html.haml
@@ -2,8 +2,8 @@
   = image_tag "landing/hero/dematerialiser.svg", class: "paperless-logo", alt: "moins de papier"
   .baseline.center
     %p
-      %span.simple= t('views.commencer.no_procedure.ligne1')
+      %span.simple= t('views.layouts.commencer.no_procedure.line1')
       %br
-      = t('views.commencer.no_procedure.ligne2')
+      = t('views.layouts.commencer.no_procedure.line2')
       %br
-      = t('views.commencer.no_procedure.ligne3')
+      = t('views.layouts.commencer.no_procedure.line3')

--- a/app/views/shared/dossiers/_demande.html.haml
+++ b/app/views/shared/dossiers/_demande.html.haml
@@ -3,7 +3,7 @@
     .card
       = render partial: "shared/dossiers/infos_generales", locals: { dossier: dossier }
 
-  .tab-title Identité du demandeur
+  .tab-title= t('views.shared.dossiers.demande.requester_identity')
   .card
     - if dossier.france_connect_information.present?
       = render partial: "shared/dossiers/france_connect_informations", locals: { user_information: dossier.france_connect_information }
@@ -14,16 +14,16 @@
 
       - if profile == 'usager' && !dossier.read_only?
         .flex.row-reverse
-          = link_to "Modifier le SIRET", siret_dossier_path(dossier), class: 'button'
+          = link_to t('views.shared.dossiers.demande.edit_siret'), siret_dossier_path(dossier), class: 'button'
 
     - if dossier.individual.present?
       = render partial: "shared/dossiers/identite_individual", locals: { individual: dossier.individual }
 
       - if profile == 'usager' && !dossier.read_only?
         .flex.row-reverse
-          = link_to "Modifier l'identité", identite_dossier_path(dossier), class: 'button'
+          = link_to t('views.shared.dossiers.demande.edit_identity'), identite_dossier_path(dossier), class: 'button'
 
-  .tab-title Formulaire
+  .tab-title= t('views.shared.dossiers.demande.form')
   - champs = dossier.champs.includes(:type_de_champ)
   - if champs.any? || dossier.procedure.routee?
     .card

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -11,14 +11,11 @@
   = form_for dossier, form_options.merge({ html: { id: 'dossier-edit-form', class: dossier_form_class(dossier), multipart: true } }) do |f|
 
     .prologue
-      %p.mandatory-explanation
-        Les champs suivis d’un astérisque (
-        %span.mandatory> *
-        ) sont obligatoires.
+      %p.mandatory-explanation= t('utils.asterisk_html')
       - if dossier.brouillon?
         %p.mandatory-explanation
           - if autosave_available?(dossier)
-            Votre dossier est enregistré automatiquement après chaque modification. Vous pouvez à tout moment fermer la fenêtre et reprendre plus tard là où vous en étiez.
+            = t('views.shared.dossiers.edit.autosave')
           - else
             Pour enregistrer votre dossier et le reprendre plus tard, cliquez sur le bouton « Enregistrer le brouillon » en bas à gauche du formulaire.
       - if !apercu && dossier.france_connect_information.present?
@@ -56,7 +53,7 @@
                 data: { 'disable-with': "Envoi en cours…" }
 
             - if dossier.can_transition_to_en_construction?
-              = f.button 'Déposer le dossier',
+              = f.button t('views.shared.dossiers.edit.submit_dossier'),
                 name: :submit_draft,
                 value: true,
                 class: 'button send primary',
@@ -64,7 +61,7 @@
                 data: { 'disable-with': "Envoi en cours…" }
 
           - else
-            = f.button 'Enregistrer les modifications du dossier',
+            = f.button t('views.shared.dossiers.edit.save_changes'),
               class: 'button send primary',
               data: { 'disable-with': "Envoi en cours…" }
 

--- a/app/views/shared/dossiers/messages/_form.html.haml
+++ b/app/views/shared/dossiers/messages/_form.html.haml
@@ -1,14 +1,14 @@
 = form_for(commentaire, url: form_url, html: { class: 'form' }) do |f|
-  - placeholder = 'Écrivez votre message à l’administration ici'
+  - placeholder = t('views.shared.dossiers.messages.form.write_message_to_administration_placeholder')
   - if instructeur_signed_in? || administrateur_signed_in?
-    - placeholder = 'Écrivez votre message ici'
+    - placeholder = t('views.shared.dossiers.messages.form.write_message_placeholder')
   = f.text_area :body, rows: 5, placeholder: placeholder, required: true, class: 'message-textarea'
   .flex.justify-between.wrap
     %div
       = f.label :piece_jointe, for: :piece_jointe do
-        Joindre un document
-        %span.notice (taille max : 20 Mo)
+        = t('views.shared.dossiers.messages.form.attach_dossier')
+        %span.notice= t('views.shared.dossiers.messages.form.attachment_size')
       = f.file_field :piece_jointe, id: 'piece_jointe', direct_upload: true
 
     %div
-      = f.submit 'Envoyer le message', class: 'button primary send', data: { disable: true }
+      = f.submit t('views.shared.dossiers.messages.form.send_message'), class: 'button primary send', data: { disable: true }

--- a/app/views/shared/dossiers/messages/_message.html.haml
+++ b/app/views/shared/dossiers/messages/_message.html.haml
@@ -5,7 +5,7 @@
     %span.mail
       = render partial: 'shared/dossiers/messages/message_issuer', locals: { commentaire: commentaire, connected_user: connected_user }
     - if commentaire_is_from_guest(commentaire)
-      %span.guest Invité
+      %span.guest= t('views.shared.dossiers.messages.message.guest')
     %span.date{ class: highlight_if_unseen_class(messagerie_seen_at, commentaire.created_at) }
       = commentaire_date(commentaire)
   .rich-text= pretty_commentaire(commentaire)
@@ -18,4 +18,4 @@
     - if show_reply_button
       = button_tag type: 'button', class: 'button small message-answer-button', onclick: 'document.querySelector("#commentaire_body").focus()' do
         %span.icon.reply
-        Répondre
+        = t('views.shared.dossiers.messages.message.reply')

--- a/app/views/shared/dossiers/messages/_message_issuer.html.haml
+++ b/app/views/shared/dossiers/messages/_message_issuer.html.haml
@@ -1,6 +1,6 @@
 - if commentaire.sent_by_system?
-  Email automatique
+  = t('views.shared.dossiers.messages.message_issuer.automatic_email')
 - elsif commentaire.sent_by?(connected_user)
-  Vous
+  = t('views.shared.dossiers.messages.message_issuer.you')
 - else
   = commentaire.redacted_email

--- a/app/views/users/dossiers/_autosave.html.haml
+++ b/app/views/users/dossiers/_autosave.html.haml
@@ -1,8 +1,8 @@
 .autosave.autosave-state-idle
   %p.autosave-explanation
     %span.autosave-explanation-text
-      Votre brouillon est automatiquement enregistré.
-    = link_to 'En savoir plus', FAQ_AUTOSAVE_URL, target: '_blank', rel: 'noopener', class: 'autosave-more-infos'
+      = t('views.users.dossiers.autosave.autosave_draft')
+    = link_to t('views.users.dossiers.autosave.more_infos'), FAQ_AUTOSAVE_URL, target: '_blank', rel: 'noopener', class: 'autosave-more-infos'
 
   %p.autosave-status.succeeded
     %span.autosave-icon.icon.accept

--- a/app/views/users/dossiers/_dossier_actions.html.haml
+++ b/app/views/users/dossiers/_dossier_actions.html.haml
@@ -6,7 +6,7 @@
 - if has_actions
   .dropdown.user-dossier-actions
     %button.button.dropdown-button{ 'aria-expanded' => 'false', 'aria-controls' => 'actions-menu' }
-      Actions
+      = t('views.users.dossiers.dossier_action.actions')
     #actions-menu.dropdown-content.fade-in-down
       %ul.dropdown-items
         - if !dossier.read_only?
@@ -15,24 +15,24 @@
               = link_to(url_for_dossier(dossier)) do
                 %span.icon.edit
                 .dropdown-description
-                  Modifier le brouillon
+                  = t('views.users.dossiers.dossier_action.edit_draft')
           - else
             %li
               = link_to modifier_dossier_path(dossier) do
                 %span.icon.edit
                 .dropdown-description
-                  Modifier le dossier
+                  = t('views.users.dossiers.dossier_action.edit_dossier')
 
         - if has_new_dossier_action
           %li
             = link_to procedure_lien(dossier.procedure) do
               %span.icon.new-folder
               .dropdown-description
-                Commencer un autre dossier
+                = t('views.users.dossiers.dossier_action.start_other_dossier')
 
         - if has_delete_action
           %li.danger
             = link_to ask_deletion_dossier_path(dossier), method: :post, data: { disable: true, confirm: "En continuant, vous allez supprimer ce dossier ainsi que les informations qu’il contient. Toute suppression entraîne l’annulation de la démarche en cours.\n\nConfirmer la suppression ?" } do
               %span.icon.delete
               .dropdown-description
-                Supprimer le dossier
+                = t('views.users.dossiers.dossier_action.delete_dossier')

--- a/app/views/users/dossiers/_dossiers_list.html.haml
+++ b/app/views/users/dossiers/_dossiers_list.html.haml
@@ -2,13 +2,13 @@
   %table.table.dossiers-table.hoverable
     %thead
       %tr
-        %th.number-col Nº dossier
-        %th Démarche
+        %th.number-col= t('views.users.dossiers.dossiers_list.n_dossier')
+        %th= t('views.users.dossiers.dossiers_list.procedure')
         - if dossiers.present?
-          %th Demandeur
-        %th.status-col Statut
-        %th.updated-at-col Mis à jour
-        %th.sr-only Actions
+          %th= t('views.users.dossiers.dossiers_list.requester')
+        %th.status-col= t('views.users.dossiers.dossiers_list.status')
+        %th.updated-at-col= t('views.users.dossiers.dossiers_list.updated')
+        %th.sr-only= t('views.users.dossiers.dossiers_list.actions')
     %tbody
       - dossiers.each do |dossier|
         %tr{ data: { 'dossier-id': dossier.id } }
@@ -33,7 +33,7 @@
 
 - else
   .blank-tab
-    %h2.empty-text Aucun dossier.
+    %h2.empty-text Aucun dossier
     %p.empty-text-details
       Pour remplir une démarche, contactez votre administration en lui demandant le lien de la démarche.
       %br

--- a/app/views/users/dossiers/demande.html.haml
+++ b/app/views/users/dossiers/demande.html.haml
@@ -1,4 +1,4 @@
-- content_for(:title, "Demande · Dossier nº #{@dossier.id} (#{@dossier.procedure.libelle})")
+- content_for(:title, "Demande · Dossier nº#{@dossier.id} (#{@dossier.procedure.libelle})")
 
 - content_for :footer do
   = render partial: "users/procedure_footer", locals: { procedure: @dossier.procedure, dossier: @dossier }
@@ -10,5 +10,5 @@
 
   .container
     - if !@dossier.read_only?
-      = link_to "Modifier le dossier", modifier_dossier_path(@dossier), class: 'button accepted edit-form', 'title'=> "Vous pouvez modifier votre dossier tant qu'il n’est passé en instruction"
+      = link_to t('views.users.dossiers.demande.edit_dossier'), modifier_dossier_path(@dossier), class: 'button accepted edit-form', 'title'=> "Vous pouvez modifier votre dossier tant qu'il n'est passé en instruction"
       .clearfix

--- a/app/views/users/dossiers/identite.html.haml
+++ b/app/views/users/dossiers/identite.html.haml
@@ -4,13 +4,13 @@
 
 - if !dossier_submission_is_closed?(@dossier)
   = form_for @dossier.individual, url: update_identite_dossier_path(@dossier), html: { class: "form" } do |f|
-    %h1 Données d’identité
+    %h1= t('views.users.dossiers.identite.identity_data')
 
-    %p.mb-1 Merci de remplir vos informations personnelles pour accéder à la démarche.
+    %p.mb-1= t('views.users.dossiers.identite.complete_data')
 
     %fieldset
       %legend
-        = f.label :gender
+        = f.label :gender, t('activerecord.attributes.individual.gender')
       .radios
         %label
           = f.radio_button :gender, Individual::GENDER_FEMALE, required: true
@@ -27,8 +27,9 @@
         = f.label :nom
         = f.text_field :nom, class: "small", required: true, autocomplete: 'family-name'
 
+
     - if @dossier.procedure.ask_birthday?
       = f.label :birthdate
       = f.date_field :birthdate, value: @dossier.individual.birthdate, placeholder: 'format : AAAA-MM-JJ', required: true, class: "small"
 
-    = f.submit "Continuer", class: "button large primary expand"
+    = f.submit t('views.users.dossiers.identite.continue'), class: "button large primary expand"

--- a/app/views/users/dossiers/index.html.haml
+++ b/app/views/users/dossiers/index.html.haml
@@ -13,7 +13,7 @@
       = render partial: "dossiers_list", locals: { dossiers: @dossiers }
 
     - else
-      %h1.page-title Dossiers
+      %h1.page-title= t('views.users.dossiers.index.dossiers')
       %ul.tabs
         - if @user_dossiers.count > 0
           = tab_item(t('pluralize.mes_dossiers', count: @user_dossiers.count),

--- a/app/views/users/dossiers/merci.html.haml
+++ b/app/views/users/dossiers/merci.html.haml
@@ -6,23 +6,23 @@
 .merci
   .container
     = image_tag('user/envoi-dossier.svg', alt: '')
-    %h1 Merci !
+    %h1= t('views.users.dossiers.merci.thanks')
     %p.send
-      Votre dossier sur la démarche
+      = t('views.users.dossiers.merci.dossier_send_l1')
       %b= @dossier.procedure.libelle
-      a bien été envoyé.
+      = t('views.users.dossiers.merci.dossier_send_l2')
     %p
-      Vous avez désormais accès à votre
-      %b dossier en ligne.
+      = t('views.users.dossiers.merci.dossier_acces_l1')
+      %b= t('views.users.dossiers.merci.dossier_acces_l2')
     %p
-      Vous pouvez
+      = t('views.users.dossiers.merci.dossier_edit_l1')
       - if !@dossier.read_only?
-        %b le modifier
-        et
-      %b échanger avec un instructeur.
+        %b= t('views.users.dossiers.merci.dossier_edit_l2')
+        = t('views.users.dossiers.merci.dossier_edit_l3')
+      %b= t('views.users.dossiers.merci.dossier_edit_l4')
 
     .flex.column.align-center
-      = link_to 'Accéder à votre dossier', dossier_path(@dossier), class: 'button large primary'
-      = link_to 'Déposer un autre dossier', procedure_lien(@dossier.procedure)
+      = link_to t('views.users.dossiers.merci.acces_dossier'), dossier_path(@dossier), class: 'button large primary'
+      = link_to t('views.users.dossiers.merci.submit_dossier'), procedure_lien(@dossier.procedure)
       .monavis
         != @dossier.procedure.monavis_embed

--- a/app/views/users/dossiers/messagerie.html.haml
+++ b/app/views/users/dossiers/messagerie.html.haml
@@ -8,6 +8,6 @@
 
   .container
     %p.messagerie-explanation
-      La messagerie vous permet de contacter l’instructeur en charge de votre dossier.
+      = t('views.users.dossiers.messagerie.mailbox')
 
   = render partial: "shared/dossiers/messagerie", locals: { dossier: @dossier, connected_user: current_user, messagerie_seen_at: nil, new_commentaire: @commentaire, form_url: commentaire_dossier_path(@dossier) }

--- a/app/views/users/dossiers/show/_header.html.haml
+++ b/app/views/users/dossiers/show/_header.html.haml
@@ -6,21 +6,21 @@
       %span.icon.folder
       %h1= dossier.procedure.libelle
       %h2
-        Dossier nº #{dossier.id}
+        = t('views.users.dossiers.show.header.dossier_number', dossier_id: dossier.id)
         - if dossier.en_construction_at.present?
-          = "- Déposé le #{l(dossier.en_construction_at, format: '%d %B %Y')}"
+          = t('views.users.dossiers.show.header.submit_date', date_du_dossier: I18n.l(dossier.en_construction_at))
 
     - if current_user.owns?(dossier)
       .header-actions
         = render partial: 'invites/dropdown', locals: { dossier: dossier }
         - if dossier.can_be_updated_by_user? && !current_page?(modifier_dossier_path(dossier))
-          = link_to "Modifier mon dossier", modifier_dossier_path(dossier), class: 'button accepted edit-form', 'title'=> "Vous pouvez modifier votre dossier tant qu'il n’est passé en instruction"
+          = link_to t('views.users.dossiers.show.header.edit_dossier'), modifier_dossier_path(dossier), class: 'button accepted edit-form', 'title'=> "Vous pouvez modifier votre dossier tant qu'il n'est passé en instruction"
         %span.dropdown.print-menu-opener
-          %button.button.dropdown-button.icon-only{ title: 'imprimer', 'aria-label': 'imprimer', 'aria-expanded' => 'false', 'aria-controls' => 'print-menu' }
+          %button.button.dropdown-button.icon-only{ title: t('views.users.dossiers.show.header.print'), 'aria-label': 'imprimer', 'aria-expanded' => 'false', 'aria-controls' => 'print-menu' }
             %span.icon.printer
           %ul#print-menu.print-menu.dropdown-content
             %li
-              = link_to "Tout le dossier", dossier_path(dossier, format: :pdf), target: "_blank", rel: "noopener", class: "menu-item menu-link"
+              = link_to t('views.users.dossiers.show.header.print_dossier'), dossier_path(dossier, format: :pdf), target: "_blank", rel: "noopener", class: "menu-item menu-link"
 
     - if dossier.close_to_expiration?
       .card.warning
@@ -39,6 +39,6 @@
         = button_to 'Repousser sa suppression', users_dossier_repousser_expiration_path(dossier), class: 'button secondary'
 
     %ul.tabs
-      = dynamic_tab_item('Résumé', dossier_path(dossier))
-      = dynamic_tab_item('Demande', [demande_dossier_path(dossier), modifier_dossier_path(dossier)])
-      = dynamic_tab_item('Messagerie', messagerie_dossier_path(dossier))
+      = dynamic_tab_item(t('views.users.dossiers.show.header.summary'), dossier_path(dossier))
+      = dynamic_tab_item(t('views.users.dossiers.show.header.request'), [demande_dossier_path(dossier), modifier_dossier_path(dossier)])
+      = dynamic_tab_item(t('views.users.dossiers.show.header.mailbox'), messagerie_dossier_path(dossier))

--- a/app/views/users/dossiers/show/_latest_message.html.haml
+++ b/app/views/users/dossiers/show/_latest_message.html.haml
@@ -1,7 +1,7 @@
 - latest_message = dossier.commentaires.last
 - if latest_message.present?
   .latest-message-section
-    %h3.tab-title Dernier message
+    %h3.tab-title= t('views.users.dossiers.show.latest_message.latest_message')
 
     .message.inverted-background
       = render partial: "shared/dossiers/messages/message", locals: { commentaire: latest_message, connected_user: current_user, messagerie_seen_at: nil, show_reply_button: false }

--- a/app/views/users/dossiers/show/_status_overview.html.haml
+++ b/app/views/users/dossiers/show/_status_overview.html.haml
@@ -3,13 +3,14 @@
     %ul.status-timeline
       - if dossier.brouillon?
         %li.brouillon{ class: dossier.brouillon? ? 'active' : nil }
-          brouillon
+          = t('views.users.dossiers.show.status_overview.status_draft')
       %li.en-construction{ class: dossier.en_construction? ? 'active' : nil }
-        en construction
+        = t('views.users.dossiers.show.status_overview.status_in_progress')
       %li.en-instruction{ class: dossier.en_instruction? ? 'active' : nil }
-        en instruction
+        = t('views.users.dossiers.show.status_overview.status_review')
       %li.termine{ class: dossier.termine? ? 'active' : nil }
-        terminé
+        = t('views.users.dossiers.show.status_overview.status_completed')
+
 
   .status-explanation
     - if dossier.brouillon?
@@ -20,30 +21,22 @@
     - elsif dossier.en_construction?
       .en-construction
         %p
-          Votre dossier est en construction. Cela signifie que
-          = succeed '.' do
-            %strong vous pouvez encore le modifier
-          Vous ne pourrez plus modifier votre dossier lorsque l’administration le passera « en instruction ».
+          t('views.users.dossiers.show.status_overview.en_construction_html')
 
         = render partial: 'users/dossiers/show/estimated_delay', locals: { procedure: dossier.procedure }
 
         %p
-          %strong Vous avez une question ?
-          Utilisez la messagerie pour
-          = succeed '.' do
-            = link_to 'contacter l’administration directement', messagerie_dossier_url(dossier)
+          t('views.users.dossiers.show.status_overview.use_mailbox_for_questions_html', mailbox_url: messagerie_dossier_url(dossier))
 
     - elsif dossier.en_instruction?
       .en-instruction
-        %p Votre dossier est en cours d’instruction par l’administration. Vous ne pouvez plus le modifier.
+        %p
+          t('views.users.dossiers.show.status_overview.admin_review')
 
         = render partial: 'users/dossiers/show/estimated_delay', locals: { procedure: dossier.procedure }
 
         %p
-          %strong Vous avez une question ?
-          Utilisez la messagerie pour
-          = succeed '.' do
-            = link_to 'contacter l’administration directement', messagerie_dossier_url(dossier)
+          t('views.users.dossiers.show.status_overview.use_mailbox_for_questions_html', mailbox_url: messagerie_dossier_url(dossier))
 
     - elsif dossier.accepte?
       .accepte

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -3,29 +3,29 @@
 .auth-form.sign-in-form
 
   = form_for resource, url: user_session_path, html: { class: "form" } do |f|
-    %h1.huge-title= t('views.sessions.new.title')
+    %h1.huge-title= t('views.users.sessions.new.sign_in')
 
     = render partial: 'shared/france_connect_login', locals: { url: france_connect_particulier_path }
 
-    = f.label :email, t('views.sessions.new.email')
+    = f.label :email, t('views.users.sessions.new.email')
     = f.text_field :email, type: :email, autocomplete: 'username', autofocus: true
 
-    = f.label :password, t('views.sessions.new.password', min_length: PASSWORD_MIN_LENGTH)
+    = f.label :password, t('views.users.sessions.new.password', min_length: PASSWORD_MIN_LENGTH)
     = f.password_field :password, autocomplete: 'current-password'
 
     .auth-options
       .flex-no-shrink
         = f.check_box :remember_me
-        = f.label :remember_me, t('views.sessions.new.remember_me'), class: 'remember-me'
+        = f.label :remember_me, t('views.users.sessions.new.remember_me'), class: 'remember-me'
 
       .text-right
-        = link_to t('views.sessions.new.reset_password'), new_user_password_path, class: "link"
+        = link_to t('views.users.sessions.new.reset_password'), new_user_password_path, class: "link"
 
-    = f.submit t('views.sessions.new.connection'), class: "button large primary expand"
+    = f.submit t('views.users.sessions.new.connection'), class: "button large primary expand"
 
   %hr
   %p.center
-    %span= t('views.sessions.new.are_you_new', app_name: APPLICATION_NAME.gsub("-","&#8209;")).html_safe
+    %span= t('views.users.sessions.new.are_you_new', app_name: APPLICATION_NAME.gsub("-","&#8209;")).html_safe
     %br
     %br
-    = link_to t('views.sessions.new.find_procedure'), COMMENT_TROUVER_MA_DEMARCHE_URL, target: "_blank", class: "button expend secondary"
+    = link_to t('views.users.sessions.new.find_procedure'), COMMENT_TROUVER_MA_DEMARCHE_URL, target: "_blank", class: "button expend secondary"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,31 +38,142 @@ en:
     subject: Subject
     message: Message
     send_mail: Send message
+  helpers:
+    procedure:
+      testing_procedure: testing procedure
+    commentaire:
+      send_message_to_instructeur: "Send a message to the instructor"
+      reply_in_mailbox: "Reply in mailbox"
   views:
+    commencer:
+      show:
+        start_procedure: Start the procedure
+        existing_dossiers: You already have files for this procedure
+        show_dossiers: View my current files
+        start_new_dossier: Start a new file
+    invites:
+      dropdown:
+        invite_to_edit: Invite someone to edit this file
+        view_invited_people: "View invited people"
+        invite_to_view: "Invite someone to view this file"
+      form:
+        invite_to_edit_line1: You can invite someone to complete this file with you.
+        invite_to_edit_line2: This person will have the right to edit your file.
+        email: Email address
+        invite_message: Add a message to the person you invite (optional)
+        send_invitation: Send an invitation
+        invite_to_participate: "Invited people to participate in this file"
+        withdraw_permission: "Withdraw the permission"
+        want_to_withdraw_permission: "Would you like to withdraw the permission?"
+        edit_dossier: "These people can edit this file."
+        submit_dossier_yourself: "You must submit the file yourself when it is complete."
+    layouts:
+      commencer:
+        no_procedure:
+          line1: A simple tool
+          line2: to manage dematerialized
+          line3: administrative forms.
     pagination:
       next: Next
       last: Last
       previous: Previous
       first: First
       truncate: '&hellip;'
-    sessions:
-      new:
-        title: Sign in
-        email: Email address (name@site.com)
-        password: Password
-        remember_me: Remember me
-        reset_password: Forgot password?
-        connection: Sign in
-        are_you_new: First time on %{app_name} ?
-        find_procedure: Find your procedure
-    commencer:
-      no_procedure:
-        ligne1: A simple tool
-        ligne2: to manage dematerialized
-        ligne3: administrative forms.
-    passwords:
-      new:
-        send_me_reset_password_instructions: "Fill-in your account's email, and we’ll send you instructions to reset your password."
+    shared:
+      dossiers:
+        edit:
+          autosave: Your file is automatically saved after each modification. You can close the window at any time and pick up where you left off later.
+          submit_dossier: Submit the file
+          save_changes: Save the changes of the file
+        messages:
+          message_issuer:
+            automatic_email: "Automatic email"
+            you: "You"
+          message:
+            reply: "Reply"
+            guest: "Guest"
+          form:
+            send_message: "Send message"
+            attachment_size: "(attachment size max : 20 Mo)"
+            attach_dossier: "Attach a file"
+            write_message_placeholder: "Write your message here"
+            write_message_to_administration_placeholder: "Write your message to the administration here"
+        demande:
+          requester_identity: "Identity of the requester"
+          form: "Form"
+          edit_siret: "Edit SIRET"
+          edit_identity: "Edit identity data"
+    users:
+      dossiers:
+        autosave:
+          autosave_draft: Your draft is automatically saved.
+          more_infos: More informations
+        identite:
+          identity_data: Identity data
+          complete_data: Please complete your personal information to access the procedure.
+          continue: Continue
+        merci:
+          thanks: Thank you!
+          dossier_send_l1: Your file on the procedure
+          dossier_send_l2: has been sent.
+          dossier_acces_l1: You have now access to your
+          dossier_acces_l2: online file.
+          dossier_edit_l1: You can
+          dossier_edit_l2: edit it
+          dossier_edit_l3: and
+          dossier_edit_l4: talk with an instructor.
+          acces_dossier: Access your file
+          submit_dossier: Submit an other file
+        show:
+          header:
+            edit_dossier: Edit my file
+            summary: "Summary"
+            request: "Request"
+            mailbox: "Mailbox"
+            dossier_number: "File n. %{dossier_id}"
+            submit_date: "- Submit on %{date_du_dossier}"
+            print: "print"
+            print_dossier: "All the file"
+          status_overview:
+            status_draft: draft
+            status_in_progress: in progress
+            en_construction_html: Your file is in progress. It means that <strong>you can still edit it</strong>. You will no longer be able to edit the file when the administration will switch it to "review".
+            status_review: undergoing review
+            admin_review: The administration is reviewing your file. You are no longer able to edit it.
+            status_completed: completed
+            use_mailbox_for_questions_html: "<strong>You have a question?</strong> Use the mailbox to <a href=\"%{mailbox_url}\">contact the administration directly</a>."
+          latest_message:
+            latest_message: "Latest message"
+        messagerie:
+          mailbox: "The mailbox allows you to contact the instructor in charge of your file."
+        demande:
+          edit_dossier: "Edit file"
+        index:
+          dossiers: "Files"
+        dossiers_list:
+          procedure: "Procedure"
+          n_dossier: "File n."
+          requester: "Requester"
+          status: "Status"
+          updated: "Updated"
+          actions: "Actions"
+          accessibility_question: "What do you think about the accessibility of this service?"
+        dossier_action:
+          edit_dossier: "Edit the file"
+          start_other_dossier: "Start an other file"
+          delete_dossier: "Delete the file"
+          edit_draft: "Edit the draft"
+          actions: "Actions"
+      sessions:
+        new:
+          sign_in: Sign in
+          email: Email address (name@site.com)
+          password: Password (minimum length %{min_length} characters)
+          remember_me: Remember me
+          reset_password: Forgot password?
+          connection: Sign in
+          are_you_new: First time on %{app_name}?
+          find_procedure: Find your procedure
   modal:
     publish:
       title:
@@ -164,6 +275,18 @@ en:
       zero: archived
       one: archived
       other: archived
+    mes_dossiers:
+      zero: my file
+      one: my file
+      other: my files
+    dossiers_invites:
+      zero: guest file
+      one: guest file
+      other: guest files
+    dossiers_supprimes:
+      zero: deleted file
+      one: deleted file
+      other: deleted files
     dossier_trouve:
       zero: 0 file found
       one: 1 file found
@@ -180,3 +303,16 @@ en:
       zero: Draft
       one: Draft
       other: Drafts
+  users:
+    dossiers:
+      test_procedure: "This file is submitted on a test procedure. Any modification of the procedure by the administrator (addition of a field, publication of the procedure, etc.) will result in the removal of the file."
+      message_send: "Your message has been sent to the instructor in charge of your file."
+      no_access: "You do not have access to this file"
+      no_longer_editable: "Your file can no longer be edited"
+      undergoingreview: "Your file is undergoing review. It is no longer possible to delete your file. To cancel the undergoingreview contact the adminitration via the mailbox."
+      deleted_dossier: "Your file has been successfully deleted"
+      archived_dossier: "Your file will be archived for an additional month"
+      draft_saved: "Your draft has been saved."
+      no_establishment: "There is no establishment tied to this file"
+      identity_saved: "Identity data is registred"
+      no_longer_available: "The certificate is no longer available on this file."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -28,46 +28,156 @@ fr:
     subject: Sujet
     message: Message
     send_mail: Envoyer le message
+  helpers:
+    procedure:
+      testing_procedure: démarche en test
+    commentaire:
+      send_message_to_instructeur: "Envoyer un message à l’instructeur"
+      reply_in_mailbox: "Répondre dans la messagerie."
   views:
+    commencer:
+      show:
+        start_procedure: Commencer la démarche
+        existing_dossiers: Vous avez déjà des dossiers pour cette démarche
+        show_dossiers: Voir mes dossiers en cours
+        start_new_dossier: Commencer un nouveau dossier
+    invites:
+      dropdown:
+        invite_to_edit: Inviter une personne à modifier ce dossier
+        view_invited_people: "Voir les personnes invitées"
+        invite_to_view: "Inviter une personne à consulter ce dossier"
+      form:
+        invite_to_edit_line1: Vous pouvez inviter quelqu’un à remplir ce dossier avec vous.
+        invite_to_edit_line2: Cette personne aura le droit de modifier votre dossier.
+        email: Adresse mail
+        invite_message: Ajouter un message à la personne invitée (optionnel)
+        send_invitation: Envoyer une invitation
+        invite_to_participate: "Personnes invitées à participer à ce dossier"
+        withdraw_permission: "Révoquer l’autorisation"
+        want_to_withdraw_permission: "Souhaitez-vous supprimer l’autorisation ?"
+        edit_dossier: "Ces personnes peuvent modifier ce dossier."
+        submit_dossier_yourself: "Une fois le dossier complet, vous devez le déposer vous-même."
+    layouts:
+      commencer:
+        no_procedure:
+          line1: Un outil simple
+          line2: pour gérer les formulaires
+          line3: administratifs dématérialisés.
     pagination:
       next: Suivant
       last: Dernier
       previous: Précédent
       first: Premier
       truncate: '&hellip;'
-    sessions:
-      new:
-        title: Connectez-vous
-        email: Email (nom@site.com)
-        password: Mot de passe
-        remember_me: Se souvenir de moi
-        reset_password: Mot de passe oublié ?
-        connection: Se connecter
-        are_you_new: Vous êtes nouveau sur %{app_name} ?
-        find_procedure: Trouvez votre démarche
-    commencer:
-      no_procedure:
-        ligne1: Un outil simple
-        ligne2: pour gérer les formulaires
-        ligne3: administratifs dématérialisés.
-    passwords:
-      new:
-        send_me_reset_password_instructions: "Indiquez l’email de votre compte, et nous vous enverrons un lien pour créer un nouveau mot de passe."
+    shared:
+      dossiers:
+        edit:
+          autosave: Votre dossier est enregistré automatiquement après chaque modification. Vous pouvez à tout moment fermer la fenêtre et reprendre plus tard là où vous en étiez.
+          submit_dossier: Déposer le dossier
+          save_changes: Enregistrer les modifications du dossier
+        messages:
+          message_issuer:
+            automatic_email: "Email automatique"
+            you: "Vous"
+          message:
+            reply: "Répondre"
+            guest: "Invité"
+          form:
+            send_message: "Envoyer le message"
+            attachment_size: "(taille max : 20 Mo)"
+            attach_dossier: "Joindre un document"
+            write_message_placeholder: "Écrivez votre message ici"
+            write_message_to_administration_placeholder: "Écrivez votre message à l’administration ici"
+        demande:
+          requester_identity: "Identité du demandeur"
+          form: "Formulaire"
+          edit_siret: "Modifier le SIRET"
+          edit_identity: "Modifier l’identité"
     users:
+      dossiers:
+        autosave:
+          autosave_draft: Votre brouillon est automatiquement enregistré.
+          more_infos: En savoir plus
+        identite:
+          identity_data: Données d’identité
+          complete_data: Merci de remplir vos informations personnelles pour accéder à la démarche.
+          continue: Continuer
+        merci:
+          thanks: Merci !
+          dossier_send_l1: Votre dossier sur la démarche
+          dossier_send_l2: a bien été envoyé.
+          dossier_acces_l1: Vous avez désormais accès à votre
+          dossier_acces_l2: dossier en ligne.
+          dossier_edit_l1: Vous pouvez
+          dossier_edit_l2: le modifier
+          dossier_edit_l3: et
+          dossier_edit_l4: échanger avec un instructeur.
+          acces_dossier: Accéder à votre dossier
+          submit_dossier: Déposer un autre dossier
+        show:
+          header:
+            edit_dossier: Modifier mon dossier
+            summary: "Résumé"
+            request: "Demande"
+            mailbox: "Messagerie"
+            dossier_number: "Dossier nº %{dossier_id}"
+            submit_date: "- Déposé le %{date_du_dossier}"
+            print: "imprimer"
+            print_dossier: "Tout le dossier"
+          status_overview:
+            status_draft: brouillon
+            status_in_progress: en construction
+            en_construction_html: "Votre dossier est en construction. Cela signifie que <strong>vous pouvez encore le modifier</strong>. Vous ne pourrez plus modifier votre dossier lorsque l’administration le passera « en instruction »."
+            status_review: en instruction
+            admin_review: Votre dossier est en cours d’instruction par l’administration. Vous ne pouvez plus le modifier.
+            status_completed: terminé
+            use_mailbox_for_questions_html: "<strong>Vous avez une question ?</strong> Utilisez la messagerie pour <a href=\"%{mailbox_url}\">contacter l’administration directement</a>."
+          latest_message:
+            latest_message: "Dernier message"
+        messagerie:
+          mailbox: "La messagerie vous permet de contacter l’instructeur en charge de votre dossier."
+        demande:
+          edit_dossier: "Modifier le dossier"
+        index:
+          dossiers: "Dossiers"
+        dossiers_list:
+          procedure: "Démarche"
+          n_dossier: "Nº dossier"
+          requester: "Demandeur"
+          status: "Statut"
+          updated: "Mis à jour"
+          actions: "Actions"
+          accessibility_question: "Que pensez-vous de la facilité d’utilisation de ce service ?"
+        dossier_action:
+          edit_dossier: "Modifier le dossier"
+          start_other_dossier: "Commencer un autre dossier"
+          delete_dossier: "Supprimer le dossier"
+          edit_draft: "Modifier le brouillon"
+          actions: "Actions"
+      sessions:
+        new:
+          sign_in: Connectez-vous
+          email: Email (nom@site.com)
+          password: Mot de passe (%{min_length} caractères minimum)
+          remember_me: Se souvenir de moi
+          reset_password: Mot de passe oublié ?
+          connection: Se connecter
+          are_you_new: Vous êtes nouveau sur %{app_name} ?
+          find_procedure: Trouvez votre démarche
       passwords:
         reset_link_sent:
           email_sent_html: "Nous vous avons envoyé un email à l’adresse <strong>%{email}</strong>."
           click_link_to_reset_password: "Cliquez sur le lien contenu dans l’email pour changer votre mot de passe."
-          no_mail: "Vous n’avez pas reçu l’email ?"
+          no_mail: "Vous n’avez pas reçu l’email ?"
           check_spams: "Vérifiez la boite Indésirables ou Spam de votre boite email."
-          check_account: "Avez-vous bien créé un compte %{application_name} avec l’adresse %{email} ? Si aucun compte n’existe avec cette adresse, vous ne recevrez pas de message."
-          check_france_connect_html: "Vous êtes-vous connecté avec France Connect par le passé ? Dans ce cas <a href=\"%{href}\">essayez à nouveau avec France Connect</a>."
+          check_account: "Avez-vous bien créé un compte %{application_name} avec l’adresse %{email} ? Si aucun compte n’existe avec cette adresse, vous ne recevrez pas de message."
+          check_france_connect_html: "Vous êtes-vous connecté avec France Connect par le passé ? Dans ce cas <a href=\"%{href}\">essayez à nouveau avec France Connect</a>."
           got_it: "Bien reçu !"
           open_your_mailbox: "Maintenant ouvrez votre boite email."
           title: "Lien de réinitialisation du mot de passe envoyé"
-      shared:
-        email_can_take_a_while_html: "<strong>Attention</strong>, ce message peut mettre jusqu’à <strong>15 minutes</strong> pour arriver."
-        contact_us_if_any_trouble_html: "En cas de difficultés, nous restons joignables <a href=\"%{href}\">via ce formulaire</a>."
+        shared:
+          email_can_take_a_while_html: "<strong>Attention</strong>, ce message peut mettre jusqu’à <strong>15 minutes</strong> pour arriver."
+          contact_us_if_any_trouble_html: "En cas de difficultés, nous restons joignables <a href=\"%{href}\">via ce formulaire</a>."
   modal:
     publish:
       title:
@@ -208,3 +318,16 @@ fr:
       zero: Brouillon
       one: Brouillon
       other: Brouillons
+  users:
+    dossiers:
+      test_procedure: "Ce dossier est déposé sur une démarche en test. Toute modification de la démarche par l’administrateur (ajout d'un champ, publication de la démarche...) entraînera sa suppression."
+      message_send: "Votre message a bien été envoyé à l’instructeur en charge de votre dossier."
+      no_access: "Vous n’avez pas accès à ce dossier"
+      no_longer_editable: "Votre dossier ne peut plus être modifié"
+      undergoingreview: "L’instruction de votre dossier a commencé, il n’est plus possible de supprimer votre dossier. Si vous souhaitez annuler l’instruction contactez votre administration par la messagerie de votre dossier."
+      deleted_dossier: "Votre dossier a bien été supprimé."
+      archived_dossier: "Votre dossier sera conservé un mois supplémentaire"
+      draft_saved: "Votre brouillon a bien été sauvegardé."
+      no_establishment: "Aucun établissement n’est associé à ce dossier"
+      identity_saved: "Identité enregistrée"
+      no_longer_available: "L’attestation n'est plus disponible sur ce dossier."

--- a/config/locales/models/individual/en.yml
+++ b/config/locales/models/individual/en.yml
@@ -1,0 +1,11 @@
+en:
+  activerecord:
+    attributes:
+      individual:
+        gender: Gender
+        nom: Last name
+        prenom: First name
+        birthdate: Date de naissance
+        gender_options:
+          "Mme": "Ms"
+          "M.": "Mr"

--- a/config/locales/models/individual/fr.yml
+++ b/config/locales/models/individual/fr.yml
@@ -8,4 +8,4 @@ fr:
         birthdate: Date de naissance
         gender_options:
           "Mme": "Madame"
-          "M." : "Monsieur"
+          "M.": "Monsieur"


### PR DESCRIPTION
La construction d’une clé et de son chemin :
 = t(chemin_de_la_view.dénomination_la_plus_proche)

  L’idée est de pouvoir retrouver via les fichiers yml où se situe les trad dans les views.  Tous les fichiers modifiés par au moins une traduction ne le sont pas obligatoirement dans leur entièreté (souvent parce que le champs à traduire à des paramètres et je n’ai pas trouvé la page correspondante pour vérifier le bon fonctionnement de la traduction).
