### PR TITLE
Ajout d'un linter pour vérifier que toutes les chaînes localisées sont traduites en français

### DIFF
--- a/app/controllers/champs/siret_controller.rb
+++ b/app/controllers/champs/siret_controller.rb
@@ -18,7 +18,7 @@ class Champs::SiretController < ApplicationController
     begin
       etablissement = find_etablissement_with_siret
     rescue APIEntreprise::API::Error::RequestFailed, APIEntreprise::API::Error::ServiceUnavailable
-      # i18n-tasks-use t('errors.siret_network_error')
+      # i18n-tasks-use t('errors.messages.siret_network_error')
       return siret_error(:network_error)
     end
     if etablissement.nil?

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -318,13 +318,13 @@ module Users
 
     def show_demarche_en_test_banner
       if @dossier.present? && @dossier.revision.draft?
-        flash.now.alert = t('.test_procedure')
+        flash.now.alert = t('users.dossiers.test_procedure')
       end
     end
 
     def ensure_dossier_can_be_updated
       if !dossier.can_be_updated_by_user?
-        flash.alert = t('.no_longer_editable')
+        flash.alert = t('users.dossiers.no_longer_editable')
         redirect_to dossiers_path
       end
     end
@@ -425,7 +425,7 @@ module Users
     end
 
     def forbidden!
-      flash[:alert] = t('.no_access')
+      flash[:alert] = t('users.dossiers.no_access')
       redirect_to root_path
     end
 

--- a/app/views/instructeurs/archives/index.html.haml
+++ b/app/views/instructeurs/archives/index.html.haml
@@ -48,14 +48,13 @@
             - if matching_archive.status == 'generated' && matching_archive.file.attached?
               = link_to url_for(matching_archive.file), class: 'button primary' do
                 %span.icon.download-white
-                = t(:archive_ready_html, generated_period: time_ago_in_words(matching_archive.updated_at), scope: [:instructeurs, :procedure])
+                = t(:archive_ready_html, scope: [:instructeurs, :procedure], generated_period: time_ago_in_words(matching_archive.updated_at))
             - else
               %span.icon.retry
-              = t(:archive_pending_html, created_period: time_ago_in_words(matching_archive.created_at), scope: [:instructeurs, :procedure])
+              = t(:archive_pending_html, scope: [:instructeurs, :procedure], created_period: time_ago_in_words(matching_archive.created_at))
           - elsif weight < 1.gigabyte
             = link_to instructeur_archives_path(@procedure, type:'monthly', month: month.strftime('%Y-%m')), method: :post, class: "button" do
               %span.icon.new-folder
               Demander la création
           - else
             Archive trop volumineuse
-

--- a/app/views/new_administrateur/procedures/_revision_changes.html.haml
+++ b/app/views/new_administrateur/procedures/_revision_changes.html.haml
@@ -16,16 +16,22 @@
         %li.mb-1= t("update_description#{postfix}", label: change[:label], to: change[:to], scope: [:new_administrateur, :revision_changes])
       - when :mandatory
         - if change[:from] == false
-          %li.mb-1= t(:enabled, label: change[:label], scope: [:new_administrateur, :revision_changes, "update_mandatory#{postfix}"])
+          -# i18n-tasks-use t('new_administrateur.revision_changes.update_mandatory.enabled')
+          -# i18n-tasks-use t('new_administrateur.revision_changes.update_mandatory_private.enabled')
+          %li.mb-1= t("new_administrateur.revision_changes.update_mandatory#{postfix}.enabled", label: change[:label])
         - else
-          %li.mb-1= t(:disabled, label: change[:label], scope: [:new_administrateur, :revision_changes, "update_mandatory#{postfix}"])
+          -# i18n-tasks-use t('new_administrateur.revision_changes.update_mandatory.disabled')
+          -# i18n-tasks-use t('new_administrateur.revision_changes.update_mandatory_private.disabled')
+          %li.mb-1= t("new_administrateur.revision_changes.update_mandatory#{postfix}.disabled", label: change[:label])
       - when :piece_justificative_template
