### PR TITLE
Get more results from communes API and use local matcher

### DIFF
--- a/app/javascript/components/ComboCommunesSearch.jsx
+++ b/app/javascript/components/ComboCommunesSearch.jsx
@@ -3,7 +3,12 @@ import { QueryClientProvider } from 'react-query';
 import { matchSorter } from 'match-sorter';
 
 import ComboSearch from './ComboSearch';
-import { queryClient, searchResultsLimit } from './shared/queryClient';
+import { queryClient } from './shared/queryClient';
+
+// Avoid hiding similar matches for precise queries (like "Sainte Marie")
+function searchResultsLimit(term) {
+  return term.length > 5 ? 10 : 5;
+}
 
 function expandResultsWithMultiplePostalCodes(term, results) {
   // A single result may have several associated postal codes.

--- a/app/javascript/components/shared/queryClient.js
+++ b/app/javascript/components/shared/queryClient.js
@@ -2,6 +2,19 @@ import { QueryClient } from 'react-query';
 import { isNumeric } from '@utils';
 import { matchSorter } from 'match-sorter';
 
+const API_EDUCATION_QUERY_LIMIT = 5;
+const API_GEO_QUERY_LIMIT = 5;
+const API_ADRESSE_QUERY_LIMIT = 5;
+
+// When searching for short strings like "mer", le exact match shows up quite far in
+// the ordering (~50).
+//
+// That's why we deliberately fetch a lot of results, and then let the local matching
+// (match-sorter) do the work.
+//
+// NB: 60 is arbitrary, we may add more if needed.
+const API_GEO_COMMUNES_QUERY_LIMIT = 60;
+
 const { api_geo_url, api_adresse_url, api_education_url } =
   gon.autocomplete || {};
 
@@ -13,28 +26,22 @@ export const queryClient = new QueryClient({
   }
 });
 
-// Avoid hiding similar matches for precise queries (like "Sainte Marie")
-export function searchResultsLimit(term) {
-  return term.length > 5 ? 10 : 5;
-}
-
 function buildURL(scope, term) {
   term = encodeURIComponent(term.replace(/\(|\)/g, ''));
   if (scope === 'adresse') {
-    return `${api_adresse_url}/search?q=${term}&limit=5`;
+    return `${api_adresse_url}/search?q=${term}&limit=${API_ADRESSE_QUERY_LIMIT}`;
   } else if (scope === 'annuaire-education') {
-    return `${api_education_url}/search?dataset=fr-en-annuaire-education&q=${term}&rows=5`;
+    return `${api_education_url}/search?dataset=fr-en-annuaire-education&q=${term}&rows=${API_EDUCATION_QUERY_LIMIT}`;
   } else if (scope === 'communes') {
     if (isNumeric(term)) {
-      return `${api_geo_url}/communes?codePostal=${term}&limit=5`;
+      return `${api_geo_url}/communes?codePostal=${term}&limit=${API_GEO_COMMUNES_QUERY_LIMIT}`;
     }
-    const limit = searchResultsLimit(term);
-    return `${api_geo_url}/communes?nom=${term}&boost=population&limit=${limit}`;
+    return `${api_geo_url}/communes?nom=${term}&boost=population&limit=${API_GEO_COMMUNES_QUERY_LIMIT}`;
   } else if (isNumeric(term)) {
     const code = term.padStart(2, '0');
-    return `${api_geo_url}/${scope}?code=${code}&limit=5`;
+    return `${api_geo_url}/${scope}?code=${code}&limit=${API_GEO_QUERY_LIMIT}`;
   }
-  return `${api_geo_url}/${scope}?nom=${term}&limit=5`;
+  return `${api_geo_url}/${scope}?nom=${term}&limit=${API_GEO_QUERY_LIMIT}`;
 }
 
 function buildOptions() {


### PR DESCRIPTION
HS: https://secure.helpscout.net/conversation/1560453371/103222?folderId=1784050

Dans le cas d'une recherche comme "mer" le résultat arrive très loin dans le classement (~50). La solution c'est de récupérer plus de résultats depuis l'API GEO et de laisser le matching local (`match-sorter`) faire le travail. 60 ici est assez arbitraire, on pourra augmenter si besoin.