### PR TITLE
Amélioration du log des erreurs ActionController::InvalidAuthenticityToken

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   include TrustedDeviceConcern
   include Pundit
   include Devise::StoreLocationExtension
+  include ApplicationController::ErrorHandling
 
   MAINTENANCE_MESSAGE = 'Le site est actuellement en maintenance. Il sera à nouveau disponible dans un court instant.'
 

--- a/app/controllers/application_controller/error_handling.rb
+++ b/app/controllers/application_controller/error_handling.rb
@@ -1,0 +1,29 @@
+module ApplicationController::ErrorHandling
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from ActionController::InvalidAuthenticityToken do
+      if cookies.count == 0
+        # When some browsers (like Safari) re-open a previously closed tab, they attempts
+        # to reload the page – even if it is a POST request. But in that case, they don’t
+        # sends any of the cookies.
+        #
+        # Ignore this error.
+        render plain: "Les cookies doivent être activés pour utiliser #{APPLICATION_NAME}.", status: 403
+      else
+        log_invalid_authenticity_token_error
+        raise # propagate the exception up, to render the default exception page
+      end
+    end
+  end
+
+  def log_invalid_authenticity_token_error
+    Sentry.with_scope do |temp_scope|
+      tags = {
+        action: "#{self.class.name}#{action_name}"
+      }
+      temp_scope.set_tags(tags)
+      Sentry.capture_message("ActionController::InvalidAuthenticityToken")
+    end
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -81,18 +81,6 @@ class Users::SessionsController < Devise::SessionsController
   private
 
   def handle_unverified_request
-    log_invalid_authenticity_token_error
     super
-  end
-
-  def log_invalid_authenticity_token_error
-    Sentry.with_scope do |temp_scope|
-      tags = {
-        request_tokens: request_authenticity_tokens.compact.map { |t| t.gsub(/.....$/, '*****') }.join(', '),
-        session_token: session[:_csrf_token]&.gsub(/.....$/, '*****')
-      }
-      temp_scope.set_tags(tags)
-      Sentry.capture_message("ActionController::InvalidAuthenticityToken in Users::SessionsController")
-    end
   end
 end

--- a/spec/controllers/application_controller/error_handling_spec.rb
+++ b/spec/controllers/application_controller/error_handling_spec.rb
@@ -1,0 +1,48 @@
+RSpec.describe ApplicationController::ErrorHandling, type: :controller do
+  controller(ActionController::Base) do
+    include ApplicationController::ErrorHandling
+
+    def invalid_authenticity_token
+      raise ActionController::InvalidAuthenticityToken
+    end
+  end
+
+  before do
+    routes.draw { post 'invalid_authenticity_token' => 'anonymous#invalid_authenticity_token' }
+  end
+
+  describe 'handling ActionController::InvalidAuthenticityToken' do
+    let(:request_cookies) do
+      { 'some_cookie': true }
+    end
+
+    before { cookies.update(request_cookies) }
+
+    it 'logs the error' do
+      allow(Sentry).to receive(:capture_message)
+      post :invalid_authenticity_token rescue nil
+      expect(Sentry).to have_received(:capture_message)
+    end
+
+    it 'forwards the error upwards' do
+      expect { post :invalid_authenticity_token }.to raise_error(ActionController::InvalidAuthenticityToken)
+    end
+
+    context 'when Safari retries a POST request without cookies' do
+      let(:request_cookies) do
+        {}
+      end
+
+      it 'returns a message' do
+        post :invalid_authenticity_token
+
+        expect(response).to have_http_status(403)
+        expect(response.body).to include('cookies')
+      end
+
+      it 'renders the standard exception page' do
+        expect { post :invalid_authenticity_token }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
- On remonte l'erreur sur tous les controllers (plutôt que seulement le controller de sessions),
- Amélioration de la description de l'erreur,
- Les requêtes POST cheloues envoyées par Safari sont ignorées.

Pour l'instant ça ne change pas le comportement, c'est juste la manière dont c'est loggué.

Refs #6102