### PR TITLE
empèche les jobs d'export de réessayer indéfiniement les exports inexistants

### DIFF
--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -1,6 +1,8 @@
 class ExportJob < ApplicationJob
   queue_as :exports
 
+  discard_on ActiveRecord::RecordNotFound
+
   def perform(export)
     export.compute
   end


### PR DESCRIPTION
Parfois un export est détruit car `MAX_DUREE_CONSERVATION_EXPORT` (3h) se sont écoulés depuis la demande et l'export est périmé.

Le job n'arrivera jamais a le récupérer, il convient donc de l'ignorer.