### PR TITLE
Accélération du temps des tests sur la CI

### DIFF
--- a/.github/actions/ci-save-split-tests/action.yml
+++ b/.github/actions/ci-save-split-tests/action.yml
@@ -1,0 +1,17 @@
+name: 'Save split-tests'
+description: 'Save Junit test results and timing data, to better split future tests'
+
+inputs:
+  results_path:
+    description: 'Glob pattern to the JUnit files to save'
+    required: true
+
+# This should be run once the results from all runs are collected.
+runs:
+  using: composite
+  steps:
+    - name: Save test reports
+      uses: actions/cache@v2
+      with:
+        path: ${{ inputs.results_path }}
+        key: tests-reports-${{ github.ref }}-${{ github.sha }}-${{ github.run_id }}

--- a/.github/actions/ci-setup-assets/action.yml
+++ b/.github/actions/ci-setup-assets/action.yml
@@ -1,0 +1,26 @@
+name: 'Setup Rails assets'
+description: 'Pre-compile and cache the app assets'
+
+runs:
+  using: composite
+  steps:
+    - name: Assets cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          public/assets
+          public/packs-test
+          tmp/cache/webpacker
+        key: asset-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
+        restore-keys: |
+          asset-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
+          asset-cache-${{ runner.os }}-${{ github.ref }}-
+          asset-cache-${{ runner.os }}-
+
+    - name: Precompile assets
+      env:
+        RAILS_ENV: test
+      run: |
+        rm bin/yarn
+        bin/rails assets:precompile --trace
+      shell: bash

--- a/.github/actions/ci-setup-rails/action.yml
+++ b/.github/actions/ci-setup-rails/action.yml
@@ -1,0 +1,37 @@
+name: 'Setup Rails app'
+description: 'Setup the environment for running the Rails app'
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+        cache: 'yarn'
+
+    - name: Install Node modules
+      run: yarn install --frozen-lockfile
+      shell: bash
+
+    - name: Setup environment variables
+      run: cp config/env.example .env
+      shell: bash
+
+    - name: Setup test database
+      env:
+        RAILS_ENV: test
+        DATABASE_URL: "postgres://tps_test@localhost:5432/tps_test"
+      run: bin/rails db:create db:schema:load db:migrate
+      shell: bash
+
+    - name: Setup split_tests binary
+      run: |
+        curl --no-progress-meter -L https://github.com/leonid-shevtsov/split_tests/releases/download/v0.3.0/split_tests.linux.gz | gunzip -c > split_tests
+        chmod +x split_tests
+      shell: bash

--- a/.github/actions/ci-setup-rails/action.yml
+++ b/.github/actions/ci-setup-rails/action.yml
@@ -29,9 +29,3 @@ runs:
         DATABASE_URL: "postgres://tps_test@localhost:5432/tps_test"
       run: bin/rails db:create db:schema:load db:migrate
       shell: bash
-
-    - name: Setup split_tests binary
-      run: |
-        curl --no-progress-meter -L https://github.com/leonid-shevtsov/split_tests/releases/download/v0.3.0/split_tests.linux.gz | gunzip -c > split_tests
-        chmod +x split_tests
-      shell: bash

--- a/.github/actions/ci-setup-split-tests/action.yml
+++ b/.github/actions/ci-setup-split-tests/action.yml
@@ -1,0 +1,46 @@
+name: 'Setup split-tests'
+description: 'Setup the environment for splitting tests'
+
+inputs:
+  results_path:
+    description: 'Glob pattern to the JUnit files to save'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Setup split_tests binary
+      run: |
+        curl --no-progress-meter -L https://github.com/leonid-shevtsov/split_tests/releases/download/v0.3.0/split_tests.linux.gz | gunzip -c > split_tests
+        chmod +x split_tests
+      shell: bash
+
+    - name: Generate an unique random value
+      run: echo dummy_random_value=$RANDOM >> $GITHUB_ENV
+      shell: bash
+
+    # Restore previous runs timing from the cache.
+    #
+    # NB: at the end of the job, the `actions/cache@v2` action will attempt
+    # to save the results back to the same key. However at this stage only
+    # tests results for a single instance will be available.
+    #
+    # To avoid the cache being overwritten with this single result, we define
+    # a random cache key, which the action will use to save the single-instance
+    # report to a dummy location.
+    #
+    # The actual retrieval uses the `restore-keys` instead.
+    - name: Restore previous runs timings
+      uses: actions/cache@v2
+      with:
+        path: ${{ inputs.results_path }}
+        key: single-instance-report-${{ github.sha }}-${{ env.dummy_random_value }}
+        restore-keys: |
+          tests-reports-${{ github.ref }}-${{ github.sha }}-${{ github.run_id }}
+          tests-reports-${{ github.ref }}-${{ github.sha }}-
+          tests-reports-${{ github.ref }}-
+          tests-reports-
+
+    - name: Display previous runs timings used for splitting tests
+      run: ls ${{ inputs.results_path }} || true
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,15 +47,14 @@ jobs:
       matrix:
         pattern:
           - bin/rake zeitwerk:check
