### PR TITLE
Enforce some contraints at the database level

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -2,47 +2,47 @@
 #
 # Table name: procedures
 #
-#  id                                  :integer          not null, primary key
-#  aasm_state                          :string           default("brouillon")
-#  allow_expert_review                 :boolean          default(TRUE), not null
-#  api_entreprise_token                :string
-#  ask_birthday                        :boolean          default(FALSE), not null
-#  auto_archive_on                     :date
-#  cadre_juridique                     :string
-#  cerfa_flag                          :boolean          default(FALSE)
-#  cloned_from_library                 :boolean          default(FALSE)
-#  closed_at                           :datetime
-#  declarative_with_state              :string
-#  description                         :string
-#  direction                           :string
-#  duree_conservation_dossiers_dans_ds :integer
-#  duree_conservation_dossiers_hors_ds :integer
-#  durees_conservation_required        :boolean          default(TRUE)
-#  euro_flag                           :boolean          default(FALSE)
-#  for_individual                      :boolean          default(FALSE)
+#  id                                        :integer          not null, primary key
+#  aasm_state                                :string           default("brouillon")
+#  allow_expert_review                       :boolean          default(TRUE), not null
+#  api_entreprise_token                      :string
+#  ask_birthday                              :boolean          default(FALSE), not null
+#  auto_archive_on                           :date
+#  cadre_juridique                           :string
+#  cerfa_flag                                :boolean          default(FALSE)
+#  cloned_from_library                       :boolean          default(FALSE)
+#  closed_at                                 :datetime
+#  declarative_with_state                    :string
+#  description                               :string
+#  direction                                 :string
+#  duree_conservation_dossiers_dans_ds       :integer
+#  duree_conservation_dossiers_hors_ds       :integer
+#  durees_conservation_required              :boolean          default(TRUE)
+#  euro_flag                                 :boolean          default(FALSE)
 #  experts_require_administrateur_invitation :boolean          default(FALSE)
-#  hidden_at                           :datetime
-#  juridique_required                  :boolean          default(TRUE)
-#  libelle                             :string
-#  lien_demarche                       :string
-#  lien_notice                         :string
-#  lien_site_web                       :string
-#  monavis_embed                       :text
-#  organisation                        :string
-#  path                                :string           not null
-#  published_at                        :datetime
-#  routing_criteria_name               :text             default("Votre ville")
-#  test_started_at                     :datetime
-#  unpublished_at                      :datetime
-#  web_hook_url                        :string
-#  whitelisted_at                      :datetime
-#  created_at                          :datetime         not null
-#  updated_at                          :datetime         not null
-#  canonical_procedure_id              :bigint
-#  draft_revision_id                   :bigint
-#  parent_procedure_id                 :bigint
-#  published_revision_id               :bigint
-#  service_id                          :bigint
+#  for_individual                            :boolean          default(FALSE)
+#  hidden_at                                 :datetime
+#  juridique_required                        :boolean          default(TRUE)
+#  libelle                                   :string
+#  lien_demarche                             :string
+#  lien_notice                               :string
+#  lien_site_web                             :string
+#  monavis_embed                             :text
+#  organisation                              :string
+#  path                                      :string           not null
+#  published_at                              :datetime
+#  routing_criteria_name                     :text             default("Votre ville")
+#  test_started_at                           :datetime
+#  unpublished_at                            :datetime
+#  web_hook_url                              :string
+#  whitelisted_at                            :datetime
+#  created_at                                :datetime         not null
+#  updated_at                                :datetime         not null
+#  canonical_procedure_id                    :bigint
+#  draft_revision_id                         :bigint
+#  parent_procedure_id                       :bigint
+#  published_revision_id                     :bigint
+#  service_id                                :bigint
 #
 
 class Procedure < ApplicationRecord

--- a/db/migrate/20210427120000_add_unique_index_to_invites.rb
+++ b/db/migrate/20210427120000_add_unique_index_to_invites.rb
@@ -1,0 +1,14 @@
+class AddUniqueIndexToInvites < ActiveRecord::Migration[6.1]
+  include Database::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  def up
+    delete_duplicates :invites, [:email, :dossier_id]
+    add_concurrent_index :invites, [:email, :dossier_id], unique: true
+  end
+
+  def down
+    remove_index :invites, column: [:email, :dossier_id]
+  end
+end

--- a/db/migrate/20210427120001_add_unique_index_to_procedures.rb
+++ b/db/migrate/20210427120001_add_unique_index_to_procedures.rb
@@ -1,0 +1,14 @@
+class AddUniqueIndexToProcedures < ActiveRecord::Migration[6.1]
+  include Database::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  def up
+    delete_duplicates :procedures, [:path, :closed_at, :hidden_at, :unpublished_at]
+    add_concurrent_index :procedures, [:path, :closed_at, :hidden_at, :unpublished_at], name: 'procedure_path_uniqueness', unique: true
+  end
+
+  def down
+    remove_index :procedures, [:path, :closed_at, :hidden_at, :unpublished_at], name: 'procedure_path_uniqueness'
+  end
+end

--- a/db/migrate/20210427120002_add_unique_index_to_individuals.rb
+++ b/db/migrate/20210427120002_add_unique_index_to_individuals.rb
@@ -1,0 +1,14 @@
+class AddUniqueIndexToIndividuals < ActiveRecord::Migration[6.1]
+  include Database::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  def up
+    delete_duplicates :individuals, [:dossier_id]
+    add_concurrent_index :individuals, [:dossier_id], unique: true
+  end
+
+  def down
+    remove_index :individuals, [:dossier_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_22_101149) do
+ActiveRecord::Schema.define(version: 2021_04_27_120002) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -446,7 +446,7 @@ ActiveRecord::Schema.define(version: 2021_04_22_101149) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.date "birthdate"
-    t.index ["dossier_id"], name: "index_individuals_on_dossier_id"
+    t.index ["dossier_id"], name: "index_individuals_on_dossier_id", unique: true
   end
 
   create_table "initiated_mails", id: :serial, force: :cascade do |t|
@@ -474,6 +474,7 @@ ActiveRecord::Schema.define(version: 2021_04_22_101149) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text "message"
+    t.index ["email", "dossier_id"], name: "index_invites_on_email_and_dossier_id", unique: true
   end
 
   create_table "module_api_cartos", id: :serial, force: :cascade do |t|
@@ -559,6 +560,7 @@ ActiveRecord::Schema.define(version: 2021_04_22_101149) do
     t.index ["draft_revision_id"], name: "index_procedures_on_draft_revision_id"
     t.index ["hidden_at"], name: "index_procedures_on_hidden_at"
     t.index ["parent_procedure_id"], name: "index_procedures_on_parent_procedure_id"
+    t.index ["path", "closed_at", "hidden_at", "unpublished_at"], name: "procedure_path_uniqueness", unique: true
     t.index ["path", "closed_at", "hidden_at"], name: "index_procedures_on_path_and_closed_at_and_hidden_at", unique: true
     t.index ["published_revision_id"], name: "index_procedures_on_published_revision_id"
     t.index ["service_id"], name: "index_procedures_on_service_id"


### PR DESCRIPTION
Enforce uniqueness constraints at the database level, on:
- Invites,
- Procedures,
- Individuals.

These are the tables less likely to have duplicates.

A follow-up PR will contains similar migrations, but more likely to have existing duplicates that need to be removed.

Refs #6124 6013