### PR TITLE
[Rubocop] ETQ développeur, je souhaiterais pouvoir exploiter le plein potentiel de Ruby 2.7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,7 @@ inherit_gem:
     - config/rails.yml
 
 AllCops:
+  TargetRubyVersion: 2.7
   Exclude:
     - "db/schema.rb"
     - "db/migrate/20190730153555_recreate_structure.rb"

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -289,7 +289,7 @@ class StatsController < ApplicationController
       dossiers_grouped_by_groupe_instructeur = dossier_plucks.group_by { |(groupe_instructeur_id, *_)| groupe_instructeur_id }
 
       # Compute the mean time for this procedure
-      procedure_processing_times = dossiers_grouped_by_groupe_instructeur.map do |groupe_instructeur_id, procedure_dossiers|
+      procedure_processing_times = dossiers_grouped_by_groupe_instructeur.filter_map do |groupe_instructeur_id, procedure_dossiers|
         procedure_fields_count = groupe_instructeur_id_type_de_champs_count[groupe_instructeur_id]
 
         if (procedure_fields_count == 0 || procedure_fields_count.nil?)
@@ -302,7 +302,6 @@ class StatsController < ApplicationController
         # We normalize the data for 24 fields
         procedure_mean * (MEAN_NUMBER_OF_CHAMPS_IN_A_FORM / procedure_fields_count)
       end
-        .compact
 
       # Compute the average mean time for all the procedures of this month
       month_average = mean(procedure_processing_times)

--- a/app/models/attestation_template.rb
+++ b/app/models/attestation_template.rb
@@ -45,13 +45,13 @@ class AttestationTemplate < ApplicationRecord
         acc
       end
 
-    used_tags.map do |used_tag|
+    used_tags.filter_map do |used_tag|
       corresponding_champ = all_champs_with_libelle_index[used_tag]
 
       if corresponding_champ && corresponding_champ.value.blank?
         corresponding_champ
       end
-    end.compact
+    end
   end
 
   def dup

--- a/app/models/champs/carte_champ.rb
+++ b/app/models/champs/carte_champ.rb
@@ -56,9 +56,9 @@ class Champs::CarteChamp < Champ
       :zones_humides,
       :znieff,
       :cadastres
-    ].map do |layer|
+    ].filter_map do |layer|
       layer_enabled?(layer) ? layer : nil
-    end.compact
+    end
   end
 
   def render_options
@@ -82,7 +82,7 @@ class Champs::CarteChamp < Champ
     bounding_box = RGeo::Cartesian::BoundingBox.new(factory)
 
     if geo_areas.present?
-      geo_areas.map(&:rgeo_geometry).compact.each do |geometry|
+      geo_areas.filter_map(&:rgeo_geometry).each do |geometry|
         bounding_box.add(geometry)
       end
     elsif dossier.present?

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -879,7 +879,7 @@ class Dossier < ApplicationRecord
   end
 
   def linked_dossiers_for(instructeur_or_expert)
-    dossier_ids = champs.filter(&:dossier_link?).map(&:value).compact
+    dossier_ids = champs.filter(&:dossier_link?).filter_map(&:value)
     instructeur_or_expert.dossiers.where(id: dossier_ids)
   end
 
@@ -920,7 +920,7 @@ class Dossier < ApplicationRecord
     factory = RGeo::Geographic.simple_mercator_factory
     bounding_box = RGeo::Cartesian::BoundingBox.new(factory)
 
-    geo_areas.map(&:rgeo_geometry).compact.each do |geometry|
+    geo_areas.filter_map(&:rgeo_geometry).each do |geometry|
       bounding_box.add(geometry)
     end
 

--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -135,8 +135,8 @@ class ProcedurePresentation < ApplicationRecord
       case table
       when 'self'
         dates = values
-          .map { |v| Time.zone.parse(v).beginning_of_day rescue nil }
-          .compact
+          .filter_map { |v| Time.zone.parse(v).beginning_of_day rescue nil }
+
         dossiers.filter_by_datetimes(column, dates)
       when TYPE_DE_CHAMP
         dossiers.with_type_de_champ(column)
@@ -147,8 +147,8 @@ class ProcedurePresentation < ApplicationRecord
       when 'etablissement'
         if column == 'entreprise_date_creation'
           dates = values
-            .map { |v| v.to_date rescue nil }
-            .compact
+            .filter_map { |v| v.to_date rescue nil }
+
           dossiers
             .includes(table)
             .where(table.pluralize => { column => dates })

--- a/app/services/dossier_projection_service.rb
+++ b/app/services/dossier_projection_service.rb
@@ -81,6 +81,7 @@ class DossierProjectionService
           .pluck(:id, *fields.map { |f| f[COLUMN].to_sym })
           .each { |id, *columns| fields.zip(columns).each { |field, value| field[:id_value_h][id] = value } }
       when 'followers_instructeurs'
+        # rubocop:disable Style/HashTransformValues
         fields[0][:id_value_h] = Follow
           .active
           .joins(instructeur: :user)
