### PR TITLE
remove the ability to download an 'everything' archive

### DIFF
--- a/app/controllers/instructeurs/archives_controller.rb
+++ b/app/controllers/instructeurs/archives_controller.rb
@@ -7,7 +7,6 @@ module Instructeurs
       @average_dossier_weight = procedure.average_dossier_weight
 
       @count_dossiers_termines_by_month = Traitement.count_dossiers_termines_by_month(groupe_instructeurs)
-      @nb_dossiers_termines = @count_dossiers_termines_by_month.sum { |count_by_month| count_by_month["count"] }
 
       @archives = Archive
         .for_groupe_instructeur(groupe_instructeurs)

--- a/app/views/instructeurs/archives/index.html.haml
+++ b/app/views/instructeurs/archives/index.html.haml
@@ -30,31 +30,6 @@
         %th.center Télécharger
 
     %tbody
-      %tr
-        - matching_archive = @archives.find { |archive| archive.time_span_type == 'everything' }
-        - weight = estimate_weight(matching_archive, @nb_dossiers_termines, @average_dossier_weight)
-        %td
-          Tous les dossiers
-        %td.text-right
-          = @nb_dossiers_termines
-        %td.text-right
-          = number_to_human_size(weight)
-        %td.center
-          - if matching_archive.try(&:available?)
-            = link_to url_for(matching_archive.file), class: 'button primary' do
-              %span.icon.download-white
-              = t(:archive_ready_html, generated_period: time_ago_in_words(matching_archive.updated_at), scope: [:instructeurs, :procedure])
-          - elsif matching_archive.try(&:pending?)
-            %span.icon.retry
-            = t(:archive_pending_html, created_period: time_ago_in_words(matching_archive.created_at), scope: [:instructeurs, :procedure])
-          - elsif @nb_dossiers_termines == 0
-            Rien à télécharger !
-          - elsif weight < 1.gigabyte
-            = link_to instructeur_archives_path(@procedure, type: 'everything'), method: :post, class: "button" do
-              %span.icon.new-folder
-              Demander la création
-          - else
-            Archive trop volumineuse
     - @count_dossiers_termines_by_month.each do |count_by_month|
       - month = count_by_month["month"].to_date
       - nb_dossiers_termines = count_by_month["count"]

--- a/spec/controllers/instructeurs/archives_controller_spec.rb
+++ b/spec/controllers/instructeurs/archives_controller_spec.rb
@@ -25,7 +25,6 @@ describe Instructeurs::ArchivesController, type: :controller do
     it 'displays archives' do
       get :index, { params: { procedure_id: procedure1.id } }
 
-      expect(assigns(:nb_dossiers_termines).size).to eq(8)
       expect(assigns(:archives)).to eq([archive1])
     end
   end


### PR DESCRIPTION
there are sometimes an error that happen when building an everything
archive. The error explanation is not understood at the moment.
To deliver the archive feature quickly, we remove the 'everything' archive for
the moment