### PR TITLE
petites améliorations de l'UI de instructeur/procedure/show

### DIFF
--- a/app/assets/stylesheets/dossiers_table.scss
+++ b/app/assets/stylesheets/dossiers_table.scss
@@ -46,8 +46,6 @@
   }
 
   .notification-col {
-    width: 45px;
-
     a {
       font-size: 16px;
     }

--- a/app/views/instructeurs/procedures/_header_field.html.haml
+++ b/app/views/instructeurs/procedures/_header_field.html.haml
@@ -1,8 +1,9 @@
 %th{ class: classname }
   = link_to update_sort_instructeur_procedure_path(@procedure, table: field['table'], column: field['column']) do
-    = field['label']
     - if @procedure_presentation.sort['table'] == field['table'] && @procedure_presentation.sort['column'] == field['column']
       - if @procedure_presentation.sort['order'] == 'asc'
-        %img.caret-icon{ src: image_url("table/up_caret.svg"), width: 10, height: 6, loading: 'lazy' }
+        #{field['label']} ↑
       - else
-        %img.caret-icon{ src: image_url("table/down_caret.svg"), width: 10, height: 6, loading: 'lazy' }
+        #{field['label']} ↓
+    - else
+      #{field['label']}

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -38,7 +38,7 @@
             badge: number_with_html_delimiter(@traites_count),
             notification: @has_termine_notifications)
 
-          = tab_item('tous les dossiers',
+          = tab_item('au total',
             instructeur_procedure_path(@procedure, statut: 'tous'),
             active: @statut == 'tous',
             badge: number_with_html_delimiter(@tous_count))

--- a/app/views/shared/_tab_item.html.haml
+++ b/app/views/shared/_tab_item.html.haml
@@ -2,6 +2,6 @@
   - if notification
     %span.notifications{ 'aria-label': 'notifications' }
   = link_to(url) do
-    = label
     - if badge.present?
       %span.badge= badge
+    = label

--- a/spec/features/instructeurs/instruction_spec.rb
+++ b/spec/features/instructeurs/instruction_spec.rb
@@ -216,11 +216,11 @@ feature 'Instructing a dossier:', js: true do
 
   def test_statut_bar(a_suivre: 0, suivi: 0, traite: 0, tous_les_dossiers: 0, archive: 0)
     texts = [
-      "à suivre #{a_suivre}",
-      "suivi #{suivi}",
-      "traité #{traite}",
-      "tous les dossiers #{tous_les_dossiers}",
-      "archivé #{archive}"
+      "#{a_suivre} à suivre",
+      "#{suivi} suivi",
+      "#{traite} traité",
+      "#{tous_les_dossiers} au total",
+      "#{archive} archivé"
     ]
 
     texts.each { |text| expect(page).to have_text(text) }


### PR DESCRIPTION
**réécrit les compteurs dans le sens de lecture**

![Screenshot_2021-04-26 attestation · demarches-simplifiees fr(2)](https://user-images.githubusercontent.com/907405/116116829-deae6b80-a6bb-11eb-8836-a2a1eb8b4652.png)

à

![Screenshot_2021-04-26 attestation · demarches-simplifiees fr(3)](https://user-images.githubusercontent.com/907405/116116850-e5d57980-a6bb-11eb-9a7f-660fd737abdc.png)



**colle le texte et les flèches correspondantes dans l'entête du tableau**

![Screenshot_2021-04-26 attestation · demarches-simplifiees fr(1)](https://user-images.githubusercontent.com/907405/116117087-2634f780-a6bc-11eb-81fb-5226191b8d91.png)

à

![Screenshot_2021-04-26 attestation · demarches-simplifiees fr(4)](https://user-images.githubusercontent.com/907405/116117355-6e541a00-a6bc-11eb-905a-546c7139d33b.png)


