### PR TITLE
Erreurs ActionController::InvalidAuthenticityToken : lorsqu'il n'y a pas de cookies, la page d'erreur par défaut est affichée

### DIFF
--- a/app/controllers/application_controller/error_handling.rb
+++ b/app/controllers/application_controller/error_handling.rb
@@ -3,19 +3,20 @@ module ApplicationController::ErrorHandling
 
   included do
     rescue_from ActionController::InvalidAuthenticityToken do
-      if cookies.count == 0
-        # When some browsers (like Safari) re-open a previously closed tab, they attempts
-        # to reload the page – even if it is a POST request. But in that case, they don’t
-        # sends any of the cookies.
-        #
-        # Ignore this error.
-        render plain: "Les cookies doivent être activés pour utiliser #{APPLICATION_NAME}.", status: 403
-      else
+      # When some browsers (like Safari) re-open a previously closed tab, they attempts
+      # to reload the page – even if it is a POST request. But in that case, they don’t
+      # sends any of the cookies.
+      #
+      # In that case, don’t report this error.
+      if request.cookies.count > 0
         log_invalid_authenticity_token_error
-        raise # propagate the exception up, to render the default exception page
       end
+
+      raise # propagate the exception up, to render the default exception page
     end
   end
+
+  private
 
   def log_invalid_authenticity_token_error
     Sentry.with_scope do |temp_scope|

--- a/spec/controllers/application_controller/error_handling_spec.rb
+++ b/spec/controllers/application_controller/error_handling_spec.rb
@@ -33,15 +33,10 @@ RSpec.describe ApplicationController::ErrorHandling, type: :controller do
         {}
       end
 
-      it 'returns a message' do
-        post :invalid_authenticity_token
-
-        expect(response).to have_http_status(403)
-        expect(response.body).to include('cookies')
-      end
-
-      it 'renders the standard exception page' do
-        expect { post :invalid_authenticity_token }.not_to raise_error
+      it 'doesn’t log the error' do
+        allow(Sentry).to receive(:capture_message)
+        post :invalid_authenticity_token rescue nil
+        expect(Sentry).not_to have_received(:capture_message)
       end
     end
   end


### PR DESCRIPTION
Petit revirement par rapport à la PR précédente (#6321).

La situation "Pas de cookies" survient principalement quand Safari re-tente une requête POST (mais sans envoyer aucun des cookies).

Ce que fait Github dans ce cas, c'est juste afficher un texte "Les cookies doivent être activés". Et c'est ce que j'avais codé initialement.

Mais en fait notre page d'erreur 422 custom est maintenant très bien, et elle est bien plus utile aux usagers. Avec cette PR on affiche donc cette page 422 custom, plutôt qu'un texte brut.