### PR TITLE
[GraphQL] expose deleted dossiers

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -340,6 +340,67 @@ type DecimalNumberChamp implements Champ {
   value: Float
 }
 
+"""
+Un dossier supprimé
+"""
+type DeletedDossier {
+  """
+  Date de suppression.
+  """
+  dateSupression: ISO8601DateTime!
+  id: ID!
+
+  """
+  Le numéro du dossier qui a été supprimé.
+  """
+  number: Int!
+
+  """
+  La raison de la suppression du dossier.
+  """
+  reason: String!
+
+  """
+  L’état du dossier supprimé.
+  """
+  state: DossierState!
+}
+
+"""
+The connection type for DeletedDossier.
+"""
+type DeletedDossierConnection {
+  """
+  A list of edges.
+  """
+  edges: [DeletedDossierEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [DeletedDossier]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+}
+
+"""
+An edge in a connection.
+"""
+type DeletedDossierEdge {
+  """
+  A cursor for use in pagination.
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge.
+  """
+  node: DeletedDossier
+}
+
 interface Demandeur {
   id: ID!
 }
@@ -380,6 +441,41 @@ type Demarche {
   L’état de dossier pour une démarche déclarative
   """
   declarative: DossierDeclarativeState
+
+  """
+  Liste de tous les dossiers supprimés d’une démarche.
+  """
+  deletedDossiers(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Dossiers supprimés depuis la date.
+    """
+    deletedSince: ISO8601DateTime
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+
+    """
+    L’ordre des dossiers supprimés.
+    """
+    order: Order = ASC
+  ): DeletedDossierConnection!
 
   """
   Description de la démarche.

--- a/app/graphql/types/deleted_dossier_type.rb
+++ b/app/graphql/types/deleted_dossier_type.rb
@@ -1,0 +1,16 @@
+module Types
+  class DeletedDossierType < Types::BaseObject
+    description "Un dossier supprimé"
+
+    global_id_field :id
+    field :number, Int, "Le numéro du dossier qui a été supprimé.", null: false, method: :dossier_id
+    field :state, Types::DossierType::DossierState, "L’état du dossier supprimé.", null: false
+    field :reason, String, "La raison de la suppression du dossier.", null: false
+
+    field :date_supression, GraphQL::Types::ISO8601DateTime, "Date de suppression.", null: false, method: :deleted_at
+
+    def self.authorized?(object, context)
+      context.authorized_demarche?(object.procedure)
+    end
+  end
+end

--- a/app/graphql/types/demarche_type.rb
+++ b/app/graphql/types/demarche_type.rb
@@ -43,6 +43,11 @@ module Types
       argument :min_revision, ID, required: false, description: "Seulement les dossiers pour les révisons après la révision donnée."
     end
 
+    field :deleted_dossiers, Types::DeletedDossierType.connection_type, "Liste de tous les dossiers supprimés d’une démarche.", null: false do
+      argument :order, Types::Order, default_value: :asc, required: false, description: "L’ordre des dossiers supprimés."
+      argument :deleted_since, GraphQL::Types::ISO8601DateTime, required: false, description: "Dossiers supprimés depuis la date."
+    end
+
     field :champ_descriptors, [Types::ChampDescriptorType], null: false, method: :types_de_champ
     field :annotation_descriptors, [Types::ChampDescriptorType], null: false, method: :types_de_champ_private
 
@@ -100,6 +105,16 @@ module Types
       end
 
       dossiers
+    end
+
+    def deleted_dossiers(deleted_since: nil, order:)
+      dossiers = object.deleted_dossiers
+
+      if deleted_since.present?
+        dossiers = dossiers.deleted_since(deleted_since)
+      end
+
+      dossiers.order(deleted_at: order)
     end
 
     def self.authorized?(object, context)

--- a/app/models/deleted_dossier.rb
+++ b/app/models/deleted_dossier.rb
@@ -20,6 +20,7 @@ class DeletedDossier < ApplicationRecord
   validates :dossier_id, uniqueness: true
 
   scope :order_by_updated_at, -> (order = :desc) { order(created_at: order) }
+  scope :deleted_since,       -> (since) { where('deleted_dossiers.deleted_at >= ?', since) }
 
   enum reason: {
     user_request:      'user_request',

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -649,6 +649,44 @@ describe API::V2::GraphqlController do
       end
     end
 
+    context "deletedDossiers" do
+      let(:query) do
+        "{
+          demarche(number: #{procedure.id}) {
+            deletedDossiers {
+              nodes {
+                id
+                number
+                state
+                reason
+                dateSupression
+              }
+            }
+          }
+        }"
+      end
+      let(:deleted_dossier) { create(:deleted_dossier, procedure: procedure) }
+
+      before { deleted_dossier }
+
+      it "should be returned" do
+        expect(gql_errors).to eq(nil)
+        expect(gql_data).to eq(demarche: {
+          deletedDossiers: {
+            nodes: [
+              {
+                id: deleted_dossier.to_typed_id,
+                number: deleted_dossier.dossier_id,
+                state: deleted_dossier.state,
+                reason: deleted_dossier.reason,
+                dateSupression: deleted_dossier.deleted_at.iso8601
+              }
+            ]
+          }
+        })
+      end
+    end
+
     context "champ" do
       let(:champ) { create(:champ_piece_justificative, dossier: dossier) }
       let(:byte_size) { 2712286911 }


### PR DESCRIPTION
Cette PR expose sur l’API les dossiers supprimés. C’est utile pour les intégrations qui font de la synchronisation.