### PR TITLE
Ajout d'un commentaire à propos d'une PR upstream sur la validation des tailles des pièces jointes

### DIFF
--- a/app/models/concerns/file_validation_concern.rb
+++ b/app/models/concerns/file_validation_concern.rb
@@ -1,6 +1,10 @@
 module FileValidationConcern
   extend ActiveSupport::Concern
   class_methods do
+    # This method works around missing `%{min_size}` and `%{max_size}` variables in active_record_validation
+    # default error message.
+    #
+    # Hopefully this will be fixed upstream in https://github.com/igorkasyanchuk/active_storage_validations/pull/134
     def file_size_validation(file_max_size = 200.megabytes)
       { less_than: file_max_size, message: I18n.t('errors.messages.file_size_out_of_range', file_size_limit: ActiveSupport::NumberHelper.number_to_human_size(file_max_size)) }
     end


### PR DESCRIPTION
J'ai ouvert [une PR](https://github.com/igorkasyanchuk/active_storage_validations/pull/134) dans active_storage_validation pour qu'on n'ai plus à faire de workaround.

Je pense que c'est mieux d'attendre que la PR soit mergée upstream avant d'enlever notre workaround. Mais du coup je documente, pour qu'on pense éventuellement à en faire quelque chose.