### PR TITLE
archives: don't update dossiers

### DIFF
--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -56,7 +56,9 @@ class PiecesJustificativesService
                 include_infos_administration: true,
                 dossier: dossier
               })
-    dossier.pdf_export_for_instructeur.attach(io: StringIO.open(pdf), filename: "export-#{dossier.id}.pdf", content_type: 'application/pdf')
+    ActiveRecord::Base.no_touching do
+      dossier.pdf_export_for_instructeur.attach(io: StringIO.open(pdf), filename: "export-#{dossier.id}.pdf", content_type: 'application/pdf')
+    end
     dossier.pdf_export_for_instructeur
   end
 

--- a/spec/services/pieces_justificatives_service_spec.rb
+++ b/spec/services/pieces_justificatives_service_spec.rb
@@ -44,4 +44,18 @@ describe PiecesJustificativesService do
       expect(subject.any? { |piece| piece.name == 'serialized' }).to be_truthy
     end
   end
+
+  describe '.generate_dossier_export' do
+    subject { PiecesJustificativesService.generate_dossier_export(dossier) }
+    it "generates pdf export for instructeur" do
+      subject
+      expect(dossier.pdf_export_for_instructeur).to be_attached
+    end
+
+    it "doesn't update dossier" do
+      before_export = Time.zone.now
+      subject
+      expect(dossier.updated_at).to be <= before_export
+    end
+  end
 end


### PR DESCRIPTION
Cette PR empêche la modification du champ `updated_at` d'un dossier après l'attacheemnt du pdf d'export d'un instructeur.

NB : je n'ai pas réussi à trouver une autre solution qu'utiliser le fix `ActiveRecord::Base.no_touching`. L'attribut `touch: false` n'existe pas pour `has_one_attached`. Si vous connaissez une autre solution, je suis preneur