### PR TITLE
i18n: ajout des traductions pour la page reset-link-sent

### DIFF
--- a/app/javascript/components/shared/mapbox/styles/base.js
+++ b/app/javascript/components/shared/mapbox/styles/base.js
@@ -204,16 +204,10 @@ export default {
       type: 'vector',
       url: 'https://openmaptiles.geo.data.gouv.fr/data/france-vector.json'
     },
-    'photographies-aeriennes': {
-      type: 'raster',
-      tiles: [
-        'https://tiles.geo.api.gouv.fr/photographies-aeriennes/tiles/{z}/{x}/{y}'
-      ],
-      tileSize: 256,
-      attribution: 'Images aériennes © IGN',
-      minzoom: 0,
-      maxzoom: 19
-    },
+    'photographies-aeriennes': rasterSource(
+      [ignServiceURL('ORTHOIMAGERY.ORTHOPHOTOS', 'image/jpeg')],
+      'IGN-F/Géoportail'
+    ),
     cadastre: {
       type: 'vector',
       url: 'https://openmaptiles.geo.data.gouv.fr/data/cadastre.json'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,6 +202,19 @@ en:
           connection: Sign in
           are_you_new: First time on %{app_name}?
           find_procedure: Find your procedure
+      password:
+        reset_link_sent:
+          got_it: Got it!
+          open_your_mailbox: Now open your mailbox.
+          email_sent_html: We have sent you an email to the address <strong>%{email}</strong>.
+          click_link_to_reset_password: Click on the link in the email to change your password.
+          no_mail: Didn't receive the email?
+          check_spams: Check your junk or spam email.
+          check_account: Have you created a %{application_name} account with the adress %{email}? You will not receive any message if no account is linked to your email adress.
+          check_france_connect_html: Have you once logged in with France Connect? If yes, <a href=\"%{href}\">try again with France Connect</a>.
+        shared:
+          email_can_take_a_while_html: <strong>Please note</strong> that this message can take up to 15 minutes to arrive.
+          contact_us_if_any_trouble_html: You can contact us <a href=\"%{href}\">through this form</a> if a problem still exists.
   modal:
     publish:
       title:


### PR DESCRIPTION
Initialement, nous avions convenu avec @tchak d'inscrire les traductions dans le fichier config>locales>devise.en.yml.
La première partie de la traduction, c'est-à-dire les clés, était déjà présente dans le fichier fr.yml.
J'ai donc continué dans ce sens.