### PR TITLE
#6239 - Fix sentry environment

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -244,7 +244,7 @@ class ApplicationController < ActionController::Base
     sentry = Rails.application.secrets.sentry
 
     {
-      key: sentry[:client_key],
+      key: sentry[:js_client_key],
       enabled: sentry[:enabled],
       environment: sentry[:environment],
       browser: { modern: BrowserSupport.supported?(browser) },

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,10 +1,12 @@
 Sentry.init do |config|
-  config.dsn = ENV['SENTRY_ENABLED'] == 'enabled' ? ENV['SENTRY_DSN_RAILS'] : nil
+  secrets = Rails.application.secrets.sentry
+
+  config.dsn = secrets[:enabled] ? secrets[:rails_client_key] : nil
   config.send_default_pii = false
-  config.environment = ENV.fetch('SENTRY_ENVIRONMENT', Rails.env)
-  config.enabled_environments = ['production', ENV['SENTRY_ENVIRONMENT'].presence].compact
+  config.environment = secrets[:environment] || Rails.env
+  config.enabled_environments = ['production', secrets[:environment].presence].compact
   config.breadcrumbs_logger = [:active_support_logger]
-  config.traces_sample_rate = ENV['SENTRY_ENABLED'] == 'enabled' ? 0.001 : nil
+  config.traces_sample_rate = secrets[:enabled] ? 0.001 : nil
   config.excluded_exceptions += [
     # Ignore exceptions caught by ActiveJob.retry_on
     # https://github.com/getsentry/sentry-ruby/issues/1347

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,7 +1,8 @@
 Sentry.init do |config|
   config.dsn = ENV['SENTRY_ENABLED'] == 'enabled' ? ENV['SENTRY_DSN_RAILS'] : nil
   config.send_default_pii = false
-  config.enabled_environments = ['production']
+  config.environment = ENV.fetch('SENTRY_ENVIRONMENT', Rails.env)
+  config.enabled_environments = ['production', ENV['SENTRY_ENVIRONMENT'].presence].compact
   config.breadcrumbs_logger = [:active_support_logger]
   config.traces_sample_rate = ENV['SENTRY_ENABLED'] == 'enabled' ? 0.001 : nil
   config.excluded_exceptions += [

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -50,7 +50,8 @@ defaults: &defaults
     client_key: <%= ENV['MATOMO_ID'] %>
   sentry:
     enabled: <%= ENV['SENTRY_ENABLED'] == 'enabled' %>
-    client_key: <%= ENV['SENTRY_DSN_JS'] %>
+    js_client_key: <%= ENV['SENTRY_DSN_JS'] %>
+    rails_client_key: <%= ENV['SENTRY_DSN_RAILS'] %>
     environment: <%= ENV['SENTRY_CURRENT_ENV'] %>
   crisp:
     enabled: <%= ENV['CRISP_ENABLED'] == 'enabled' %>


### PR DESCRIPTION
Fixed #6239 "ETQ dev, je souhaite spécifier l'environnement actuel dans la configuration de Sentry " / @adullact

##  Actuellement

Selon la configuration de DS, les erreurs `500` peuvent ne pas remonter dans **Sentry**  :

- Il s'avère que le seul environnement activé est `production` (voir [`config/initializers/sentry.rb `](https://github.com/betagouv/demarches-simplifiees.fr/blob/main/config/initializers/sentry.rb#L4))
- L'environnement par défaut de Sentry est le même que celui de `RACK_ENV`, et celui-ci n'est pas surchargé.

voir : https://github.com/getsentry/sentry-ruby/blob/master/sentry-ruby/lib/sentry/configuration.rb#L72-L73
```ruby
    # RACK_ENV by default.
    attr_reader :environment
```

## Comportement attendu

Les erreurs 500 sont remontées dans **Sentry** sans soucis par rapport à la configuration de DS utilisée.

## Correctif proposé  

Déclaration de l'environnement de **Sentry** via la variable d'environnement `SENTRY_CURRENT_ENV` déjà existante, qui n'est pas utilisé dans  [`config/initializers/sentry.rb `](https://github.com/betagouv/demarches-simplifiees.fr/blob/main/config/initializers/sentry.rb#L4), ou à défaut la valeur de Rails.env.

Fichier [`config/secrets.yml`](https://github.com/betagouv/demarches-simplifiees.fr/blob/main/config/secrets.yml#L51)
```diff
 sentry:
   enabled: <%= ENV['SENTRY_ENABLED'] == 'enabled' %>
-  client_key: <%= ENV['SENTRY_DSN_JS'] %>
+  js_client_key: <%= ENV['SENTRY_DSN_JS'] %>
+  rails_client_key: <%= ENV['SENTRY_DSN_RAILS'] %>
   environment: <%= ENV['SENTRY_CURRENT_ENV'] %>
```


Fichier [`config/initializers/sentry.rb `](https://github.com/betagouv/demarches-simplifiees.fr/blob/main/config/initializers/sentry.rb#L4)

```diff
 Sentry.init do |config|
+ secrets = Rails.application.secrets.sentry
+ config.dsn = secrets[:enabled] ? secrets[:rails_client_key] : nil
- config.dsn = ENV['SENTRY_ENABLED'] == 'enabled' ? ENV['SENTRY_DSN_RAILS'] : nil
  config.send_default_pii = false
+ config.environment = secrets[:environment] || Rails.env
+ config.enabled_environments = ['production', secrets[:environment].presence].compact
- config.enabled_environments = ['production']
```

--------------

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe betagouv sur le ticket et sur cette PR (répondre aux commentaires, pousser des commits, ...).


## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur BetaGouv 
pour faire le rebase directement sur notre dépôt.
   