### PR TITLE
archives: count archived dossiers

### DIFF
--- a/app/models/traitement.rb
+++ b/app/models/traitement.rb
@@ -29,7 +29,7 @@ class Traitement < ApplicationRecord
   def self.count_dossiers_termines_by_month(groupe_instructeurs)
     last_traitements_per_dossier = Traitement
       .select('max(traitements.processed_at) as processed_at')
-      .where(dossier: Dossier.termine.where(groupe_instructeur: groupe_instructeurs))
+      .where(dossier: Dossier.state_termine.where(groupe_instructeur: groupe_instructeurs))
       .group(:dossier_id)
       .to_sql
 

--- a/spec/models/traitement_spec.rb
+++ b/spec/models/traitement_spec.rb
@@ -6,6 +6,7 @@ describe Traitement do
     before do
       create_dossier_for_month(procedure, 2021, 3)
       create_dossier_for_month(procedure, 2021, 3)
+      create_archived_dossier_for_month(procedure, 2021, 3)
       create_dossier_for_month(procedure, 2021, 2)
     end
 
@@ -16,7 +17,7 @@ describe Traitement do
     end
 
     it 'count dossiers_termines by month' do
-      expect(count_for_month(subject, 3)).to eq 2
+      expect(count_for_month(subject, 3)).to eq 3
       expect(count_for_month(subject, 2)).to eq 1
     end
 
@@ -37,6 +38,12 @@ describe Traitement do
   def create_dossier_for_month(procedure, year, month)
     Timecop.freeze(Time.zone.local(year, month, 5)) do
       create(:dossier, :accepte, :with_attestation, procedure: procedure)
+    end
+  end
+
+  def create_archived_dossier_for_month(procedure, year, month)
+    Timecop.freeze(Time.zone.local(year, month, 5)) do
+      create(:dossier, :accepte, :archived, :with_attestation, procedure: procedure)
     end
   end
 end


### PR DESCRIPTION
Cette PR corrige les compteurs du nombre de dossiers de la page index Archives. Le compteur prend en compte désormais tous les dossiers traités, même s'ils sont archivés.