### PR TITLE
#6237 - Fix (InstructeursImportService): test fails randomly

### DIFF
--- a/spec/services/instructeurs_import_service_spec.rb
+++ b/spec/services/instructeurs_import_service_spec.rb
@@ -7,6 +7,7 @@ describe InstructeursImportService do
       procedure
         .groupe_instructeurs
         .map { |gi| [gi.label, gi.instructeurs.map(&:email)] }
+        .to_h
     end
 
     subject { service.import(procedure, lines) }
@@ -23,11 +24,10 @@ describe InstructeursImportService do
       it 'imports' do
         errors = subject
 
-        expect(procedure_groupes).to match_array([
-          ["Auvergne Rhone-Alpes", ["john@lennon.fr"]],
-          ["Occitanie", ["paul@mccartney.uk", "ringo@starr.uk"]],
-          ["défaut", []]
-        ])
+        expect(procedure_groupes.keys).to contain_exactly("Auvergne Rhone-Alpes", "Occitanie", "défaut")
+        expect(procedure_groupes["Auvergne Rhone-Alpes"]).to contain_exactly("john@lennon.fr")
+        expect(procedure_groupes["Occitanie"]).to contain_exactly("paul@mccartney.uk", "ringo@starr.uk")
+        expect(procedure_groupes["défaut"]).to be_empty
 
         expect(errors).to match_array([])
       end
@@ -48,10 +48,9 @@ describe InstructeursImportService do
       it 'adds instructeur to existing groupe' do
         subject
 
-        expect(procedure_groupes).to match_array([
-          ["Occitanie", ["george@harisson.uk", "ringo@starr.uk"]],
-          ["défaut", []]
-        ])
+        expect(procedure_groupes.keys).to contain_exactly("Occitanie", "défaut")
+        expect(procedure_groupes["Occitanie"]).to contain_exactly("george@harisson.uk", "ringo@starr.uk")
+        expect(procedure_groupes["défaut"]).to be_empty
       end
     end
 
@@ -67,12 +66,11 @@ describe InstructeursImportService do
       it 'ignores or corrects' do
         errors = subject
 
-        expect(procedure_groupes).to match_array([
-          ["Occitanie", ["paul@mccartney.uk", "ringo@starr.uk"]],
-          ["défaut", []]
-        ])
+        expect(procedure_groupes.keys).to contain_exactly("Occitanie", "défaut")
+        expect(procedure_groupes["Occitanie"]).to contain_exactly("paul@mccartney.uk", "ringo@starr.uk")
+        expect(procedure_groupes["défaut"]).to be_empty
 
-        expect(errors).to match_array(['paul'])
+        expect(errors).to contain_exactly("paul")
       end
     end
 
@@ -88,10 +86,9 @@ describe InstructeursImportService do
       it 'reuses instructeur' do
         subject
 
-        expect(procedure_groupes).to match_array([
-          ["Occitanie", [instructeur.email, "ringo@starr.uk"]],
-          ["défaut", []]
-        ])
+        expect(procedure_groupes.keys).to contain_exactly("Occitanie", "défaut")
+        expect(procedure_groupes["Occitanie"]).to contain_exactly(instructeur.email, "ringo@starr.uk")
+        expect(procedure_groupes["défaut"]).to be_empty
       end
     end
 
@@ -106,10 +103,9 @@ describe InstructeursImportService do
       it 'ignores duplicated instructeur' do
         subject
 
-        expect(procedure_groupes).to match_array([
-          ["Occitanie", ["ringo@starr.uk"]],
-          ["défaut", []]
-        ])
+        expect(procedure_groupes.keys).to contain_exactly("Occitanie", "défaut")
+        expect(procedure_groupes["Occitanie"]).to contain_exactly("ringo@starr.uk")
+        expect(procedure_groupes["défaut"]).to be_empty
       end
     end
 
@@ -124,14 +120,10 @@ describe InstructeursImportService do
       it 'ignores instructeur' do
         errors = subject
 
-        expect(procedure_groupes).to match_array([
-          ["défaut", []]
-        ])
+        expect(procedure_groupes.keys).to contain_exactly("défaut")
+        expect(procedure_groupes["défaut"]).to be_empty
 
-        expect(errors).to match_array([
-          'ringo@starr.uk',
-          'paul@starr.uk'
-        ])
+        expect(errors).to contain_exactly("ringo@starr.uk", "paul@starr.uk")
       end
     end
   end


### PR DESCRIPTION
Fixed #6237 "ETQ dev, je souhaite éviter qu'un test échoue de manière aléatoire (InstructeursImport)" / @adullact

## Résumé 

Échec aléatoire des tests sur [`./spec/services/instructeurs_import_service_spec.rb`](https://github.com/betagouv/demarches-simplifiees.fr/blob/main/spec/services/instructeurs_import_service_spec.rb).

##  Actuellement

Le test suivant échoue de manière aléatoire :

```ruby
bin/rspec ./spec/services/instructeurs_import_service_spec.rb
Failures:
  1) InstructeursImportService#import when an email is malformed ignores or corrects
     Failure/Error:
       expect(procedure_groupes).to match_array([
         ["Occitanie", ["paul@mccartney.uk", "ringo@starr.uk"]],
         ["défaut", []]
       ])
       expected collection contained:  [["Occitanie", ["paul@mccartney.uk", "ringo@starr.uk"]], ["défaut", []]]
       actual collection contained:    [["Occitanie", ["ringo@starr.uk", "paul@mccartney.uk"]], ["défaut", []]]
       the missing elements were:      [["Occitanie", ["paul@mccartney.uk", "ringo@starr.uk"]]]
       the extra elements were:        [["Occitanie", ["ringo@starr.uk", "paul@mccartney.uk"]]]
     # ./spec/services/instructeurs_import_service_spec.rb:70:in `block (4 levels) in <main>'
```

## Comportement attendu

```ruby
bin/rspec ./spec/services/instructeurs_import_service_spec.rb
...
6 examples, 0 failures
```

## Correctif proposé 

Comparaison de tableaux à une dimension 
et utilisation du sélecteur RSpec `contain_exactly` 
pour éviter ce comportement. 

- Doc : https://relishapp.com/rspec/rspec-expectations/v/3-8/docs/built-in-matchers/contain-exactly-matcher
- Similaire à #6188


--------------

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe betagouv sur le ticket et sur cette PR (répondre aux commentaires, pousser des commits, ...).


## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur BetaGouv 
pour faire le rebase directement sur notre dépôt.