### PR TITLE
purge old sendinblue mails

### DIFF
--- a/app/jobs/cron/purge_old_sib_mails_job.rb
+++ b/app/jobs/cron/purge_old_sib_mails_job.rb
@@ -1,0 +1,9 @@
+class Cron::PurgeOldSibMailsJob < Cron::CronJob
+  self.schedule_expression = "every day at midnight"
+
+  def perform
+    sib = Sendinblue::API.new
+    day_to_delete = (Time.zone.today - 31.days).strftime("%Y-%m-%d")
+    sib.delete_events(day_to_delete)
+  end
+end

--- a/app/lib/sendinblue/api.rb
+++ b/app/lib/sendinblue/api.rb
@@ -55,6 +55,21 @@ class Sendinblue::API
     []
   end
 
+  def delete_events(day, opts = {})
+    client = ::SibApiV3Sdk::TransactionalEmailsApi.new
+    event_opts = { start_date: day, end_date: day, limit: 100 }.merge(opts)
+    while (events = client.get_email_event_report(event_opts).events).present?
+      message_ids = events.map(&:message_id).uniq
+      message_ids.each do |message_id|
+        client.smtp_log_message_id_delete(message_id)
+      end
+    end
+    true
+  rescue ::SibApiV3Sdk::ApiError => e
+    Rails.logger.error e.message
+    false
+  end
+
   def unblock_user(email_address)
     client = ::SibApiV3Sdk::TransactionalEmailsApi.new
     client.smtp_blocked_contacts_email_delete(email_address)


### PR DESCRIPTION
Cette PR supprime chaque nuit le contenu des logs sendinblue du jour J-31
A noter que, les metadata des logs (expediteur, destinataire, objet, date, du mail) ne sont pas supprimés. Sendinblue ne permet pour l'instant pas de le faire