### PR TITLE
Administrateur : le formulaire de publication valide que les blocs répétables ne sont pas vides

### DIFF
--- a/app/assets/stylesheets/card_admin.scss
+++ b/app/assets/stylesheets/card_admin.scss
@@ -23,6 +23,10 @@
     color: $blue-france-500;
   }
 
+  .card-admin-status-error {
+    color: $light-red;
+  }
+
   .card-admin-title {
     font-weight: bold;
     font-size: 18px;

--- a/app/helpers/procedure_helper.rb
+++ b/app/helpers/procedure_helper.rb
@@ -24,6 +24,12 @@ module ProcedureHelper
     t(action, scope: [:modal, :publish, key])
   end
 
+  # Returns a hash of { attribute: full_message } errors.
+  def procedure_publication_errors(procedure)
+    procedure.validate(:publication)
+    procedure.errors.to_hash(full_messages: true).except(:path)
+  end
+
   def types_de_champ_data(procedure)
     {
       isAnnotation: false,

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -712,7 +712,7 @@ class Procedure < ApplicationRecord
   private
 
   def before_publish
-    update!(closed_at: nil, unpublished_at: nil)
+    assign_attributes(closed_at: nil, unpublished_at: nil)
   end
 
   def after_publish(canonical_procedure = nil)

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -234,6 +234,7 @@ class Procedure < ApplicationRecord
   validates :description, presence: true, allow_blank: false, allow_nil: false
   validates :administrateurs, presence: true
   validates :lien_site_web, presence: true, if: :publiee?
+  validates :draft_revision, 'revisions/no_empty_repetitions': true, if: :validate_for_publication?
   validate :check_juridique
   validates :path, presence: true, format: { with: /\A[a-z0-9_\-]{3,200}\z/ }, uniqueness: { scope: [:path, :closed_at, :hidden_at, :unpublished_at], case_sensitive: false }
   validates :duree_conservation_dossiers_dans_ds, allow_nil: false, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: MAX_DUREE_CONSERVATION }
@@ -710,6 +711,10 @@ class Procedure < ApplicationRecord
   end
 
   private
+
+  def validate_for_publication?
+    validation_context == :publication || publiee?
+  end
 
   def before_publish
     assign_attributes(closed_at: nil, unpublished_at: nil)

--- a/app/validators/revisions/no_empty_repetitions_validator.rb
+++ b/app/validators/revisions/no_empty_repetitions_validator.rb
@@ -1,0 +1,22 @@
+class Revisions::NoEmptyRepetitionsValidator < ActiveModel::EachValidator
+  def validate_each(procedure, attribute, revision)
+    return if revision.nil?
+
+    revision_tdcs = revision.types_de_champ + revision.types_de_champ_private
+    repetitions = revision_tdcs.filter(&:repetition?)
+    repetitions.each do |repetition|
+      validate_repetition_not_empty(procedure, attribute, repetition)
+    end
+  end
+
+  private
+
+  def validate_repetition_not_empty(procedure, attribute, repetition)
+    if repetition.types_de_champ.blank?
+      procedure.errors.add(
+        attribute,
+        procedure.errors.generate_message(attribute, :empty_repetition, { value: repetition.libelle })
+      )
+    end
+  end
+end

--- a/app/validators/siret_format_validator.rb
+++ b/app/validators/siret_format_validator.rb
@@ -1,7 +1,7 @@
 class SiretFormatValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     if !format_is_valid(value)
-      record.errors.add(attribute, :format)
+      record.errors.add(attribute, :length)
     end
 
     if !luhn_passed(value)

--- a/app/views/administrateurs/procedures/_publication_form.html.haml
+++ b/app/views/administrateurs/procedures/_publication_form.html.haml
@@ -1,6 +1,13 @@
 .card.mb-4
   %h2.card-title Publiez votre démarche
   = form_tag admin_procedure_publish_path(procedure_id: procedure.id), method: :put, class: 'form' do
+    - publication_errors = procedure_publication_errors(procedure)
+    - if publication_errors.present?
+      .card.warning
+        .card-title Des problèmes empêchent la publication de la démarche
+        - publication_errors.each do |_attribute, full_messages|
+          %p= full_messages.to_sentence
+
     - if procedure.draft_changed?
       %p.mb-4 Publiez une nouvelle version de votre démarche. Les modifications suivantes seront appliquées :
       = render partial: 'revision_changes', locals: { changes: procedure.revision_changes }
@@ -31,4 +38,4 @@
                           placeholder: 'https://exemple.gouv.fr/ma_demarche')
 
     .flex.justify-end