-          - bin/rspec spec/controllers/*_spec.rb
-          - bin/rspec spec/controllers/[a-l]**/*_spec.rb
-          - bin/rspec spec/controllers/[m-z]**/*_spec.rb
-          - bin/rspec spec/system
-          - bin/rspec spec/helpers spec/lib spec/middlewares
-          - bin/rspec spec/mailers spec/jobs spec/policies
-          - bin/rspec spec/models
-          - bin/rspec spec/serializers spec/services
-          - bin/rspec spec/views
+          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=0 -split-total=6)
+          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=1 -split-total=6)
+          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=2 -split-total=6)
+          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=3 -split-total=6)
+          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=4 -split-total=6)
+          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=5 -split-total=6)
+          - bin/rspec $(./split_tests -line-count -glob='spec/system/**/*_spec.rb' -split-index=0 -split-total=2)
+          - bin/rspec $(./split_tests -line-count -glob='spec/system/**/*_spec.rb' -split-index=1 -split-total=2)
 
     steps:
       - name: Checkout code
@@ -74,6 +73,11 @@ jobs:
 
       - name: Install Node modules
         run: yarn install --frozen-lockfile
+
+      - name: Setup split_tests binary
+        run: |
+          curl --no-progress-meter -L https://github.com/leonid-shevtsov/split_tests/releases/download/v0.3.0/split_tests.linux.gz | gunzip -c > split_tests
+          chmod +x split_tests
 
       - name: Setup test database
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,30 +9,28 @@ jobs:
   linters:
     name: Linters
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_USER: tps_test
+          POSTGRES_DB: tps_test
+          POSTGRES_PASSWORD: tps_test
+        ports: [ "5432:5432" ]
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: '14'
-          cache: yarn
-
-      - name: Install node modules
-        run: yarn install --frozen-lockfile
+      - name: Setup the app code and dependancies
+        uses: ./.github/actions/ci-setup-rails
 
       - name: Run linters
         run: |
           bundle exec rake lint
+          bundle exec rake zeitwerk:check
 
-  tests:
-    name: Tests
+  unit_tests:
+    name: Unit tests
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -45,70 +43,50 @@ jobs:
 
     strategy:
       matrix:
-        pattern:
-          - bin/rake zeitwerk:check
-          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=0 -split-total=6)
-          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=1 -split-total=6)
-          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=2 -split-total=6)
-          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=3 -split-total=6)
-          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=4 -split-total=6)
-          - bin/rspec $(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=5 -split-total=6)
-          - bin/rspec $(./split_tests -line-count -glob='spec/system/**/*_spec.rb' -split-index=0 -split-total=2)
-          - bin/rspec $(./split_tests -line-count -glob='spec/system/**/*_spec.rb' -split-index=1 -split-total=2)
+        split_index: [0, 1, 2, 3, 4, 5]
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
+      - name: Setup the app runtime and dependencies
+        uses: ./.github/actions/ci-setup-rails
 
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: '14'
-          cache: 'yarn'
-
-      - name: Install Node modules
-        run: yarn install --frozen-lockfile
-
-      - name: Setup split_tests binary
-        run: |
-          curl --no-progress-meter -L https://github.com/leonid-shevtsov/split_tests/releases/download/v0.3.0/split_tests.linux.gz | gunzip -c > split_tests
-          chmod +x split_tests
-
-      - name: Setup test database
-        env:
-          RAILS_ENV: test
-          DATABASE_URL: "postgres://tps_test@localhost:5432/tps_test"
-        run: |
-          bin/rails db:create db:schema:load db:migrate
-
-      - name: Setup environment variables
-        run: |
-          cp config/env.example .env
-
-      - name: Assets cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            public/assets
-            public/packs-test
-            tmp/cache/webpacker
-          key: asset-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
-          restore-keys: |
-            asset-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
-            asset-cache-${{ runner.os }}-${{ github.ref }}-
-            asset-cache-${{ runner.os }}-
-
-      - name: Precompile assets
-        env:
-          RAILS_ENV: test
-        run: |
-          rm bin/yarn
-          bin/rails assets:precompile --trace
+      - name: Pre-compile assets
+        uses: ./.github/actions/ci-setup-assets
 
       - name: Run tests
