### PR TITLE
Amélioration de la vitesse des specs graphql

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    aasm (5.1.1)
+    aasm (5.2.0)
       concurrent-ruby (~> 1.0)
     acsv (0.0.1)
     actioncable (6.1.4.1)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -76,4 +76,10 @@ Rails.application.configure do
     debounce_delay: 500,
     status_visible_duration: 500
   }
+
+  # BCrypt is slow by design - but during tests we want to make it faster
+  # to compute hashes of passwords.
+  silence_warnings do
+    BCrypt::Engine::DEFAULT_COST = BCrypt::Engine::MIN_COST
+  end
 end

--- a/spec/controllers/api/v1/dossiers_controller_spec.rb
+++ b/spec/controllers/api/v1/dossiers_controller_spec.rb
@@ -256,7 +256,7 @@ describe API::V1::DossiersController do
 
           describe 'repetition' do
             let(:procedure) { create(:procedure, :with_repetition, administrateur: admin) }
-            let(:dossier) { create(:dossier, :en_construction, :with_all_champs, procedure: procedure) }
+            let(:dossier) { create(:dossier, :en_construction, :with_populated_champs, procedure: procedure) }
 
             subject { super().first[:rows] }
 

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -14,7 +14,6 @@ describe API::V2::GraphqlController do
   end
   let(:dossier1) { create(:dossier, :en_construction, :with_individual, procedure: procedure, en_construction_at: 1.day.ago) }
   let(:dossier2) { create(:dossier, :en_construction, :with_individual, :archived, procedure: procedure, en_construction_at: 3.days.ago) }
-  let(:dossier_brouillon) { create(:dossier, :with_individual, procedure: procedure) }
   let(:dossiers) { [dossier2, dossier1, dossier] }
   let(:instructeur) { create(:instructeur, followed_dossiers: dossiers) }
 

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -5,8 +5,7 @@ describe API::V2::GraphqlController do
   let(:dossier)  { create(:dossier, :en_construction, :with_individual, procedure: procedure) }
   let(:dossier1) { create(:dossier, :en_construction, :with_individual, procedure: procedure, en_construction_at: 1.day.ago) }
   let(:dossier2) { create(:dossier, :en_construction, :with_individual, :archived, procedure: procedure, en_construction_at: 3.days.ago) }
-  #let(:dossiers) { [dossier2, dossier1, dossier] }
-  let(:dossiers) { [dossier2, dossier1, dossier] }
+  let(:dossiers) { [dossier] }
   let(:instructeur) { create(:instructeur, followed_dossiers: dossiers) }
 
   def compute_checksum_in_chunks(io)
@@ -162,6 +161,8 @@ describe API::V2::GraphqlController do
       end
 
       describe "filter dossiers" do
