### PR TITLE
Tests : amélioration des factories

### DIFF
--- a/spec/controllers/new_administrateur/services_controller_spec.rb
+++ b/spec/controllers/new_administrateur/services_controller_spec.rb
@@ -131,7 +131,7 @@ describe NewAdministrateur::ServicesController, type: :controller do
       end
 
       it { expect(service.reload).not_to be_nil }
-      it { expect(flash.alert).to eq("la démarche #{procedure.libelle} utilise encore le service service. Veuillez l'affecter à un autre service avant de pouvoir le supprimer") }
+      it { expect(flash.alert).to eq("la démarche #{procedure.libelle} utilise encore le service #{service.nom}. Veuillez l'affecter à un autre service avant de pouvoir le supprimer") }
       it { expect(flash.notice).to be_nil }
       it { expect(response).to redirect_to(admin_services_path(procedure_id: 12)) }
     end

--- a/spec/factories/champ.rb
+++ b/spec/factories/champ.rb
@@ -190,7 +190,7 @@ FactoryBot.define do
     end
 
     factory :champ_siret, class: 'Champs::SiretChamp' do
-      association :type_de_champ, factory: [:type_de_champ_siret]
+      type_de_champ { association :type_de_champ_siret, procedure: dossier.procedure }
       association :etablissement, factory: [:etablissement]
       value { '44011762001530' }
     end

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -90,9 +90,7 @@ FactoryBot.define do
     end
 
     trait :with_commentaires do
-      after(:create) do |dossier, _evaluator|
-        dossier.commentaires += create_list(:commentaire, 2)
-      end
+      commentaires { [build(:commentaire), build(:commentaire)] }
     end
 
     trait :followed do

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     state { Dossier.states.fetch(:brouillon) }
 
     user { association :user }
+    groupe_instructeur { procedure.routee? ? nil : procedure.defaut_groupe_instructeur }
 
     transient do
       for_individual? { false }
@@ -18,11 +19,6 @@ FactoryBot.define do
       procedure = evaluator.procedure
 
       dossier.revision = procedure.active_revision
-
-      # Assign the procedure to the dossier through the groupe_instructeur
-      if dossier.groupe_instructeur.nil?
-        dossier.groupe_instructeur = procedure.routee? ? nil : procedure.defaut_groupe_instructeur
-      end
 
       if procedure.for_individual? && dossier.individual.blank?
         build(:individual, :empty, dossier: dossier)

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -5,6 +5,8 @@ FactoryBot.define do
 
     user { association :user }
     groupe_instructeur { procedure.routee? ? nil : procedure.defaut_groupe_instructeur }
+    revision { procedure.active_revision }
+    individual { association(:individual, :empty, dossier: instance, strategy: :build) if procedure.for_individual? }
 
     transient do
       for_individual? { false }
@@ -13,16 +15,6 @@ FactoryBot.define do
       # (due to some internal ActiveRecord error).
       # TODO: find a way to find the issue and just `build` the procedure.
       procedure { create(:procedure, :published, :with_type_de_champ, :with_type_de_champ_private, for_individual: for_individual?) }
-    end
-
-    after(:build) do |dossier, evaluator|
-      procedure = evaluator.procedure
-
-      dossier.revision = procedure.active_revision
-
-      if procedure.for_individual? && dossier.individual.blank?
-        build(:individual, :empty, dossier: dossier)
-      end
     end
 
     trait :with_entreprise do

--- a/spec/factories/groupe_instructeur.rb
+++ b/spec/factories/groupe_instructeur.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
   factory :groupe_instructeur do
     label { generate(:groupe_label) }
     association :procedure
+
+    trait :default do
+      label { GroupeInstructeur::DEFAUT_LABEL }
+    end
   end
 end

--- a/spec/factories/individual.rb
+++ b/spec/factories/individual.rb
@@ -5,5 +5,12 @@ FactoryBot.define do
     prenom { 'Xavier' }
     birthdate { Date.new(1991, 11, 01) }
     association :dossier
+
+    trait :empty do
+      gender { nil }
+      nom { nil }
+      prenom { nil }
+      birthdate { nil }
+    end
   end
 end

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -80,9 +80,7 @@ FactoryBot.define do
     end
 
     trait :with_service do
-      after(:build) do |procedure, _evaluator|
-        procedure.service = create(:service)
-      end
+      service { association :service, administrateur: administrateurs.first }
     end
 
     trait :with_instructeur do
@@ -98,9 +96,7 @@ FactoryBot.define do
     end
 
     trait :for_individual do
