### PR TITLE
db: fix migration adding unique index to Individuals

### DIFF
--- a/db/migrate/20210427120002_add_unique_index_to_individuals.rb
+++ b/db/migrate/20210427120002_add_unique_index_to_individuals.rb
@@ -5,10 +5,12 @@ class AddUniqueIndexToIndividuals < ActiveRecord::Migration[6.1]
 
   def up
     delete_duplicates :individuals, [:dossier_id]
+    remove_index :individuals, [:dossier_id]
     add_concurrent_index :individuals, [:dossier_id], unique: true
   end
 
   def down
-    remove_index :individuals, [:dossier_id]
+    remove_index :individuals, [:dossier_id], unique: true
+    add_concurrent_index :individuals, [:dossier_id]
   end
 end


### PR DESCRIPTION
La table a déjà un index existant : il faut donc le supprimer avant de le re-créer, sinon le déploiement échoue.