### PR TITLE
gems: upgrade delayed_job_web

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'daemons'
 gem 'deep_cloneable' # Enable deep clone of active record models
 gem 'delayed_cron_job' # Cron jobs
 gem 'delayed_job_active_record'
-gem 'delayed_job_web'
+gem 'delayed_job_web', '>= 1.4.4'
 gem 'devise' # Gestion des comptes utilisateurs
 gem 'devise-async'
 gem 'devise-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,7 +195,7 @@ GEM
     delayed_job_active_record (4.1.5)
       activerecord (>= 3.0, < 6.2)
       delayed_job (>= 3.0, < 5)
-    delayed_job_web (1.4.3)
+    delayed_job_web (1.4.4)
       activerecord (> 3.0.0)
       delayed_job (> 2.0.3)
       rack-protection (>= 1.5.5)
@@ -801,7 +801,7 @@ DEPENDENCIES
   deep_cloneable
   delayed_cron_job
   delayed_job_active_record
-  delayed_job_web
+  delayed_job_web (>= 1.4.4)
   devise
   devise-async
   devise-i18n


### PR DESCRIPTION
fix error when attempting to "retry" or "reload" a failed job via the web interface.

bump delayed_job_web from 1.4.3 to 1.4.4
See [Changelog](https://github.com/ejschmitt/delayed_job_web/blob/v1.4.4/CHANGELOG.md)