### PR TITLE
Corrige une duplication des dossiers dans le tableau d'une procedure

### DIFF
--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -121,6 +121,7 @@ class ProcedurePresentation < ApplicationRecord
         .joins('LEFT OUTER JOIN users instructeurs_users ON instructeurs_users.instructeur_id = instructeurs.id')
         .order("instructeurs_users.email #{order}")
         .pluck(:id)
+        .uniq
     when 'self', 'user', 'individual', 'etablissement', 'groupe_instructeur'
       (table == 'self' ? dossiers : dossiers.includes(table))
         .order("#{self.class.sanitized_column(table, column)} #{order}")

--- a/app/services/dossier_projection_service.rb
+++ b/app/services/dossier_projection_service.rb
@@ -81,7 +81,7 @@ class DossierProjectionService
           .where(dossier_id: dossiers_ids)
           .pluck('dossier_id, users.email')
           .group_by { |dossier_id, _| dossier_id }
-          .to_h { |dossier_id, dossier_id_emails| [dossier_id, dossier_id_emails.map { |_, email| email }&.join(', ')] }
+          .to_h { |dossier_id, dossier_id_emails| [dossier_id, dossier_id_emails.sort.map { |_, email| email }&.join(', ')] }
       end
     end
 

--- a/spec/models/procedure_presentation_spec.rb
+++ b/spec/models/procedure_presentation_spec.rb
@@ -273,6 +273,7 @@ describe ProcedurePresentation do
 
       before do
         create(:follow, dossier: dossier_a, instructeur: create(:instructeur, email: 'abaca@exemple.fr'))
+        create(:follow, dossier: dossier_a, instructeur: create(:instructeur, email: 'abaca2@exemple.fr'))
         create(:follow, dossier: dossier_z, instructeur: create(:instructeur, email: 'zythum@exemple.fr'))
       end
 

--- a/spec/services/dossier_projection_service_spec.rb
+++ b/spec/services/dossier_projection_service_spec.rb
@@ -136,10 +136,11 @@ describe DossierProjectionService do
         let(:column) { 'email' }
 
         let(:dossier) { create(:dossier) }
-        let!(:follow1) { create(:follow, dossier: dossier, instructeur: create(:instructeur, email: 'user1@host')) }
-        let!(:follow2) { create(:follow, dossier: dossier, instructeur: create(:instructeur, email: 'user2@host')) }
+        let!(:follow1) { create(:follow, dossier: dossier, instructeur: create(:instructeur, email: 'b@host')) }
+        let!(:follow2) { create(:follow, dossier: dossier, instructeur: create(:instructeur, email: 'a@host')) }
+        let!(:follow3) { create(:follow, dossier: dossier, instructeur: create(:instructeur, email: 'c@host')) }
 
-        it { is_expected.to eq "user1@host, user2@host" }
+        it { is_expected.to eq "a@host, b@host, c@host" }
       end
 
       context 'for type_de_champ table' do


### PR DESCRIPTION
Cette duplication apparaît lorsque la clé d'ordonnancement est l'email des instructeurs qui suivent le dossier.

En bonus, cette pr affiche le nom des instructeur qui suivent le dossier dans l'ordre alphabétique.