### PR TITLE
controllers: use default Rails settings for protecting against forgery

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,9 +5,6 @@ class ApplicationController < ActionController::Base
 
   MAINTENANCE_MESSAGE = 'Le site est actuellement en maintenance. Il sera à nouveau disponible dans un court instant.'
 
-  # Prevent CSRF attacks by raising an exception.
-  # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :exception, if: -> { !Rails.env.test? }
   before_action :set_current_roles
   before_action :set_sentry_user
   before_action :redirect_if_untrusted

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -12,7 +12,7 @@ describe AttachmentsController, type: :controller do
 
     subject do
       request.headers['HTTP_REFERER'] = dossier_url(dossier)
-      get :show, params: { id: attachment.id, signed_id: signed_id }, format: format
+      get :show, params: { id: attachment.id, signed_id: signed_id }, format: format, xhr: (format == :js)
     end
 
     context 'when authenticated' do

--- a/spec/controllers/champs/carte_controller_spec.rb
+++ b/spec/controllers/champs/carte_controller_spec.rb
@@ -116,21 +116,19 @@ describe Champs::CarteController, type: :controller do
     describe 'GET #index' do
       render_views
 
-      let(:params) do
-        { champ_id: champ.id }
-      end
-
       before do
-        request.accept = "application/javascript"
-        request.content_type = "application/javascript"
-        get :index, params: params
+        get :index, params: params, format: :js, xhr: true
       end
 
-      context "update list" do
-        it {
+      context 'without focus' do
+        let(:params) do
+          { champ_id: champ.id }
+        end
+
+        it 'updates the list' do
           expect(response.body).not_to include("DS.fire('map:feature:focus'")
           expect(response.status).to eq 200
-        }
+        end
       end
 
       context "update list and focus" do
@@ -141,10 +139,10 @@ describe Champs::CarteController, type: :controller do
           }
         end
 
-        it {
+        it 'updates the list and focuses the map' do
           expect(response.body).to include("DS.fire('map:feature:focus'")
           expect(response.status).to eq 200
-        }
+        end
       end
     end
   end

--- a/spec/controllers/champs/dossier_link_controller_spec.rb
+++ b/spec/controllers/champs/dossier_link_controller_spec.rb
@@ -22,9 +22,9 @@ describe Champs::DossierLinkController, type: :controller do
       let(:dossier_id) { dossier.id }
 
       context 'when the dossier exist' do
-        before {
-          get :show, params: params, format: 'js'
-        }
+        before do
+          get :show, params: params, format: :js, xhr: true
+        end
 
         it 'renders the procedure name' do
           expect(response.body).to include('Dossier en brouillon')
@@ -36,9 +36,9 @@ describe Champs::DossierLinkController, type: :controller do
 
       context 'when the dossier does not exist' do
         let(:dossier_id) { '13' }
-        before {
-          get :show, params: params, format: 'js'
-        }
+        before do
+          get :show, params: params, format: :js, xhr: true
+        end
 
         it 'renders error message' do
           expect(response.body).to include('Ce dossier est inconnu')
@@ -48,9 +48,9 @@ describe Champs::DossierLinkController, type: :controller do
     end
 
     context 'when user is not connected' do
-      before {
-        get :show, params: { position: '1' }, format: 'js'
-      }
+      before do
+        get :show, params: { position: '1' }, format: :js, xhr: true
+      end
 
       it { expect(response.code).to eq('401') }
     end

--- a/spec/controllers/champs/siret_controller_spec.rb
+++ b/spec/controllers/champs/siret_controller_spec.rb
@@ -38,7 +38,7 @@ describe Champs::SiretController, type: :controller do
       end
 
       context 'when the SIRET is empty' do
-        subject! { get :show, params: params, format: 'js' }
+        subject! { get :show, params: params, format: :js, xhr: true }
 
         it 'clears the etablissement and SIRET on the model' do
           champ.reload
@@ -55,7 +55,7 @@ describe Champs::SiretController, type: :controller do
       context 'when the SIRET is invalid' do
         let(:siret) { '1234' }
 
-        subject! { get :show, params: params, format: 'js' }
+        subject! { get :show, params: params, format: :js, xhr: true }
 
         it 'clears the etablissement and SIRET on the model' do
           champ.reload
@@ -72,7 +72,7 @@ describe Champs::SiretController, type: :controller do
         let(:siret) { '82161143100015' }
         let(:api_etablissement_status) { 503 }
 
-        subject! { get :show, params: params, format: 'js' }
+        subject! { get :show, params: params, format: :js, xhr: true }
 
         it 'clears the etablissement and SIRET on the model' do
           champ.reload
@@ -89,7 +89,7 @@ describe Champs::SiretController, type: :controller do
         let(:siret) { '00000000000000' }
         let(:api_etablissement_status) { 404 }
 
-        subject! { get :show, params: params, format: 'js' }
+        subject! { get :show, params: params, format: :js, xhr: true }
 
         it 'clears the etablissement and SIRET on the model' do
           champ.reload
@@ -107,7 +107,7 @@ describe Champs::SiretController, type: :controller do
         let(:api_etablissement_status) { 200 }
         let(:api_etablissement_body) { File.read('spec/fixtures/files/api_entreprise/etablissements.json') }
 
-        subject! { get :show, params: params, format: 'js' }
+        subject! { get :show, params: params, format: :js, xhr: true }
 
         it 'populates the etablissement and SIRET on the model' do
           champ.reload
@@ -120,7 +120,7 @@ describe Champs::SiretController, type: :controller do
     end
 
     context 'when user is not signed in' do
-      subject! { get :show, params: { position: '1' }, format: 'js' }
+      subject! { get :show, params: { position: '1' }, format: :js, xhr: true }
 
       it { expect(response.code).to eq('401') }
     end


### PR DESCRIPTION
Rails uses `config.action_controller.allow_forgery_protection` to enable or disable forgery protection globaly.

This is disabled for tests by default. So our custom config is not required.