### PR TITLE
docs: remove `geos` from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,7 @@ Les informations nécessaire à l'initialisation de la base doivent être pré-c
 
 Sous Ubuntu, certains packages doivent être installés au préalable :
 
-    sudo apt-get install libcurl3 libcurl3-gnutls libcurl4-openssl-dev libcurl4-gnutls-dev zlib1g-dev libgeos-dev
-
-Sous Mac, certains packages doivent être installés au préalable :
-
-    brew install geos
+    sudo apt-get install libcurl3 libcurl3-gnutls libcurl4-openssl-dev libcurl4-gnutls-dev zlib1g-dev
 
 Afin d'initialiser l'environnement de développement, exécutez la commande suivante :
 


### PR DESCRIPTION
We now use our own Ruby code to avoid a dependency on the `geos` C library.

It means that DS works without geos – and even that it doesn't work when geos is installed (because RGeos tries to auto-detect it).