### PR TITLE
Tentative d'accélérer les specs

### DIFF
--- a/.github/actions/ci-save-split-tests/action.yml
+++ b/.github/actions/ci-save-split-tests/action.yml
@@ -1,0 +1,17 @@
+name: 'Save split-tests'
+description: 'Save Junit test results and timing data, to better split future tests'
+
+inputs:
+  results_path:
+    description: 'Glob pattern to the JUnit files to save'
+    required: true
+
+# This should be run once the results from all runs are collected.
+runs:
+  using: composite
+  steps:
+    - name: Save test reports
+      uses: actions/cache@v2
+      with:
+        path: ${{ inputs.results_path }}
+        key: test-reports-${{ github.ref }}-${{ github.sha }}-${{ github.run_id }}

--- a/.github/actions/ci-setup-assets/action.yml
+++ b/.github/actions/ci-setup-assets/action.yml
@@ -1,0 +1,26 @@
+name: 'Setup Rails assets'
+description: 'Pre-compile and cache the app assets'
+
+runs:
+  using: composite
+  steps:
+    - name: Assets cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          public/assets
+          public/packs-test
+          tmp/cache/webpacker
+        key: asset-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
+        restore-keys: |
+          asset-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
+          asset-cache-${{ runner.os }}-${{ github.ref }}-
+          asset-cache-${{ runner.os }}-
+
+    - name: Precompile assets
+      env:
+        RAILS_ENV: test
+      run: |
+        rm bin/yarn
+        bin/rails assets:precompile --trace
+      shell: bash

--- a/.github/actions/ci-setup-rails/action.yml
+++ b/.github/actions/ci-setup-rails/action.yml
@@ -1,0 +1,37 @@
+name: 'Setup Rails app'
+description: 'Setup the environment for running the Rails app'
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+        cache: 'yarn'
+
+    - name: Install Node modules
+      run: yarn install --frozen-lockfile
+      shell: bash
+
+    - name: Setup environment variables
+      run: cp config/env.example .env
+      shell: bash
+
+    - name: Setup test database
+      env:
+        RAILS_ENV: test
+        DATABASE_URL: "postgres://tps_test@localhost:5432/tps_test"
+      run: bin/rails db:create db:schema:load db:migrate
+      shell: bash
+
+    - name: Setup split_tests binary
+      run: |
+        curl --no-progress-meter -L https://github.com/leonid-shevtsov/split_tests/releases/download/v0.3.0/split_tests.linux.gz | gunzip -c > split_tests
+        chmod +x split_tests
+      shell: bash

--- a/.github/actions/ci-setup-rails/action.yml
+++ b/.github/actions/ci-setup-rails/action.yml
@@ -29,9 +29,3 @@ runs:
         DATABASE_URL: "postgres://tps_test@localhost:5432/tps_test"
       run: bin/rails db:create db:schema:load db:migrate
       shell: bash
-
-    - name: Setup split_tests binary
-      run: |
-        curl --no-progress-meter -L https://github.com/leonid-shevtsov/split_tests/releases/download/v0.3.0/split_tests.linux.gz | gunzip -c > split_tests
-        chmod +x split_tests
-      shell: bash

--- a/.github/actions/ci-setup-split-tests/action.yml
+++ b/.github/actions/ci-setup-split-tests/action.yml
@@ -15,15 +15,23 @@ runs:
         chmod +x split_tests
       shell: bash
 
-    - name: generate UNIQUE_RUN_ID variable based on timestamp
-      run: echo UNIQUE_RUN_ID=split-tests-unique-id--$(date +%s) >> $GITHUB_ENV
+    - name: Generate an unique random value
+      run: echo random_value=$RANDOM >> $GITHUB_ENV
       shell: bash
 
