### PR TITLE
Améliore la lisibilité du taux d'acceptation

### DIFF
--- a/app/models/concerns/procedure_stats_concern.rb
+++ b/app/models/concerns/procedure_stats_concern.rb
@@ -31,11 +31,12 @@ module ProcedureStatsConcern
   end
 
   def stats_termines_states
+    nb_dossiers_termines = dossiers.state_termine.count
     Rails.cache.fetch("#{cache_key_with_version}/stats_termines_states", expires_in: 12.hours) do
       [
-        ['Acceptés', dossiers.where(state: :accepte).count],
-        ['Refusés', dossiers.where(state: :refuse).count],
-        ['Classés sans suite', dossiers.where(state: :sans_suite).count]
+        ['Acceptés', percentage(dossiers.where(state: :accepte).count, nb_dossiers_termines)],
+        ['Refusés', percentage(dossiers.where(state: :refuse).count, nb_dossiers_termines)],
+        ['Classés sans suite', percentage(dossiers.where(state: :sans_suite).count, nb_dossiers_termines)]
       ]
     end
   end
@@ -104,6 +105,10 @@ module ProcedureStatsConcern
 
   def convert_seconds_in_days(seconds)
     (seconds / 60.0 / 60.0 / 24.0).ceil
+  end
+
+  def percentage(value, total)
+    (100 * value / total.to_f).round(1)
   end
 
   def pretty_month(month)

--- a/app/views/shared/procedures/_stats.html.haml
+++ b/app/views/shared/procedures/_stats.html.haml
@@ -30,10 +30,17 @@
   .stat-cards
     .stat-card.stat-card-half.pull-left
       %span.stat-card-title TAUX D’ACCEPTATION
+      .stat-card-details depuis le lancement de la procédure
       .chart-container
         .chart
           - colors = %w(#C3D9FF #0069CC #1C7EC9) # from _colors.scss
-          = pie_chart @termines_states, colors: colors
+          = pie_chart @termines_states,
+            code: true,
+            colors: colors,
+            label: 'Taux',
+            suffix: '%',
+            library: { plotOptions: { pie: {  dataLabels: { enabled: true, format: '{point.name} : {point.percentage: .1f}%' } } } }
+
 
     .stat-card.stat-card-half.pull-left
       %span.stat-card-title RÉPARTITION PAR SEMAINE

--- a/app/views/shared/procedures/_stats.html.haml
+++ b/app/views/shared/procedures/_stats.html.haml
@@ -33,10 +33,9 @@
       .stat-card-details depuis le lancement de la procédure
       .chart-container
         .chart
-          - colors = %w(#C3D9FF #0069CC #1C7EC9) # from _colors.scss
           = pie_chart @termines_states,
             code: true,
-            colors: colors,
+            colors: %w(#387EC3 #AE2C2B #FAD859),
             label: 'Taux',
             suffix: '%',
             library: { plotOptions: { pie: {  dataLabels: { enabled: true, format: '{point.name} : {point.percentage: .1f}%' } } } }


### PR DESCRIPTION
close #6381 

Cette PR 

- précise la période prise en compte
- indique en légende les taux, pas uniquement lors d'un rollover sur la fraction du camembert considéré
- indique dans le rollover la valeur en pourcentage et non en absolu
- utilise les mêmes couleurs que pour le graphe de répartition par semaine

## Avant la PR

![tx-acceptation-avant](https://user-images.githubusercontent.com/1111966/129006590-f0bb9903-2753-46f0-a014-52a5c6da0840.png)

## Après la PR

![tx-acceptation](https://user-images.githubusercontent.com/1111966/129006408-a059eda0-ad4d-4e11-a5a1-b371fd09ef8a.png)
