### PR TITLE
Revert "Expose dossier PDF export as IO"

### DIFF
--- a/app/jobs/archive_creation_job.rb
+++ b/app/jobs/archive_creation_job.rb
@@ -1,6 +1,4 @@
 class ArchiveCreationJob < ApplicationJob
-  queue_as :exports
-
   def perform(procedure, archive, instructeur)
     ProcedureArchiveService
       .new(procedure)

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -69,6 +69,7 @@ class Dossier < ApplicationRecord
   has_many :attestations, dependent: :destroy
 
   has_one_attached :justificatif_motivation
+  has_one_attached :pdf_export_for_instructeur
 
   has_many :champs, -> { root.public_ordered }, inverse_of: false, dependent: :destroy
   has_many :champs_private, -> { root.private_ordered }, class_name: 'Champ', inverse_of: false, dependent: :destroy

--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -49,30 +49,6 @@ class PiecesJustificativesService
     end
   end
 
-  class FakeAttachment < Hashie::Dash
-    property :filename
-    property :name
-    property :file
-    property :id
-    property :created_at
-
-    def download
-      file
-    end
-
-    def read(*args)
-      file.read(*args)
-    end
-
-    def close
-      file.close
-    end
-
-    def attached?
-      true
-    end
-  end
-
   def self.generate_dossier_export(dossier)
     pdf = ApplicationController
       .render(template: 'dossiers/show', formats: [:pdf],
@@ -80,14 +56,10 @@ class PiecesJustificativesService
                 include_infos_administration: true,
                 dossier: dossier
               })
-
-    FakeAttachment.new(
-      file: StringIO.new(pdf),
-      filename: "export-#{dossier.id}.pdf",
-      name: 'pdf_export_for_instructeur',
-      id: dossier.id,
-      created_at: dossier.updated_at
-    )
+    ActiveRecord::Base.no_touching do
+      dossier.pdf_export_for_instructeur.attach(io: StringIO.open(pdf), filename: "export-#{dossier.id}.pdf", content_type: 'application/pdf')
+    end
+    dossier.pdf_export_for_instructeur
   end
 
   private

--- a/app/services/procedure_archive_service.rb
+++ b/app/services/procedure_archive_service.rb
@@ -26,7 +26,7 @@ class ProcedureArchiveService
 
     Zip::OutputStream.open(tmp_file) do |zipfile|
       files.each do |attachment, pj_filename|
-        zipfile.put_next_entry("procedure-#{@procedure.id}/#{pj_filename}")
+        zipfile.put_next_entry(pj_filename)
         zipfile.puts(attachment.download)
       end
     end

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -201,6 +201,15 @@ FactoryBot.define do
       end
     end
 
+    trait :with_pdf_export do
+      after(:create) do |dossier, _evaluator|
+        dossier.pdf_export_for_instructeur.attach(
+          io: StringIO.new('Hello World'),
+          filename: 'export.pdf'
+        )
+      end
+    end
+
     trait :with_justificatif do
       after(:create) do |dossier, _evaluator|
         dossier.justificatif_motivation.attach(

--- a/spec/lib/active_storage/downloadable_file_spec.rb
+++ b/spec/lib/active_storage/downloadable_file_spec.rb
@@ -1,12 +1,12 @@
 describe ActiveStorage::DownloadableFile do
-  let(:dossier) { create(:dossier, :en_construction) }
+  let(:dossier) { create(:dossier, :en_construction, :with_pdf_export) }
 
   subject(:list) { ActiveStorage::DownloadableFile.create_list_from_dossier(dossier) }
 
   describe 'create_list_from_dossier' do
     context 'when no piece_justificative is present' do
       it { expect(list.length).to eq 1 }
-      it { expect(list.first[0].name).to eq "pdf_export_for_instructeur" }
+      it { expect(list.first[0].record_type).to eq "Dossier" }
     end
 
     context 'when there is a piece_justificative' do

--- a/spec/services/pieces_justificatives_service_spec.rb
+++ b/spec/services/pieces_justificatives_service_spec.rb
@@ -49,6 +49,7 @@ describe PiecesJustificativesService do
     subject { PiecesJustificativesService.generate_dossier_export(dossier) }
     it "generates pdf export for instructeur" do
       subject
+      expect(dossier.pdf_export_for_instructeur).to be_attached
     end
 
     it "doesn't update dossier" do


### PR DESCRIPTION
Reverts betagouv/demarches-simplifiees.fr#6302

Le pdf export de chaque dossier n'est pas valide. 
Exemple de contenu d'un pdf export : 
`#<StringIO:0x00005579573fa220>`

