### PR TITLE
fix(dossiers): wrap dossier discard in a transaction

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -672,7 +672,7 @@ class Procedure < ApplicationRecord
   def restore(author)
     if discarded? && undiscard
       dossiers.with_discarded.discarded.find_each do |dossier|
-        dossier.restore(author, true)
+        dossier.restore_if_discarded_with_procedure(author)
       end
     end
   end


### PR DESCRIPTION
By doing this we ensure that deleted_dossier are not created when dossier is not discarded

fix #6568