### PR TITLE
routes: replace the email param in the URL by a query param

### DIFF
--- a/app/controllers/experts/avis_controller.rb
+++ b/app/controllers/experts/avis_controller.rb
@@ -91,7 +91,7 @@ module Experts
         redirect_to url_for(expert_all_avis_path)
       else
         flash[:alert] = user.errors.full_messages
-        redirect_to url_for(sign_up_expert_avis_path(procedure_id, avis_id, email))
+        redirect_to sign_up_expert_avis_path(procedure_id, avis_id, email: email)
       end
     end
 

--- a/app/views/avis_mailer/avis_invitation.html.haml
+++ b/app/views/avis_mailer/avis_invitation.html.haml
@@ -1,5 +1,5 @@
 - content_for(:title, 'Invitation à donner votre avis')
-- avis_link = @avis.expert.user.active?.present? ? expert_avis_url(@avis.procedure, @avis) : sign_up_expert_avis_url(@avis.procedure, @avis.id, @avis.expert.email)
+- avis_link = @avis.expert.user.active?.present? ? expert_avis_url(@avis.procedure, @avis) : sign_up_expert_avis_url(@avis.procedure, @avis.id, email: @avis.expert.email)
 
 - content_for(:footer) do
   Merci de ne pas répondre à cet email. Donnez votre avis

--- a/app/views/experts/avis/sign_up.html.haml
+++ b/app/views/experts/avis/sign_up.html.haml
@@ -4,7 +4,7 @@
       %p.description= @dossier.procedure.libelle
       %p.dossier Dossier nº #{@dossier.id}
     .column
-      = form_for(User.new, url: { controller: "experts/avis", action: :update_expert }, method: :post, html: { class: "form" }) do |f|
+      = form_for(User.new, url: sign_up_expert_avis_path(email: @email), method: :post, html: { class: "form" }) do |f|
         %h1 Créez-vous un compte
 
         = f.label :email, "Email"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,7 +105,8 @@ Rails.application.routes.draw do
   devise_scope :user do
     get '/users/no_procedure' => 'users/sessions#no_procedure'
     get 'connexion-par-jeton/:id' => 'users/sessions#sign_in_by_link', as: 'sign_in_by_link'
-    get 'lien-envoye/:email' => 'users/sessions#link_sent', constraints: { email: /.*/ }, as: 'link_sent'
+    get 'lien-envoye' => 'users/sessions#link_sent', as: 'link_sent'
+    get 'lien-envoye/:email' => 'users/sessions#link_sent', constraints: { email: /.*/ }, as: 'link_sent_legacy' # legacy, can be removed as soon as the previous line is deployed to production servers
     get '/users/password/reset-link-sent' => 'users/passwords#reset_link_sent'
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -301,10 +301,6 @@ Rails.application.routes.draw do
   #
   scope module: 'experts', as: 'expert' do
     get 'avis', to: 'avis#index', as: 'all_avis'
-    # this redirections are ephemeral, to ensure that emails sent to experts before are still valid
-    # TODO : they will be removed in September, 2020
-    get 'avis/:id', to: redirect('/procedures/old/avis/%{id}')
-    get 'avis/:id/sign_up/email/:email', to: redirect("/procedures/old/avis/%{id}/sign_up/email/%{email}"), constraints: { email: /.*/ }
 
     resources :procedures, only: [], param: :procedure_id do
       member do
@@ -330,11 +326,6 @@ Rails.application.routes.draw do
   #
 
   scope module: 'instructeurs', as: 'instructeur' do
-    # this redirections are ephemeral, to ensure that emails sent to experts before are still valid
-    # TODO : they will be removed in September, 2020
-    get 'avis/:id', to: redirect('/procedures/old/avis/%{id}')
-    get 'avis/:id/sign_up/email/:email', to: redirect("/procedures/old/avis/%{id}/sign_up/email/%{email}"), constraints: { email: /.*/ }
-
     resources :procedures, only: [:index, :show], param: :procedure_id do
       member do
         resources :groupes, only: [:index, :show], controller: 'groupe_instructeurs' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -313,8 +313,13 @@ Rails.application.routes.draw do
             post 'avis' => 'avis#create_avis'
             get 'bilans_bdf'
 