-        %li.mb-1= t("update_piece_justificative_template#{postfix}", label: change[:label], scope: [:new_administrateur, :revision_changes])
+        -# i18n-tasks-use t('new_administrateur.revision_changes.update_piece_justificative_template')
+        -# i18n-tasks-use t('new_administrateur.revision_changes.update_piece_justificative_template_private')
+        %li.mb-1= t("new_administrateur.revision_changes.update_piece_justificative_template#{postfix}", label: change[:label])
       - when :drop_down_options
         - added = change[:to].sort - change[:from].sort
         - removed = change[:from].sort - change[:to].sort
         %li.mb-1
-          = t("update_drop_down_options#{postfix}", label: change[:label], scope: [:new_administrateur, :revision_changes])
+          = t("update_drop_down_options#{postfix}", scope: [:new_administrateur, :revision_changes], label: change[:label])
           %ul
             - if added.present?
               %li= t(:add_option, scope: [:new_administrateur, :revision_changes], items: added.map{ |term| "« #{term.strip} »" }.join(", "))
@@ -35,7 +41,7 @@
         - added = change[:to].sort - change[:from].sort
         - removed = change[:from].sort - change[:to].sort
         %li.mb-1
-          = t("update_carte_layers#{postfix}", label: change[:label], scope: [:new_administrateur, :revision_changes])
+          = t("update_carte_layers#{postfix}", scope: [:new_administrateur, :revision_changes], label: change[:label])
           %ul
             - if added.present?
               %li= t(:add_option, scope: [:new_administrateur, :revision_changes], items: added.map{ |term| "« #{t(term, scope: [:new_administrateur, :carte_layers])} »" }.join(", "))

--- a/app/views/new_administrateur/procedures/_revision_changes.html.haml
+++ b/app/views/new_administrateur/procedures/_revision_changes.html.haml
@@ -28,9 +28,9 @@
           = t("update_drop_down_options#{postfix}", label: change[:label], scope: [:new_administrateur, :revision_changes])
           %ul
             - if added.present?
-              %li= t(:add_option, items: added.map{ |term| "« #{term.strip} »" }.join(", "), scope: [:new_administrateur, :revision_changes])
+              %li= t(:add_option, scope: [:new_administrateur, :revision_changes], items: added.map{ |term| "« #{term.strip} »" }.join(", "))
             - if removed.present?
-              %li= t(:remove_option, items: removed.map{ |term| "« #{term.strip} »" }.join(", "), scope: [:new_administrateur, :revision_changes])
+              %li= t(:remove_option, scope: [:new_administrateur, :revision_changes], items: removed.map{ |term| "« #{term.strip} »" }.join(", "))
       - when :carte_layers
         - added = change[:to].sort - change[:from].sort
         - removed = change[:from].sort - change[:to].sort
@@ -38,11 +38,11 @@
           = t("update_carte_layers#{postfix}", label: change[:label], scope: [:new_administrateur, :revision_changes])
           %ul
             - if added.present?
-              %li= t(:add_option, items: added.map{ |term| "« #{t(term, scope: [:new_administrateur, :carte_layers])} »" }.join(", "), scope: [:new_administrateur, :revision_changes])
+              %li= t(:add_option, scope: [:new_administrateur, :revision_changes], items: added.map{ |term| "« #{t(term, scope: [:new_administrateur, :carte_layers])} »" }.join(", "))
             - if removed.present?
-              %li= t(:remove_option, items: removed.map{ |term| "« #{t(term, scope: [:new_administrateur, :carte_layers])} »" }.join(", "), scope: [:new_administrateur, :revision_changes])
+              %li= t(:remove_option, scope: [:new_administrateur, :revision_changes], items: removed.map{ |term| "« #{t(term, scope: [:new_administrateur, :carte_layers])} »" }.join(", "))
   - move_changes, move_private_changes = changes.filter { |change| change[:op] == :move }.partition { |change| !change[:private] }
   - if move_changes.size != 0
