### PR TITLE
SuperAdmin : correction de la page /manager/dossiers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'active_model_serializers'
 gem 'activestorage-openstack'
 gem 'active_storage_validations'
 gem 'administrate', git: 'https://github.com/thoughtbot/administrate.git', ref: 'refs/pull/1972/head' # Provides an administration UI (pull request #1972 has fixes for Rails 6.1.3.2)
+gem 'administrate-field-enum' # Allow using Field::Enum in administrate
 gem 'after_party'
 gem 'anchored'
 gem 'bcrypt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,8 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    administrate-field-enum (0.0.9)
+      administrate (~> 0.12)
     aes_key_wrap (1.1.0)
     after_party (1.11.2)
     anchored (1.1.0)
@@ -776,6 +778,7 @@ DEPENDENCIES
   active_storage_validations
   activestorage-openstack
   administrate!
+  administrate-field-enum
   after_party
   anchored
   annotate

--- a/app/dashboards/dossier_dashboard.rb
+++ b/app/dashboards/dossier_dashboard.rb
@@ -10,7 +10,7 @@ class DossierDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::Number.with_options(searchable: true),
     procedure: Field::HasOne,
-    state: Field::String,
+    state: Field::Enum,
     user: Field::BelongsTo,
     text_summary: Field::String.with_options(searchable: false),
     created_at: Field::DateTime,

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -1088,7 +1088,7 @@ enum DossierState {
   refuse
 
   """
-  Sans suite
+  Classé sans suite
   """
   sans_suite
 }

--- a/app/graphql/types/dossier_type.rb
+++ b/app/graphql/types/dossier_type.rb
@@ -2,7 +2,7 @@ module Types
   class DossierType < Types::BaseObject
     class DossierState < Types::BaseEnum
       Dossier.aasm.states.reject { |state| state.name == :brouillon }.each do |state|
-        value(state.name.to_s, state.display_name, value: state.name.to_s)
+        value(state.name.to_s, Dossier.human_attribute_name("state.#{state.name}"), value: state.name.to_s)
       end
     end
 

--- a/app/helpers/dossier_helper.rb
+++ b/app/helpers/dossier_helper.rb
@@ -51,7 +51,7 @@ module DossierHelper
 
   def dossier_display_state(dossier_or_state, lower: false)
     state = dossier_or_state.is_a?(Dossier) ? dossier_or_state.state : dossier_or_state
-    display_state = I18n.t(state, scope: [:activerecord, :attributes, :dossier, :state])
+    display_state = Dossier.human_attribute_name("state.#{state}")
     lower ? display_state.downcase : display_state
   end
 

--- a/config/locales/models/dossier/fr.yml
+++ b/config/locales/models/dossier/fr.yml
@@ -9,20 +9,16 @@ fr:
         montant_projet: 'Le montant du projet'
         montant_aide_demande: "Le montant d’aide demandée"
         date_previsionnelle: "La date de début prévisionnelle"
-        state: &state
-          brouillon: "Brouillon"
-          en_construction: "En construction"
-          en_instruction: "En instruction"
-          accepte: "Accepté"
-          refuse: "Refusé"
-          sans_suite: "Classé sans suite"
+        state: "État"
         autorisation_donnees: Acceptation des CGU
-        state/brouillon: Brouillon
-        state/en_construction: En construction
-        state/en_instruction: En instruction
-        state/accepte: Accepté
-        state/refuse: Refusé
-        state/sans_suite: Sans suite
+      dossier/state: &state
+        brouillon: "Brouillon"
+        en_construction: "En construction"
+        en_instruction: "En instruction"
+        accepte: "Accepté"
+        refuse: "Refusé"
+        sans_suite: "Classé sans suite"
       traitement:
-        state:
-          <<: *state
+        state: "État"
+      traitement/state:
+        <<: *state


### PR DESCRIPTION
Les traductions de Dossier.state étaient déclarées bizarrement, ce qui faisait crasher les nouvelles version d'administrate.

Cette PR nettoie les traductions de Dossier.state, qui sont maintenant conformes aux guidelines Rails.