### PR TITLE
Correction d'une erreur lors d'un échec de l'enregistrement automatique d'un brouillon

### DIFF
--- a/app/javascript/new_design/dossiers/auto-save.js
+++ b/app/javascript/new_design/dossiers/auto-save.js
@@ -64,7 +64,7 @@ addEventListener('autosave:end', () => {
 addEventListener('autosave:error', (event) => {
   let error = event.detail;
 
-  if (error.xhr.status == 401) {
+  if (error.xhr && error.xhr.status == 401) {
     // If we are unauthenticated, reload the page using a GET request.
     // This will allow Devise to properly redirect us to sign-in, and then back to this page.
     document.location.reload();


### PR DESCRIPTION
Sentry reports many cases of the xhr object being missing in the error handler.

Ensure the error handling code doesn't crash because of the missing xhr.

Fix https://sentry.io/organizations/demarches-simplifiees/issues/2529823946