### PR TITLE
Ajout de contraintes d'unicités supplémentaires sur Champs, DeletedDossiers et Etablissements

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -812,7 +812,7 @@ Rails/UniqBeforePluck:
   Enabled: true
 
 Rails/UniqueValidationWithoutIndex:
-  Enabled: false
+  Enabled: true
 
 Rails/UnknownEnv:
   Enabled: false

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -12,7 +12,6 @@
 #  deleted_user_email_never_send                      :string
 #  en_construction_at                                 :datetime
 #  en_construction_close_to_expiration_notice_sent_at :datetime
-#  en_construction_conservation_extension             :interval         default(0 seconds)
 #  en_instruction_at                                  :datetime
 #  groupe_instructeur_updated_at                      :datetime
 #  hidden_at                                          :datetime

--- a/db/migrate/20210722133440_add_unique_index_to_champs.rb
+++ b/db/migrate/20210722133440_add_unique_index_to_champs.rb
@@ -1,0 +1,14 @@
+class AddUniqueIndexToChamps < ActiveRecord::Migration[6.1]
+  include Database::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  def up
+    delete_duplicates :champs, [:type_de_champ_id, :dossier_id, :row]
+    add_concurrent_index :champs, [:type_de_champ_id, :dossier_id, :row], unique: true
+  end
+
+  def down
+    remove_index :champs, [:type_de_champ_id, :dossier_id, :row]
+  end
+end

--- a/db/migrate/20210722133531_add_unique_index_to_deleted_dossiers.rb
+++ b/db/migrate/20210722133531_add_unique_index_to_deleted_dossiers.rb
@@ -1,0 +1,14 @@
+class AddUniqueIndexToDeletedDossiers < ActiveRecord::Migration[6.1]
+  include Database::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  def up
+    delete_duplicates :deleted_dossiers, [:dossier_id]
+    add_concurrent_index :deleted_dossiers, [:dossier_id], unique: true
+  end
+
+  def down
+    remove_index :deleted_dossiers, [:dossier_id]
+  end
+end

--- a/db/migrate/20210722133553_add_unique_index_to_etablissement.rb
+++ b/db/migrate/20210722133553_add_unique_index_to_etablissement.rb
@@ -1,0 +1,16 @@
+class AddUniqueIndexToEtablissement < ActiveRecord::Migration[6.1]
+  include Database::MigrationHelpers
+
+  disable_ddl_transaction!
+
+  def up
+    delete_duplicates :etablissements, [:dossier_id]
+    remove_index :etablissements, [:dossier_id]
+    add_concurrent_index :etablissements, [:dossier_id], unique: true
+  end
+
+  def down
+    remove_index :etablissements, [:dossier_id]
+    add_concurrent_index :etablissements, [:dossier_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_04_095054) do
+ActiveRecord::Schema.define(version: 2021_07_22_133440) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -174,6 +174,7 @@ ActiveRecord::Schema.define(version: 2021_06_04_095054) do
     t.index ["parent_id"], name: "index_champs_on_parent_id"
     t.index ["private"], name: "index_champs_on_private"
     t.index ["row"], name: "index_champs_on_row"
+    t.index ["type_de_champ_id", "dossier_id", "row"], name: "index_champs_on_type_de_champ_id_and_dossier_id_and_row", unique: true
     t.index ["type_de_champ_id"], name: "index_champs_on_type_de_champ_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_22_133531) do
+ActiveRecord::Schema.define(version: 2021_07_22_133553) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -340,7 +340,7 @@ ActiveRecord::Schema.define(version: 2021_07_22_133531) do
     t.jsonb "entreprise_bilans_bdf"
     t.string "entreprise_bilans_bdf_monnaie"
     t.string "enseigne"
-    t.index ["dossier_id"], name: "index_etablissements_on_dossier_id"
+    t.index ["dossier_id"], name: "index_etablissements_on_dossier_id", unique: true
   end
 
   create_table "exercices", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_05_095054) do
+ActiveRecord::Schema.define(version: 2021_06_04_095054) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -276,9 +276,9 @@ ActiveRecord::Schema.define(version: 2021_06_05_095054) do
     t.string "api_entreprise_job_exceptions", array: true
     t.interval "conservation_extension", default: "PT0S"
     t.string "deleted_user_email_never_send"
+    t.datetime "declarative_triggered_at"
     t.index "to_tsvector('french'::regconfig, (search_terms || private_search_terms))", name: "index_dossiers_on_search_terms_private_search_terms", using: :gin
     t.index "to_tsvector('french'::regconfig, search_terms)", name: "index_dossiers_on_search_terms", using: :gin
-    t.datetime "declarative_triggered_at"
     t.index ["archived"], name: "index_dossiers_on_archived"
     t.index ["groupe_instructeur_id"], name: "index_dossiers_on_groupe_instructeur_id"
     t.index ["hidden_at"], name: "index_dossiers_on_hidden_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_22_133440) do
+ActiveRecord::Schema.define(version: 2021_07_22_133531) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -229,6 +229,7 @@ ActiveRecord::Schema.define(version: 2021_07_22_133440) do
     t.bigint "user_id"
     t.bigint "groupe_instructeur_id"
     t.bigint "revision_id"
+    t.index ["dossier_id"], name: "index_deleted_dossiers_on_dossier_id", unique: true
     t.index ["procedure_id"], name: "index_deleted_dossiers_on_procedure_id"
   end
 


### PR DESCRIPTION
Cette PR rajoute les dernières contraintes d'unicité manquantes en base (fix #6013)

## Pourquoi

Pour mémoire, les contraintes d'unicité déclarées au niveau des validateurs Rails ne sont pas suffisantes pour garantir qu'aucun enregistrement dupliqué n'existera jamais en base. En effet deux serveurs webs peuvent essayer de créer en même temps le même enregistrement – et contourner ainsi la validation Rails. Ces contraintes Rails doivent donc être doublées d'une contrainte en base de donnée.

## Comment

Les trois tables migrées ici comportent en ce moment en production des données dupliquées.

Chaque migration se déroule donc en trois étapes :
1. Recherche des doublons,
2. Suppression des doublons,
3. Ajout de la contrainte d'unicité.

Chacune de ces étapes peut prendre du temps (~ 20 mn au total en dev, probablement moins de 5mn en prod). Pour éviter de verrouiller la base pendant trop longtemps, chaque étape est effectuée de manière asynchrone, sans verrouiller ni le contenu de la base ni son schéma.

