### PR TITLE
Corrige une exception lors de la réinitialisation du mot de passe lorsque le token a expiré

### DIFF
--- a/app/controllers/concerns/devise_populated_resource.rb
+++ b/app/controllers/concerns/devise_populated_resource.rb
@@ -2,9 +2,12 @@ module DevisePopulatedResource
   extend ActiveSupport::Concern
 
   # During a GET /password/edit, the resource is a brand new object.
-  # This method gives access to the actual resource record, complete with email, relationships, etc.
+  # This method gives access to the actual resource record (if available), complete with email, relationships, etc.
+  #
+  # If the resource can't be found (typically because the reset password token has expired),
+  # returns the default blank record.
   def populated_resource
-    resource_class.with_reset_password_token(resource.reset_password_token)
+    resource_class.with_reset_password_token(resource.reset_password_token) || resource
   end
 
   included do

--- a/spec/controllers/concerns/devise_populated_resource_spec.rb
+++ b/spec/controllers/concerns/devise_populated_resource_spec.rb
@@ -17,12 +17,27 @@ describe DevisePopulatedResource, type: :controller do
   end
 
   context 'when initiating a password reset' do
-    subject { get :edit, params: { reset_password_token: @token } }
+    subject { get :edit, params: { reset_password_token: token } }
 
-    it 'returns the fully populated resource' do
-      subject
-      expect(controller.populated_resource.id).to eq(user.id)
-      expect(controller.populated_resource.email).to eq(user.email)
+    context 'with a valid token' do
+      let(:token) { @token }
+
+      it 'returns the fully populated resource' do
+        subject
+        expect(controller.populated_resource.id).to eq(user.id)
+        expect(controller.populated_resource.email).to eq(user.email)
+      end
+    end
+
+    context 'with an expired token' do
+      let(:token) { 'invalid-token' }
+
+      it 'returns a new blank resource' do
+        subject
+        expect(controller.populated_resource).to be_present
+        expect(controller.populated_resource.new_record?).to be(true)
+        expect(controller.populated_resource.email).to be_blank
+      end
     end
   end
 

--- a/spec/features/users/managing_password_spec.rb
+++ b/spec/features/users/managing_password_spec.rb
@@ -98,4 +98,14 @@ feature 'Managing password:' do
       expect(page).to have_content('Votre mot de passe a bien été modifié.')
     end
   end
+
+  scenario 'the password reset token has expired' do
+    visit edit_user_password_path(reset_password_token: 'invalid-password-token')
+    expect(page).to have_content 'Changement de mot de passe'
+
+    fill_in 'user_password', with: 'SomePassword'
+    fill_in 'user_password_confirmation', with: 'SomePassword'
+    click_on 'Changer le mot de passe'
+    expect(page).to have_content('Votre lien de nouveau mot de passe a expiré')
+  end
 end


### PR DESCRIPTION
Lorsque le token a expiré, plutôt que de renvoyer un User nil, on renvoie le défaut de Devise (un User vide).

Corrige https://sentry.io/organizations/demarches-simplifiees/issues/2648190725/