### PR TITLE
#6187 - Fix(API Entreprise): test fails randomly

### DIFF
--- a/spec/jobs/api_entreprise/exercices_job_spec.rb
+++ b/spec/jobs/api_entreprise/exercices_job_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe APIEntreprise::ExercicesJob, type: :job do
 
   it 'updates etablissement' do
     subject
-    expect(Etablissement.find(etablissement.id).exercices[0].ca).to eq('21009417')
+    ca_list = Etablissement.find(etablissement.id).exercices.map(&:ca)
+    expect(ca_list).to contain_exactly('21009417', '18968298', '17768838')
   end
 end


### PR DESCRIPTION
Fixed #6187 "ETQ developpeur, je souhaite éviter qu'un test sur API Entreprise échoue de manière aléatoire" / @adullact

## Résumé 

Échec aléatoire d'un test sur API Entreprise.

##  Actuellement

Le test suivant échoue de manière aléatoire :
```ruby
rspec ./spec/jobs/api_entreprise/exercices_job_spec.rb

  1) APIEntreprise::ExercicesJob updates etablissement
     Failure/Error: expect(Etablissement.find(etablissement.id).exercices[0].ca).to eq('21009417')

       expected: "21009417"
            got: "17768838"

       (compared using ==)
     # ./spec/jobs/api_entreprise/exercices_job_spec.rb:18:in `block (2 levels) in <main>'
```

## Comportement attendu

```ruby
bin/rspec ./spec/jobs/api_entreprise/exercices_job_spec.rb
...
1 example, 0 failures
```

## Correctif proposé

Ne pas présumer de l'ordre du tableau, vérifier simplement que toutes les valeurs sont présentes. 
Pour cela RSpec met à disposition un _matcher_ `contain_exactly`.

Doc : https://relishapp.com/rspec/rspec-expectations/v/3-8/docs/built-in-matchers/contain-exactly-matcher

--------------

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe betagouv sur le ticket et sur cette PR (répondre aux commentaires, pousser des commits, ...).


## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur BetaGouv pour faire le rebase directement sur notre dépôt.

