### PR TITLE
integrate a mininum weight for the average dossier weight

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -55,6 +55,7 @@ class Procedure < ApplicationRecord
   MAX_DUREE_CONSERVATION = 36
   MAX_DUREE_CONSERVATION_EXPORT = 3.hours
 
+  MIN_WEIGHT = 350000
   has_many :revisions, -> { order(:id) }, class_name: 'ProcedureRevision', inverse_of: :procedure
   belongs_to :draft_revision, class_name: 'ProcedureRevision', optional: false
   belongs_to :published_revision, class_name: 'ProcedureRevision', optional: true
@@ -684,7 +685,7 @@ class Procedure < ApplicationRecord
         .where(type: Champs::PieceJustificativeChamp.to_s, dossier: dossiers_sample)
         .sum('active_storage_blobs.byte_size')
 
-      total_size / dossiers_sample.length
+      MIN_WEIGHT + total_size / dossiers_sample.length
     else
       nil
     end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -1026,7 +1026,7 @@ describe Procedure do
     end
 
     it 'estimates average dossier weight' do
-      expect(procedure.reload.average_dossier_weight).to eq 5
+      expect(procedure.reload.average_dossier_weight).to eq(5 + Procedure::MIN_WEIGHT)
     end
   end
 


### PR DESCRIPTION
before this commit, the average dossier weight took account only pieces
justificatives. With this commit, we add a minimum weight for other
files included in an archive like pdf_export, log operations,
attachments added to traitements. This minimum weight is set arbitrary,
from the observation of some random procedures in production