### PR TITLE
Correction de la génération PDF de dossiers comportant des champs "Pays"

### DIFF
--- a/app/models/champs/pays_champ.rb
+++ b/app/models/champs/pays_champ.rb
@@ -20,7 +20,7 @@
 class Champs::PaysChamp < Champs::TextChamp
   def localized_value
     if external_id
-      I18nData.countries(I18n.locale)[external_id]
+      I18nData.countries(I18n.locale)[external_id].to_s
     else
       value.present? ? value.to_s : ''
     end


### PR DESCRIPTION
Before this, the result of `Champs::Pays#to_s` could be `nil`, which would break various things (like the PDF rendering of these champs).

Fix https://sentry.io/organizations/demarches-simplifiees/issues/2631320893/events/c590ca775be84cbfb477e195a3548196/