### PR TITLE
i18n : ajout d'un test pour le sélecteur de langues

### DIFF
--- a/spec/features/i18n_spec.rb
+++ b/spec/features/i18n_spec.rb
@@ -1,0 +1,19 @@
+feature 'Accessing the website in different languages:' do
+  context 'when the i18n feature-flag is enabled' do
+    before { ENV['LOCALIZATION_ENABLED'] = 'true' }
+    after { ENV['LOCALIZATION_ENABLED'] = 'false' }
+
+    scenario 'I can change the language of the page' do
+      visit new_user_session_path
+      expect(page).to have_text('Connectez-vous')
+
+      click_on 'Translate'
+      click_on 'EN - English'
+
+      # The page is now in English
+      expect(page).to have_text('Sign in')
+      # The page URL stayed the same
+      expect(page).to have_current_path(new_user_session_path)
+    end
+  end
+end


### PR DESCRIPTION
Cette PR ajoute un test d'intégration pour le sélecteur de langues.