### PR TITLE
activate rack_mini_profiler in dev

### DIFF
--- a/config/initializers/rack_mini_profiler.rb
+++ b/config/initializers/rack_mini_profiler.rb
@@ -1,3 +1,3 @@
 if Rails.env.development?
-  Rack::MiniProfiler.config.authorization_mode = :whitelist
+  Rack::MiniProfiler.config.show_total_sql_count = true
 end


### PR DESCRIPTION
Certaines de nos pages ont des temps de réponse qui impactent l'expérience utilisateur.
L'idée de cette PR n'est pas d'optimiser les performances à tout prix, ni trop tôt, mais de permettre au dev d'avoir facilement accès au profiler avant de pousser du code.

poke @LeSim 