### PR TITLE
Small UI changes

### DIFF
--- a/app/assets/stylesheets/card_admin.scss
+++ b/app/assets/stylesheets/card_admin.scss
@@ -2,6 +2,7 @@
 @import "constants";
 
 .card-admin {
+  color: $black;
   padding-top: 10px;
   padding-bottom: 10px;
   width: 236px;
@@ -34,6 +35,18 @@
 
   .card-admin-action {
     margin-top: auto;
+  }
+
+  .button {
+    margin: auto auto 0 auto;
+  }
+
+  &:hover {
+    color: $blue;
+
+    .button {
+      color: $blue;
+    }
   }
 }
 

--- a/app/assets/stylesheets/dossiers_table.scss
+++ b/app/assets/stylesheets/dossiers_table.scss
@@ -5,7 +5,7 @@
   font-size: 14px;
 
   th {
-    vertical-align: middle;
+    vertical-align: top;
     padding: (2 * $default-spacer) $default-spacer;
   }
 

--- a/app/helpers/procedure_helper.rb
+++ b/app/helpers/procedure_helper.rb
@@ -30,7 +30,8 @@ module ProcedureHelper
       typeDeChampsTypes: TypeDeChamp.type_de_champ_types_for(procedure, current_user),
       typeDeChamps: (procedure.draft_revision ? procedure.draft_revision : procedure).types_de_champ.as_json_for_editor,
       baseUrl: admin_procedure_types_de_champ_path(procedure),
-      directUploadUrl: rails_direct_uploads_url
+      directUploadUrl: rails_direct_uploads_url,
+      continuerUrl: admin_procedure_path(procedure)
     }
   end
 
@@ -40,7 +41,8 @@ module ProcedureHelper
       typeDeChampsTypes: TypeDeChamp.type_de_champ_types_for(procedure, current_user),
       typeDeChamps: (procedure.draft_revision ? procedure.draft_revision : procedure).types_de_champ_private.as_json_for_editor,
       baseUrl: admin_procedure_types_de_champ_path(procedure),
-      directUploadUrl: rails_direct_uploads_url
+      directUploadUrl: rails_direct_uploads_url,
+      continuerUrl: admin_procedure_path(procedure)
     }
   end
 

--- a/app/javascript/components/TypesDeChampEditor/components/TypeDeChamps.jsx
+++ b/app/javascript/components/TypesDeChampEditor/components/TypeDeChamps.jsx
@@ -60,12 +60,9 @@ function TypeDeChamps({ state: rootState, typeDeChamps }) {
           &nbsp;&nbsp;
           {addChampLabel(state.isAnnotation)}
         </button>
-        <button
-          className="button primary"
-          onClick={() => state.flash.success()}
-        >
-          Enregistrer
-        </button>
+        <a className="button accepted" href={state.continuerUrl}>
+          Continuer &gt;
+        </a>
       </div>
     </div>
   );

--- a/app/javascript/components/TypesDeChampEditor/index.jsx
+++ b/app/javascript/components/TypesDeChampEditor/index.jsx
@@ -22,7 +22,8 @@ class TypesDeChampEditor extends Component {
       defaultTypeDeChampAttributes,
       typeDeChampsTypes: props.typeDeChampsTypes,
       directUploadUrl: props.directUploadUrl,
-      isAnnotation: props.isAnnotation
+      isAnnotation: props.isAnnotation,
+      continuerUrl: props.continuerUrl
     };
   }
 