-      = submit_tag procedure_publish_label(procedure, :submit), { class: "button primary", id: 'publish' }
+      = submit_tag procedure_publish_label(procedure, :submit), { disabled: publication_errors.present?, class: "button primary", id: 'publish' }

--- a/app/views/administrateurs/procedures/show.html.haml
+++ b/app/views/administrateurs/procedures/show.html.haml
@@ -52,15 +52,22 @@
       %p.button Modifier
 
     - if !@procedure.locked? || @procedure.feature_enabled?(:procedure_revisions)
-      = link_to champs_admin_procedure_path(@procedure), class: 'card-admin' do
-        - if @procedure.draft_types_de_champ.count > 0
-          %div
-            %span.icon.accept
-            %p.card-admin-status-accept Validé
-        - else
+      - @procedure.validate(:publication)
+      - error_messages = @procedure.errors.messages_for(:draft_revision).to_sentence
+
+      = link_to champs_admin_procedure_path(@procedure), class: 'card-admin', title: error_messages do
+        - if @procedure.draft_types_de_champ.count == 0
           %div
             %span.icon.clock
             %p.card-admin-status-todo À faire
+        - elsif error_messages.present?
+          %div
+            %span.icon.refuse
+            %p.card-admin-status-error À modifier
+        - else
+          %div
+            %span.icon.accept
+            %p.card-admin-status-accept Validé
         %div
           %p.card-admin-title
             %span.badge.baseline= @procedure.draft_types_de_champ.count

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,6 +51,9 @@ module TPS
     # Set the queue name for the mail delivery jobs to 'mailers'
     config.action_mailer.deliver_later_queue_name = :mailers
 
+    # Allow the error messages format to be customized
+    config.active_model.i18n_customize_full_message = true
+
     # Set the queue name for the analysis jobs to 'active_storage_analysis'
     config.active_storage.queues.analysis = :active_storage_analysis
 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -308,6 +308,7 @@ fr:
         connexion: "Erreur lors de la connexion à France Connect."
         forbidden_html: "Seul-e-s les usagers peuvent se connecter via France Connect. En tant qu’instructeur ou administrateur, nous vous invitons à <a href='%{reset_link}'>réininitialiser votre mot de passe</a>."
       procedure_archived: "Cette démarche en ligne a été close, il n’est plus possible de déposer de dossier."
+      empty_repetition: 'Le bloc répétable « %{value} » doit comporter au moins un champ'
       # procedure_not_draft: "Cette démarche n’est maintenant plus en brouillon."
       cadastres_empty:
         one: "Aucune parcelle cadastrale sur la zone sélectionnée"

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -23,4 +23,5 @@ fr:
           attributes:
             api_particulier_token:
               invalid: 'n’a pas le bon format'
-
+            draft_revision:
+              format: '%{message}'

--- a/config/locales/models/siret/fr.yml
+++ b/config/locales/models/siret/fr.yml
@@ -10,6 +10,6 @@ fr:
         siret:
           attributes:
             siret:
-              format: 'Le numéro SIRET doit comporter 14 chiffres'
+              length: 'Le numéro SIRET doit comporter 14 chiffres'
               checksum: 'Le numéro SIRET comporte une erreur, vérifiez les chiffres composant le numéro'
               invalid: 'Le numéro SIRET ne correspond pas à un établissement existant'

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -622,6 +622,19 @@ describe Administrateurs::ProceduresController, type: :controller do
         let(:path) { 'Invalid Procedure Path' }
         it { expect { put :publish, params: { procedure_id: procedure.id, path: path, lien_site_web: lien_site_web } }.to raise_error(ActiveRecord::RecordInvalid) }
       end