-        run: ${{ matrix.pattern }}
+        run: |
+          SPEC_FILES=$(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=${{ matrix.split_index }} -split-total=6)
+          echo "Running tests for bin/rspec $SPEC_FILES"
+          bin/rspec $SPEC_FILES
+
+  system_tests:
+    name: System tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:12
+        env:
+          POSTGRES_USER: tps_test
+          POSTGRES_DB: tps_test
+          POSTGRES_PASSWORD: tps_test
+        ports: ["5432:5432"]
+
+    strategy:
+      matrix:
+        split_index: [0, 1]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup the app runtime and dependencies
+        uses: ./.github/actions/ci-setup-rails
+
+      - name: Pre-compile assets
+        uses: ./.github/actions/ci-setup-assets
+
+      - name: Run tests
+        run: |
+          SPEC_FILES=$(./split_tests -line-count -glob='spec/system/**/*_spec.rb' -split-index=${{ matrix.split_index }} -split-total=2)
+          echo "Running tests for bin/rspec $SPEC_FILES"
+          bin/rspec $SPEC_FILES

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
         env:
           RAILS_ENV: test
         run: |
+          rm bin/yarn
           bin/rails assets:precompile --trace
 
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           RAILS_ENV: test
           DATABASE_URL: "postgres://tps_test@localhost:5432/tps_test"
         run: |
-          bundle exec rake db:create db:schema:load db:migrate
+          bin/rails db:create db:schema:load db:migrate
 
       - name: Setup environment variables
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
 
     strategy:
       matrix:
-        split_index: [0, 1, 2, 3, 4, 5]
+        instances: [0, 1, 2, 3, 4, 5]
 
     steps:
       - uses: actions/checkout@v2
@@ -54,11 +54,22 @@ jobs:
       - name: Pre-compile assets
         uses: ./.github/actions/ci-setup-assets
 