-      after(:build) do |procedure, _evaluator|
-        procedure.for_individual = true
-      end
+      for_individual { true }
     end
 
     trait :with_auto_archive do

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -13,6 +13,8 @@ FactoryBot.define do
     lien_site_web { "https://mon-site.gouv" }
     path { SecureRandom.uuid }
 
+    administrateurs { administrateur.present? ? [administrateur] : [association(:administrateur)] }
+
     transient do
       administrateur { }
       instructeurs { [] }
@@ -22,12 +24,6 @@ FactoryBot.define do
     end
 
     after(:build) do |procedure, evaluator|
-      if evaluator.administrateur
-        procedure.administrateurs = [evaluator.administrateur]
-      elsif procedure.administrateurs.empty?
-        procedure.administrateurs = [build(:administrateur)]
-      end
-
       initial_revision = build(:procedure_revision, procedure: procedure)
       add_types_de_champs(evaluator.types_de_champ, to: initial_revision, scope: :public)
       add_types_de_champs(evaluator.types_de_champ_private, to: initial_revision, scope: :private)

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
     lien_site_web { "https://mon-site.gouv" }
     path { SecureRandom.uuid }
 
+    groupe_instructeurs { [association(:groupe_instructeur, :default, procedure: instance, strategy: :build)] }
     administrateurs { administrateur.present? ? [administrateur] : [association(:administrateur)] }
 
     transient do

--- a/spec/factories/procedure_revision.rb
+++ b/spec/factories/procedure_revision.rb
@@ -1,4 +1,21 @@
 FactoryBot.define do
   factory :procedure_revision do
+    transient do
+      from_original { nil }
+    end
+
+    after(:build) do |revision, evaluator|
+      if evaluator.from_original
+        original = evaluator.from_original
+
+        revision.procedure = original.procedure
+        original.revision_types_de_champ.each do |r_tdc|
+          revision.revision_types_de_champ << build(:procedure_revision_type_de_champ, from_original: r_tdc)
+        end
+        original.revision_types_de_champ_private.each do |r_tdc|
+          revision.revision_types_de_champ_private << build(:procedure_revision_type_de_champ, from_original: r_tdc)
+        end
+      end
+    end
   end
 end

--- a/spec/factories/procedure_revision_type_de_champ.rb
+++ b/spec/factories/procedure_revision_type_de_champ.rb
@@ -1,4 +1,16 @@
 FactoryBot.define do
   factory :procedure_revision_type_de_champ do
+    transient do
+      from_original { nil }
+    end
+
+    after(:build) do |revision_type_de_champ, evaluator|
+      if evaluator.from_original
+        original = evaluator.from_original
+
+        revision_type_de_champ.type_de_champ = original.type_de_champ
+        revision_type_de_champ.position      = original.position
+      end
+    end
   end
 end

--- a/spec/factories/service.rb
+++ b/spec/factories/service.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :service do
-    nom { 'service' }
+    sequence(:nom) { |n| "Service #{n}" }
     organisme { 'organisme' }
     type_organisme { Service.type_organismes.fetch(:association) }
     email { 'email@toto.com' }

--- a/spec/helpers/dossier_helper_spec.rb
+++ b/spec/helpers/dossier_helper_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe DossierHelper, type: :helper do
       let(:procedure) { create(:simple_procedure, :for_individual) }
 
       context "when the individual is not provided" do
-        let(:individual) { nil }
+        let(:individual) { build(:individual, :empty) }
         it { is_expected.to be_blank }
       end
 

--- a/spec/jobs/api_entreprise/job_spec.rb
+++ b/spec/jobs/api_entreprise/job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe APIEntreprise::Job, type: :job do
   describe '#perform' do
     let(:dossier) { create(:dossier, :with_entreprise) }
 
-    context 'when a un retryable error is raised' do
+    context 'when an un-retriable error is raised' do
       let(:errors) { [:standard_error] }
 
       it 'does not retry' do
@@ -14,7 +14,7 @@ RSpec.describe APIEntreprise::Job, type: :job do
       end
     end
 
-    context 'when a retryable error is raised' do
+    context 'when a retriable error is raised' do
       let(:errors) { [:service_unavaible, :bad_gateway, :timed_out] }
 
       it 'retries 5 times' do

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe ApplicationMailer, type: :mailer do
   describe 'dealing with invalid emails' do
-    let(:dossier) { create(:dossier, procedure: build(:simple_procedure)) }
+    let(:dossier) { create(:dossier, procedure: create(:simple_procedure)) }
     subject { DossierMailer.notify_new_draft(dossier) }
 
     describe 'invalid emails are not sent' do

