### PR TITLE
Fix "Initialization autoloaded the constants ActionText::ContentHelper" warning message

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem 'kaminari', '1.2.1' # Pagination
 gem 'listen' # Required by ActiveSupport::EventedFileUpdateChecker
 gem 'lograge'
 gem 'logstash-event'
-gem 'mailjet'
+gem 'mailjet', require: false
 gem 'openid_connect'
 gem 'pg'
 gem 'phonelib'

--- a/config/initializers/mailjet.rb
+++ b/config/initializers/mailjet.rb
@@ -1,5 +1,9 @@
-Mailjet.configure do |config|
-  config.api_key = Rails.application.secrets.mailjet[:api_key]
-  config.secret_key = Rails.application.secrets.mailjet[:secret_key]
-  config.default_from = CONTACT_EMAIL
+ActiveSupport.on_load(:action_mailer) do
+  require 'mailjet'
+
+  Mailjet.configure do |config|
+    config.api_key = Rails.application.secrets.mailjet[:api_key]
+    config.secret_key = Rails.application.secrets.mailjet[:secret_key]
+    config.default_from = CONTACT_EMAIL
+  end
 end


### PR DESCRIPTION
This fixes an error message on app startup about autoloaded constants:

> DEPRECATION WARNING: Initialization autoloaded the constants ActionText::ContentHelper and ActionText::TagHelper.

## Details

The reason for this error is that the Mailjet gem forces the immediate loading of `action_mailer`. Which leads to the following sequence of events:

On app init, when bundler requires all the gems in the Gemfile:
- The Mailjet gem is required,
- It loads `ActionMailer::Base`.

Later, when Rails initializes itself:
- `ActionText` creates an `action_text.helpers` initializer,
- This initializer register hooks to add `ActionText` helpers when either `action_controller_base` or `action_mailer` are loaded.
- But as `action_mailer` has already been loaded, the hook is trigerred immediately,
- ActiveSupport::Dependencies notices `ActionText` constants do not exist yet, auto-load them, and add the constants to `ActiveSupport::Dependencies.autoloaded_constants`.

And even later, at the end of the Rails initialization process:
- The `:warn_if_autoloaded` initializer is run,
- It notices that `autoloaded_constants` is not empty, and prints the warning message.

See mailjet/mailjet-gem#213