-            get 'sign_up/email/:email' => 'avis#sign_up', constraints: { email: /.*/ }, as: 'sign_up'
-            post 'sign_up/email/:email' => 'avis#update_expert', constraints: { email: /.*/ }
+            get 'sign_up' => 'avis#sign_up'
+            post 'sign_up' => 'avis#update_expert'
+
+            # This redirections are ephemeral, to ensure that emails sent to experts before are still valid
+            # TODO : remove these lines after September, 2021
+            get 'sign_up/email/:email' => 'avis#sign_up', constraints: { email: /.*/ }, as: 'sign_up_legacy'
+            post 'sign_up/email/:email' => 'avis#update_expert', constraints: { email: /.*/ }, as: 'update_expert_legacy'
           end
         end
       end

--- a/spec/features/experts/expert_spec.rb
+++ b/spec/features/experts/expert_spec.rb
@@ -12,7 +12,7 @@ feature 'Inviting an expert:' do
 
     context 'when I don’t already have an account' do
       scenario 'I can sign up' do
-        visit sign_up_expert_avis_path(avis.dossier.procedure, avis, avis.expert.email)
+        visit sign_up_expert_avis_path(avis.dossier.procedure, avis, email: avis.expert.email)
 
         expect(page).to have_field('Email', with: avis.expert.email, disabled: true)
         fill_in 'Mot de passe', with: 'This is a very complicated password !'
@@ -29,7 +29,7 @@ feature 'Inviting an expert:' do
         avis.expert.user.reload
       end
       scenario 'I can sign in' do
-        visit sign_up_expert_avis_path(avis.dossier.procedure, avis, avis.expert.email)
+        visit sign_up_expert_avis_path(avis.dossier.procedure, avis, email: avis.expert.email)
 
         expect(page).to have_current_path(new_user_session_path)
         login_as avis.expert.user, scope: :user

--- a/spec/features/instructeurs/expert_spec.rb
+++ b/spec/features/instructeurs/expert_spec.rb
@@ -45,7 +45,7 @@ feature 'Inviting an expert:', js: true do
 
       invitation_email = open_email(expert.email.to_s)
       avis = expert.avis.find_by(dossier: dossier)
-      sign_up_link = sign_up_expert_avis_path(avis.dossier.procedure, avis, avis.expert.email)
+      sign_up_link = sign_up_expert_avis_path(avis.dossier.procedure, avis, email: avis.expert.email)
       expect(invitation_email.body).to include(sign_up_link)
     end
 

--- a/spec/mailers/avis_mailer_spec.rb
+++ b/spec/mailers/avis_mailer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe AvisMailer, type: :mailer do
     it { expect(subject.body).to include(instructeur_avis_url(avis.dossier.procedure.id, avis)) }
 
     context 'when the recipient is not already registered' do
-      it { expect(subject.body).to include(sign_up_expert_avis_url(avis.dossier.procedure.id, avis.id, avis.expert.email)) }
+      it { expect(subject.body).to include(sign_up_expert_avis_url(avis.dossier.procedure.id, avis.id, email: avis.expert.email)) }
     end
 
     context 'when the dossier has been deleted before the avis was sent' do


### PR DESCRIPTION
This PR replaces every route that uses an email address as a parameter by a route that instead reads the email as a query param.

It means that the following routes:

- `/lien-envoye/foo@example.com`
- `/procedures/:id/avis/:avis_id/sign_up/email/foo@example.com`

are turned into:

- `/lien-envoye?email=foo@example.com`
- `/procedures/:id/avis/:avis_id/sign_up?email=foo@example.com`

Why that? Because **we don't want email addresses to appear into our logging tools**. And logging tools (Matomo, Sentry, Kibana) can't censor an email address embedded into an URL – but can easily censor an `email=` query param.

In the long run, this will allow us to expose our Matomo stats publicly (like every other beta.gouv.fr project).

## Implementation note

I kept the old routes for retro-compatibility, because:
- During the deployment of this code, an old instance might generate an old-style URL, but on click it could be sent to a new instance (so the new code need to understand the old format),
- Expert registration links are sent by email, and so will remain around much longer than the deployment time. So we'll delete the old-style routes in a few months.