-    %li.mb-1= t(:move, count: move_changes.size, scope: [:new_administrateur, :revision_changes])
+    %li.mb-1= t(:move, scope: [:new_administrateur, :revision_changes], count: move_changes.size)
   - if move_private_changes.size != 0
-    %li.mb-1= t(:move_private, count: move_private_changes.size, scope: [:new_administrateur, :revision_changes])
+    %li.mb-1= t(:move_private, scope: [:new_administrateur, :revision_changes], count: move_private_changes.size)

--- a/app/views/shared/champs/siret/_etablissement.html.haml
+++ b/app/views/shared/champs/siret/_etablissement.html.haml
@@ -8,7 +8,6 @@
 
 - when :network_error
   = t('errors.messages.siret_network_error')
-  -# i18n-tasks-use t('errors.messages.siret_network_error')
 
 - else
   - if siret.present? && siret == etablissement&.siret

--- a/app/views/shared/dossiers/_identite_entreprise.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise.html.haml
@@ -2,7 +2,7 @@
   %tbody
     - if etablissement.diffusable_commercialement == false && profile != 'instructeur'
       %tr
-        %td= t('warning_for_private_info', etablissement: raison_sociale_or_name(etablissement), scope: 'views.shared.dossiers.identite_entreprise')
+        %td= t('warning_for_private_info', scope: 'views.shared.dossiers.identite_entreprise', etablissement: raison_sociale_or_name(etablissement))
     - else
       %tr
         %th.libelle Dénomination :

--- a/app/views/shared/dossiers/editable_champs/_civilite.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_civilite.html.haml
@@ -3,8 +3,8 @@
     Sélectionnez une des valeurs
   %label
     = form.radio_button :value, Individual::GENDER_FEMALE
-    = t(Individual::GENDER_FEMALE, scope: 'activerecord.attributes.individual.gender_options')
+    = Individual.human_attribute_name('gender.female')
 
   %label
     = form.radio_button :value, Individual::GENDER_MALE
-    = t('activerecord.attributes.individual.gender_options')[Individual::GENDER_MALE.to_sym] # GENDER_MALE contains a point letter
+    = Individual.human_attribute_name('gender.male')

--- a/app/views/support/admin.html.haml
+++ b/app/views/support/admin.html.haml
@@ -26,7 +26,7 @@
 
       .contact-champ
         = label_tag :phone do
-          = t('professional_phone_number', scope: [:supportadmin])
+          = t('pro_phone_number', scope: [:supportadmin])
         = text_field_tag :phone
 
       .contact-champ

--- a/app/views/users/dossiers/etablissement.html.haml
+++ b/app/views/users/dossiers/etablissement.html.haml
@@ -9,7 +9,7 @@
 
     - etablissement = @dossier.etablissement
     - if etablissement.diffusable_commercialement == false
-      %p= t('warning_for_private_info', etablissement: raison_sociale_or_name(etablissement), scope: 'views.shared.dossiers.identite_entreprise')
+      %p= t('warning_for_private_info', scope: 'views.shared.dossiers.identite_entreprise', etablissement: raison_sociale_or_name(etablissement))
 
     - else
       %p

--- a/app/views/users/dossiers/identite.html.haml
+++ b/app/views/users/dossiers/identite.html.haml
@@ -14,10 +14,10 @@
       .radios
         %label
           = f.radio_button :gender, Individual::GENDER_FEMALE, required: true
-          = t(Individual::GENDER_FEMALE, scope: 'activerecord.attributes.individual.gender_options')
+          = Individual.human_attribute_name('gender.female')
         %label
           = f.radio_button :gender, Individual::GENDER_MALE, required: true
