### PR TITLE
ETQ admin/instructeur, je veux envoyer un message à tous les usagers d'un coup

### DIFF
--- a/app/controllers/new_administrateur/groupe_instructeurs_controller.rb
+++ b/app/controllers/new_administrateur/groupe_instructeurs_controller.rb
@@ -74,9 +74,19 @@ module NewAdministrateur
         .without_group(@groupe_instructeur)
     end
 
+    def reaffecter_bulk_messages(target_group)
+      bulk_messages = BulkMessage.joins(:groupe_instructeurs).where(groupe_instructeurs: { id: groupe_instructeur.id })
+      bulk_messages.each do |bulk_message|
+        bulk_message.groupe_instructeurs.delete(groupe_instructeur)
+        if !bulk_message.groupe_instructeur_ids.include?(target_group.id)
+          bulk_message.groupe_instructeurs << target_group
+        end
+      end
+    end
+
     def reaffecter
       target_group = procedure.groupe_instructeurs.find(params[:target_group])
-
+      reaffecter_bulk_messages(target_group)
       groupe_instructeur.dossiers.with_discarded.find_each do |dossier|
         dossier.assign_to_groupe_instructeur(target_group, current_administrateur)
       end

--- a/app/mailers/dossier_mailer.rb
+++ b/app/mailers/dossier_mailer.rb
@@ -18,10 +18,11 @@ class DossierMailer < ApplicationMailer
     end
   end
 
-  def notify_new_answer(dossier)
+  def notify_new_answer(dossier, body = nil)
     @dossier = dossier
     @service = dossier.procedure.service
     @logo_url = attach_logo(dossier.procedure)
+    @body = body
 
     subject = "Nouveau message pour votre dossier nº #{dossier.id} (#{dossier.procedure.libelle})"
 

--- a/app/models/bulk_message.rb
+++ b/app/models/bulk_message.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: bulk_messages
+#
+#  id             :bigint           not null, primary key
+#  body           :text             not null
+#  dossier_count  :integer
+#  dossier_state  :string
+#  sent_at        :datetime         not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  instructeur_id :bigint           not null
+#
+class BulkMessage < ApplicationRecord
+  belongs_to :instructeur
+  has_one_attached :piece_jointe
+  has_and_belongs_to_many :groupe_instructeurs
+end

--- a/app/models/commentaire.rb
+++ b/app/models/commentaire.rb
@@ -18,7 +18,7 @@ class Commentaire < ApplicationRecord
   belongs_to :instructeur, optional: true
   belongs_to :expert, optional: true
 
-  validate :messagerie_available?, on: :create
+  validate :messagerie_available?, on: :create, unless: -> { dossier.brouillon? }
 
   has_one_attached :piece_jointe
 
@@ -95,7 +95,7 @@ class Commentaire < ApplicationRecord
   end
 
   def notify_user
-    DossierMailer.notify_new_answer(dossier).deliver_later
+    DossierMailer.notify_new_answer(dossier, body).deliver_later
   end
 
   def messagerie_available?

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -26,6 +26,7 @@ class Instructeur < ApplicationRecord
   has_many :previously_followed_dossiers, -> { distinct }, through: :previous_follows, source: :dossier
   has_many :trusted_device_tokens, dependent: :destroy
   has_many :archives
+  has_many :bulk_messages, dependent: :destroy
 
   has_one :user, dependent: :nullify
 

--- a/app/views/dossier_mailer/notify_new_answer.html.haml
+++ b/app/views/dossier_mailer/notify_new_answer.html.haml
@@ -3,16 +3,19 @@
 
 %p
   Bonjour,
+  %p
+    Vous avez reçu un
+    %strong nouveau message
+    de la part du service en charge de votre dossier.
 
-%p
-  Vous avez reçu un
-  %strong nouveau message
-  de la part du service en charge de votre dossier.
+- if !@dossier.brouillon?
+  %p
+    Pour consulter le message et y répondre, cliquez sur le bouton ci-dessous :
 
-%p
-  Pour consulter le message et y répondre, cliquez sur le bouton ci-dessous :
-
-= round_button('Lire le message', messagerie_dossier_url(@dossier), :primary)
+  = round_button('Lire le message', messagerie_dossier_url(@dossier), :primary)
+- else
+  %p{ style: "padding: 8px; color: #333333; background-color: #EEEEEE; font-size: 14px;" }
+    = @body
 
 = render 'layouts/mailers/signature', service: @service
 