--- a/spec/mailers/dossier_mailer_spec.rb
+++ b/spec/mailers/dossier_mailer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe DossierMailer, type: :mailer do
   end
 
   describe '.notify_new_draft' do
-    let(:dossier) { create(:dossier, procedure: build(:simple_procedure, :with_auto_archive)) }
+    let(:dossier) { create(:dossier, procedure: create(:simple_procedure, :with_auto_archive)) }
 
     subject { described_class.notify_new_draft(dossier) }
 
@@ -27,7 +27,7 @@ RSpec.describe DossierMailer, type: :mailer do
   end
 
   describe '.notify_new_answer with dossier brouillon' do
-    let(:dossier) { create(:dossier, procedure: build(:simple_procedure)) }
+    let(:dossier) { create(:dossier, procedure: create(:simple_procedure)) }
     let(:commentaire) { create(:commentaire, dossier: dossier) }
     subject { described_class.with(commentaire: commentaire).notify_new_answer }
 
@@ -39,8 +39,9 @@ RSpec.describe DossierMailer, type: :mailer do
   end
 
   describe '.notify_new_answer with dossier en construction' do
-    let(:dossier) { create(:dossier, state: "en_construction", procedure: build(:simple_procedure)) }
+    let(:dossier) { create(:dossier, :en_construction, procedure: create(:simple_procedure)) }
     let(:commentaire) { create(:commentaire, dossier: dossier) }
+
     subject { described_class.with(commentaire: commentaire).notify_new_answer }
 
     it { expect(subject.subject).to include("Nouveau message") }
@@ -51,7 +52,7 @@ RSpec.describe DossierMailer, type: :mailer do
   end
 
   describe '.notify_new_answer with commentaire discarded' do
-    let(:dossier) { create(:dossier, procedure: build(:simple_procedure)) }
+    let(:dossier) { create(:dossier, procedure: create(:simple_procedure)) }
     let(:commentaire) { create(:commentaire, dossier: dossier, discarded_at: 2.minutes.ago) }
 
     subject { described_class.with(commentaire: commentaire).notify_new_answer }
@@ -83,7 +84,7 @@ RSpec.describe DossierMailer, type: :mailer do
   end
 
   describe '.notify_revert_to_instruction' do
-    let(:dossier) { create(:dossier, procedure: build(:simple_procedure)) }
+    let(:dossier) { create(:dossier, procedure: create(:simple_procedure)) }
 
     subject { described_class.notify_revert_to_instruction(dossier) }
 

--- a/spec/models/champs/iban_champ_spec.rb
+++ b/spec/models/champs/iban_champ_spec.rb
@@ -1,4 +1,3 @@
-
 describe Champs::IbanChamp do
   describe '#valid?' do
     it do

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -193,11 +193,21 @@ describe Dossier do
         expect(dossier.champs.count).to eq(1)
         expect(dossier.champs_private.count).to eq(1)
       end
+    end
+
+    describe '#build_default_individual' do
+      let(:dossier) { build(:dossier, procedure: procedure, user: user) }
+
+      subject do
+        dossier.individual = nil
+        dossier.build_default_individual
+      end
 
       context 'when the dossier belongs to a procedure for individuals' do
-        let(:procedure) { create(:procedure, :with_type_de_champ, for_individual: true) }
+        let(:procedure) { create(:procedure, for_individual: true) }
 
         it 'creates a default individual' do
+          subject
           expect(dossier.individual).to be_present
           expect(dossier.individual.nom).to be_nil
           expect(dossier.individual.prenom).to be_nil
@@ -209,6 +219,7 @@ describe Dossier do
           let(:user) { build(:user, france_connect_information: france_connect_information) }
 
           it 'fills the individual with the informations from France Connect' do
+            subject
             expect(dossier.individual.nom).to eq('DUBOIS')
             expect(dossier.individual.prenom).to eq('Angela Claire Louise')
             expect(dossier.individual.gender).to eq(Individual::GENDER_FEMALE)
@@ -217,9 +228,10 @@ describe Dossier do
       end
 
       context 'when the dossier belongs to a procedure for moral personas' do
-        let(:procedure) { create(:procedure, :with_type_de_champ, for_individual: false) }
+        let(:procedure) { create(:procedure, for_individual: false) }
 
         it 'doesn’t create a individual' do
+          subject
           expect(dossier.individual).to be_nil
         end
       end

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -262,14 +262,14 @@ describe Instructeur, type: :model do
   end
 
   describe '#notifications_for_groupe_instructeurs' do
-    # one procedure, one group, 2 instructeurs
+    # a procedure, one group, 2 instructeurs
     let(:procedure) { create(:simple_procedure, :routee, :with_type_de_champ_private, :for_individual) }
     let(:gi_p1) { procedure.groupe_instructeurs.last }