+
+      context 'procedure revision is invalid' do
+        let(:path) { 'new_path' }
+        let(:empty_repetition) { build(:type_de_champ_repetition, types_de_champ: []) }
+        let(:procedure) do
+          create(:procedure,
+                 administrateur: admin,
+                 lien_site_web: lien_site_web,
+                 types_de_champ: [empty_repetition])
+        end
+
+        it { expect { put :publish, params: { procedure_id: procedure.id, path: path, lien_site_web: lien_site_web } }.to raise_error(ActiveRecord::RecordInvalid) }
+      end
     end
 
     context 'when admin is not the owner of the procedure' do

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -278,6 +278,43 @@ describe Procedure do
 
       it_behaves_like 'duree de conservation'
     end
+
+    describe 'draft_revision' do
+      let(:repetition) { build(:type_de_champ_repetition, libelle: 'Enfants') }
+      let(:text_field) { build(:type_de_champ_text) }
+      let(:procedure) { create(:procedure, types_de_champ: [repetition]) }
+      let(:invalid_repetition_error_message) { 'Le bloc répétable « Enfants » doit comporter au moins un champ' }
+
+      context 'on a draft procedure' do
+        it 'doesn’t validate repetitions' do
+          procedure.validate
+          expect(procedure.errors[:draft_revision]).not_to include(invalid_repetition_error_message)
+        end
+      end
+
+      context 'on a published procedure' do
+        before { procedure.publish }
+
+        it 'validates that no repetition type de champ is empty' do
+          procedure.validate
+          expect(procedure.errors[:draft_revision]).to include(invalid_repetition_error_message)
+
+          text_field.revision = repetition.revision
+          text_field.order_place = repetition.types_de_champ.size
+          procedure.draft_revision.types_de_champ.find(&:repetition?).types_de_champ << text_field
+
+          procedure.validate
+          expect(procedure.errors[:draft_revision]).not_to include(invalid_repetition_error_message)
+        end
+      end
+
+      context 'when validating for publication' do
+        it 'validates that no repetition type de champ is empty' do
+          procedure.validate(:publication)
+          expect(procedure.errors[:draft_revision]).to include(invalid_repetition_error_message)
+        end
+      end
+    end
   end
 
   describe 'active' do

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -297,21 +297,21 @@ describe Procedure do
 
         it 'validates that no repetition type de champ is empty' do
           procedure.validate
-          expect(procedure.errors[:draft_revision]).to include(invalid_repetition_error_message)
+          expect(procedure.errors.full_messages_for(:draft_revision)).to include(invalid_repetition_error_message)
 
           text_field.revision = repetition.revision
           text_field.order_place = repetition.types_de_champ.size
           procedure.draft_revision.types_de_champ.find(&:repetition?).types_de_champ << text_field
 
           procedure.validate
-          expect(procedure.errors[:draft_revision]).not_to include(invalid_repetition_error_message)
+          expect(procedure.errors.full_messages_for(:draft_revision)).not_to include(invalid_repetition_error_message)
         end
       end
 
       context 'when validating for publication' do
         it 'validates that no repetition type de champ is empty' do
           procedure.validate(:publication)
-          expect(procedure.errors[:draft_revision]).to include(invalid_repetition_error_message)
+          expect(procedure.errors.full_messages_for(:draft_revision)).to include(invalid_repetition_error_message)
         end
       end
     end

--- a/spec/system/administrateurs/procedure_creation_spec.rb
+++ b/spec/system/administrateurs/procedure_creation_spec.rb
@@ -50,5 +50,23 @@ describe 'Creating a new procedure', js: true do
         expect(page).to have_field('libelle de champ')
       end
     end
+
+    scenario 'a warning is displayed when creating an invalid procedure' do
+      visit champs_admin_procedure_path(procedure)
+
+      # Add an empty repetition type de champ
+      add_champ(remove_flash_message: true)
+      select('Bloc répétable', from: 'champ-0-type_champ')
+      fill_in 'champ-0-libelle', with: 'libellé de champ'
+      blur
+      expect(page).to have_content('Formulaire enregistré')
+
+      click_link procedure.libelle
+      expect(page).to have_current_path(admin_procedure_path(procedure))
+
+      champs_card = find('.card-admin', text: 'Champs du formulaire')
+      expect(champs_card).to have_selector('.icon.refuse')
+      expect(champs_card).to have_content('À modifier')
+    end
   end
 end

--- a/spec/system/administrateurs/procedure_creation_spec.rb
+++ b/spec/system/administrateurs/procedure_creation_spec.rb
@@ -1,71 +1,38 @@
 require 'system/administrateurs/procedure_spec_helper'
 
