### PR TITLE
fix(export): remove wrong columns from repetition spreadsheets

### DIFF
--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -297,13 +297,12 @@ class TypeDeChamp < ApplicationRecord
       # otherwise return all types_de_champ in their latest state
       types_de_champ = TypeDeChamp
         .fillable
-        .joins(:parent)
-        .where(parent: { stable_id: stable_id })
+        .joins(parent: :revision_types_de_champ)
+        .where(parent: { stable_id: stable_id }, revision_types_de_champ: { revision_id: revision })
 
       TypeDeChamp
         .where(id: types_de_champ.group(:stable_id).select('MAX(types_de_champ.id)'))
-        .joins(parent: :revision_types_de_champ)
-        .order(:order_place, 'procedure_revision_types_de_champ.revision_id': :desc)
+        .order(:order_place, id: :desc)
     end
   end
 

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -342,13 +342,22 @@ describe ProcedureExportService do
         expect(subject.sheets.map(&:name)).to eq(['Dossiers', 'Etablissements', 'Avis', champ_repetition.libelle_for_export])
       end
 
-      it 'should have headers' do
-        expect(repetition_sheet.headers).to eq([
-          "Dossier ID",
-          "Ligne",
-          "Nom",
-          "Age"
-        ])
+      context 'with cloned procedure' do
+        let(:other_parent) { create(:type_de_champ_repetition, stable_id: champ_repetition.stable_id) }
+
+        before do
+          create(:procedure_revision_type_de_champ, type_de_champ: other_parent, revision: create(:procedure).active_revision)
+          create(:type_de_champ, parent: other_parent)
+        end
+
+        it 'should have headers' do
+          expect(repetition_sheet.headers).to eq([
+            "Dossier ID",
+            "Ligne",
+            "Nom",
+            "Age"
+          ])
+        end
       end
 
       it 'should have data' do


### PR DESCRIPTION
This fix prevent repetition children types de champ from being pulled from cloned procedures. stable_id is stable across revisions but also across cloned procedures.