### PR TITLE
ETQ Super Admin je veux changer le mail d'un instructeur (#6515)

### DIFF
--- a/app/controllers/manager/users_controller.rb
+++ b/app/controllers/manager/users_controller.rb
@@ -2,10 +2,11 @@ module Manager
   class UsersController < Manager::ApplicationController
     def update
       user = User.find(params[:id])
-
       preexisting_user = User.find_by(email: targeted_email)
 
-      if preexisting_user.nil?
+      if user.administrateur.present?
+        flash[:error] = "« #{targeted_email} » est un administrateur. On ne sait pas encore faire."
+      elsif preexisting_user.nil?
         user.skip_reconfirmation!
         user.update(email: targeted_email)
 

--- a/app/controllers/manager/users_controller.rb
+++ b/app/controllers/manager/users_controller.rb
@@ -17,7 +17,12 @@ module Manager
       else
         user.dossiers.update_all(user_id: preexisting_user.id)
 
-        user.instructeur&.update(user: preexisting_user)
+        if preexisting_user.instructeur.nil?
+          user.instructeur&.update(user: preexisting_user)
+        else
+          preexisting_user.instructeur.merge(user.instructeur)
+        end
+
         user.expert&.update(user: preexisting_user)
       end
 

--- a/app/controllers/manager/users_controller.rb
+++ b/app/controllers/manager/users_controller.rb
@@ -23,7 +23,11 @@ module Manager
           preexisting_user.instructeur.merge(user.instructeur)
         end
 
-        user.expert&.update(user: preexisting_user)
+        if preexisting_user.expert.nil?
+          user.expert&.update(user: preexisting_user)
+        else
+          preexisting_user.expert.merge(user.expert)
+        end
       end
 
       redirect_to edit_manager_user_path(user)

--- a/app/controllers/manager/users_controller.rb
+++ b/app/controllers/manager/users_controller.rb
@@ -28,6 +28,8 @@ module Manager
         else
           preexisting_user.expert.merge(user.expert)
         end
+
+        flash[:notice] = "Le compte « #{targeted_email} » a absorbé le compte « #{user.email} »."
       end
 
       redirect_to edit_manager_user_path(user)

--- a/app/models/administrateurs_instructeur.rb
+++ b/app/models/administrateurs_instructeur.rb
@@ -1,0 +1,13 @@
+# == Schema Information
+#
+# Table name: administrateurs_instructeurs
+#
+#  created_at        :datetime
+#  updated_at        :datetime
+#  administrateur_id :integer
+#  instructeur_id    :integer
+#
+class AdministrateursInstructeur < ApplicationRecord
+  belongs_to :administrateur
+  belongs_to :instructeur
+end

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -11,6 +11,7 @@ class Expert < ApplicationRecord
   has_many :experts_procedures
   has_many :avis, through: :experts_procedures
   has_many :dossiers, through: :avis
+  has_many :commentaires
 
   default_scope { eager_load(:user) }
 
@@ -33,5 +34,10 @@ class Expert < ApplicationRecord
       result = avis.select(query)[0]
       @avis_summary = { unanswered: result.unanswered, total: result.total }
     end
+  end
+
+  def merge(old_expert)
+    old_expert.experts_procedures.update_all(expert_id: id)
+    old_expert.commentaires.update_all(expert_id: id)
   end
 end

--- a/spec/controllers/manager/instructeurs_controller_spec.rb
+++ b/spec/controllers/manager/instructeurs_controller_spec.rb
@@ -1,4 +1,4 @@
-xdescribe Manager::InstructeursController, type: :controller do
+describe Manager::InstructeursController, type: :controller do
   let(:super_admin) { create(:super_admin) }
   let(:instructeur) { create(:instructeur) }
 

--- a/spec/controllers/manager/procedures_controller_spec.rb
+++ b/spec/controllers/manager/procedures_controller_spec.rb
@@ -1,4 +1,4 @@
-xdescribe Manager::ProceduresController, type: :controller do
+describe Manager::ProceduresController, type: :controller do
   let(:super_admin) { create :super_admin }
 
   before { sign_in super_admin }

--- a/spec/controllers/manager/users_controller_spec.rb
+++ b/spec/controllers/manager/users_controller_spec.rb
@@ -1,6 +1,8 @@
 describe Manager::UsersController, type: :controller do
   let(:super_admin) { create(:super_admin) }
 
+  before { sign_in super_admin }
+
   describe '#show' do
     render_views
 
@@ -8,7 +10,6 @@ describe Manager::UsersController, type: :controller do
     let(:user) { create(:user) }
 
     before do
