### PR TITLE
Suppression de la clef `"migrated": true` sur les filtres des ProcedurePresentation

### DIFF
--- a/lib/tasks/deployment/20210720133539_remove_migration_status_on_filters.rake
+++ b/lib/tasks/deployment/20210720133539_remove_migration_status_on_filters.rake
@@ -1,0 +1,25 @@
+namespace :after_party do
+  desc 'Deployment task: remove_migration_status_on_filters'
+  task remove_migration_status_on_filters: :environment do
+    rake_puts "Running deploy task 'remove_migration_status_on_filters'"
+
+    # In a9a4f6e2a801b19b127aae8eaec0d1f384b1a53a, a task to migrate ProcedurePresentation's filters
+    # was added.
+    # This task added a "migrated: true" key to all migrated filters.
+    #
+    # Now that this task has run, we can safely remove the extra key.
+
+    procedure_presentations = ProcedurePresentation.where("filters -> 'migrated' IS NOT NULL")
+    progress = ProgressReport.new(procedure_presentations.count)
+
+    procedure_presentations.find_each do |pp|
+      pp.filters.delete('migrated')
+      pp.save!
+      progress.inc
+    end
+    progress.finish
+
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/task_helper.rb
+++ b/lib/tasks/task_helper.rb
@@ -15,6 +15,17 @@ def rake_print(*args)
   end
 end
 
+# Display progress of a long-running Rake task.
+#
+# Usage:
+#
+# ```
+# progress = ProgressReport.new(100)
+# (0..100).times do
+#   progress.inc
+# end
+# progress.finish
+# ````
 class ProgressReport
   def initialize(total)
     @start = Time.zone.now

--- a/spec/lib/tasks/deployment/20210720133539_remove_migration_status_on_filters_spec.rb
+++ b/spec/lib/tasks/deployment/20210720133539_remove_migration_status_on_filters_spec.rb
@@ -1,0 +1,45 @@
+describe '20201001161931_migrate_filters_to_use_stable_id' do
+  let(:rake_task) { Rake::Task['after_party:remove_migration_status_on_filters'] }
+
+  let(:procedure) { create(:simple_procedure) }
+  let(:instructeur_1) { create(:instructeur) }
+  let(:instructeur_2) { create(:instructeur) }
+
+  let(:assign_to_1) { create(:assign_to, procedure: procedure, instructeur: instructeur_1) }
+  let(:assign_to_2) { create(:assign_to, procedure: procedure, instructeur: instructeur_2) }
+
+  let(:procedure_presentation_with_migration) { create(:procedure_presentation, assign_to: assign_to_1, filters: filters.merge('migrated': true)) }
+  let(:procedure_presentation_without_migration) { create(:procedure_presentation, assign_to: assign_to_2, filters: filters) }
+
+  let(:filters) do
+    { "suivis" => [{ "table" => "user", "column" => "email", "value" => "test@example.com" }] }
+  end
+
+  before do
+    procedure_presentation_with_migration
+    procedure_presentation_without_migration
+
+    rake_task.invoke
+
+    procedure_presentation_with_migration.reload
+    procedure_presentation_without_migration.reload
+  end
+
+  after { rake_task.reenable }
+
+  context 'when the procedure presentation has a "migrated" key' do
+    it 'removes the "migrated" key' do
+      expect(procedure_presentation_with_migration.filters).not_to have_key('migrated')
+    end
+
+    it 'leaves other keys unchanged' do
+      expect(procedure_presentation_with_migration.filters['suivis']).to be_present
+    end
+  end
+
+  context 'when the procedure presentation doesn’t have a "migrated" key' do
+    it 'leaves keys unchanged' do
+      expect(procedure_presentation_without_migration.filters['suivis']).to be_present
+    end
+  end
+end


### PR DESCRIPTION
In a9a4f6e, a task to migrate ProcedurePresentation's filters was added.

This task added a "migrated: true" key to all migrated filters.

Now that this task has run, we can safely remove the extra key.