-describe 'As an administrateur I wanna create a new procedure', js: true do
+describe 'Creating a new procedure', js: true do
   include ProcedureSpecHelper
 
-  let(:administrateur) { create(:administrateur, :with_procedure) }
+  let(:administrateur) { create(:administrateur) }
 
   before do
     login_as administrateur.user, scope: :user
     visit root_path
   end
 
-  context 'Right after sign_in I shall see all procedure states links' do
-    scenario 'Finding draft procedures' do
-      page.all('.tabs li a')[1].click
-      expect(page).to have_current_path(admin_procedures_path(statut: 'brouillons'))
-    end
+  scenario 'an admin can create a new procedure from scratch' do
+    expect(page).to have_selector('#new-procedure')
+    find('#new-procedure').click
 
-    scenario 'Finding active procedures' do
-      page.all('.tabs li a').first.click
-      expect(page).to have_current_path(admin_procedures_path(statut: 'publiees'))
-    end
+    expect(page).to have_current_path(new_from_existing_admin_procedures_path)
+    click_on 'Créer une nouvelle démarche de zéro'
+    expect(find('#procedure_for_individual_true')).to be_checked
+    expect(find('#procedure_for_individual_false')).not_to be_checked
+    fill_in 'procedure_duree_conservation_dossiers_dans_ds', with: '3'
+    click_on 'Créer la démarche'
 
-    scenario 'Finding archived procedures' do
-      page.all('.tabs li a').last.click
-      expect(page).to have_current_path(admin_procedures_path(statut: 'archivees'))
-    end
+    expect(page).to have_text('Libelle doit être rempli')
+    fill_in_dummy_procedure_details
+    click_on 'Créer la démarche'
+
+    expect(page).to have_current_path(champs_admin_procedure_path(Procedure.last))
   end
 
-  context 'Creating a new procedure' do
-    context "when publish_draft enabled" do
-      scenario 'Finding save button for new procedure, libelle, description and cadre_juridique required' do
-        expect(page).to have_selector('#new-procedure')
-        find('#new-procedure').click
+  context 'with an empty procedure' do
+    let(:procedure) { create(:procedure, :with_service, administrateur: administrateur) }
 
-        expect(page).to have_current_path(new_from_existing_admin_procedures_path)
-        click_on 'Créer une nouvelle démarche de zéro'
-        expect(find('#procedure_for_individual_true')).to be_checked
-        expect(find('#procedure_for_individual_false')).not_to be_checked
-        fill_in 'procedure_duree_conservation_dossiers_dans_ds', with: '3'
-        click_on 'Créer la démarche'
-
-        expect(page).to have_text('Libelle doit être rempli')
-        fill_in_dummy_procedure_details
-        click_on 'Créer la démarche'
-
-        expect(page).to have_current_path(champs_admin_procedure_path(Procedure.last))
-      end
-    end
-  end
-
-  context 'Editing a new procedure' do
-    before 'Create procedure' do
-      expect(page).to have_selector('#new-procedure')
-      find('#new-procedure').click
-
-      expect(page).to have_current_path(new_from_existing_admin_procedures_path)
-      click_on 'Créer une nouvelle démarche de zéro'
-      fill_in_dummy_procedure_details
-      click_on 'Créer la démarche'
-
-      procedure = Procedure.last
-      procedure.update(service: create(:service))
-    end
-
-    scenario 'Add champ, add file, visualize them in procedure preview' do
-      page.refresh
-      expect(page).to have_current_path(champs_admin_procedure_path(Procedure.last))
+    scenario 'an admin can add types de champs' do
+      visit champs_admin_procedure_path(procedure)
 
       add_champ(remove_flash_message: true)
       fill_in 'champ-0-libelle', with: 'libelle de champ'
@@ -82,30 +49,6 @@ describe 'As an administrateur I wanna create a new procedure', js: true do
         expect(page).to have_current_path(apercu_admin_procedure_path(Procedure.last))
         expect(page).to have_field('libelle de champ')
       end
