### PR TITLE
i18n: affichage du sélecteur de langues pour les navigateurs non-francophones

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -72,7 +72,11 @@ class ApplicationController < ActionController::Base
   alias_method :pundit_user, :current_account
 
   def localization_enabled?
-    ENV.fetch('LOCALIZATION_ENABLED', 'false') == 'true' || cookies[:locale].present?
+    ENV.fetch('LOCALIZATION_ENABLED', 'false') == 'true' || cookies[:locale].present? || !browser_prefers_french?
+  end
+
+  def browser_prefers_french?
+    http_accept_language.compatible_language_from(I18n.available_locales) == 'fr'
   end
 
   def set_locale(locale)

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -49,6 +49,20 @@ Capybara::Screenshot.register_driver :headless_chrome do |driver, path|
 end
 
 RSpec.configure do |config|
+  # Set the user preferred language before Javascript feature specs.
+  #
+  # Features specs without Javascript run in a Rack stack, and respect the Accept-Language value.
+  # However specs using Javascript are run into a Headless Chrome, which doesn't support setting
+  # the default Accept-Language value reliably.
+  # So instead we set the locale cookie explicitly before each Javascript test.
+  config.before(:each, js: true) do
+    visit '/' # Webdriver needs visiting a page before setting the cookie
+    Capybara.current_session.driver.browser.manage.add_cookie(
+      name: :locale,
+      value: Rails.application.config.i18n.default_locale
+    )
+  end
+
   # Examples tagged with :capybara_ignore_server_errors will allow Capybara
   # to continue when an exception in raised by Rails.
   # This allows to test for error cases.

--- a/spec/views/new_administrateur/procedures/show.html.haml_spec.rb
+++ b/spec/views/new_administrateur/procedures/show.html.haml_spec.rb
@@ -34,7 +34,7 @@ describe 'new_administrateur/procedures/show.html.haml', type: :view do
       render
     end
 
-    describe 'archive button is visible', js: true do
+    describe 'archive button is visible' do
       it { expect(rendered).not_to have_css('#publish-procedure-link') }
       it { expect(rendered).to have_css('#close-procedure-link') }
     end


### PR DESCRIPTION
Fix #3949