### PR TITLE
Remonte les exceptions des jobs dans Sentry

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,7 +170,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     connection_pool (2.2.3)
     crack (0.4.5)
       rexml
@@ -244,7 +244,7 @@ GEM
     execjs (2.7.0)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
-    faraday (1.4.2)
+    faraday (1.4.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -7,13 +7,5 @@ Sentry.init do |config|
   config.enabled_environments = ['production', secrets[:environment].presence].compact
   config.breadcrumbs_logger = [:active_support_logger]
   config.traces_sample_rate = secrets[:enabled] ? 0.001 : nil
-  config.excluded_exceptions += [
-    # Ignore exceptions caught by ActiveJob.retry_on
-    # https://github.com/getsentry/sentry-ruby/issues/1347
-    'Excon::Error::BadRequest',
-    'ActiveStorage::IntegrityError',
-    'VirusScannerJob::FileNotAnalyzedYetError',
-    'TitreIdentiteWatermarkJob::WatermarkFileNotScannedYetError',
-    'APIEntreprise::API::Error::TimedOut'
-  ]
+  config.delayed_job.report_after_job_retries = true
 end


### PR DESCRIPTION
Previously Sentry reported job exceptions even if a retry strategy was specified. So we had to ignore retried job exceptions entirely.

Since sentry-delayed-job 0.4.4, we can instead let Sentry report job exceptions when the retry count is exhausted. Which is exactly the behavior we want.