### PR TITLE
Montre l'onglet "Avis" sur tous les profils

### DIFF
--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -40,6 +40,8 @@
         %ul.header-tabs
           %li
             = active_link_to "Dossiers", dossiers_path, active: :inclusive, class: 'tab-link'
+          - if current_user.expert && current_expert.avis_summary[:total] > 0
+            = render partial: 'layouts/header/avis_tab', locals: { current_expert: current_expert }
 
     %ul.header-right-content
       - if params[:controller] == 'recherche'

--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -25,11 +25,7 @@
             %li
               = active_link_to "Démarches", instructeur_procedures_path, active: ['dossiers','procedures'].include?(controller_name), class: 'tab-link'
           - if current_instructeur.user.expert && current_expert.avis_summary[:total] > 0
-            %li
-              = active_link_to expert_all_avis_path, active: controller_name == 'avis', class: 'tab-link' do
-                Avis
-                - if current_expert.avis_summary[:unanswered] > 0
-                  %span.badge.warning= current_expert.avis_summary[:unanswered]
+            = render partial: 'layouts/header/avis_tab', locals: { current_expert: current_expert }
 
       - if nav_bar_profile == :expert && expert_signed_in?
         %ul.header-tabs
@@ -38,11 +34,7 @@
               = active_link_to "Démarches", instructeur_procedures_path, active: ['dossiers','procedures'].include?(controller_name), class: 'tab-link'
 
           - if current_expert.avis_summary[:total] > 0
-            %li
-              = active_link_to expert_all_avis_path, active: controller_name == 'avis', class: 'tab-link' do
-                Avis
-                - if current_expert.avis_summary[:unanswered] > 0
-                  %span.badge.warning= current_expert.avis_summary[:unanswered]
+            = render partial: 'layouts/header/avis_tab', locals: { current_expert: current_expert }
 
       - if nav_bar_profile == :user
         %ul.header-tabs

--- a/app/views/layouts/header/_avis_tab.html.haml
+++ b/app/views/layouts/header/_avis_tab.html.haml
@@ -1,0 +1,5 @@
+%li
+  = active_link_to expert_all_avis_path, active: controller_name == 'avis', class: 'tab-link' do
+    Avis
+    - if current_expert.avis_summary[:unanswered] > 0
+      %span.badge.warning= current_expert.avis_summary[:unanswered]


### PR DESCRIPTION
En ce moment, l'onglet "Avis" est affiché dans la barre de navigation si l'utilisateur est connecté avec le profil Instructeur ou Expert.

Mais si l'utilisateur est connecté en tant qu'Usager (ce qui est le cas par défaut quand un Expert se connecte), alors l'onglet Avis n'apparait pas – même si l'expert a des demandes d'avis en attente.

Cette PR fait en sorte que, si l'utilisateur a des demandes d'Avis en tant qu'Expert, l'onglet "Avis" s'affiche quel que soit son profil.

## Pistes futures

Idéalement, je pense qu'on devrait montrer les onglets non pas en fonction du profil, mais en fonction de ce qui est disponible sur le compte :

- "Dossiers" si l'utilisateur a déposé des dossiers en tant qu'Usager
- "Avis" si l'utilisateur a des demandes d'Avis en tant qu'Expert
- "Démarches" si l'utilisateur a des démarches dont il est instructeur
- etc.

Comme ça on pourrait se passer du sélecteur de profil (qui est plus perturbant qu'autre chose, et surtout on peut probablement s'en passer).

