### PR TITLE
Correction du champ "Pays" sous Edge et Safari

### DIFF
--- a/app/javascript/components/shared/queryClient.js
+++ b/app/javascript/components/shared/queryClient.js
@@ -1,5 +1,5 @@
 import { QueryClient } from 'react-query';
-import { isNumeric } from '@utils';
+import { getJSON, isNumeric } from '@utils';
 import { matchSorter } from 'match-sorter';
 
 const API_EDUCATION_QUERY_LIMIT = 5;
@@ -73,7 +73,7 @@ async function defaultQueryFn({ queryKey: [scope, term] }) {
 let paysCache;
 async function getPays() {
   if (!paysCache) {
-    paysCache = await fetch('/api/pays').then((response) => response.json());
+    paysCache = await getJSON('/api/pays', null);
   }
   return paysCache;
 }


### PR DESCRIPTION
The `/api/pays` API requires user authentication. However older versions of Edge and Safari don't transmit cookies by default during a `fetch` request.

Use our `getJSON` helper instead, which will insert the `credentials: 'same-origin'` option explicitly to fix the countries list.

Fix #6502