### PR TITLE
CI : mise à jour de l'action 'rebase'

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -13,6 +13,6 @@ jobs:
       with:
         fetch-depth: 0
     - name: Automatic Rebase
-      uses: cirrus-actions/rebase@1.3.1
+      uses: cirrus-actions/rebase@1.5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Ça corrige un bug où déclencher un rebase automatique en postant un commentaire `/rebase` ne déclenchait pas la CI (ce qui empêchait la PR d'être mergée).