### PR TITLE
archives: move bugreport

### DIFF
--- a/app/services/procedure_archive_service.rb
+++ b/app/services/procedure_archive_service.rb
@@ -27,7 +27,7 @@ class ProcedureArchiveService
     Zip::OutputStream.open(tmp_file) do |zipfile|
       bug_reports = ''
       files.each do |attachment, pj_filename|
-        zipfile.put_next_entry("procedure-#{@procedure.id}/#{pj_filename}")
+        zipfile.put_next_entry("#{zip_root_folder(@procedure)}/#{pj_filename}")
         begin
           zipfile.puts(attachment.download)
         rescue
@@ -35,7 +35,7 @@ class ProcedureArchiveService
         end
       end
       if !bug_reports.empty?
-        zipfile.put_next_entry("LISEZMOI.txt")
+        zipfile.put_next_entry("#{zip_root_folder(@procedure)}/LISEZMOI.txt")
         zipfile.puts(bug_reports)
       end
     end
@@ -57,6 +57,10 @@ class ProcedureArchiveService
   end
 
   private
+
+  def zip_root_folder(procedure)
+    "procedure-#{@procedure.id}"
+  end
 
   def create_list_of_attachments(dossiers)
     dossiers.flat_map do |dossier|

--- a/spec/services/procedure_archive_service_spec.rb
+++ b/spec/services/procedure_archive_service_spec.rb
@@ -90,7 +90,7 @@ describe ProcedureArchiveService do
           archive.file.open do |f|
             files = ZipTricks::FileReader.read_zip_structure(io: f)
             expect(files.size).to be 4
-            expect(files.last.filename).to include("LISEZMOI")
+            expect(files.last.filename).to eq("procedure-#{procedure.id}/LISEZMOI.txt")
             expect(extract(f, files.last)).to match(/Impossible de .*cni.*png/)
           end
         end


### PR DESCRIPTION
Actuellement, toutes les pièces de chaque dossier sont dans un répertoire procedure-xxxx/dossier-xxx
Avant cette PR, le fichier LISEZMOI.txt de bugreport est placé à la racine.
Lors de l'extraction, il y a pas un risque que le fichier ne soit pas clairement visible pour l'utilisateur.

Cette PR déplace le fichier LISEZMOI.txt dans le répertoire procedure-xxx 