-    let!(:dossier) { create(:dossier, :with_individual, :followed, groupe_instructeur: gi_p1, state: Dossier.states.fetch(:en_construction)) }
+    let!(:dossier) { create(:dossier, :with_individual, :followed, procedure: procedure, groupe_instructeur: gi_p1, state: Dossier.states.fetch(:en_construction)) }
     let(:instructeur) { dossier.follows.first.instructeur }
     let!(:instructeur_2) { create(:instructeur, groupe_instructeurs: [gi_p1]) }
 
-    # one other procedure, dossier followed by a third instructeur
+    # another procedure, dossier followed by a third instructeur
     let!(:dossier_on_procedure_2) { create(:dossier, :followed, state: Dossier.states.fetch(:en_construction)) }
     let!(:instructeur_on_procedure_2) { dossier_on_procedure_2.follows.first.instructeur }
     let(:gi_p2) { dossier.groupe_instructeur }

--- a/spec/models/procedure_presentation_and_revisions_spec.rb
+++ b/spec/models/procedure_presentation_and_revisions_spec.rb
@@ -16,7 +16,7 @@ describe ProcedurePresentation do
 
     context 'for a published procedure' do
       let(:procedure) { create(:procedure, :published) }
-      let!(:tdc) { { type_champ: :number, libelle: 'libelle 1' } }
+      let(:tdc) { { type_champ: :number, libelle: 'libelle 1' } }
 
       before do
         procedure.draft_revision.add_type_de_champ(tdc)
@@ -26,7 +26,7 @@ describe ProcedurePresentation do
       it { is_expected.to match(['libelle 1']) }
 
       context 'when there is another published revision with an added tdc' do
-        let!(:added_tdc) { { type_champ: :number, libelle: 'libelle 2' } }
+        let(:added_tdc) { { type_champ: :number, libelle: 'libelle 2' } }
 
         before do
           procedure.draft_revision.add_type_de_champ(added_tdc)
@@ -37,7 +37,7 @@ describe ProcedurePresentation do
       end
 
       context 'add one tdc above the first one' do
-        let!(:tdc2) { { type_champ: :number, libelle: 'libelle 2' } }
+        let(:tdc2) { { type_champ: :number, libelle: 'libelle 2' } }
 
         before do
           created_tdc2 = procedure.draft_revision.add_type_de_champ(tdc2)
@@ -47,7 +47,7 @@ describe ProcedurePresentation do
 
         it { is_expected.to match(['libelle 2', 'libelle 1']) }
 
-        context 'and finaly, when this tdc is removed' do
+        context 'and finally, when this tdc is removed' do
           let!(:previous_tdc2) { procedure.published_revision.types_de_champ.find_by(libelle: 'libelle 2') }
 
           before do

--- a/spec/models/procedure_presentation_spec.rb
+++ b/spec/models/procedure_presentation_spec.rb
@@ -320,8 +320,8 @@ describe ProcedurePresentation do
 
       let(:procedure) { create(:procedure, :for_individual) }
 
-      let!(:first_dossier) { create(:dossier, procedure: procedure, individual: create(:individual, gender: 'M', prenom: 'Alain', nom: 'Antonelli')) }
-      let!(:last_dossier) { create(:dossier, procedure: procedure, individual: create(:individual, gender: 'Mme', prenom: 'Zora', nom: 'Zemmour')) }
+      let!(:first_dossier) { create(:dossier, procedure: procedure, individual: build(:individual, gender: 'M', prenom: 'Alain', nom: 'Antonelli')) }
+      let!(:last_dossier) { create(:dossier, procedure: procedure, individual: build(:individual, gender: 'Mme', prenom: 'Zora', nom: 'Zemmour')) }
 
       context 'for gender column' do
         let(:column) { 'gender' }
@@ -617,8 +617,8 @@ describe ProcedurePresentation do
 
     context 'for individual table' do
       let(:procedure) { create(:procedure, :for_individual) }
-      let!(:kept_dossier) { create(:dossier, procedure: procedure, individual: create(:individual, gender: 'Mme', prenom: 'Josephine', nom: 'Baker')) }
-      let!(:discarded_dossier) { create(:dossier, procedure: procedure, individual: create(:individual, gender: 'M', prenom: 'Jean', nom: 'Tremblay')) }
+      let!(:kept_dossier) { create(:dossier, procedure: procedure, individual: build(:individual, gender: 'Mme', prenom: 'Josephine', nom: 'Baker')) }
+      let!(:discarded_dossier) { create(:dossier, procedure: procedure, individual: build(:individual, gender: 'M', prenom: 'Jean', nom: 'Tremblay')) }
 
       context 'for gender column' do
         let(:filter) { [{ 'table' => 'individual', 'column' => 'gender', 'value' => 'Mme' }] }
