### PR TITLE
add bug report to archive

### DIFF
--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -95,6 +95,10 @@ class PiecesJustificativesService
     def attached?
       true
     end
+
+    def record_type
+      'Fake'
+    end
   end
 
   def self.generate_dossier_export(dossier)

--- a/app/services/procedure_archive_service.rb
+++ b/app/services/procedure_archive_service.rb
@@ -25,13 +25,18 @@ class ProcedureArchiveService
     tmp_file = Tempfile.new(['tc', '.zip'])
 
     Zip::OutputStream.open(tmp_file) do |zipfile|
+      bug_reports = ''
       files.each do |attachment, pj_filename|
         zipfile.put_next_entry("procedure-#{@procedure.id}/#{pj_filename}")
         begin
           zipfile.puts(attachment.download)
         rescue
-          raise "Problem while trying to attach #{pj_filename}"
+          bug_reports += "Impossible de récupérer le fichier #{pj_filename}\n"
         end
+      end
+      if !bug_reports.empty?
+        zipfile.put_next_entry("LISEZMOI.txt")
+        zipfile.puts(bug_reports)
       end
     end
 


### PR DESCRIPTION
Au moment de la génération d'une archive, lorsqu'une pièce du dossier n'est pas trouvée, l'archive est quand même générée et un fichier LISEZMOI.txt est ajouté dedans indiquant le fichier manquant

close #6377 