-          = t('activerecord.attributes.individual.gender_options')[Individual::GENDER_MALE.to_sym] # GENDER_MALE contains a point letter
+          = Individual.human_attribute_name('gender.male')
 
     .flex
       .inline-champ

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -29,8 +29,8 @@ data:
   # External locale data (e.g. gems).
   # This data is not considered unused and is never written to.
   external:
-    ## Example (replace %#= with %=):
-    # - "<%#= %x[bundle show vagrant].chomp %>/templates/locales/%{locale}.yml"
+    - "<%= %x[bundle info --path administrate].chomp %>/config/locales/*%{locale}.yml"
+    - "<%= %x[bundle info --path devise-i18n].chomp %>/rails/locales/*%{locale}.yml"
 
   ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
   # router: conservative_router

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,7 +64,6 @@ en:
         start_procedure: Start the procedure
         existing_dossiers: You already have files for this procedure
         show_dossiers: View my current files
-        start_new_dossier: Start a new file
         already_draft: "You already started to fill a file"
         already_draft_detail_html: "You started to fill a file for the \"%{procedure}\" procedure <strong>%{time_ago} ago</strong>"
         already_not_draft: "You already submitted a file"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -351,13 +351,20 @@ en:
   users:
     dossiers:
       test_procedure: "This file is submitted on a test procedure. Any modification of the procedure by the administrator (addition of a field, publication of the procedure, etc.) will result in the removal of the file."
-      message_send: "Your message has been sent to the instructor in charge of your file."
       no_access: "You do not have access to this file"
       no_longer_editable: "Your file can no longer be edited"
-      undergoingreview: "Your file is undergoing review. It is no longer possible to delete your file. To cancel the undergoingreview contact the adminitration via the mailbox."
-      deleted_dossier: "Your file has been successfully deleted"
-      archived_dossier: "Your file will be archived for an additional month"
-      draft_saved: "Your draft has been saved."
-      no_establishment: "There is no establishment tied to this file"
-      identity_saved: "Identity data is registred"
-      no_longer_available: "The certificate is no longer available on this file."
+      create_commentaire:
+        message_send: "Your message has been sent to the instructor in charge of your file."
+      ask_deletion:
+        undergoingreview: "Your file is undergoing review. It is no longer possible to delete your file. To cancel the undergoingreview contact the adminitration via the mailbox."
+        deleted_dossier: "Your file has been successfully deleted"
+      extend_conservation:
+        archived_dossier: "Your file will be archived for an additional month"
+      update_brouillon:
+        draft_saved: "Your draft has been saved."
+      etablissement:
+        no_establishment: "There is no establishment tied to this file"
+      update_identite:
+        identity_saved: "Identity data is registred"
+      attestation:
+        no_longer_available: "The certificate is no longer available on this file."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,7 +202,7 @@ en:
           connection: Sign in
           are_you_new: First time on %{app_name}?
           find_procedure: Find your procedure
-      password:
+      passwords:
         reset_link_sent:
           got_it: Got it!
           open_your_mailbox: Now open your mailbox.
@@ -212,9 +212,9 @@ en:
           check_spams: Check your junk or spam email.
           check_account: Have you created a %{application_name} account with the adress %{email}? You will not receive any message if no account is linked to your email adress.
           check_france_connect_html: Have you once logged in with France Connect? If yes, <a href=\"%{href}\">try again with France Connect</a>.
-        shared:
-          email_can_take_a_while_html: <strong>Please note</strong> that this message can take up to 15 minutes to arrive.
-          contact_us_if_any_trouble_html: You can contact us <a href=\"%{href}\">through this form</a> if a problem still exists.
+      shared:
+        email_can_take_a_while_html: <strong>Please note</strong> that this message can take up to 15 minutes to arrive.
+        contact_us_if_any_trouble_html: You can contact us <a href=\"%{href}\">through this form</a> if a problem still exists.
   modal:
     publish:
       title:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -359,17 +359,29 @@ fr:
   users:
     dossiers:
       test_procedure: "Ce dossier est déposé sur une démarche en test. Toute modification de la démarche par l’administrateur (ajout d'un champ, publication de la démarche...) entraînera sa suppression."
