### PR TITLE
Fix autocomplete select on blur

### DIFF
--- a/app/javascript/components/ComboMultipleDropdownList.jsx
+++ b/app/javascript/components/ComboMultipleDropdownList.jsx
@@ -21,6 +21,8 @@ import { fire } from '@utils';
 import { XIcon } from '@heroicons/react/outline';
 import isHotkey from 'is-hotkey';
 
+import { useDeferredSubmit } from './shared/hooks';
+
 const Context = createContext();
 
 function ComboMultipleDropdownList({
@@ -78,37 +80,10 @@ function ComboMultipleDropdownList({
     () => document.querySelector(`input[data-uuid="${hiddenFieldId}"]`),
     [hiddenFieldId]
   );
+  const awaitFormSubmit = useDeferredSubmit(hiddenField);
 
   const handleChange = (event) => {
     setTerm(event.target.value);
-  };
-
-  const onKeyDown = (event) => {
-    if (
-      isHotkey('enter', event) ||
-      isHotkey(' ', event) ||
-      isHotkey(',', event) ||
-      isHotkey(';', event)
-    ) {
-      if (
-        term &&
-        [...extraOptions, ...options].map(([label]) => label).includes(term)
-      ) {
-        event.preventDefault();
-        return onSelect(term);
-      }
-    }
-  };
-
-  const onBlur = (event) => {
-    if (
-      acceptNewValues &&
-      term &&
-      [...extraOptions, ...options].map(([label]) => label).includes(term)
-    ) {
-      event.preventDefault();
-      return onSelect(term);
-    }
   };
 
   const saveSelection = (fn) => {
@@ -138,6 +113,7 @@ function ComboMultipleDropdownList({
       saveSelection((selections) => [...selections, selectedValue]);
     }
     setTerm('');
+    awaitFormSubmit.done();
   };
 
   const onRemove = (label) => {
@@ -151,6 +127,34 @@ function ComboMultipleDropdownList({
       );
     }
     inputRef.current.focus();
+  };
+
+  const onKeyDown = (event) => {
+    if (
+      isHotkey('enter', event) ||
+      isHotkey(' ', event) ||
+      isHotkey(',', event) ||
+      isHotkey(';', event)
+    ) {
+      if (
+        term &&
+        [...extraOptions, ...options].map(([label]) => label).includes(term)
+      ) {
+        event.preventDefault();
+        onSelect(term);
+      }
+    }
+  };
+
+  const onBlur = () => {
+    if (
+      term &&
+      [...extraOptions, ...options].map(([label]) => label).includes(term)
+    ) {
+      awaitFormSubmit(() => {
+        onSelect(term);
+      });
+    }
   };
 
   return (

--- a/app/javascript/components/ComboSearch.jsx
+++ b/app/javascript/components/ComboSearch.jsx
@@ -45,17 +45,23 @@ function ComboSearch({
   const [debouncedSearchTerm] = useDebounce(searchTerm, 300);
   const [value, setValue] = useState(initialValue);
   const resultsMap = useRef({});
-  const setExternalValue = useCallback((value) => {
-    if (hiddenValueField) {
-      hiddenValueField.setAttribute('value', value);
-      fire(hiddenValueField, 'autosave:trigger');
-    }
-  });
-  const setExternalId = useCallback((key) => {
-    if (hiddenIdField) {
-      hiddenIdField.setAttribute('value', key);
-    }
-  });
+  const setExternalValue = useCallback(
+    (value) => {
+      if (hiddenValueField) {
+        hiddenValueField.setAttribute('value', value);
+        fire(hiddenValueField, 'autosave:trigger');
+      }
+    },
+    [hiddenValueField]
+  );
+  const setExternalId = useCallback(
+    (key) => {
+      if (hiddenIdField) {
+        hiddenIdField.setAttribute('value', key);
+      }
+    },
+    [hiddenIdField]
+  );
   const setExternalValueAndId = useCallback((value) => {
     const [key, result] = resultsMap.current[value];
     setExternalId(key);
@@ -63,7 +69,7 @@ function ComboSearch({
     if (onChange) {
       onChange(value, result);
     }
-  });
+  }, []);
 
   const handleOnChange = useCallback(
     ({ target: { value } }) => {
@@ -82,7 +88,7 @@ function ComboSearch({
   const handleOnSelect = useCallback((value) => {
     setExternalValueAndId(value);
     setValue(value);
-  });
+  }, []);
 
   const { isSuccess, data } = useQuery([scope, debouncedSearchTerm], {
     enabled: !!debouncedSearchTerm,

--- a/app/javascript/components/shared/hooks.js
+++ b/app/javascript/components/shared/hooks.js
@@ -1,0 +1,33 @@
+import { useRef, useCallback } from 'react';
+
+export function useDeferredSubmit(input) {
+  const calledRef = useRef(false);
+  const awaitFormSubmit = useCallback(
+    (callback) => {
+      const form = input.form;
+      if (!form) {
+        return;
+      }
+      const interceptFormSubmit = (event) => {
+        event.preventDefault();
+        runCallback();
+        form.submit();
+      };
+      calledRef.current = false;
+      form.addEventListener('submit', interceptFormSubmit);
+      const runCallback = () => {
+        form.removeEventListener('submit', interceptFormSubmit);
+        clearTimeout(timer);
+        if (!calledRef.current) {
+          callback();
+        }
+      };
+      const timer = setTimeout(runCallback, 400);
+    },
+    [input]
+  );
+  awaitFormSubmit.done = () => {
+    calledRef.current = true;
+  };
+  return awaitFormSubmit;
+}


### PR DESCRIPTION
Nous avons deux composants react autocomplete – simple sélect et multi select. Les deux s'intégrent de manière similaire avec les forms rails. 

Le form rails crée un input avec type "hidden". À l'initialisation la valeur est récupérée depuis cet input. Lorsque la valeur est modifiée via la sélection ou l'input, on écrit la valeur dans l’input "hidden" et la valeur est soumise avec le form rails. Ça marche plutôt bien dans les cas basiques, mais pose des problèmes dans certains “edge cases”. 

Le problème survient lorsque l'usager ne fait que saisir une valeur dans le champ et ensuite soit passe au champ suivant, soit click directement sur le bouton submit du formulaire. Ici, il faut bien comprendre la succession d'événement DOM impliqué. 

Lorsqu’on click en dehors de l’input DOM un événement "blur" est émis. On peut utiliser cet événement pour de manière synchrone répliquée la sélection dans l’input "hidden" – ça fonctionne même lorsque on click le button de submit du form. Bonne nouvelle. 

Mais du coup, nous avons un nouveau problème – que se passe-t-il si l'usager click sur une des suggestions dans le dropdown du autocomplete ? Et bien, la séquence des événements est la suivante: "blur" -> "select". Et là, c'est le drame – il est impossible de savoir au moment du "blur" si c'est un click en dehors de l’input ou si c'est une sélection dans le menu. 

Le correctif que j'applique dans cette PR essaye d'attendre l'événement "select" pendant 400ms. Pour palier au fait que si l'usager click directement sur le button submit du formulaire j'intercepte le submit du form parent et je bloque jusqu'à ce que je suis sur que j'ai sélectionné la bonne valeur.