### PR TITLE
ETQ Expert, je ne peux plus me connecter après avoir accepté une demande d'avis

### DIFF
--- a/app/controllers/concerns/create_avis_concern.rb
+++ b/app/controllers/concerns/create_avis_concern.rb
@@ -44,7 +44,7 @@ module CreateAvisConcern
       persisted.each do |avis|
         avis.dossier.demander_un_avis!(avis)
         if avis.dossier == dossier
-          AvisMailer.avis_invitation(avis).deliver_later
+          AvisMailer.avis_invitation(avis, avis.expert.user.get_reset_password_token).deliver_later
           sent_emails_addresses << avis.expert.email
           # the email format is already verified, we update value to nil
           avis.update_column(:email, nil)

--- a/app/mailers/avis_mailer.rb
+++ b/app/mailers/avis_mailer.rb
@@ -4,10 +4,12 @@ class AvisMailer < ApplicationMailer
 
   layout 'mailers/layout'
 
-  def avis_invitation(avis)
+  def avis_invitation(avis, reset_password_token)
     if avis.dossier.present?
       @avis = avis
       email = @avis.expert&.email
+      @reset_password_token = reset_password_token
+
       subject = "Donnez votre avis sur le dossier nº #{@avis.dossier.id} (#{@avis.dossier.procedure.libelle})"
 
       mail(to: email, subject: subject)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -103,6 +103,10 @@ class User < ApplicationRecord
     AdministrateurMailer.activate_before_expiration(self, reset_password_token).deliver_later
   end
 
+  def get_reset_password_token
+    set_reset_password_token
+  end
+
   def self.create_or_promote_to_instructeur(email, password, administrateurs: [])
     user = User
       .create_with(password: password, confirmed_at: Time.zone.now)

--- a/app/views/avis_mailer/avis_invitation.html.haml
+++ b/app/views/avis_mailer/avis_invitation.html.haml
@@ -1,5 +1,6 @@
 - content_for(:title, 'Invitation à donner votre avis')
-- avis_link = @avis.expert.user.active?.present? ? expert_avis_url(@avis.procedure, @avis) : sign_up_expert_avis_url(@avis.procedure, @avis.id, email: @avis.expert.email)
+- avis_link = expert_avis_url(@avis.procedure, @avis)
+- sign_in_link = users_activate_url(token: @reset_password_token)
 
 - content_for(:footer) do
   Merci de ne pas répondre à cet email. Donnez votre avis
@@ -22,12 +23,11 @@
   %br
 %p{ style: "padding: 8px; color: #333333; background-color: #EEEEEE; font-size: 14px;" }
   = @avis.introduction
-
 - if @avis.expert.user.active?.present?
   %p
     = round_button("Donner votre avis", avis_link, :primary)
 - else
   %p
-    = round_button("Inscrivez-vous pour donner votre avis", avis_link, :primary)
+    = round_button("Inscrivez-vous pour donner votre avis", sign_in_link, :primary)
 
 = render partial: "layouts/mailers/signature"

--- a/spec/features/instructeurs/expert_spec.rb
+++ b/spec/features/instructeurs/expert_spec.rb
@@ -45,8 +45,8 @@ feature 'Inviting an expert:', js: true do
 
       invitation_email = open_email(expert.email.to_s)
       avis = expert.avis.find_by(dossier: dossier)
-      sign_up_link = sign_up_expert_avis_path(avis.dossier.procedure, avis, email: avis.expert.email)
-      expect(invitation_email.body).to include(sign_up_link)
+      expert_avis_link = expert_avis_path(avis.procedure, avis)
+      expect(invitation_email.body).to include(expert_avis_link)
     end
 
     context 'when experts submitted their answer' do

--- a/spec/mailers/avis_mailer_spec.rb
+++ b/spec/mailers/avis_mailer_spec.rb
@@ -5,8 +5,9 @@ RSpec.describe AvisMailer, type: :mailer do
     let(:dossier) { create(:dossier) }
     let(:experts_procedure) { create(:experts_procedure, expert: expert, procedure: dossier.procedure) }
     let(:avis) { create(:avis, dossier: dossier, claimant: claimant, experts_procedure: experts_procedure, introduction: 'intro') }
+    let(:token) { expert.user.get_reset_password_token }
 
-    subject { described_class.avis_invitation(avis.reload) }
+    subject { described_class.avis_invitation(avis.reload, token) }
 
     it { expect(subject.subject).to eq("Donnez votre avis sur le dossier nº #{avis.dossier.id} (#{avis.dossier.procedure.libelle})") }
     it { expect(subject.body).to have_text("Vous avez été invité par\r\n#{avis.claimant.email}\r\nà donner votre avis sur le dossier nº #{avis.dossier.id} de la démarche :\r\n#{avis.dossier.procedure.libelle}") }
@@ -14,7 +15,7 @@ RSpec.describe AvisMailer, type: :mailer do
     it { expect(subject.body).to include(instructeur_avis_url(avis.dossier.procedure.id, avis)) }
 
     context 'when the recipient is not already registered' do
-      it { expect(subject.body).to include(sign_up_expert_avis_url(avis.dossier.procedure.id, avis.id, email: avis.expert.email)) }
+      it { expect(subject.body).to include(users_activate_url(token: token)) }
     end
 
     context 'when the dossier has been deleted before the avis was sent' do


### PR DESCRIPTION
#6281 

Le process ne change pas, uniquement le lien de redirection pour créer son mot de passe.

**Lorsque l'expert ne s'est jamais connecté et reçoit une demande d'avis:**

![image](https://user-images.githubusercontent.com/21340608/123431085-2cb2f300-d5c9-11eb-9f93-9e9733982c23.png)

**L'expert doit définir son mot de passe :** 

![image](https://user-images.githubusercontent.com/21340608/123431543-a814a480-d5c9-11eb-8f6d-58d04cb7e981.png)

**Lorsque l'expert s'est déjà connecté et reçoit une demande d'avis :**

![image](https://user-images.githubusercontent.com/21340608/123431227-53712980-d5c9-11eb-82fd-5ff4cc62d832.png)