@@ -646,7 +646,7 @@ describe ProcedurePresentation do
           ]
         end
 
-        let!(:other_kept_dossier) { create(:dossier, procedure: procedure, individual: create(:individual, gender: 'M', prenom: 'Romuald', nom: 'Pistis')) }
+        let!(:other_kept_dossier) { create(:dossier, procedure: procedure, individual: build(:individual, gender: 'M', prenom: 'Romuald', nom: 'Pistis')) }
 
         it 'returns every dossier that matches any of the search criteria for a given column' do
           is_expected.to contain_exactly(kept_dossier.id, other_kept_dossier.id)

--- a/spec/serializers/dossier_serializer_spec.rb
+++ b/spec/serializers/dossier_serializer_spec.rb
@@ -21,11 +21,11 @@ describe DossierSerializer do
       let(:dossier) { create(:dossier, :en_construction, procedure: create(:procedure, :published, :with_type_de_champ)) }
 
       before do
-        dossier.champs << build(:champ_carte)
-        dossier.champs << build(:champ_siret)
-        dossier.champs << build(:champ_integer_number)
-        dossier.champs << build(:champ_decimal_number)
-        dossier.champs << build(:champ_linked_drop_down_list)
+        dossier.champs << build(:champ_carte, dossier: dossier)
+        dossier.champs << build(:champ_siret, dossier: dossier)
+        dossier.champs << build(:champ_integer_number, dossier: dossier)
+        dossier.champs << build(:champ_decimal_number, dossier: dossier)
+        dossier.champs << build(:champ_linked_drop_down_list, dossier: dossier)
       end
 
       it {

--- a/spec/services/dossier_projection_service_spec.rb
+++ b/spec/services/dossier_projection_service_spec.rb
@@ -92,7 +92,7 @@ describe DossierProjectionService do
       context 'for individual table' do
         let(:table) { 'individual' }
         let(:procedure) { create(:procedure, :for_individual, :with_type_de_champ, :with_type_de_champ_private) }
-        let(:dossier) { create(:dossier, procedure: procedure, individual: create(:individual, nom: 'Martin', prenom: 'Jacques', gender: 'M.')) }
+        let(:dossier) { create(:dossier, procedure: procedure, individual: build(:individual, nom: 'Martin', prenom: 'Jacques', gender: 'M.')) }
 
         context 'for prenom column' do
           let(:column) { 'prenom' }

--- a/spec/system/accessibilite/wcag_usager_spec.rb
+++ b/spec/system/accessibilite/wcag_usager_spec.rb
@@ -1,5 +1,5 @@
 describe 'wcag rules for usager', js: true do
-  let(:procedure) { create(:procedure, :with_type_de_champ, :with_all_champs, :with_service, :for_individual, :published) }
+  let(:procedure) { create(:procedure, :published, :with_all_champs, :with_service, :for_individual) }
   let(:password) { 'a very complicated password' }
   let(:litteraire_user) { create(:user, password: password) }
 

--- a/spec/views/shared/dossiers/_demande.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_demande.html.haml_spec.rb
@@ -32,7 +32,7 @@ describe 'shared/dossiers/demande.html.haml', type: :view do
   end
 
   context 'when dossier was created by an individual' do
-    let(:individual) { create(:individual) }
+    let(:individual) { build(:individual) }
 
     it 'renders the individual identity infos' do
       expect(subject).to include(individual.gender)


### PR DESCRIPTION
Cette PR nettoie les factories de Procedure et Dossier, pour éviter d'appeler du code métier dedans.

Appeler du code métier dans une factory est un code-smell, parce que :

- On devrait configurer le record de test directement avec les données qu'on veut (plutôt que de le faire passer par tout le cycle de vie d'une démarche) ;
- Quand le code métier change, ça fait changer le code des factories de manière inattendue ;
- Appeler du code métier nécessite souvent de sauvegarder le record en base, ce qui est lent.

Après ce refactor, la création des Procedure dans les test est plus rapide, et peut se faire juste en buildant le record en mémoire (sans avoir forcément besoin de le persister en base de données).

## Autres améliorations

Cette PR contient aussi d'autres nettoyages mineurs des tests, et d'autres simplifications des factories (par exemple en essayant de tendre vers un style plus déclaratif).

---

Ça se relit bien commit-par-commit.