+    # Restore previous runs timing from the cache.
+    #
+    # NB: at the end of the job, the `actions/cache@v2` action will attempt
+    # to save the results back to the same key. However at this stage only
+    # tests results for a single run will be available.
+    # To avoid the cache being overwritten with this single result, we define
+    # a random cache key, which will be used to save the data.
+    # The actual retrieval uses the `restore-keys` instead.
     - name: Restore previous runs timings
       uses: actions/cache@v2
       with:
         path: ${{ inputs.results_path }}
-        key: single-spec-report-${{ env.UNIQUE_RUN_ID }}
+        key: single-spec-report-${{ github.sha }}-${{ env.random_value }}
         restore-keys: |
           specs-reports-${{ github.ref }}-${{ github.sha }}-${{ github.run_id }}
           specs-reports-${{ github.ref }}-${{ github.sha }}-

--- a/.github/actions/ci-setup-split-tests/action.yml
+++ b/.github/actions/ci-setup-split-tests/action.yml
@@ -1,0 +1,30 @@
+name: 'Setup split-tests'
+description: 'Setup the environment for splitting tests'
+
+runs:
+  using: composite
+  steps:
+    - name: Setup split_tests binary
+      run: |
+        curl --no-progress-meter -L https://github.com/leonid-shevtsov/split_tests/releases/download/v0.3.0/split_tests.linux.gz | gunzip -c > split_tests
+        chmod +x split_tests
+      shell: bash
+
+    - name: generate UNIQUE_RUN_ID variable based on timestamp
+      run: echo UNIQUE_RUN_ID=split-tests-unique-id--$(date +%s) >> $GITHUB_ENV
+      shell: bash
+
+    - name: Restore previous runs timings
+      uses: actions/cache@v2
+      with:
+        path: tmp/*.junit.xml
+        key: single-spec-report-${{ env.UNIQUE_RUN_ID }}
+        restore-keys: |
+          specs-reports-${{ github.ref }}-${{ github.sha }}-${{ github.run_id }}
+          specs-reports-${{ github.ref }}-${{ github.sha }}-
+          specs-reports-${{ github.ref }}-
+          specs-reports-
+
+    - name: Display previous runs timings used for splitting tests
+      run: ls tmp/*.junit.xml || true
+      shell: bash

--- a/.github/actions/ci-setup-split-tests/action.yml
+++ b/.github/actions/ci-setup-split-tests/action.yml
@@ -16,22 +16,25 @@ runs:
       shell: bash
 
     - name: Generate an unique random value
-      run: echo random_value=$RANDOM >> $GITHUB_ENV
+      run: echo dummy_random_value=$RANDOM >> $GITHUB_ENV
       shell: bash
 
     # Restore previous runs timing from the cache.
     #
     # NB: at the end of the job, the `actions/cache@v2` action will attempt
     # to save the results back to the same key. However at this stage only
-    # tests results for a single run will be available.
+    # tests results for a single instance will be available.
+    #
     # To avoid the cache being overwritten with this single result, we define
-    # a random cache key, which will be used to save the data.
+    # a random cache key, which the action will use to save the single-instance
+    # report to a dummy location.
+    #
     # The actual retrieval uses the `restore-keys` instead.
     - name: Restore previous runs timings
       uses: actions/cache@v2
       with:
         path: ${{ inputs.results_path }}
-        key: single-spec-report-${{ github.sha }}-${{ env.random_value }}
+        key: single-spec-report-${{ github.sha }}-${{ env.dummy_random_value }}
         restore-keys: |
           specs-reports-${{ github.ref }}-${{ github.sha }}-${{ github.run_id }}
           specs-reports-${{ github.ref }}-${{ github.sha }}-

--- a/.github/actions/ci-setup-split-tests/action.yml
+++ b/.github/actions/ci-setup-split-tests/action.yml
@@ -1,6 +1,11 @@
 name: 'Setup split-tests'
 description: 'Setup the environment for splitting tests'
 
+inputs:
+  results_path:
+    description: 'Glob pattern to the JUnit files to save'
+    required: true
+
 runs:
   using: composite
   steps:
@@ -17,7 +22,7 @@ runs:
     - name: Restore previous runs timings
       uses: actions/cache@v2
       with:
-        path: tmp/*.junit.xml
+        path: ${{ inputs.results_path }}
         key: single-spec-report-${{ env.UNIQUE_RUN_ID }}
         restore-keys: |
           specs-reports-${{ github.ref }}-${{ github.sha }}-${{ github.run_id }}
@@ -26,5 +31,5 @@ runs:
           specs-reports-
 
     - name: Display previous runs timings used for splitting tests
-      run: ls tmp/*.junit.xml || true
+      run: ls ${{ inputs.results_path }} || true
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,15 +47,14 @@ jobs:
       matrix:
         pattern:
           - bin/rake zeitwerk:check
-          - bin/rspec spec/controllers/*_spec.rb
-          - bin/rspec spec/controllers/[a-l]**/*_spec.rb
-          - bin/rspec spec/controllers/[m-z]**/*_spec.rb
-          - bin/rspec spec/system
-          - bin/rspec spec/helpers spec/lib spec/middlewares
-          - bin/rspec spec/mailers spec/jobs spec/policies
-          - bin/rspec spec/models
-          - bin/rspec spec/serializers spec/services
-          - bin/rspec spec/views
+          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=0 -split-total=6)
+          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=1 -split-total=6)
+          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=2 -split-total=6)
+          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=3 -split-total=6)
+          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=4 -split-total=6)
+          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=5 -split-total=6)
+          - bin/rspec $(./split_tests -line-count -glob='spec/system/**/*_spec.rb' -split-index=0 -split-total=2)
+          - bin/rspec $(./split_tests -line-count -glob='spec/system/**/*_spec.rb' -split-index=1 -split-total=2)
 
     steps:
       - name: Checkout code
