### PR TITLE
feat(i18n): enable localization by query param

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -89,7 +89,7 @@ class RootController < ApplicationController
   end
 
   def save_locale
-    cookies[:locale] = params[:locale]
-    redirect_to request.referer
+    set_locale(params[:locale])
+    redirect_back(fallback_location: root_path)
   end
 end

--- a/app/views/layouts/_header.haml
+++ b/app/views/layouts/_header.haml
@@ -82,6 +82,6 @@
         - else
           = render partial: 'shared/help/help_button'
 
-      - if ENV.fetch('LOCALIZATION_ENABLED', 'false') == 'true'
+      - if localization_enabled?
         %li
           = render partial: 'layouts/locale_dropdown'

--- a/app/views/layouts/_locale_dropdown.html.haml
+++ b/app/views/layouts/_locale_dropdown.html.haml
@@ -1,11 +1,11 @@
-.dropdown.locale-dropdown
-  %button.button.dropdown-button.icon-only.header-menu-button{ title: "Translate", 'aria-expanded' => 'false', 'aria-controls' => 'locale_menu' }
+.dropdown.locale-dropdown.header-menu-opener
+  %button.button.dropdown-button.icon-only.header-menu-button{ title: "Translate", aria: { expanded: 'false', controls: 'locale_menu' } }
     .hidden Translate
-    = image_tag "icons/translate-icon.svg", alt: 'Translate', 'aria-hidden':'true'
+    = image_tag "icons/translate-icon.svg", alt: 'Translate', width: 24, height: 24, lazy: true, aria: { hidden: true }
   %ul.header-menu.dropdown-content
     %li
-    = link_to save_locale_path(locale: :en), method: :post, class: "menu-item menu-link" do
-      EN - English
+      = link_to save_locale_path(locale: :en), method: :post, class: "menu-item menu-link" do
+        EN – English
     %li
-    = link_to save_locale_path(locale: :fr), method: :post, class: "menu-item menu-link" do
-      FR - français
+      = link_to save_locale_path(locale: :fr), method: :post, class: "menu-item menu-link" do
+        FR – français

--- a/spec/features/i18n_spec.rb
+++ b/spec/features/i18n_spec.rb
@@ -8,7 +8,7 @@ feature 'Accessing the website in different languages:' do
       expect(page).to have_text('Connectez-vous')
 
       click_on 'Translate'
-      click_on 'EN - English'
+      click_on 'EN – English'
 
       # The page is now in English
       expect(page).to have_text('Sign in')

--- a/spec/views/layouts/_header_spec.rb
+++ b/spec/views/layouts/_header_spec.rb
@@ -5,6 +5,7 @@ describe 'layouts/_header.html.haml', type: :view do
     allow(view).to receive(:multiple_devise_profile_connect?).and_return(false)
     allow(view).to receive(:instructeur_signed_in?).and_return((profile == :instructeur))
     allow(view).to receive(:current_instructeur).and_return(current_instructeur)
+    allow(view).to receive(:localization_enabled?).and_return(false)
 
     if user
       sign_in user

--- a/spec/views/layouts/procedure_context.html.haml_spec.rb
+++ b/spec/views/layouts/procedure_context.html.haml_spec.rb
@@ -5,6 +5,7 @@ describe 'layouts/procedure_context.html.haml', type: :view do
   before do
     allow(view).to receive(:instructeur_signed_in?).and_return(false)
     allow(view).to receive(:administrateur_signed_in?).and_return(false)
+    allow(view).to receive(:localization_enabled?).and_return(false)
   end
 
   subject do


### PR DESCRIPTION
Providing a query param ("locale") will enable localization. A language picker will be shown once
localization is activated. Locale is stored in a cookie "locale".