+      - name: Setup split tests
+        uses: ./.github/actions/ci-setup-split-tests
+        with:
+          results_path: tmp/*.junit.xml
+
       - name: Run tests
         run: |
-          SPEC_FILES=$(./split_tests -line-count -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=${{ matrix.split_index }} -split-total=6)
+          SPEC_FILES=$(./split_tests -glob='spec/**/*_spec.rb' -exclude-glob='spec/system/**' -split-index=${{ strategy.job-index }} -split-total=${{ strategy.job-total }} -junit -junit-path=tmp/*.junit.xml)
           echo "Running tests for bin/rspec $SPEC_FILES"
-          bin/rspec $SPEC_FILES
+          bin/rspec $SPEC_FILES --format progress --format RspecJunitFormatter --out tmp/rspec_${{ github.job }}_${{ strategy.job-index }}.junit.xml
+
+      - name: Upload test results for this instance
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-reports
+          path: tmp/rspec_${{ github.job }}_${{ strategy.job-index }}.junit.xml
 
   system_tests:
     name: System tests
@@ -74,7 +85,7 @@ jobs:
 
     strategy:
       matrix:
-        split_index: [0, 1]
+        instances: [0, 1]
 
     steps:
       - uses: actions/checkout@v2
@@ -85,8 +96,38 @@ jobs:
       - name: Pre-compile assets
         uses: ./.github/actions/ci-setup-assets
 
+      - name: Setup split tests
+        uses: ./.github/actions/ci-setup-split-tests
+        with:
+          results_path: tmp/*.junit.xml
+
       - name: Run tests
         run: |
-          SPEC_FILES=$(./split_tests -line-count -glob='spec/system/**/*_spec.rb' -split-index=${{ matrix.split_index }} -split-total=2)
+          SPEC_FILES=$(./split_tests -glob='spec/system/**/*_spec.rb' -split-index=${{ strategy.job-index }} -split-total=${{ strategy.job-total }} -junit -junit-path=tmp/*.junit.xml)
           echo "Running tests for bin/rspec $SPEC_FILES"
-          bin/rspec $SPEC_FILES
+          bin/rspec $SPEC_FILES --format progress --format RspecJunitFormatter --out tmp/rspec_${{ github.job }}_${{ strategy.job-index }}.junit.xml
+
+      - name: Upload test results for this instance
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-reports
+          path: tmp/rspec_${{ github.job }}_${{ strategy.job-index }}.junit.xml
+
+  save_test_reports:
+    name: Save test reports
+    needs: [unit_tests, system_tests]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Collect test results from all instances
+        uses: actions/download-artifact@v2
+        with:
+          name: test-reports
+          path: tmp
+
+      - name: Save test results and timing data, to better split future tests
+        uses: ./.github/actions/ci-save-split-tests
+        with:
+          results_path: tmp/*.junit.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,5 +90,24 @@ jobs:
         run: |
           cp config/env.example .env
 
+      - name: Assets cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            public/assets
+            public/packs-test
+            tmp/cache/webpacker
+          key: asset-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            asset-cache-${{ runner.os }}-${{ github.ref }}-${{ github.sha }}
+            asset-cache-${{ runner.os }}-${{ github.ref }}-
+            asset-cache-${{ runner.os }}-
+
+      - name: Precompile assets
+        env:
+          RAILS_ENV: test
+        run: |
+          bin/rails assets:precompile --trace
+
       - name: Run tests
         run: ${{ matrix.pattern }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,19 +22,10 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '14'
-      - name: Find yarn cache location
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - name: JS package cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: Install packages
-        run: |
-          yarn install --frozen-lockfile
+          cache: yarn
+
+      - name: Install node modules
+        run: yarn install --frozen-lockfile
 
       - name: Run linters
         run: |
@@ -79,19 +70,10 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '14'
-      - name: Find yarn cache location
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - name: JS package cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: Install packages
-        run: |
-          yarn install --frozen-lockfile
+          cache: 'yarn'
+
+      - name: Install Node modules
+        run: yarn install --frozen-lockfile
 
       - name: Setup test database
         env:

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
 --require rails_helper
+--profile

--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,7 @@ group :test do
   gem 'factory_bot'
   gem 'launchy'
   gem 'rails-controller-testing'
+  gem 'rspec_junit_formatter'
   gem 'selenium-webdriver'
   gem 'shoulda-matchers', require: false
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -596,6 +596,8 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.10.2)
+    rspec_junit_formatter (0.4.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (1.10.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
@@ -856,6 +858,7 @@ DEPENDENCIES
   rgeo-geojson
   rqrcode
   rspec-rails
+  rspec_junit_formatter
   rubocop
   rubocop-rails_config
   rubocop-rspec-focused

--- a/yarn.lock
+++ b/yarn.lock
@@ -3525,15 +3525,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001039, caniuse-lite@^1.0.30001219:
-  version "1.0.30001228"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz#bfdc5942cd3326fa51ee0b42fbef4da9d492a7fa"
-  integrity sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==
-
-caniuse-lite@^1.0.30001254:
-  version "1.0.30001257"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001257.tgz#150aaf649a48bee531104cfeda57f92ce587f6e5"
-  integrity sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001039, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001254:
+  version "1.0.30001271"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz"
+  integrity sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==
 
 cardinal@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
Cette PR modifie le fichier de CI de Github Actions pour faire en sorte que la CI soit plus rapide.

- Refactor du fichier `ci.yml` en plusieurs sous-fichiers plus faciles à composer,
- Pré-compilation des assets avant de lancer les tests (pour que les stats de "Quel test prend du temps" ne soient pas polluées par la précompilation lazy lors du premier test),
- Mise en cache des assets pré-compilés,
- Répartition automatique des tests dans les instances, en fonction du timing des tests précédents.

Le plus gros gain vient de la répartition automatique des tests, qui lisse automatiquement le temps de run des différentes instances. Et en plus c'est maintenant facile d'augmenter le nombre d'instances si on veut.

Une fois que les caches sont chauds, les tests passent maintenant sur la CI en ~4mn 15s.

Fait partie de #6563