### PR TITLE
Instructeurs : limitation de la valeur d'un filtre à 100 caractères

### DIFF
--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -22,6 +22,8 @@ class ProcedurePresentation < ApplicationRecord
   TYPE_DE_CHAMP = 'type_de_champ'
   TYPE_DE_CHAMP_PRIVATE = 'type_de_champ_private'
 
+  FILTERS_VALUE_MAX_LENGTH = 100
+
   belongs_to :assign_to, optional: false
 
   delegate :procedure, to: :assign_to
@@ -30,6 +32,7 @@ class ProcedurePresentation < ApplicationRecord
   validate :check_allowed_sort_column
   validate :check_allowed_sort_order
   validate :check_allowed_filter_columns
+  validate :check_filters_max_length
 
   def fields
     fields = [
@@ -279,6 +282,14 @@ class ProcedurePresentation < ApplicationRecord
     table, column = field.values_at(TABLE, COLUMN)
     if !valid_column?(table, column, extra_columns)
       errors.add(kind, "#{table}.#{column} n’est pas une colonne permise")
+    end
+  end
+
+  def check_filters_max_length
+    filters.values.flatten.each do |filter|
+      if filter['value']&.length.to_i > FILTERS_VALUE_MAX_LENGTH
+        errors.add(:filters, :too_long)
+      end
     end
   end
 

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -86,7 +86,7 @@
             = select_tag :field, options_for_select(@displayed_fields_options)
             %br
             = label_tag :value, "Valeur"
-            = text_field_tag :value
+            = text_field_tag :value, nil, maxlength: ProcedurePresentation::FILTERS_VALUE_MAX_LENGTH
             = hidden_field_tag :statut, @statut
             %br
             = submit_tag "Ajouter le filtre", class: 'button'

--- a/spec/models/procedure_presentation_spec.rb
+++ b/spec/models/procedure_presentation_spec.rb
@@ -45,6 +45,7 @@ describe ProcedurePresentation do
 
     context 'of filters' do
       it { expect(build(:procedure_presentation, filters: { "suivis" => [{ "table" => "user", "column" => "reset_password_token", "order" => "asc" }] })).to be_invalid }
+      it { expect(build(:procedure_presentation, filters: { "suivis" => [{ "table" => "user", "column" => "email", "value" => "A" * 200 }] })).to be_invalid }
     end
   end
 


### PR DESCRIPTION
This prevents the URL from exceeding the max size, and causing '414: Request-URI too large' errors.

HS #103870