-      message_send: "Votre message a bien été envoyé à l’instructeur en charge de votre dossier."
       no_access: "Vous n’avez pas accès à ce dossier"
       no_longer_editable: "Votre dossier ne peut plus être modifié"
-      undergoingreview: "L’instruction de votre dossier a commencé, il n’est plus possible de supprimer votre dossier. Si vous souhaitez annuler l’instruction contactez votre administration par la messagerie de votre dossier."
-      deleted_dossier: "Votre dossier a bien été supprimé."
-      archived_dossier: "Votre dossier sera conservé un mois supplémentaire"
-      draft_saved: "Votre brouillon a bien été sauvegardé."
-      no_establishment: "Aucun établissement n’est associé à ce dossier"
-      identity_saved: "Identité enregistrée"
-      no_longer_available: "L’attestation n'est plus disponible sur ce dossier."
+      create_commentaire:
+        message_send: "Votre message a bien été envoyé à l’instructeur en charge de votre dossier."
+      ask_deletion:
+        undergoingreview: "L’instruction de votre dossier a commencé, il n’est plus possible de supprimer votre dossier. Si vous souhaitez annuler l’instruction contactez votre administration par la messagerie de votre dossier."
+        deleted_dossier: "Votre dossier a bien été supprimé."
+      extend_conservation:
+        archived_dossier: "Votre dossier sera conservé un mois supplémentaire"
+      update_brouillon:
+        draft_saved: "Votre brouillon a bien été sauvegardé."
+      etablissement:
+        no_establishment: "Aucun établissement n’est associé à ce dossier"
+      update_identite:
+        identity_saved: "Identité enregistrée"
+      attestation:
+        no_longer_available: "L’attestation n'est plus disponible sur ce dossier."
   new_administrateur:
+    procedures:
+      show:
+        ready: "Validé"
+        needs_configuration: "À configurer"
+        configure_api_particulier_token: "Configurer le jeton API particulier"
     jeton_particulier:
       show:
         configure_token: "Configurer le jeton API Particulier"
@@ -380,11 +392,6 @@ fr:
         no_scopes_token: "Mise à jour impossible : le jeton n'a pas acces aux données.<br /><br />Vérifier le auprès de <a href='https://datapass.api.gouv.fr/'>https://datapass.api.gouv.fr/</a>"
         not_found_token: "Mise à jour impossible : le jeton n'a pas été trouvé ou n'est pas actif<br /><br />Vérifier le auprès de <a href='https://datapass.api.gouv.fr/'>https://datapass.api.gouv.fr/</a>"
         network_error:  "Mise à jour impossible : une erreur réseau est survenue"
-    procedures:
-      show:
-        ready: "Validé"
-        needs_configuration: "À configurer"
-        configure_api_particulier_token: "Configurer le jeton API particulier"
       api_particulier:
         already_configured: "Déjà rempli"
         needs_configuration: "À remplir"

--- a/config/locales/models/individual/en.yml
+++ b/config/locales/models/individual/en.yml
@@ -6,6 +6,6 @@ en:
         nom: Last name
         prenom: First name
         birthdate: Date de naissance
-        gender_options:
-          "Mme": "Ms"
-          "M.": "Mr"
+      individual/gender:
+        female: Ms
+        male: Mr

--- a/config/locales/models/individual/fr.yml
+++ b/config/locales/models/individual/fr.yml
@@ -6,6 +6,6 @@ fr:
         nom: Nom
         prenom: Prénom
         birthdate: Date de naissance
-        gender_options:
-          "Mme": "Madame"
-          "M.": "Monsieur"
+      individual/gender:
+        female: Madame
+        male: Monsieur

