### PR TITLE
Use HELO (custom dev SMTP)

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -87,7 +87,21 @@ Rails.application.configure do
       authentication: :cram_md5
     }
   else
-    config.action_mailer.delivery_method = :letter_opener_web
+    # https://usehelo.com
+    if ENV['HELO_ENABLED'] == 'enabled'
+      config.action_mailer.delivery_method = :smtp
+      config.action_mailer.smtp_settings = {
+        user_name: APPLICATION_NAME,
+        password: '',
+        address: '127.0.0.1',
+        domain: '127.0.0.1',
+        port: ENV.fetch('HELO_PORT', '2525'),
+        authentication: :plain
+      }
+    else
+      config.action_mailer.delivery_method = :letter_opener_web
+    end
+
     config.action_mailer.default_url_options = {
       host: 'localhost',
       port: 3000


### PR DESCRIPTION
J’ai récemment découvert HELO https://usehelo.com et c’est tellement bien. Ça vaut tellement les 15$ et c’est fait par des dev indep sympa. Le souci c’est que c’est un peu chiant d’overrider dans l’état la config du smtp en dev. Donc je propose cette PR qui ajoute une config optionnelle du serveur local de HELO. L’autre option serait d’ajouter plusieurs variables d’ENV en dev pour faire du setup de smtp custom. Si vous préférez cette deuxième option plus générique, je transformerai ma PR.