+        let(:dossiers) { [dossier, dossier1, dossier2] }
+
         let(:query) do
           "{
             demarche(number: #{procedure.id}) {
@@ -189,6 +190,7 @@ describe API::V2::GraphqlController do
       end
 
       describe "filter archived dossiers" do
+        let(:dossiers) { [dossier, dossier1, dossier2] }
         let(:query) do
           "{
             demarche(number: #{procedure.id}) {
@@ -911,6 +913,7 @@ describe API::V2::GraphqlController do
       end
 
       describe 'dossierPasserEnInstruction' do
+        let(:dossiers) { [dossier2, dossier1, dossier] }
         let(:dossier) { create(:dossier, :en_construction, :with_individual, procedure: procedure) }
         let(:instructeur_id) { instructeur.to_typed_id }
         let(:disable_notification) { false }

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -2,16 +2,7 @@ describe API::V2::GraphqlController do
   let(:admin) { create(:administrateur) }
   let(:token) { admin.renew_api_token }
   let(:procedure) { create(:procedure, :published, :for_individual, :with_service, :with_all_champs, :with_all_annotations, administrateurs: [admin]) }
-  let(:dossier) do
-    dossier = create(:dossier,
-      :en_construction,
-      :with_populated_champs,
-      :with_populated_annotations,
-      :with_individual,
-      procedure: procedure)
-    create(:commentaire, :with_file, dossier: dossier, email: 'test@test.com')
-    dossier
-  end
+  let(:dossier)  { create(:dossier, :en_construction, :with_individual, procedure: procedure) }
   let(:dossier1) { create(:dossier, :en_construction, :with_individual, procedure: procedure, en_construction_at: 1.day.ago) }
   let(:dossier2) { create(:dossier, :en_construction, :with_individual, :archived, procedure: procedure, en_construction_at: 3.days.ago) }
   let(:dossiers) { [dossier2, dossier1, dossier] }
@@ -298,6 +289,17 @@ describe API::V2::GraphqlController do
     end
 
     describe "dossier" do
+      let(:dossier) do
+        dossier = create(:dossier,
+                         :en_construction,
+                         :with_populated_champs,
+                         :with_populated_annotations,
+                         :with_individual,
+                         procedure: procedure)
+        create(:commentaire, :with_file, dossier: dossier, email: 'test@test.com')
+        dossier
+      end
+
       context "with individual" do
         let(:query) do
           "{

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -5,8 +5,8 @@ describe API::V2::GraphqlController do
   let(:dossier) do
     dossier = create(:dossier,
       :en_construction,
-      :with_all_champs,
-      :with_all_annotations,
+      :with_populated_champs,
+      :with_populated_annotations,
       :with_individual,
       procedure: procedure)
     create(:commentaire, :with_file, dossier: dossier, email: 'test@test.com')

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -116,7 +116,7 @@ describe API::V2::GraphqlController do
       request.env['HTTP_AUTHORIZATION'] = authorization_header
     end
 
-    context "demarche" do
+    describe "demarche" do
       it "should be returned" do
         expect(gql_errors).to eq(nil)
         expect(gql_data).to eq(demarche: {
@@ -166,7 +166,7 @@ describe API::V2::GraphqlController do
         })
       end
 
-      context "filter dossiers" do
+      describe "filter dossiers" do
         let(:query) do
           "{
             demarche(number: #{procedure.id}) {
@@ -193,7 +193,7 @@ describe API::V2::GraphqlController do
         end
       end
 
-      context "filter archived dossiers" do
+      describe "filter archived dossiers" do
         let(:query) do
           "{
             demarche(number: #{procedure.id}) {
@@ -210,7 +210,8 @@ describe API::V2::GraphqlController do
 
         context 'with archived=true' do
           let(:archived_filter) { 'true' }
-          it "only archived dossiers should be returned" do
+
+          it 'returns only archived dossiers' do
             expect(gql_errors).to eq(nil)
             expect(gql_data).to eq(demarche: {
               id: procedure.to_typed_id,
@@ -224,7 +225,8 @@ describe API::V2::GraphqlController do
 
         context 'with archived=false' do
           let(:archived_filter) { 'false' }
-          it "only not archived dossiers should be returned" do
+
+          it 'returns only non-archived dossiers' do
             expect(gql_errors).to eq(nil)
             expect(gql_data).to eq(demarche: {
               id: procedure.to_typed_id,
@@ -237,7 +239,7 @@ describe API::V2::GraphqlController do
         end
       end
 
-      context "filter by minRevision" do
+      describe "filter by minRevision" do
         let(:query) do
           "{
             demarche(number: #{procedure.id}) {
@@ -266,7 +268,7 @@ describe API::V2::GraphqlController do
         end
       end
 
-      context "filter by maxRevision" do
+      describe "filter by maxRevision" do
         let(:query) do
           "{
             demarche(number: #{procedure.id}) {
@@ -296,7 +298,7 @@ describe API::V2::GraphqlController do
       end
     end
 
-    context "dossier" do
+    describe "dossier" do
       context "with individual" do
         let(:query) do
           "{
@@ -661,7 +663,7 @@ describe API::V2::GraphqlController do
       end
     end
 
-    context "deletedDossiers" do
+    describe "deletedDossiers" do
       let(:query) do
         "{
           demarche(number: #{procedure.id}) {
@@ -699,7 +701,7 @@ describe API::V2::GraphqlController do
       end
     end
 
-    context "champ" do
+    describe "champ" do
       let(:champ) { create(:champ_piece_justificative, dossier: dossier) }
       let(:byte_size) { 2712286911 }
 
@@ -766,7 +768,7 @@ describe API::V2::GraphqlController do
       end
     end
 
-    context "groupeInstructeur" do
+    describe "groupeInstructeur" do
       let(:groupe_instructeur) { procedure.groupe_instructeurs.first }
       let(:query) do
         "{
@@ -796,7 +798,7 @@ describe API::V2::GraphqlController do
       end
     end
 
-    context "mutations" do
+    describe "mutations" do
       describe 'dossierEnvoyerMessage' do
         context 'success' do
           let(:query) do
@@ -1563,7 +1565,7 @@ describe API::V2::GraphqlController do
       expect(gql_errors).not_to eq(nil)
     end
 
-    context "dossier" do
+    describe "dossier" do
       let(:query) { "{ dossier(number: #{dossier.id}) { id number usager { email } } }" }
 
       it "should return error" do
@@ -1572,7 +1574,7 @@ describe API::V2::GraphqlController do
       end
     end
 
-    context "mutation" do
+    describe "mutation" do
       let(:query) do
         "mutation {
           dossierEnvoyerMessage(input: {

--- a/spec/controllers/instructeurs/dossiers_controller_spec.rb
+++ b/spec/controllers/instructeurs/dossiers_controller_spec.rb
@@ -560,8 +560,8 @@ describe Instructeurs::DossiersController, type: :controller do
       let(:dossier) do
         create(:dossier,
           :accepte,
-          :with_all_champs,
-          :with_all_annotations,
+          :with_populated_champs,
+          :with_populated_annotations,
           :with_motivation,
           :with_entreprise,
           :with_commentaires, procedure: procedure)
@@ -593,7 +593,7 @@ describe Instructeurs::DossiersController, type: :controller do
         build(:type_de_champ_repetition, :with_types_de_champ, position: 3)
       ], instructeurs: instructeurs)
     end
-    let(:dossier) { create(:dossier, :en_construction, :with_all_annotations, procedure: procedure) }
+    let(:dossier) { create(:dossier, :en_construction, :with_populated_annotations, procedure: procedure) }
     let(:another_instructeur) { create(:instructeur) }
     let(:now) { Time.zone.parse('01/01/2100') }
 

--- a/spec/controllers/recherche_controller_spec.rb
+++ b/spec/controllers/recherche_controller_spec.rb
@@ -1,10 +1,10 @@
 describe RechercheController, type: :controller do
-  let(:dossier) { create(:dossier, :en_construction, :with_all_annotations) }
+  let(:dossier) { create(:dossier, :en_construction, :with_populated_annotations) }
   let(:dossier2) { create(:dossier, :en_construction, procedure: dossier.procedure) }
   let(:instructeur) { create(:instructeur) }
 
   let(:dossier_with_expert) { avis.dossier }
-  let(:avis) { create(:avis, dossier: create(:dossier, :en_construction, :with_all_annotations)) }
+  let(:avis) { create(:avis, dossier: create(:dossier, :en_construction, :with_populated_annotations)) }
 
   let(:user) { instructeur.user }
 

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -879,7 +879,7 @@ describe Users::DossiersController, type: :controller do
       let(:dossier) do
         create(:dossier,
           :accepte,
-          :with_all_champs,
+          :with_populated_champs,
           :with_motivation,
           :with_commentaires,
           procedure: procedure,

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -212,7 +212,7 @@ FactoryBot.define do
       end
     end
 
-    trait :with_all_champs do
+    trait :with_populated_champs do
       after(:create) do |dossier, _evaluator|
         dossier.champs = dossier.types_de_champ.map do |type_de_champ|
           build(:"champ_#{type_de_champ.type_champ}", dossier: dossier, type_de_champ: type_de_champ)
@@ -221,7 +221,7 @@ FactoryBot.define do
       end
     end
 
-    trait :with_all_annotations do
+    trait :with_populated_annotations do
       after(:create) do |dossier, _evaluator|
         dossier.champs_private = dossier.types_de_champ_private.map do |type_de_champ|
           build(:"champ_#{type_de_champ.type_champ}", private: true, dossier: dossier, type_de_champ: type_de_champ)

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -32,7 +32,7 @@ describe ProcedureExportService do
     end
 
     describe 'Dossiers sheet' do
-      let!(:dossier) { create(:dossier, :en_instruction, :with_all_champs, :with_individual, procedure: procedure) }
+      let!(:dossier) { create(:dossier, :en_instruction, :with_populated_champs, :with_individual, procedure: procedure) }
 
       let(:nominal_headers) do
         [
@@ -119,7 +119,7 @@ describe ProcedureExportService do
 
     describe 'Etablissement sheet' do
       let(:procedure) { create(:procedure, :published, :with_all_champs) }
-      let!(:dossier) { create(:dossier, :en_instruction, :with_all_champs, :with_entreprise, procedure: procedure) }
+      let!(:dossier) { create(:dossier, :en_instruction, :with_populated_champs, :with_entreprise, procedure: procedure) }
 
       let(:dossier_etablissement) { etablissements_sheet.data[1] }
       let(:champ_etablissement) { etablissements_sheet.data[0] }
@@ -309,7 +309,7 @@ describe ProcedureExportService do
     end
 
     describe 'Avis sheet' do
-      let!(:dossier) { create(:dossier, :en_instruction, :with_all_champs, :with_individual, procedure: procedure) }
+      let!(:dossier) { create(:dossier, :en_instruction, :with_populated_champs, :with_individual, procedure: procedure) }
       let!(:avis) { create(:avis, :with_answer, dossier: dossier) }
 
       it 'should have headers' do
@@ -332,8 +332,8 @@ describe ProcedureExportService do
     describe 'Repetitions sheet' do
       let!(:dossiers) do
         [
-          create(:dossier, :en_instruction, :with_all_champs, :with_individual, procedure: procedure),
-          create(:dossier, :en_instruction, :with_all_champs, :with_individual, procedure: procedure)
+          create(:dossier, :en_instruction, :with_populated_champs, :with_individual, procedure: procedure),
+          create(:dossier, :en_instruction, :with_populated_champs, :with_individual, procedure: procedure)
         ]
       end
       let(:champ_repetition) { dossiers.first.champs.find { |champ| champ.type_champ == 'repetition' } }
@@ -381,7 +381,7 @@ describe ProcedureExportService do
       end
 
       context 'with non unique labels' do
-        let(:dossier) { create(:dossier, :en_instruction, :with_all_champs, :with_individual, procedure: procedure) }
+        let(:dossier) { create(:dossier, :en_instruction, :with_populated_champs, :with_individual, procedure: procedure) }
         let(:champ_repetition) { dossier.champs.find { |champ| champ.type_champ == 'repetition' } }
         let(:type_de_champ_repetition) { create(:type_de_champ_repetition, procedure: procedure, libelle: champ_repetition.libelle) }
         let!(:another_champ_repetition) { create(:champ_repetition, type_de_champ: type_de_champ_repetition, dossier: dossier) }

--- a/spec/system/users/list_dossiers_spec.rb
+++ b/spec/system/users/list_dossiers_spec.rb
@@ -1,7 +1,7 @@
 describe 'user access to the list of their dossiers' do
   let(:user) { create(:user) }
   let!(:dossier_brouillon)       { create(:dossier, user: user) }
-  let!(:dossier_en_construction) { create(:dossier, :with_all_champs, :en_construction, user: user) }
+  let!(:dossier_en_construction) { create(:dossier, :with_populated_champs, :en_construction, user: user) }
   let!(:dossier_en_instruction)  { create(:dossier, :en_instruction, user: user) }
   let!(:dossier_archived)        { create(:dossier, :en_instruction, :archived, user: user) }
   let(:dossiers_per_page) { 25 }
@@ -121,7 +121,7 @@ describe 'user access to the list of their dossiers' do
     end
 
     context "when user search for something inside the dossier" do
-      let(:dossier_en_construction2) { create(:dossier, :with_all_champs, :en_construction, user: user) }
+      let(:dossier_en_construction2) { create(:dossier, :with_populated_champs, :en_construction, user: user) }
       before do
         page.find_by_id('q').set(dossier_en_construction.champs.first.value)
       end


### PR DESCRIPTION
Aujourd'hui les specs GraphQL sont les plus lentes du projet : chaque exemple prend environ 4s (!).

C'est parce que pour les specs graphql on crée une grosse démarche avec beaucoup de champs, et beaucoup de dossiers sur cette démarche.

Cette PR optimise la vitesse de ces specs, en :

- créant une démarche plus légère par défaut,
- créant moins de dossiers par défaut.

On passe cette spec de 2m 20s à ~~47s~~ 20s.