### PR TITLE
SuperAdmin : réparation du manager après la mise à jour à Rails 6.1.3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'active_link_to' # Automatically set a class on active links
 gem 'active_model_serializers'
 gem 'activestorage-openstack'
 gem 'active_storage_validations'
-gem 'administrate'
+gem 'administrate', git: 'https://github.com/thoughtbot/administrate.git', ref: 'refs/pull/1972/head' # Provides an administration UI (pull request #1972 has fixes for Rails 6.1.3.2)
 gem 'after_party'
 gem 'anchored'
 gem 'bcrypt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,22 @@ GIT
       open4 (~> 1.3.4)
       rake
 
+GIT
+  remote: https://github.com/thoughtbot/administrate.git
+  revision: 27404f6bbbfa8ae7227ff205ac8cc4ad194194dd
+  ref: refs/pull/1972/head
+  specs:
+    administrate (0.15.0)
+      actionpack (>= 5.0)
+      actionview (>= 5.0)
+      activerecord (>= 5.0)
+      datetime_picker_rails (~> 0.0.7)
+      jquery-rails (>= 4.0)
+      kaminari (>= 1.0)
+      momentjs-rails (~> 2.8)
+      sassc-rails (~> 2.1)
+      selectize-rails (~> 0.6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -86,17 +102,6 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    administrate (0.14.0)
-      actionpack (>= 4.2)
-      actionview (>= 4.2)
-      activerecord (>= 4.2)
-      autoprefixer-rails (>= 6.0)
-      datetime_picker_rails (~> 0.0.7)
-      jquery-rails (>= 4.0)
-      kaminari (>= 1.0)
-      momentjs-rails (~> 2.8)
-      sassc-rails (~> 2.1)
-      selectize-rails (~> 0.6)
     aes_key_wrap (1.1.0)
     after_party (1.11.2)
     anchored (1.1.0)
@@ -107,8 +112,6 @@ GEM
     attr_encrypted (3.1.0)
       encryptor (~> 3.0.0)
     attr_required (1.0.1)
-    autoprefixer-rails (10.2.4.0)
-      execjs
     axe-matchers (2.6.1)
       dumb_delegator (~> 0.8)
       virtus (~> 1.0)
@@ -772,7 +775,7 @@ DEPENDENCIES
   active_model_serializers
   active_storage_validations
   activestorage-openstack
-  administrate
+  administrate!
   after_party
   anchored
   annotate

--- a/app/views/manager/application/_navigation.html.erb
+++ b/app/views/manager/application/_navigation.html.erb
@@ -16,7 +16,7 @@ as defined by the routes in the `admin/` namespace
 
     <%= link_to(
       display_resource_name(resource),
-      [namespace, resource.path],
+      resource_index_route(resource),
       class: "navigation__link navigation__link--#{nav_link_state(resource)}"
     ) %>
   <% end %>


### PR DESCRIPTION
Rails 6.1.3.2 is a security upgrade, and we had to upgrade quickly. Unfortunately that broke the `administrate` gem we use for the Manager.

A PR has been opened to fix the issues with the newest Rails version, and will probably be merged quickly. Meanwhile we can fix the manager by using the version from the PR for now.

Once the PR is merged and a new version of administrate is released, we can use a released version of administrate again.