--- a/config/locales/views/dossier_mailer/notify_new_answer/en.yml
+++ b/config/locales/views/dossier_mailer/notify_new_answer/en.yml
@@ -1,4 +1,4 @@
-fr:
+en:
   dossier_mailer:
     notify_new_answer:
       subject: New message on your file nº %{dossier_id} « %{libelle_demarche} »

--- a/config/locales/views/new_administrateur/groupe_instructeurs/fr.yml
+++ b/config/locales/views/new_administrateur/groupe_instructeurs/fr.yml
@@ -4,7 +4,8 @@ fr:
       wrong_address:
           one: "%{value} n’est pas une adresse email valide"
           other: "%{value} ne sont pas des adresses emails valides"
-      experts_assignment:
+      create:
+        experts_assignment:
           one: "L'expert %{value} a été affecté à la démarche n° %{procedure}"
           other: "Les experts %{value} ont été affectés à la démarche n° %{procedure}"
     groupe_instructeurs:

--- a/config/locales/views/new_administrateur/revision_changes/fr.yml
+++ b/config/locales/views/new_administrateur/revision_changes/fr.yml
@@ -11,8 +11,8 @@ fr:
       update_description: La description du champ « %{label} » a été modifiée. La nouvelle description est « %{to} »
       update_type_champ: Le type du champ « %{label} » a été modifié. Il est maintenant de type « %{to} »
       update_mandatory:
-        enable: Le champ « %{label} » est maintenant obligatoire
-        disable: Le champ « %{label} » n’est plus obligatoire
+        enabled: Le champ « %{label} » est maintenant obligatoire
+        disabled: Le champ « %{label} » n’est plus obligatoire
       update_piece_justificative_template: Le modèle de pièce justificative du champ « %{label} » a été modifié
       update_drop_down_options: Les options de sélection du champ « %{label} » ont été modifiées
       update_carte_layers: Les référentiels cartographiques du champ « %{label} » ont été modifiés
@@ -25,8 +25,8 @@ fr:
       update_description_private: La description de l’annotation privée « %{label} » a été modifiée. La nouvelle description est « %{to} »
       update_type_champ_private: Le type de l’annotation privée « %{label} » a été modifié. Elle est maintenant de type « %{to} »
       update_mandatory_private:
-        enable: L’annotation privée « %{label} » est maintenant obligatoire
-        disable: L’annotation privée « %{label} » n’est plus obligatoire
+        enabled: L’annotation privée « %{label} » est maintenant obligatoire
+        disabled: L’annotation privée « %{label} » n’est plus obligatoire
       update_piece_justificative_template_private: Le modèle de pièce justificative de l’annotation privée « %{label} » a été modifié
       update_drop_down_options_private: Les options de sélection de l’annotation privée « %{label} » ont été modifiées
       update_carte_layers_private: Les référentiels cartographiques de l’annotation privée « %{label} » ont été modifiés

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -2,6 +2,7 @@ task :lint do
   sh "bundle exec rubocop --parallel"
   sh "bundle exec haml-lint app/views/"
   sh "bundle exec scss-lint app/assets/stylesheets/"
+  sh "bundle exec i18n-tasks missing --locales fr"
   sh "bundle exec brakeman --no-pager"
   sh "yarn lint:js"
 end


### PR DESCRIPTION
Avec cette PR, on teste automatiquement que les locales qu'on ajoute dans le code existent bien au moins dans la langue de référence (le français).

Ça permet de détecter les problèmes de type :

- « J'ai fait une coquille dans la clef d'une locale, et maintenant elle n'est plus traduite »,
- « J'ai renommé une vue, mais j'ai oublié de renommer les locales correspondantes »,
- etc.

Au passage, cette PR a permis de corriger un certain nombre d'erreurs de locales existantes dans le code en ce moment :)

_(NB: ça ne vérifie pas que les locales existent dans les autres langues (parce que les autres langues ne sont pas encore traduites entièrement). Il faudra voir si on peut rajouter d'autres tests pour ça – typiquement vérifier les locales pas utilisées.)_

Fix #6456