-    end
-
-    scenario 'After adding champ and file, make publication' do
-      page.refresh
-
-      add_champ(remove_flash_message: true)
-      fill_in 'champ-0-libelle', with: 'libelle de champ'
-      blur
-      expect(page).to have_content('Formulaire enregistré')
-
-      click_on Procedure.last.libelle
-      expect(page).to have_current_path(admin_procedure_path(Procedure.last))
-      find('#publish-procedure-link').click
-      expect(page).to have_content('en test')
-      # Only check the path even though the link is the complete URL
-      # (Capybara runs the app on an arbitrary host/port.)
-      expect(page).to have_link(nil, href: /#{commencer_test_path(Procedure.last.path)}/)
-
-      expect(page).to have_selector('#procedure_path', visible: true)
-      expect(find_field('procedure_path').value).to eq 'libelle-de-la-procedure'
-      fill_in 'lien_site_web', with: 'http://some.website'
-      click_on 'publish'
-
-      expect(page).to have_text('Démarche publiée')
     end
   end
 end

--- a/spec/system/administrateurs/procedure_publish_spec.rb
+++ b/spec/system/administrateurs/procedure_publish_spec.rb
@@ -1,6 +1,6 @@
 require 'system/administrateurs/procedure_spec_helper'
 
-describe 'Publication de démarches', js: true do
+describe 'Publishing a procedure', js: true do
   include ProcedureSpecHelper
 
   let(:administrateur) { create(:administrateur) }
@@ -18,20 +18,20 @@ describe 'Publication de démarches', js: true do
     login_as administrateur.user, scope: :user
   end
 
-  context "lorsqu'on essaie d'accéder au backoffice déprécié" do
-    scenario "on est redirigé pour les démarches brouillon" do
+  context 'when using a deprecated back-office URL' do
+    scenario 'the admin is redirected to the draft procedure' do
       visit admin_procedures_draft_path
       expect(page).to have_current_path(admin_procedures_path(statut: "brouillons"))
     end
 
-    scenario "on est redirigé pour les démarches archivées" do
+    scenario 'the admin is redirected to the archived procedures' do
       visit admin_procedures_archived_path
       expect(page).to have_current_path(admin_procedures_path(statut: "archivees"))
     end
   end
 
-  context 'lorsqu’une démarche est en test' do
-    scenario 'un administrateur peut la publier' do
+  context 'when a procedure isn’t published yet' do
+    scenario 'an admin can publish it' do
       visit admin_procedures_path(statut: "brouillons")
       click_on procedure.libelle
       find('#publish-procedure-link').click
@@ -44,7 +44,7 @@ describe 'Publication de démarches', js: true do
     end
   end
 
-  context 'lorsqu’une démarche est close' do
+  context 'when a procedure is closed' do
     let!(:procedure) do
       create(:procedure_with_dossiers,
         :closed,
@@ -55,7 +55,7 @@ describe 'Publication de démarches', js: true do
         administrateur: administrateur)
     end
 
-    scenario 'un administrateur peut la publier' do
+    scenario 'an admin can publish it again' do
       visit admin_procedures_path(statut: "archivees")
       click_on procedure.libelle
       find('#publish-procedure-link').click
@@ -69,7 +69,7 @@ describe 'Publication de démarches', js: true do
     end
   end
 
-  context 'lorsqu’une démarche est dépublié' do
+  context 'when a procedure is de-published' do
     let!(:procedure) do
       create(:procedure_with_dossiers,
         :unpublished,
@@ -80,7 +80,7 @@ describe 'Publication de démarches', js: true do
         administrateur: administrateur)
     end
 
-    scenario 'un administrateur peut la publier' do
+    scenario 'an admin can publish it again' do
       visit admin_procedures_path(statut: "archivees")
       click_on procedure.libelle
       find('#publish-procedure-link').click


### PR DESCRIPTION
C'est une première approche, mais elle est fragile (notamment elle est très liée au tests).

Je pense qu'on devrait plutôt utiliser un validateur custom directement sur les objets "Typedechamp::Repetition" – mais ensuite ça oblige à bubbler le message d'erreur à travers toutes les couches d'objet (Procédure -> Répétition -> RépétitionTypeDeChamp -> Type de champ).

Du coup je pense qu'on peut faire mieux, mais je sais pas trop comment faire pour éviter la traversée des couches. @tchak si tu as une idée…

## À faire

- [x] Remonter l'erreur correctement dans l'UI au moment de valider
- [x] Écrire des tests d'intégration
- [x] Améliorer le message d'erreur (supprimer le préfixe "Draft revision")


Fait partie de #6662 