-      sign_in(super_admin)
       get :show, params: { id: user.id }
     end
 
@@ -16,11 +17,8 @@ describe Manager::UsersController, type: :controller do
   end
 
   describe '#update' do
-    let!(:user) { create(:user, email: 'ancien.email@domaine.fr') }
+    let(:user) { create(:user, email: 'ancien.email@domaine.fr') }
 
-    before {
-      sign_in super_admin
-    }
     subject { patch :update, params: { id: user.id, user: { email: nouvel_email } } }
 
     describe 'with a valid email' do
@@ -46,9 +44,7 @@ describe Manager::UsersController, type: :controller do
   end
 
   describe '#delete' do
-    let!(:user) { create(:user) }
-
-    before { sign_in super_admin }
+    let(:user) { create(:user) }
 
     subject { delete :delete, params: { id: user.id } }
 

--- a/spec/controllers/manager/users_controller_spec.rb
+++ b/spec/controllers/manager/users_controller_spec.rb
@@ -97,6 +97,20 @@ describe Manager::UsersController, type: :controller do
               expect(preexisting_user.instructeur.bulk_messages).to match([bulk_message])
             end
           end
+
+          context 'and the source expert has some avis and commentaires' do
+            let(:dossier) { create(:dossier) }
+            let(:experts_procedure) { create(:experts_procedure, expert: user.expert, procedure: dossier.procedure) }
+            let!(:avis) { create(:avis, dossier: dossier, claimant: create(:instructeur), experts_procedure: experts_procedure) }
+            let!(:commentaire) { create(:commentaire, expert: expert, dossier: dossier) }
+
+            it 'transfers the avis' do
+              subject
+
+              expect(preexisting_user.expert.avis).to match([avis])
+              expect(preexisting_user.expert.commentaires).to match([commentaire])
+            end
+          end
         end
       end
     end

--- a/spec/controllers/manager/users_controller_spec.rb
+++ b/spec/controllers/manager/users_controller_spec.rb
@@ -30,6 +30,17 @@ describe Manager::UsersController, type: :controller do
 
           expect(User.find_by(id: user.id).email).to eq(nouvel_email)
         end
+
+        context 'and the user is an administrateur' do
+          let(:user) { create(:administrateur).user }
+
+          it 'rejects the modification' do
+            subject
+
+            expect(flash[:error]).to match("« nouvel.email@domaine.fr » est un administrateur. On ne sait pas encore faire.")
+            expect(user.reload.email).not_to eq(nouvel_email)
+          end
+        end
       end
 
       describe 'with an invalid email' do

--- a/spec/controllers/manager/users_controller_spec.rb
+++ b/spec/controllers/manager/users_controller_spec.rb
@@ -21,24 +21,54 @@ describe Manager::UsersController, type: :controller do
 
     subject { patch :update, params: { id: user.id, user: { email: nouvel_email } } }
 
-    describe 'with a valid email' do
-      let(:nouvel_email) { 'nouvel.email@domaine.fr' }
+    context 'when the targeted email does not exist' do
+      describe 'with a valid email' do
+        let(:nouvel_email) { 'nouvel.email@domaine.fr' }
 
-      it 'updates the user email' do
-        subject
+        it 'updates the user email' do
+          subject
 
-        expect(User.find_by(id: user.id).email).to eq(nouvel_email)
+          expect(User.find_by(id: user.id).email).to eq(nouvel_email)
+        end
+      end
+
+      describe 'with an invalid email' do
+        let(:nouvel_email) { 'plop' }
+
+        it 'does not update the user email' do
+          subject
+
+          expect(User.find_by(id: user.id).email).not_to eq(nouvel_email)
+          expect(flash[:error]).to match("Courriel invalide")
+        end
       end
     end
 
-    describe 'with an invalid email' do
-      let(:nouvel_email) { 'plop' }
+    context 'when the targeted email exists' do
+      let(:preexisting_user) { create(:user, email: 'email.existant@domaine.fr') }
+      let(:nouvel_email) { preexisting_user.email }
 
-      it 'does not update the user email' do
-        subject
+      context 'and the old account has a dossier' do
+        let!(:dossier) { create(:dossier, user: user) }
 
-        expect(User.find_by(id: user.id).email).not_to eq(nouvel_email)
-        expect(flash[:error]).to match("« #{nouvel_email} » n’est pas une adresse valide.")
+        it 'transfers the dossier' do
+          subject
+
+          expect(preexisting_user.dossiers).to match([dossier])
+        end
+      end
+
+      context 'and the old account belongs to an instructeur and expert' do
+        let!(:instructeur) { create(:instructeur, user: user) }
+        let!(:expert) { create(:expert, user: user) }
+
+        it 'transfers instructeur account' do
+          subject
+          preexisting_user.reload
+
+          expect(preexisting_user.instructeur).to match(instructeur)
+          expect(preexisting_user.expert).to match(expert)
+        end
       end
     end
   end

