### PR TITLE
spec: fix flaky expert test

### DIFF
--- a/spec/features/instructeurs/expert_spec.rb
+++ b/spec/features/instructeurs/expert_spec.rb
@@ -42,7 +42,7 @@ feature 'Inviting an expert:', js: true do
       expect(emails_sent_to(expert2.email.to_s).size).to eq(1)
 
       invitation_email = open_email(expert.email.to_s)
-      avis = expert.avis.reload.last
+      avis = expert.avis.find_by(dossier: dossier)
       sign_up_link = sign_up_expert_avis_path(avis.dossier.procedure, avis, avis.expert.email)
       expect(invitation_email.body).to include(sign_up_link)
     end


### PR DESCRIPTION
In this test, two Avis are created for each expert:
- one for the original dossier,
- one for the dossier linked to the original dossier.

When we check for a sign-up link, we should do so using the Avis for the original dossier explicitely.