### PR TITLE
#6161 - Fix (GraphQL): raise exception when blob is missing

### DIFF
--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -5,6 +5,8 @@ module Mutations
     def validate_blob(blob_id)
       begin
         blob = ActiveStorage::Blob.find_signed(blob_id)
+        raise ActiveSupport::MessageVerifier::InvalidSignature if blob.nil?
+
         # open downloads the file and checks its hash
         blob.open { |f| }
         true


### PR DESCRIPTION
Fixed #6161 "ETQ developpeur, je souhaite éviter qu'une exception soit levée par la gem GraphQL lors des tests" / @adullact

## Résumé 

Lors des tests, une exception est levée par la gem GraphQL

##  Actuellement

```ruby
rspec ./spec/controllers/api/v2/graphql_controller_spec.rb:777

Failures:

  1) API::V2::GraphqlController when authenticated mutations dossierEnvoyerMessage upload error should fail
     Failure/Error: expect(gql_errors).to eq(nil)

       expected: nil
            got: [{:backtrace=>["/usr/local/bundle/ruby/2.7.0/gems/graphql-1.12.5/lib/graphql/backtrace/tracer.rb:64:i...]
```

## Comportement attendu

```ruby
bin/rspec ./spec/controllers/api/v2/graphql_controller_spec.rb
............................................
44 examples, 0 failures
```



## Correctif proposé

Il apparaît que l'appel à `ActiveStorage::Blob.find_signed` peut à l'occasion retourner la valeur `nil`. Ce qui, sans contrôle, nous amène à exécuter `nil.open` au lieu de `blob.open` à la ligne suivante.

Afin de faire passer avec succès le test incriminé, le correctif présenté ici propose de nous éviter cette déconvenue en levant une exception `ActiveSupport::MessageVerifier::InvalidSignature` qui sera interceptée par la clause `rescue` de la méthode appelante. 

--------------

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe betagouv sur le ticket et sur cette PR (répondre aux commentaires, pousser des commits, ...).


## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur BetaGouv pour faire le rebase directement sur notre dépôt.