@@ -35,6 +36,7 @@ class TypesDeChampEditor extends Component {
 
 TypesDeChampEditor.propTypes = {
   baseUrl: PropTypes.string,
+  continuerUrl: PropTypes.string,
   directUploadUrl: PropTypes.string,
   isAnnotation: PropTypes.bool,
   typeDeChamps: PropTypes.array,

--- a/app/views/new_administrateur/_breadcrumbs.html.haml
+++ b/app/views/new_administrateur/_breadcrumbs.html.haml
@@ -4,8 +4,9 @@
       - steps.each do |step|
         %li= step
     - if defined?(preview) && preview
-      = link_to "Prévisualiser le formulaire", apercu_admin_procedure_path(@procedure), target: "_blank", rel: "noopener", class: 'button'
-      = link_to "Continuer >", admin_procedure_path(@procedure), title: 'Vous pourrez revenir ici par la suite', class: 'button accepted'
+      .mb-2
+        = link_to "Prévisualiser le formulaire", apercu_admin_procedure_path(@procedure), target: "_blank", rel: "noopener", class: 'button'
+        = link_to "Continuer >", admin_procedure_path(@procedure), title: 'Vous pourrez revenir ici par la suite', class: 'button accepted'
     - if defined?(metadatas)
       %ul.admin-metadata
         - metadatas.each do |metadata|

--- a/app/views/new_administrateur/procedures/show.html.haml
+++ b/app/views/new_administrateur/procedures/show.html.haml
@@ -32,18 +32,17 @@
 .container
   %h2.procedure-admin-explanation Indispensable avant publication
   .procedure-grid
-    .card-admin
+    = link_to edit_admin_procedure_path(@procedure), id: 'presentation', class: 'card-admin' do
       %div
         %span.icon.accept
         %p.card-admin-status-accept Validé
       %div
         %p.card-admin-title Présentation
         %p.card-admin-subtitle Logo, nom, description
-      .card-admin-action
-        = link_to 'Modifier', edit_admin_procedure_path(@procedure), class: 'button', id: "presentation"
+      %p.button Modifier
 
     - if !@procedure.locked?
-      .card-admin
+      = link_to champs_admin_procedure_path(@procedure), class: 'card-admin' do
         - if @procedure.draft_types_de_champ.count > 0
           %div
             %span.icon.accept
@@ -57,10 +56,19 @@
             %span.badge.baseline= @procedure.draft_types_de_champ.count
             Champs du formulaire
           %p.card-admin-subtitle À remplir par les usagers
-        .card-admin-action
-          = link_to 'Modifier', champs_admin_procedure_path(@procedure), class: 'button'
+        %p.button Modifier
 
-    .card-admin
+    - if @procedure.service.present?
+      - service_link = edit_admin_service_path(@procedure.service, procedure_id: @procedure.id)
+      - service_button_text = 'Modifier'
+    - elsif current_administrateur.services.present?
+      - service_link = admin_services_path(procedure_id: @procedure.id)
+      - service_button_text = 'Choisir'
+    - else
+      - service_link = new_admin_service_path(procedure_id: @procedure.id)
+      - service_button_text = 'Remplir'
+
+    = link_to service_link, class: 'card-admin' do
       - if @procedure.service_id.present?
         %div
           %span.icon.accept
@@ -76,15 +84,9 @@
             = @procedure.service.nom
           - else
             Choix du service administratif
-      .card-admin-action
-        - if @procedure.service.present?
-          = link_to 'Modifier', edit_admin_service_path(@procedure.service, procedure_id: @procedure.id), class: 'button'
-        - elsif current_administrateur.services.present?
-          = link_to 'Choisir', admin_services_path(procedure_id: @procedure.id), class: 'button'
-        - else
-          = link_to 'Remplir', new_admin_service_path(procedure_id: @procedure.id), class: 'button'
+      %p.button= service_button_text
 
-    .card-admin
+    = link_to admin_procedure_administrateurs_path(@procedure), id: 'administrateurs', class: 'card-admin' do
       %div
         %span.icon.accept
         %p.card-admin-status-accept Validé
@@ -92,17 +94,17 @@
         %p.card-admin-title
           %span.badge.baseline= @procedure.administrateurs.count
           #{"Administrateur".pluralize(@procedure.administrateurs.count)}
-
         %p.card-admin-subtitle Gestion de la démarche
-      .card-admin-action
-        = link_to 'Modifier', admin_procedure_administrateurs_path(@procedure), class: 'button', id: "administrateurs"
+      %p.button Modifier
 
-    .card-admin
-      - if feature_enabled?(:administrateur_routage)
-        %div
-          %span.icon.accept
-          %p.card-admin-status-accept Validé
-      - elsif @procedure.instructeurs.count > 1
+
+    - if feature_enabled?(:administrateur_routage)
+      - instructeur_link = admin_procedure_groupe_instructeurs_path(@procedure)
+    - else
+      - instructeur_link = admin_procedure_groupe_instructeur_path(@procedure, @procedure.defaut_groupe_instructeur)
+
+    = link_to instructeur_link, id: 'groupe-instructeurs', class: 'card-admin' do
+      - if feature_enabled?(:administrateur_routage) || @procedure.instructeurs.count > 1
         %div
           %span.icon.accept
           %p.card-admin-status-accept Validé
@@ -119,15 +121,12 @@
 
           = feature_enabled?(:administrateur_routage) ? "Groupe Instructeurs" : "#{"Instructeur".pluralize(@procedure.instructeurs.count)}"
         %p.card-admin-subtitle Suivi des dossiers
-      .card-admin-action
-        - if feature_enabled?(:administrateur_routage)
-          = link_to 'Modifier', admin_procedure_groupe_instructeurs_path(@procedure), class: 'button', id: "groupe-instructeurs"
-        - else
-          = link_to 'Modifier', admin_procedure_groupe_instructeur_path(@procedure, @procedure.defaut_groupe_instructeur), class: 'button', id: "instructeurs"
+      %p.button Modifier
 
   %h2.procedure-admin-explanation Pour aller plus loin
   .procedure-grid
-    .card-admin
+
+    = link_to edit_admin_procedure_attestation_template_path(@procedure), class: 'card-admin' do
       - if @procedure.attestation_template.present? && @procedure.attestation_template.activated
         %div
           %span.icon.accept
@@ -139,34 +138,29 @@
       %div
         %p.card-admin-title Attestation
         %p.card-admin-subtitle Délivrance automatique pour les dossiers acceptés
-      .card-admin-action
-        = link_to 'Modifier', edit_admin_procedure_attestation_template_path(@procedure), class: 'button'
+      %p.button Modifier
 
-    .card-admin
+    = link_to admin_procedure_experts_path(@procedure), class: 'card-admin' do
       %div
         %span.icon.preview
         %p.card-admin-status-todo À configurer
-
       %div
         %p.card-admin-title Avis externes
         %p.card-admin-subtitle Gérer les avis des experts invités
-
-      .card-admin-action
-        = link_to "Modifier", admin_procedure_experts_path(@procedure), class: 'button'
+      %p.button Modifier
 
 
-    .card-admin
+    = link_to admin_procedure_mail_templates_path(@procedure), class: 'card-admin' do
       %div
         %span.icon.clock
         %p.card-admin-status-todo À configurer
       %div
         %p.card-admin-title Configuration des emails
         %p.card-admin-subtitle Notifications automatiques
-      .card-admin-action
-        = link_to 'Modifier', admin_procedure_mail_templates_path(@procedure), class: 'button'
+      %p.button Modifier
 
     - if !@procedure.locked?
-      .card-admin
+      = link_to annotations_admin_procedure_path(@procedure), class: 'card-admin' do
         - if @procedure.draft_types_de_champ_private.present?
           %div
             %span.icon.accept
@@ -178,10 +172,9 @@
         %div
           %p.card-admin-title Annotations privées
           %p.card-admin-subtitle Champs à remplir par l’administration
-        .card-admin-action
-          = link_to 'Modifier', annotations_admin_procedure_path(@procedure), class: 'button'
+        %p.button Modifier
 
-    .card-admin
+    = link_to jeton_admin_procedure_path(@procedure), class: 'card-admin' do
       - if @procedure.api_entreprise_token.present?
         %div
           %span.icon.accept
@@ -193,10 +186,9 @@
       %div
         %p.card-admin-title Jeton
         %p.card-admin-subtitle Configurer le jeton API entreprise
-      .card-admin-action
-        = link_to 'Modifier', jeton_admin_procedure_path(@procedure), class: 'button'
+      %p.button Modifier
 
-    .card-admin
+    = link_to monavis_admin_procedure_path(@procedure), class: 'card-admin' do
       - if @procedure.monavis_embed.present?
         %div
           %span.icon.accept
@@ -208,5 +200,4 @@
       %div
         %p.card-admin-title MonAvis
         %p.card-admin-subtitle Avis des usagers sur votre démarche
-      .card-admin-action
-        = link_to 'Modifier', monavis_admin_procedure_path(@procedure), class: 'button'
+      %p.button Modifier

--- a/spec/features/new_administrateur/types_de_champ_spec.rb
+++ b/spec/features/new_administrateur/types_de_champ_spec.rb
@@ -13,12 +13,6 @@ feature 'As an administrateur I can edit types de champ', js: true do
     fill_in 'champ-0-libelle', with: 'libellé de champ'
     blur
     expect(page).to have_content('Formulaire enregistré')
-
-    page.refresh
-    within '.buttons' do
-      click_on 'Enregistrer'
-    end
-    expect(page).to have_content('Formulaire enregistré')
   end
 
   it "Add multiple champs" do


### PR DESCRIPTION
alignement de l'entête du tableau instructeur des dossiers

![Screenshot 2021-06-10 at 12-01-22 une bien belle procédure · demarches-simplifiees fr](https://user-images.githubusercontent.com/907405/121689330-c4dab380-cac4-11eb-952c-79d1f40d1846.png)
![Screenshot 2021-06-11 at 14-55-43 une bien belle procédure · demarches-simplifiees fr](https://user-images.githubusercontent.com/907405/121689630-226f0000-cac5-11eb-8d84-39e91b4fd80b.png)

alignement du bouton continuer dans l'édition des champs
![Screenshot 2021-06-10 at 12-16-31 demarches-simplifiees fr](https://user-images.githubusercontent.com/907405/121689366-cefcb200-cac4-11eb-9b1b-7587db1807a8.png)
![Screenshot 2021-06-10 at 12-15-32 demarches-simplifiees fr](https://user-images.githubusercontent.com/907405/121689338-c6a47700-cac4-11eb-9a33-c640938e5ea0.png)

changement du bouton en bas de l'editior de champ de enregistrer vers continuer (le bouton est en vert plein dans la vraie vie)
![Screenshot 2021-06-11 at 14-57-48 demarches-simplifiees fr](https://user-images.githubusercontent.com/907405/121689953-8bef0e80-cac5-11eb-84d0-c655d5dfe00b.png)
![Screenshot 2021-06-11 at 14-57-34 demarches-simplifiees fr](https://user-images.githubusercontent.com/907405/121689961-8f829580-cac5-11eb-9a24-31739b7908d9.png)

rend les cards admin entierement cliquable (et pas seulement le bouton `modifier`)