### PR TITLE
prend en compte uniquement les pj pour estimer la taille d'un dossier

### DIFF
--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -211,7 +211,7 @@ module Instructeurs
     end
 
     def telecharger_pjs
-      return head(:forbidden) if !dossier.attachments_downloadable?
+      return head(:forbidden) if !dossier.export_and_attachments_downloadable?
 
       files = ActiveStorage::DownloadableFile.create_list_from_dossier(dossier)
 

--- a/app/lib/active_storage/downloadable_file.rb
+++ b/app/lib/active_storage/downloadable_file.rb
@@ -1,7 +1,7 @@
 class ActiveStorage::DownloadableFile
   def self.create_list_from_dossier(dossier)
     dossier_export = PiecesJustificativesService.generate_dossier_export(dossier)
-    pjs = [dossier_export] + PiecesJustificativesService.liste_pieces_justificatives(dossier)
+    pjs = [dossier_export] + PiecesJustificativesService.liste_documents(dossier)
     pjs.map do |piece_justificative|
       [
         piece_justificative,

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -873,9 +873,8 @@ class Dossier < ApplicationRecord
     end
   end
 
-  def attachments_downloadable?
-    PiecesJustificativesService.liste_pieces_justificatives(self).present? \
-      && PiecesJustificativesService.pieces_justificatives_total_size(self) < Dossier::TAILLE_MAX_ZIP
+  def export_and_attachments_downloadable?
+    PiecesJustificativesService.pieces_justificatives_total_size(self) < Dossier::TAILLE_MAX_ZIP
   end
 
   def linked_dossiers_for(instructeur_or_expert)

--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -1,10 +1,18 @@
 class PiecesJustificativesService
-  def self.liste_pieces_justificatives(dossier)
+  def self.liste_documents(dossier)
     pjs_champs = pjs_for_champs(dossier)
     pjs_commentaires = pjs_for_commentaires(dossier)
     pjs_dossier = pjs_for_dossier(dossier)
 
     (pjs_champs + pjs_commentaires + pjs_dossier)
+      .filter(&:attached?)
+  end
+
+  def self.liste_pieces_justificatives(dossier)
+    pjs_champs = pjs_for_champs(dossier)
+    pjs_commentaires = pjs_for_commentaires(dossier)
+
+    (pjs_champs + pjs_commentaires)
       .filter(&:attached?)
   end
 

--- a/app/views/instructeurs/dossiers/_header_actions.html.haml
+++ b/app/views/instructeurs/dossiers/_header_actions.html.haml
@@ -12,16 +12,15 @@
       %li
         = link_to "Export GeoJSON", geo_data_instructeur_dossier_path(dossier.procedure, dossier), target: "_blank", rel: "noopener", class: "menu-item menu-link"
 
-- if PiecesJustificativesService.liste_pieces_justificatives(dossier).present?
-  %span.dropdown.print-menu-opener
-    %button.button.dropdown-button.icon-only{ 'aria-expanded' => 'false', 'aria-controls' => 'print-pj-menu' }
-      %span.icon.attached
-    %ul#print-pj-menu.print-menu.dropdown-content
-      %li
-        - if PiecesJustificativesService.pieces_justificatives_total_size(dossier) < Dossier::TAILLE_MAX_ZIP
-          = link_to "Télécharger le dossier et toutes ses pièces jointes", telecharger_pjs_instructeur_dossier_path(dossier.procedure, dossier), target: "_blank", rel: "noopener", class: "menu-item menu-link"
-        - else
-          %p.menu-item Le téléchargement des pièces jointes est désactivé pour les dossiers de plus de #{number_to_human_size Dossier::TAILLE_MAX_ZIP}.
+%span.dropdown.print-menu-opener
+  %button.button.dropdown-button.icon-only{ 'aria-expanded' => 'false', 'aria-controls' => 'print-pj-menu' }
+    %span.icon.attached
+  %ul#print-pj-menu.print-menu.dropdown-content
+    %li
+      - if dossier.export_and_attachments_downloadable?
+        = link_to "Télécharger le dossier et toutes ses pièces jointes", telecharger_pjs_instructeur_dossier_path(dossier.procedure, dossier), target: "_blank", rel: "noopener", class: "menu-item menu-link"
+      - else
+        %p.menu-item Le téléchargement des pièces jointes est désactivé pour les dossiers de plus de #{number_to_human_size Dossier::TAILLE_MAX_ZIP}.
 
 = render partial: "instructeurs/procedures/dossier_actions",
   locals: { procedure_id: dossier.procedure.id,

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1135,30 +1135,26 @@ describe Dossier do
     after { Timecop.return }
   end
 
-  describe '#attachments_downloadable?' do
+  describe '#export_and_attachments_downloadable?' do
     let(:dossier) { create(:dossier, user: user) }
-    # subject { dossier.attachments_downloadable? }
 
     context "no attachments" do
       it {
-        expect(PiecesJustificativesService).to receive(:liste_pieces_justificatives).and_return([])
-        expect(dossier.attachments_downloadable?).to be false
+        expect(dossier.export_and_attachments_downloadable?).to be true
       }
     end
 
     context "with a small attachment" do
       it {
-        expect(PiecesJustificativesService).to receive(:liste_pieces_justificatives).and_return([Champ.new])
         expect(PiecesJustificativesService).to receive(:pieces_justificatives_total_size).and_return(4.megabytes)
-        expect(dossier.attachments_downloadable?).to be true
+        expect(dossier.export_and_attachments_downloadable?).to be true
       }
     end
 
     context "with a too large attachment" do
       it {
-        expect(PiecesJustificativesService).to receive(:liste_pieces_justificatives).and_return([Champ.new])
         expect(PiecesJustificativesService).to receive(:pieces_justificatives_total_size).and_return(100.megabytes)
-        expect(dossier.attachments_downloadable?).to be false
+        expect(dossier.export_and_attachments_downloadable?).to be false
       }
     end
   end


### PR DESCRIPTION
Cette PR permet d'optimiser le nombre de requêtes sql pour l'affichage de la vue dossier par un instructeur

## Avant optimisation

28 requêtes sql pour le partial `_header_actions`
![avant-optim](https://user-images.githubusercontent.com/1111966/116980404-7c122c80-acc6-11eb-838a-6324ddb76140.png)

## Après optimisation

12 requêtes sql pour le partial `_header_actions`
![apres-optim](https://user-images.githubusercontent.com/1111966/116980470-8f24fc80-acc6-11eb-9414-11a8d30ad1bf.png)
