### PR TITLE
Correction d'un test de feature qui échouait aléatoirement

### DIFF
--- a/spec/features/users/brouillon_spec.rb
+++ b/spec/features/users/brouillon_spec.rb
@@ -16,6 +16,7 @@ feature 'The user' do
     fill_in('date', with: '12-12-2012')
     select_date_and_time(Time.zone.parse('06/01/2030 7h05'), form_id_for_datetime('datetime'))
     fill_in('number', with: '42')
+    find_field('checkbox').scroll_to(:center)
     check('checkbox')
     choose('Madame')
     fill_in('email', with: 'loulou@yopmail.com')


### PR DESCRIPTION
There's a random failure in this spec, where the CI triggers this error:

> Failure/Error: check('checkbox')
>     
>     Selenium::WebDriver::Error::ElementClickInterceptedError:
>       element click intercepted: Element <input required="required" type="checkbox" value="on" name="dossier[champs_attributes][7][value]" id="dossier_champs_attributes_7_value"> is not clickable at point (205, 892). Other element would receive the click: <div class="send-dossier-actions-bar">...</div>

That's because the checkbox is partially overlapped by the sticky action bar at the bottom of the screen – but only _some of the time_.

This commit attempts to fix the issue by manually scrolling the checkbox at the center of the screen before clicking it.