### PR TITLE
jobs: add Excon::Error::Socket to the list of transient errors

### DIFF
--- a/app/lib/active_job/retry_on_transient_errors.rb
+++ b/app/lib/active_job/retry_on_transient_errors.rb
@@ -4,7 +4,8 @@ module ActiveJob::RetryOnTransientErrors
   TRANSIENT_ERRORS = [
     Excon::Error::InternalServerError,
     Excon::Error::GatewayTimeout,
-    Excon::Error::BadRequest
+    Excon::Error::BadRequest,
+    Excon::Error::Socket
   ]
 
   included do


### PR DESCRIPTION
In ActiveStorage::Purge job we see a lot of SSL errors:

> Connection reset by peer - SSL_connect (Errno::ECONNRESET)

These errors seem transient, and resolve themselves after a while, so retry automatically for a while before bailing out.