### PR TITLE
i18n: add missing i18n keys for User model

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,6 +75,10 @@ en:
         publish: Publish
         reopen: Reopen
   activerecord:
+    models:
+      user:
+        one: User
+        other: Users
     attributes:
       user:
         siret: 'SIRET number'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -80,6 +80,10 @@ fr:
         publish: Publier
         reopen: Réactiver
   activerecord:
+    models:
+      user:
+        one: Utilisateur
+        other: Utilisateurs
     attributes:
       default_attributes: &default_attributes
         password: 'Le mot de passe'


### PR DESCRIPTION
The key for naming the User model was missing – so the default localization from devise-i18n was used. Unfortunately devise-i18n lacks the plural form.

This fixes the Manager dashboard displaying "User" instead of "Users".