--- a/app/views/instructeurs/procedures/email_usagers.html.haml
+++ b/app/views/instructeurs/procedures/email_usagers.html.haml
@@ -1,0 +1,12 @@
+- content_for(:title, "Contacter les usagers pour #{@procedure.libelle}")
+
+= render partial: 'new_administrateur/breadcrumbs',
+  locals: { steps: [link_to(@procedure.libelle, instructeur_procedure_path(@procedure)),
+                    'Contacter les usagers en brouillon'] }
+.messagerie.container
+  - if @bulk_messages.present?
+    %p.mb-2 Messages envoyés aux usagers :
+    - @bulk_messages.each do |bulk_message|
+      %li.mb-1 #{bulk_message.instructeur.email} a envoyé un message le #{bulk_message.sent_at.strftime('%d-%m-%Y')} à #{bulk_message.dossier_count} usagers, #{bulk_message.piece_jointe.blob.present? ? "avec" : "sans"} pièce jointe
+  %p.notice.mb-2.mt-4 Vous allez envoyer un message à #{pluralize(@dossiers_count, 'personne')} dans les groupes instructeurs : #{@groupe_instructeurs.join(', ')}.
+  = render partial: 'shared/dossiers/messages/form', locals: { commentaire: @commentaire, form_url: create_multiple_commentaire_instructeur_procedure_path(@procedure) }

--- a/app/views/instructeurs/procedures/email_usagers.html.haml
+++ b/app/views/instructeurs/procedures/email_usagers.html.haml
@@ -8,5 +8,10 @@
     %p.mb-2 Messages envoyés aux usagers :
     - @bulk_messages.each do |bulk_message|
       %li.mb-1 #{bulk_message.instructeur.email} a envoyé un message le #{bulk_message.sent_at.strftime('%d-%m-%Y')} à #{bulk_message.dossier_count} usagers, #{bulk_message.piece_jointe.blob.present? ? "avec" : "sans"} pièce jointe
-  %p.notice.mb-2.mt-4 Vous allez envoyer un message à #{pluralize(@dossiers_count, 'personne')} dans les groupes instructeurs : #{@groupe_instructeurs.join(', ')}.
-  = render partial: 'shared/dossiers/messages/form', locals: { commentaire: @commentaire, form_url: create_multiple_commentaire_instructeur_procedure_path(@procedure) }
+  - if @email_usagers_dossiers.present?
+    %p.notice.mb-2.mt-4 Vous allez envoyer un message à #{pluralize(@dossiers_count, 'personne')} dans les groupes instructeurs : #{@groupe_instructeurs.join(', ')}.
+    = render partial: 'shared/dossiers/messages/form', locals: { commentaire: @commentaire, form_url: create_multiple_commentaire_instructeur_procedure_path(@procedure) }
+  - else
+    .page-title.center
+      %h2 Il n'y a aucun dossier en brouillon dans vos groupes instructeurs
+

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -11,6 +11,8 @@
         %h1= procedure_libelle @procedure
         = link_to 'gestion des notifications', email_notifications_instructeur_procedure_path(@procedure), class: 'header-link'
         |
+        = link_to 'contacter les usagers en brouillon', email_usagers_instructeur_procedure_path(@procedure), class: 'header-link'
+        |
         = link_to 'statistiques', stats_instructeur_procedure_path(@procedure), class: 'header-link'
 
         - if @procedure.routee?

--- a/app/views/instructeurs/procedures/show.html.haml
+++ b/app/views/instructeurs/procedures/show.html.haml
@@ -10,9 +10,11 @@
       .procedure-header
         %h1= procedure_libelle @procedure
         = link_to 'gestion des notifications', email_notifications_instructeur_procedure_path(@procedure), class: 'header-link'
-        |
-        = link_to 'contacter les usagers en brouillon', email_usagers_instructeur_procedure_path(@procedure), class: 'header-link'
-        |
+
+        - if @procedure.dossiers.state_brouillon.where(groupe_instructeur: current_instructeur.groupe_instructeur_ids).includes(:groupe_instructeur).present?
+
+          = link_to 'contacter les usagers en brouillon', email_usagers_instructeur_procedure_path(@procedure), class: 'header-link'
+          |
         = link_to 'statistiques', stats_instructeur_procedure_path(@procedure), class: 'header-link'
 
         - if @procedure.routee?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -357,6 +357,8 @@ Rails.application.routes.draw do
         get 'email_notifications'
         patch 'update_email_notifications'
         get 'deleted_dossiers'