@@ -88,6 +89,7 @@ class DossierProjectionService
           .pluck('dossier_id, users.email')
           .group_by { |dossier_id, _| dossier_id }
           .to_h { |dossier_id, dossier_id_emails| [dossier_id, dossier_id_emails.sort.map { |_, email| email }&.join(', ')] }
+        # rubocop:enable Style/HashTransformValues
       end
     end
 

--- a/app/services/ip_service.rb
+++ b/app/services/ip_service.rb
@@ -12,8 +12,8 @@ class IPService
       if ENV['TRUSTED_NETWORKS'].present?
         ENV['TRUSTED_NETWORKS']
           .split
-          .map { |string| parse_address(string) }
-          .compact
+          .filter_map { |string| parse_address(string) }
+
       else
         []
       end

--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -81,7 +81,7 @@ class PiecesJustificativesService
   end
 
   def self.pjs_for_dossier(dossier)
-    bill_signatures = dossier.dossier_operation_logs.map(&:bill_signature).compact.uniq
+    bill_signatures = dossier.dossier_operation_logs.filter_map(&:bill_signature).uniq
 
     [
       dossier.justificatif_motivation,

--- a/app/services/procedure_export_service.rb
+++ b/app/services/procedure_export_service.rb
@@ -32,7 +32,7 @@ class ProcedureExportService
       [dossier.champs, dossier.champs_private]
         .flatten
         .filter { |champ| champ.is_a?(Champs::SiretChamp) }
-    end.map(&:etablissement).compact + dossiers.map(&:etablissement).compact
+    end.filter_map(&:etablissement) + dossiers.filter_map(&:etablissement)
   end
 
   def avis

--- a/spec/controllers/experts/avis_controller_spec.rb
+++ b/spec/controllers/experts/avis_controller_spec.rb
@@ -272,7 +272,7 @@ describe Experts::AvisController, type: :controller do
         context 'when the expert also shares the linked dossiers' do
           context 'and the expert can access the linked dossiers' do
             let(:created_avis) { create(:avis, dossier: dossier, claimant: claimant, email: "toto3@gmail.com") }
-            let(:linked_dossier) { Dossier.find_by(id: dossier.reload.champs.filter(&:dossier_link?).map(&:value).compact) }
+            let(:linked_dossier) { Dossier.find_by(id: dossier.reload.champs.filter(&:dossier_link?).filter_map(&:value)) }
             let(:linked_avis) { create(:avis, dossier: linked_dossier, claimant: claimant) }
             let(:invite_linked_dossiers) { true }
 

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -520,7 +520,7 @@ describe Instructeurs::DossiersController, type: :controller do
           context 'and the expert can access the linked dossiers' do
             let(:saved_avis) { Avis.last(2).first }
             let(:linked_avis) { Avis.last }
-            let(:linked_dossier) { Dossier.find_by(id: dossier.reload.champs.filter(&:dossier_link?).map(&:value).compact) }
+            let(:linked_dossier) { Dossier.find_by(id: dossier.reload.champs.filter(&:dossier_link?).filter_map(&:value)) }
             let(:invite_linked_dossiers) do
               instructeur.assign_to_procedure(linked_dossier.procedure)
               true

--- a/spec/features/instructeurs/expert_spec.rb
+++ b/spec/features/instructeurs/expert_spec.rb
@@ -8,7 +8,7 @@ feature 'Inviting an expert:', js: true do
   let(:expert_password) { 'mot de passe d’expert' }
   let(:procedure) { create(:procedure, :published, instructeurs: [instructeur]) }
   let(:dossier) { create(:dossier, :en_construction, :with_dossier_link, procedure: procedure) }
-  let(:linked_dossier) { Dossier.find_by(id: dossier.reload.champs.filter(&:dossier_link?).map(&:value).compact) }
+  let(:linked_dossier) { Dossier.find_by(id: dossier.reload.champs.filter(&:dossier_link?).filter_map(&:value)) }
 
   context 'as an Instructeur' do
     scenario 'I can invite an expert' do


### PR DESCRIPTION
# Contexte

Afin de bénéficier des règles Rubocop les plus récentes et les plus adaptées à la version de Ruby du projet DS (Ruby 2.7.1), il est nécessaire de préciser la version cible dans le fichier de configuration de Rubocop. Au risque de se retrouver avec ce type de message lorsqu'on utilise une syntaxe non-compatible avec Ruby 2.4 :

> (Using Ruby 2.4 parser; configure using TargetRubyVersion parameter, under AllCops)

Voir: https://github.com/betagouv/demarches-simplifiees.fr/pull/6245/checks?check_run_id=2794993672

Ce faisant, certaines infractions à ces règles sont remontées. Cela concerne notamment l'usage de `map { … }.compact`.

> In Ruby 2.7, Enumerable#filter_map has been added.
> This cop identifies places where map { … }.compact can be replaced by filter_map.

Voir: https://docs.rubocop.org/rubocop-performance/cops_performance.html#performancemapcompact

# Correctif

J'ai défini la version cible de Ruby dans le fichier de configuration de Rubocop ; et j'ai corrigé les infractions rencontrées.

# Note

Ce correctif a été extrait de la PR #6245 mais lui est nécessaire pour ne pas avoir d'erreur lorsque le linter Rubocop est lancé par la CI.