--- a/spec/controllers/manager/users_controller_spec.rb
+++ b/spec/controllers/manager/users_controller_spec.rb
@@ -68,6 +68,7 @@ describe Manager::UsersController, type: :controller do
 
           expect(preexisting_user.instructeur).to match(instructeur)
           expect(preexisting_user.expert).to match(expert)
+          expect(flash[:notice]).to match("Le compte « email.existant@domaine.fr » a absorbé le compte « ancien.email@domaine.fr ».")
         end
 
         context 'and the preexisting account owns an instructeur and expert as well' do

--- a/spec/controllers/manager/users_controller_spec.rb
+++ b/spec/controllers/manager/users_controller_spec.rb
@@ -1,4 +1,4 @@
-xdescribe Manager::UsersController, type: :controller do
+describe Manager::UsersController, type: :controller do
   let(:super_admin) { create(:super_admin) }
 
   describe '#show' do
@@ -40,7 +40,7 @@ xdescribe Manager::UsersController, type: :controller do
         subject
 
         expect(User.find_by(id: user.id).email).not_to eq(nouvel_email)
-        expect(flash[:error]).to match("« #{nouvel_email} » n'est pas une adresse valide.")
+        expect(flash[:error]).to match("« #{nouvel_email} » n’est pas une adresse valide.")
       end
     end
   end

--- a/spec/models/expert_spec.rb
+++ b/spec/models/expert_spec.rb
@@ -12,4 +12,67 @@ RSpec.describe Expert, type: :model do
     it { expect(ExpertsProcedure.where(expert: expert, procedure: procedure).count).to eq(1) }
     it { expect(ExpertsProcedure.where(expert: expert, procedure: procedure).first.allow_decision_access).to be_falsy }
   end
+
+  describe '#merge' do
+    let(:old_expert) { create(:expert) }
+    let(:new_expert) { create(:expert) }
+
+    subject { new_expert.merge(old_expert) }
+
+    context 'when an old expert access a procedure' do
+      let(:procedure) { create(:procedure) }
+
+      before do
+        procedure.experts << old_expert
+        subject
+      end
+
+      it 'transfers the access to the new expert' do
+        expect(procedure.reload.experts). to match_array(new_expert)
+      end
+    end
+
+    context 'when both expert access a procedure' do
+      let(:procedure) { create(:procedure) }
+
+      before do
+        procedure.experts << old_expert
+        procedure.experts << new_expert
+        subject
+      end
+
+      it 'removes the old one' do
+        expect(procedure.reload.experts). to match_array(new_expert)
+      end
+    end
+
+    context 'when an old expert has a commentaire' do
+      let(:dossier) { create(:dossier) }
+      let(:commentaire) { CommentaireService.build(old_expert, dossier, body: "Mon commentaire") }
+
+      before do
+        commentaire.save
+        subject
+      end
+
+      it 'transfers the commentaire to the new expert' do
+        expect(new_expert.reload.commentaires).to match_array(commentaire)
+      end
+    end
+
+    context 'when an old expert claims for an avis' do
+      let!(:avis) { create(:avis, dossier: create(:dossier), claimant: old_expert) }
+
+      before do
+        subject
+      end
+
+      it 'transfers the claim to the new expert' do
+        avis_claimed_by_new_expert = Avis
+          .where(claimant_id: new_expert.id, claimant_type: Expert.name)
+
+        expect(avis_claimed_by_new_expert).to match_array(avis)
+      end
+    end
+  end
 end


### PR DESCRIPTION
PR un peu conséquente pour essayer de résoudre le problème de changement de mail des instructeurs.

Dans le pire des cas, ce code transfert 
- les procédure
- les dossiers suivis
- les commentaires / commentaires en masse
- les avis d'experts
- les liens entre administrateur et instructeur

entre l'ancien et le nouveau compte.

J'ai choisi de ne pas changer les identifiants dans les DossierOperationLog ni de supprimer les anciens instructeurs / experts pour une question de tracabilité.

C'est une opération sensible, on peut potentiellement transférer de la donnée à une mauvaise personne. Je ne sais pas s'il faut rajouter des contrôles supplémentaires.

Et finalement, @kemenaran , j'ai plein de `let!` , si t'as une meilleure formulation, je prends.