+        get 'email_usagers'
+        post 'create_multiple_commentaire'
 
         resources :dossiers, only: [:show], param: :dossier_id do
           member do

--- a/db/migrate/20210722083911_create_bulk_message_mails.rb
+++ b/db/migrate/20210722083911_create_bulk_message_mails.rb
@@ -1,0 +1,18 @@
+class CreateBulkMessageMails < ActiveRecord::Migration[6.1]
+  def change
+    create_table :bulk_messages do |t|
+      t.text :body, null: false
+      t.integer :dossier_count
+      t.string :dossier_state
+      t.datetime :sent_at, null: false
+      t.bigint :instructeur_id, null: false
+
+      t.timestamps
+    end
+
+    create_join_table :bulk_messages, :groupe_instructeurs, column_options: { null: true, foreign_key: true } do |t|
+      t.index :bulk_message_id
+      t.index :groupe_instructeur_id, name: :index_bulk_messages_groupe_instructeurs_on_gi_id
+    end
+  end
+end

--- a/db/migrate/20210727172504_add_unique_index_to_bulk_messages_groupe_instructeurs.rb
+++ b/db/migrate/20210727172504_add_unique_index_to_bulk_messages_groupe_instructeurs.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToBulkMessagesGroupeInstructeurs < ActiveRecord::Migration[6.1]
+  def change
+    add_index :bulk_messages_groupe_instructeurs, [:bulk_message_id, :groupe_instructeur_id], unique: true, name: :index_bulk_msg_gi_on_bulk_msg_id_and_gi_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -156,6 +156,23 @@ ActiveRecord::Schema.define(version: 2021_07_22_133553) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "bulk_messages", force: :cascade do |t|
+    t.text "body", null: false
+    t.integer "dossier_count"
+    t.string "dossier_state"
+    t.datetime "sent_at", null: false
+    t.bigint "instructeur_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "bulk_messages_groupe_instructeurs", id: false, force: :cascade do |t|
+    t.bigint "bulk_message_id"
+    t.bigint "groupe_instructeur_id"
+    t.index ["bulk_message_id"], name: "index_bulk_messages_groupe_instructeurs_on_bulk_message_id"
+    t.index ["groupe_instructeur_id"], name: "index_bulk_messages_groupe_instructeurs_on_gi_id"
+  end
+
   create_table "champs", id: :serial, force: :cascade do |t|
     t.string "value"
     t.integer "type_de_champ_id"
@@ -767,6 +784,8 @@ ActiveRecord::Schema.define(version: 2021_07_22_133553) do
   add_foreign_key "attestation_templates", "procedures"
   add_foreign_key "attestations", "dossiers"
   add_foreign_key "avis", "experts_procedures"
+  add_foreign_key "bulk_messages_groupe_instructeurs", "bulk_messages"
+  add_foreign_key "bulk_messages_groupe_instructeurs", "groupe_instructeurs"
   add_foreign_key "champs", "champs", column: "parent_id"
   add_foreign_key "closed_mails", "procedures"
   add_foreign_key "commentaires", "dossiers"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_22_133553) do
+ActiveRecord::Schema.define(version: 2021_07_27_172504) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -169,6 +169,7 @@ ActiveRecord::Schema.define(version: 2021_07_22_133553) do
   create_table "bulk_messages_groupe_instructeurs", id: false, force: :cascade do |t|
     t.bigint "bulk_message_id"
     t.bigint "groupe_instructeur_id"
+    t.index ["bulk_message_id", "groupe_instructeur_id"], name: "index_bulk_msg_gi_on_bulk_msg_id_and_gi_id", unique: true
     t.index ["bulk_message_id"], name: "index_bulk_messages_groupe_instructeurs_on_bulk_message_id"
     t.index ["groupe_instructeur_id"], name: "index_bulk_messages_groupe_instructeurs_on_gi_id"
   end

--- a/spec/controllers/new_administrateur/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/new_administrateur/groupe_instructeurs_controller_spec.rb
@@ -137,12 +137,15 @@ describe NewAdministrateur::GroupeInstructeursController, type: :controller do
 
   describe '#reaffecter' do
     let!(:gi_1_2) { procedure.groupe_instructeurs.create(label: 'groupe instructeur 2') }
+    let!(:gi_1_3) { procedure.groupe_instructeurs.create(label: 'groupe instructeur 3') }
     let!(:dossier12) { create(:dossier, :en_construction, :with_individual, procedure: procedure, groupe_instructeur: gi_1_1) }
     let!(:dossier_discarded) do
       dossier = create(:dossier, :en_construction, :with_individual, procedure: procedure, groupe_instructeur: gi_1_1)
       dossier.discard!
       dossier
     end
