### PR TITLE
views: fix checkbox wrongly selected in multiple_drop_down_list

### DIFF
--- a/app/views/shared/dossiers/editable_champs/_multiple_drop_down_list.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_multiple_drop_down_list.html.haml
@@ -3,11 +3,10 @@
     = form.collection_check_boxes(:value, champ.enabled_non_empty_options, :to_s, :to_s) do |b|
       .editable-champ.editable-champ-checkbox
         = b.label do
-          = b.check_box({ multiple: true, checked: champ&.value&.include?(b.value) })
+          = b.check_box({ multiple: true, checked: champ&.selected_options&.include?(b.value) })
           = b.text
 
   - else
     - hidden_field_id = SecureRandom.uuid
     = form.hidden_field :value, { data: { uuid: hidden_field_id } }
     = react_component("ComboMultipleDropdownList", options: champ.options, selected: champ.selected_options, disabled: champ.disabled_options, hiddenFieldId: hidden_field_id, label: champ.libelle)
-

--- a/spec/views/shared/dossiers/_edit.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_edit.html.haml_spec.rb
@@ -61,16 +61,20 @@ describe 'shared/dossiers/edit.html.haml', type: :view do
 
   context 'with a multiple-values list' do
     let(:dossier) { create(:dossier) }
-    let(:type_de_champ) { create(:type_de_champ_multiple_drop_down_list, procedure: dossier.procedure) }
-    let(:champ) { create(:champ_multiple_drop_down_list, dossier: dossier, type_de_champ: type_de_champ) }
+    let(:type_de_champ) { create(:type_de_champ_multiple_drop_down_list, procedure: dossier.procedure, drop_down_list_value: drop_down_list_value) }
+    let(:champ) { create(:champ_multiple_drop_down_list, dossier: dossier, type_de_champ: type_de_champ, value: champ_value) }
     let(:options) { type_de_champ.drop_down_list_options }
     let(:enabled_options) { type_de_champ.drop_down_list_enabled_non_empty_options }
 
     before { dossier.champs << champ }
 
     context 'when the list is short' do
+      let(:drop_down_list_value) { ['valid', 'invalid', 'not sure yet'].join("\r\n") }
+      let(:champ_value) { ['invalid'].to_json }
+
       it 'renders the list as checkboxes' do
         expect(subject).to have_selector('input[type=checkbox]', count: enabled_options.count)
+        expect(subject).to have_selector('input[type=checkbox][checked=checked]', count: 1)
       end
 
       it 'adds an extra hidden input, to send a blank value even when all checkboxes are unchecked' do
@@ -79,7 +83,8 @@ describe 'shared/dossiers/edit.html.haml', type: :view do
     end
 
     context 'when the list is long' do
-      let(:type_de_champ) { create(:type_de_champ_multiple_drop_down_list, :long, procedure: dossier.procedure) }
+      let(:drop_down_list_value) { ['peach', 'banana', 'pear', 'apricot', 'apple', 'grapefruit'].join("\r\n") }
+      let(:champ_value) { ['banana', 'grapefruit'].to_json }
 
       it 'renders the list as a multiple-selection dropdown' do
         expect(subject).to have_selector('[data-react-class="ComboMultipleDropdownList"]')


### PR DESCRIPTION
The check for whether the checkbox should be checked or not was made by
matching the whole string.

Thus, given two options like:

- [ ] valid
- [x] invalid

The 'valid' checkbox would always appear checked even when only 'invalid' was present in the values (because `'[\"invalid\"]'.includes?('valid')`).

The code now checks against the list of items in the selected_options.

