### PR TITLE
GraphQL byte_size should be BigInt

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -1131,7 +1131,8 @@ type Entreprise {
 }
 
 type File {
-  byteSize: Int!
+  byteSize: Int! @deprecated(reason: "Utilisez le champ `byteSizeBigInt` à la place.")
+  byteSizeBigInt: BigInt!
   checksum: String!
   contentType: String!
   filename: String!

--- a/app/graphql/types/file.rb
+++ b/app/graphql/types/file.rb
@@ -2,7 +2,8 @@ module Types
   class File < Types::BaseObject
     field :url, Types::URL, null: false
     field :filename, String, null: false
-    field :byte_size, Int, null: false
+    field :byte_size, Int, null: false, deprecation_reason: "Utilisez le champ `byteSizeBigInt` à la place."
+    field :byte_size_big_int, GraphQL::Types::BigInt, null: false, method: :byte_size
     field :checksum, String, null: false
     field :content_type, String, null: false
 

--- a/app/services/serializer_service.rb
+++ b/app/services/serializer_service.rb
@@ -232,7 +232,7 @@ class SerializerService
     fragment FileFragment on File {
       filename
       checksum
-      byteSize
+      byteSize: byteSizeBigInt
       contentType
     }
   GRAPHQL


### PR DESCRIPTION
https://sentry.io/organizations/demarches-simplifiees/issues/2431297511/?project=1429550&query=is%3Aunresolved

La spec GraphQL limite le type Int à 2^31 (contrairement au JS ou c'est 2^53). Quand on représente la taille d'un fichier, c'est 2 gigabytes vs 9 petabytes...

Si je corrige le type du champ `byteSize` ça risque de casser des integrations. Je propose pour ne pas casser l'API d'introduire un nouveau champ `byteSizeBigInt`. Je vais écrire un email informant les intégrateurs que s’ils rencontrent un problème avec la taille des fichiers il faut qu'ils changent le champ qu'ils utilisent.