+    let!(:instructeur) { create(:instructeur) }
+    let!(:bulk_message) { BulkMessage.create(dossier_count: 2, dossier_state: "brouillon", body: "hello", sent_at: Time.zone.now, groupe_instructeurs: [gi_1_1, gi_1_3], instructeur: instructeur) }
 
     describe 'when the new group is a group of the procedure' do
       before do
@@ -153,6 +156,7 @@ describe NewAdministrateur::GroupeInstructeursController, type: :controller do
             target_group: gi_1_2.id
           }
         dossier12.reload
+        bulk_message.reload
       end
 
       it { expect(response).to redirect_to(admin_procedure_groupe_instructeurs_path(procedure)) }
@@ -160,6 +164,7 @@ describe NewAdministrateur::GroupeInstructeursController, type: :controller do
       it { expect(gi_1_2.dossiers.with_discarded.count).to be(2) }
       it { expect(gi_1_2.dossiers.last.id).to be(dossier12.id) }
       it { expect(dossier12.groupe_instructeur.id).to be(gi_1_2.id) }
+      it { expect(bulk_message.groupe_instructeurs).to eq([gi_1_2, gi_1_3]) }
     end
 
     describe 'when the target group is not a possible group' do
@@ -174,9 +179,11 @@ describe NewAdministrateur::GroupeInstructeursController, type: :controller do
       }
       before do
         dossier12.reload
+        bulk_message.reload
       end
 
       it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
+      it { expect(bulk_message.groupe_instructeurs).to eq([gi_1_1, gi_1_3]) }
     end
   end
 

--- a/spec/mailers/dossier_mailer_spec.rb
+++ b/spec/mailers/dossier_mailer_spec.rb
@@ -26,8 +26,20 @@ RSpec.describe DossierMailer, type: :mailer do
     it_behaves_like 'a dossier notification'
   end
 
-  describe '.notify_new_answer' do
+  describe '.notify_new_answer with dossier brouillon' do
     let(:dossier) { create(:dossier, procedure: build(:simple_procedure)) }
+
+    subject { described_class.notify_new_answer(dossier) }
+
+    it { expect(subject.subject).to include("Nouveau message") }
+    it { expect(subject.subject).to include(dossier.id.to_s) }
+    it { expect(subject.body).not_to include(messagerie_dossier_url(dossier)) }
+
+    it_behaves_like 'a dossier notification'
+  end
+
+  describe '.notify_new_answer with dossier en construction' do
+    let(:dossier) { create(:dossier, state: "en_construction", procedure: build(:simple_procedure)) }
 
     subject { described_class.notify_new_answer(dossier) }
 

--- a/spec/models/commentaire_spec.rb
+++ b/spec/models/commentaire_spec.rb
@@ -3,7 +3,6 @@ describe Commentaire do
   it { is_expected.to have_db_column(:body) }
   it { is_expected.to have_db_column(:created_at) }
   it { is_expected.to have_db_column(:updated_at) }
-  it { is_expected.to belong_to(:dossier) }
 
   describe 'messagerie_available validation' do
     subject { commentaire.valid?(:create) }
@@ -18,7 +17,7 @@ describe Commentaire do
       let(:dossier) { create :dossier, :archived }
       let(:commentaire) { build :commentaire, dossier: dossier }
 
-      it { is_expected.to be_falsey }
+      it { is_expected.to be_truthy }
     end
 
     context 'on a dossier en_construction' do


### PR DESCRIPTION
#4386 

Pour le moment on peut envoyer des messages aux usagers en brouillon qui ont choisi un groupe instructeur, les mêmes que ceux de l'instructeur.

Dans une autre PR on pourrait faire une interface dédiée pour afficher les messages envoyés aux usagers..

**Lien pour envoyer un message à tous les usagers en brouillon :** 

![image](https://user-images.githubusercontent.com/21340608/126640407-7259c83b-2c05-4d60-9c43-a34865140e30.png)

**Interface d'envoi de message à tous les usagers en broullon sans historique**

![image](https://user-images.githubusercontent.com/21340608/126651335-2c81eab3-f9da-42f7-a24c-37c045114265.png)


**Interface d'envoi de message à tous les usagers en broullon avec historique**

![image](https://user-images.githubusercontent.com/21340608/126640440-914f8270-30a1-4693-968b-ee19d514fbd2.png)

