### PR TITLE
Improve repartition par semaine

### DIFF
--- a/app/assets/stylesheets/stats.scss
+++ b/app/assets/stylesheets/stats.scss
@@ -65,7 +65,6 @@ $stat-card-half-horizontal-spacing: 4 * $default-space;
 
 .stat-card-details {
   font-size: 13px;
-  text-align: center;
   font-style: italic;
 }
 

--- a/app/models/concerns/procedure_stats_concern.rb
+++ b/app/models/concerns/procedure_stats_concern.rb
@@ -52,7 +52,12 @@ module ProcedureStatsConcern
       # rubocop:disable Style/HashTransformValues
       dossier_state_values
         .map do |state|
-          { name: state, data: chart_data.where(state: state).group_by_week { |dossier| dossier.traitements.first.processed_at }.map { |k, v| [k, v.count] }.to_h }
+          {
+            name: state,
+            data: chart_data .where(state: state) .group_by_week do |dossier|
+              dossier.traitements.first.processed_at
+            end.map { |k, v| [k, v.count] }.to_h.transform_keys { |week| pretty_week(week) }
+          }
           # rubocop:enable Style/HashTransformValues
         end
     end
@@ -103,5 +108,9 @@ module ProcedureStatsConcern
 
   def pretty_month(month)
     I18n.l(month, format: "%B %Y")
+  end
+
+  def pretty_week(week)
+    I18n.l(week, format: '%d %b')
   end
 end

--- a/app/views/shared/procedures/_stats.html.haml
+++ b/app/views/shared/procedures/_stats.html.haml
@@ -37,6 +37,7 @@
 
     .stat-card.stat-card-half.pull-left
       %span.stat-card-title RÉPARTITION PAR SEMAINE
+      .stat-card-details au cours des 6 derniers mois
       .chart-container
         .chart
-          = line_chart @termines_by_week, colors: ["#387EC3", "#AE2C2B", "#FAD859"]
+          = line_chart @termines_by_week, colors: ["#387EC3", "#AE2C2B", "#FAD859"], ytitle: 'Nb dossiers'


### PR DESCRIPTION
close #6382 

Cette PR 
- ajoute la légende *Nb de dossiers* en ordonnée
- indique dans le titre la période considérée
- affiche la légende en abscisse avec la date dans la langue courante

## Avant la PR 
 
![repartition-avant](https://user-images.githubusercontent.com/1111966/128874739-51ff3e8f-95d5-4ac8-80ee-e880da078fdd.png)


## Après la PR
 
![repartition-apres](https://user-images.githubusercontent.com/1111966/128874765-db63dc29-b75b-47ac-938d-366bcc5102c7.png)