@@ -74,6 +73,11 @@ jobs:
 
       - name: Install Node modules
         run: yarn install --frozen-lockfile
+
+      - name: Setup split_tests binary
+        run: |
+          curl --no-progress-meter -L https://github.com/leonid-shevtsov/split_tests/releases/download/v0.3.0/split_tests.linux.gz | gunzip -c > split_tests
+          chmod +x split_tests
 
       - name: Setup test database
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
 
     strategy:
       matrix:
-        split_index: [0, 1, 2, 3, 4, 5]
+        instances: [0, 1, 2, 3, 4, 5]
 
     steps:
       - uses: actions/checkout@v2
@@ -54,11 +54,19 @@ jobs:
       - name: Pre-compile assets
         uses: ./.github/actions/ci-setup-assets
 
+      - uses: ./.github/actions/ci-setup-split-tests
+
       - name: Run tests
         run: |
-          SPEC_FILES=$(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=${{ matrix.split_index }} -split-total=6)
+          SPEC_FILES=$(./split_tests -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=${{ strategy.job-index }} -split-total=${{ strategy.job-total }} -junit -junit-path=tmp/*.junit.xml)
           echo "Running tests for bin/rspec $SPEC_FILES"
-          bin/rspec $SPEC_FILES
+          bin/rspec $SPEC_FILES --format progress --format RspecJunitFormatter --out tmp/rspec_${{ github.job }}_${{ strategy.job-index }}.junit.xml
+
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-reports
+          path: tmp/rspec_${{ github.job }}_${{ strategy.job-index }}.junit.xml
 
   system_tests:
     name: System tests
@@ -74,7 +82,7 @@ jobs:
 
     strategy:
       matrix:
-        split_index: [0, 1]
+        instances: [0, 1]
 
     steps:
       - uses: actions/checkout@v2
@@ -85,8 +93,36 @@ jobs:
       - name: Pre-compile assets
         uses: ./.github/actions/ci-setup-assets
 
+      - uses: ./.github/actions/ci-setup-split-tests
+
       - name: Run tests
         run: |
-          SPEC_FILES=$(./split_tests -line-count -glob='spec/system/**/*_spec.rb' -split-index=${{ matrix.split_index }} -split-total=2)
+          SPEC_FILES=$(./split_tests -glob='spec/system/**/*_spec.rb' -split-index=${{ strategy.job-index }} -split-total=${{ strategy.job-total }} -junit -junit-path=tmp/*.junit.xml)
           echo "Running tests for bin/rspec $SPEC_FILES"
-          bin/rspec $SPEC_FILES
+          bin/rspec $SPEC_FILES --format progress --format RspecJunitFormatter --out tmp/rspec_${{ github.job }}_${{ strategy.job-index }}.junit.xml
+
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-reports
+          path: tmp/rspec_${{ github.job }}_${{ strategy.job-index }}.junit.xml
+
+  save_test_reports:
+    name: Save test reports
+    needs: [unit_tests, system_tests]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: test-reports
+          path: tmp
+
+      - name: Save test reports
+        uses: actions/cache@v2
+        with:
+          path: tmp/*.junit.xml
+          key: specs-reports-${{ github.ref }}-${{ github.sha }}-${{ github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,30 +9,28 @@ jobs:
   linters:
     name: Linters
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_USER: tps_test
+          POSTGRES_DB: tps_test
+          POSTGRES_PASSWORD: tps_test
+        ports: [ "5432:5432" ]
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: '14'
-          cache: yarn
-
-      - name: Install node modules
-        run: yarn install --frozen-lockfile
+      - name: Setup the app code and dependancies
+        uses: ./.github/actions/ci-setup-rails
 
       - name: Run linters
         run: |
           bundle exec rake lint
+          bundle exec rake zeitwerk:check
 
-  tests:
-    name: Tests
+  unit_tests:
+    name: Unit tests
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -45,70 +43,50 @@ jobs:
 
     strategy:
       matrix:
-        pattern:
-          - bin/rake zeitwerk:check
-          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=0 -split-total=6)
-          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=1 -split-total=6)
-          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=2 -split-total=6)
-          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=3 -split-total=6)
-          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=4 -split-total=6)
-          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=5 -split-total=6)
-          - bin/rspec $(./split_tests -line-count -glob='spec/system/**/*_spec.rb' -split-index=0 -split-total=2)
-          - bin/rspec $(./split_tests -line-count -glob='spec/system/**/*_spec.rb' -split-index=1 -split-total=2)
+        split_index: [0, 1, 2, 3, 4, 5]
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
+      - name: Setup the app runtime and dependencies
+        uses: ./.github/actions/ci-setup-rails
 
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: '14'
-          cache: 'yarn'
-
-      - name: Install Node modules
-        run: yarn install --frozen-lockfile
-
-      - name: Setup split_tests binary
-        run: |
-          curl --no-progress-meter -L https://github.com/leonid-shevtsov/split_tests/releases/download/v0.3.0/split_tests.linux.gz | gunzip -c > split_tests
-          chmod +x split_tests
-
-      - name: Setup test database
-        env:
-          RAILS_ENV: test
-          DATABASE_URL: "postgres://tps_test@localhost:5432/tps_test"
-        run: |
-          bin/rails db:create db:schema:load db:migrate
-
-      - name: Setup environment variables
-        run: |
-          cp config/env.example .env
-
-      - name: Assets cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            public/assets
-            public/packs-test
-            tmp/cache/webpacker
-          key: asset-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
-          restore-keys: |
-            asset-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
-            asset-cache-${{ runner.os }}-${{ github.ref }}-
-            asset-cache-${{ runner.os }}-
-
-      - name: Precompile assets
-        env:
-          RAILS_ENV: test
-        run: |
-          rm bin/yarn
-          bin/rails assets:precompile --trace
+      - name: Pre-compile assets
+        uses: ./.github/actions/ci-setup-assets
 
       - name: Run tests
-        run: ${{ matrix.pattern }}
+        run: |
+          SPEC_FILES=$(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=${{ matrix.split_index }} -split-total=6)
+          echo "Running tests for bin/rspec $SPEC_FILES"
+          bin/rspec $SPEC_FILES
+
+  system_tests:
+    name: System tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_USER: tps_test
+          POSTGRES_DB: tps_test
+          POSTGRES_PASSWORD: tps_test
+        ports: ["5432:5432"]
+
+    strategy:
+      matrix:
+        split_index: [0, 1]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup the app runtime and dependencies
+        uses: ./.github/actions/ci-setup-rails
+
+      - name: Pre-compile assets
+        uses: ./.github/actions/ci-setup-assets
+
+      - name: Run tests
+        run: |
+          SPEC_FILES=$(./split_tests -line-count -glob='spec/system/**/*_spec.rb' -split-index=${{ matrix.split_index }} -split-total=2)
+          echo "Running tests for bin/rspec $SPEC_FILES"
+          bin/rspec $SPEC_FILES

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
         env:
           RAILS_ENV: test
         run: |
+          rm bin/yarn
           bin/rails assets:precompile --trace
 
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,10 @@ jobs:
       - name: Pre-compile assets
         uses: ./.github/actions/ci-setup-assets
 
-      - uses: ./.github/actions/ci-setup-split-tests
+      - name: Setup split tests
+        uses: ./.github/actions/ci-setup-split-tests
+        with:
+          results_path: tmp/*.junit.xml
 
       - name: Run tests
         run: |
@@ -93,7 +96,10 @@ jobs:
       - name: Pre-compile assets
         uses: ./.github/actions/ci-setup-assets
 
-      - uses: ./.github/actions/ci-setup-split-tests
+      - name: Setup split tests
+        uses: ./.github/actions/ci-setup-split-tests
+        with:
+          results_path: tmp/*.junit.xml
 
       - name: Run tests
         run: |
@@ -101,7 +107,7 @@ jobs:
           echo "Running tests for bin/rspec $SPEC_FILES"
           bin/rspec $SPEC_FILES --format progress --format RspecJunitFormatter --out tmp/rspec_${{ github.job }}_${{ strategy.job-index }}.junit.xml
 
-      - name: Upload Test Results
+      - name: Upload test results
         uses: actions/upload-artifact@v2
         with:
           name: test-reports
@@ -115,14 +121,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Download Artifacts
+      - name: Collect test results from all runs
         uses: actions/download-artifact@v2
         with:
           name: test-reports
           path: tmp
 
-      - name: Save test reports
-        uses: actions/cache@v2
+      - name: Save test results and timing data, to better split future tests
+        uses: ./.github/actions/ci-save-split-tests
         with:
-          path: tmp/*.junit.xml
-          key: specs-reports-${{ github.ref }}-${{ github.sha }}-${{ github.run_id }}
+          results_path: tmp/*.junit.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           RAILS_ENV: test
           DATABASE_URL: "postgres://tps_test@localhost:5432/tps_test"
         run: |
-          bundle exec rake db:create db:schema:load db:migrate
+          bin/rails db:create db:schema:load db:migrate
 
       - name: Setup environment variables
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           echo "Running tests for bin/rspec $SPEC_FILES"
           bin/rspec $SPEC_FILES --format progress --format RspecJunitFormatter --out tmp/rspec_${{ github.job }}_${{ strategy.job-index }}.junit.xml
 
-      - name: Upload Test Results
+      - name: Upload test results for this instance
         uses: actions/upload-artifact@v2
         with:
           name: test-reports
@@ -107,7 +107,7 @@ jobs:
           echo "Running tests for bin/rspec $SPEC_FILES"
           bin/rspec $SPEC_FILES --format progress --format RspecJunitFormatter --out tmp/rspec_${{ github.job }}_${{ strategy.job-index }}.junit.xml
 
-      - name: Upload test results
+      - name: Upload test results for this instance
         uses: actions/upload-artifact@v2
         with:
           name: test-reports
@@ -121,7 +121,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Collect test results from all runs
+      - name: Collect test results from all instances
         uses: actions/download-artifact@v2
         with:
           name: test-reports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,5 +90,24 @@ jobs:
         run: |
           cp config/env.example .env
 
+      - name: Assets cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            public/assets
+            public/packs-test
+            tmp/cache/webpacker
+          key: asset-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            asset-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
+            asset-cache-${{ runner.os }}-${{ github.ref }}-
+            asset-cache-${{ runner.os }}-
+
+      - name: Precompile assets
+        env:
+          RAILS_ENV: test
+        run: |
+          bin/rails assets:precompile --trace
+
       - name: Run tests
         run: ${{ matrix.pattern }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,19 +22,10 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '14'
-      - name: Find yarn cache location
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - name: JS package cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: Install packages
-        run: |
-          yarn install --frozen-lockfile
+          cache: yarn
+
+      - name: Install node modules
+        run: yarn install --frozen-lockfile
 
       - name: Run linters
         run: |
@@ -79,19 +70,10 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '14'
-      - name: Find yarn cache location
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - name: JS package cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: Install packages
-        run: |
-          yarn install --frozen-lockfile
+          cache: 'yarn'
+
+      - name: Install Node modules
+        run: yarn install --frozen-lockfile
 
       - name: Setup test database
         env:

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
 --require rails_helper
+--profile

--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,7 @@ group :test do
   gem 'factory_bot'
   gem 'launchy'
   gem 'rails-controller-testing'
+  gem 'rspec_junit_formatter'
   gem 'selenium-webdriver'
   gem 'shoulda-matchers', require: false
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -596,6 +596,8 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.10.2)
+    rspec_junit_formatter (0.4.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (1.10.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
@@ -856,6 +858,7 @@ DEPENDENCIES
   rgeo-geojson
   rqrcode
   rspec-rails
+  rspec_junit_formatter
   rubocop
   rubocop-rails_config
   rubocop-rspec-focused

--- a/yarn.lock
+++ b/yarn.lock
@@ -3525,15 +3525,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001039, caniuse-lite@^1.0.30001219:
-  version "1.0.30001228"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz#bfdc5942cd3326fa51ee0b42fbef4da9d492a7fa"
-  integrity sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==
-
-caniuse-lite@^1.0.30001254:
-  version "1.0.30001257"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001257.tgz#150aaf649a48bee531104cfeda57f92ce587f6e5"
-  integrity sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001039, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001254:
+  version "1.0.30001271"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz"
+  integrity sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==
 
 cardinal@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
Aujourd'hui les specs sont assez lentes – en particulier les specs de modèle, où une spec prend typiquement une seconde.

À vue de nez, c'est parce que créer un objet "Procedure" est très lent.

Plusieurs pistes :
- ✅ Optimiser la validation de la complexité des mots de passe (#6566) : gros gain, de 8mn à 3mn (!)
- ✅ Éviter de créer trop de records au `build` dans les factories (#6583)
- ✅ Supprimer DatabaseCleaner (on ne devrait plus en avoir besoin depuis Rails 5.1) (#6584)
- ✅ Convertir les features spec en [system specs](ttps://medium.com/table-xi/a-quick-guide-to-rails-system-tests-in-rspec-b6e9e8a8b5f6), pour avoir un setup plus moderne (#6584)
- ✅ Optimiser les specs GraphQL, qui sont très lentes (#6610)
- Améliorer les Github Actions (plus de cache, meilleure répartition, précompiler les assets) (#6606)
- Utiliser plus souvent des [fixture](https://guides.rubyonrails.org/testing.html#the-low-down-on-fixtures)

## Timings

- Avant de merger l'optimosation de mot de passe : ~9m 57s en moyenne
- Avec optimisation du mot de passe : ~6m 44s en moyenne
- Avec optimisation des factories : ~7m 50s en moyenne
- Avec optimisation des specs systemes : ~6m 20s en moyenne
- Avec optimisation des Github Actions : ~4m 10s en moyenne