### PR TITLE
feat(graphql): expose demarche descriptor on dossier type

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -406,7 +406,7 @@ interface Demandeur {
 }
 
 """
-Une demarche
+Une démarche
 """
 type Demarche {
   annotationDescriptors: [ChampDescriptor!]!
@@ -438,7 +438,7 @@ type Demarche {
   datePublication: ISO8601DateTime
 
   """
-  L’état de dossier pour une démarche déclarative
+  Pour une démarche déclarative, état cible des dossiers à valider automatiquement
   """
   declarative: DossierDeclarativeState
 
@@ -551,7 +551,7 @@ type Demarche {
   id: ID!
 
   """
-  Le numero de la démarche.
+  Numero de la démarche.
   """
   number: Int!
   publishedRevision: Revision
@@ -559,12 +559,70 @@ type Demarche {
   service: Service!
 
   """
-  L’état de la démarche.
+  État de la démarche.
   """
   state: DemarcheState!
 
   """
-  Le titre de la démarche.
+  Titre de la démarche.
+  """
+  title: String!
+}
+
+"""
+Une démarche (métadonnées)
+Ceci est une version abrégée du type `Demarche`, qui n’expose que les métadonnées.
+Cela évite l’accès récursif aux dossiers.
+"""
+type DemarcheDescriptor {
+  """
+  Date de la création.
+  """
+  dateCreation: ISO8601DateTime!
+
+  """
+  Date de la dépublication.
+  """
+  dateDepublication: ISO8601DateTime
+
+  """
+  Date de la dernière modification.
+  """
+  dateDerniereModification: ISO8601DateTime!
+
+  """
+  Date de la fermeture.
+  """
+  dateFermeture: ISO8601DateTime
+
+  """
+  Date de la publication.
+  """
+  datePublication: ISO8601DateTime
+
+  """
+  Pour une démarche déclarative, état cible des dossiers à valider automatiquement
+  """
+  declarative: DossierDeclarativeState
+
+  """
+  Description de la démarche.
+  """
+  description: String!
+  id: ID!
+
+  """
+  Numero de la démarche.
+  """
+  number: Int!
+
+  """
+  État de la démarche.
+  """
+  state: DemarcheState!
+
+  """
+  Titre de la démarche.
   """
   title: String!
 }
@@ -650,6 +708,7 @@ type Dossier {
   """
   dateTraitement: ISO8601DateTime
   demandeur: Demandeur!
+  demarche: DemarcheDescriptor!
 
   """
   L’URL du GeoJSON contenant les données cartographiques du dossier.

--- a/app/graphql/types/demarche_descriptor_type.rb
+++ b/app/graphql/types/demarche_descriptor_type.rb
@@ -1,0 +1,24 @@
+module Types
+  class DemarcheDescriptorType < Types::BaseObject
+    description "Une démarche (métadonnées)
+Ceci est une version abrégée du type `Demarche`, qui n’expose que les métadonnées.
+Cela évite l’accès récursif aux dossiers."
+
+    global_id_field :id
+    field :number, Int, "Numero de la démarche.", null: false, method: :id
+    field :title, String, "Titre de la démarche.", null: false, method: :libelle
+    field :description, String, "Description de la démarche.", null: false
+    field :state, Types::DemarcheType::DemarcheState, "État de la démarche.", null: false
+    field :declarative, Types::DemarcheType::DossierDeclarativeState, "Pour une démarche déclarative, état cible des dossiers à valider automatiquement", null: true, method: :declarative_with_state
+
+    field :date_creation, GraphQL::Types::ISO8601DateTime, "Date de la création.", null: false, method: :created_at
+    field :date_publication, GraphQL::Types::ISO8601DateTime, "Date de la publication.", null: true, method: :published_at
+    field :date_derniere_modification, GraphQL::Types::ISO8601DateTime, "Date de la dernière modification.", null: false, method: :updated_at
+    field :date_depublication, GraphQL::Types::ISO8601DateTime, "Date de la dépublication.", null: true, method: :unpublished_at
+    field :date_fermeture, GraphQL::Types::ISO8601DateTime, "Date de la fermeture.", null: true, method: :closed_at
+
+    def state
+      object.aasm.current_state
+    end
+  end
+end

--- a/app/graphql/types/demarche_type.rb
+++ b/app/graphql/types/demarche_type.rb
@@ -14,14 +14,14 @@ module Types
       end
     end
 
-    description "Une demarche"
+    description "Une démarche"
 
     global_id_field :id
-    field :number, Int, "Le numero de la démarche.", null: false, method: :id
-    field :title, String, "Le titre de la démarche.", null: false, method: :libelle
+    field :number, Int, "Numero de la démarche.", null: false, method: :id
+    field :title, String, "Titre de la démarche.", null: false, method: :libelle
     field :description, String, "Description de la démarche.", null: false
-    field :state, DemarcheState, "L’état de la démarche.", null: false
-    field :declarative, DossierDeclarativeState, "L’état de dossier pour une démarche déclarative", null: true, method: :declarative_with_state
+    field :state, DemarcheState, "État de la démarche.", null: false
+    field :declarative, DossierDeclarativeState, "Pour une démarche déclarative, état cible des dossiers à valider automatiquement", null: true, method: :declarative_with_state
 
     field :date_creation, GraphQL::Types::ISO8601DateTime, "Date de la création.", null: false, method: :created_at
     field :date_publication, GraphQL::Types::ISO8601DateTime, "Date de la publication.", null: true, method: :published_at

--- a/app/graphql/types/dossier_type.rb
+++ b/app/graphql/types/dossier_type.rb
@@ -12,6 +12,8 @@ module Types
     field :number, Int, "Le numero du dossier.", null: false, method: :id
     field :state, DossierState, "L’état du dossier.", null: false
 
+    field :demarche, Types::DemarcheDescriptorType, null: false, method: :procedure
+
     field :date_passage_en_construction, GraphQL::Types::ISO8601DateTime, "Date de dépôt.", null: false, method: :en_construction_at
     field :date_passage_en_instruction, GraphQL::Types::ISO8601DateTime, "Date de passage en instruction.", null: true, method: :en_instruction_at
     field :date_traitement, GraphQL::Types::ISO8601DateTime, "Date de traitement.", null: true, method: :processed_at

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -310,6 +310,11 @@ describe API::V2::GraphqlController do
               motivationAttachment {
                 url
               }
+              demarche {
+                number
+                title
+                state
+              }
               usager {
                 id
                 email
@@ -382,6 +387,11 @@ describe API::V2::GraphqlController do
             dateTraitement: nil,
             motivation: nil,
             motivationAttachment: nil,
+            demarche: {
+              number: dossier.procedure.id,
+              title: dossier.procedure.libelle,
+              state: 'publiee'
+            },
             usager: {
               id: dossier.user.to_typed_id,
               email: dossier.user.email


### PR DESCRIPTION
We don't want to expose full demarche type on dossiers because it would open the door for recursive queries that we want to avoid. DemarcheDescriptorType is a lightweight representation of demarche metadata.

PS : demande récurrente au support API