### PR TITLE
Merge des comptes avec des fichiers cachés

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -201,7 +201,7 @@ class User < ApplicationRecord
 
   def merge(old_user)
     transaction do
-      old_user.dossiers.update_all(user_id: id)
+      old_user.dossiers.with_discarded.update_all(user_id: id)
       old_user.invites.update_all(user_id: id)
       old_user.merge_logs.update_all(user_id: id)
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -426,13 +426,14 @@ describe User, type: :model do
 
     context 'and the old account has some stuff' do
       let!(:dossier) { create(:dossier, user: old_user) }
+      let!(:hidden_dossier) { create(:dossier, user: old_user, hidden_at: Time.zone.now) }
       let!(:invite) { create(:invite, user: old_user) }
       let!(:merge_log) { MergeLog.create(user: old_user, from_user_id: 1, from_user_email: 'a') }
 
       it 'transfers the dossier' do
         subject
 
-        expect(targeted_user.dossiers).to match([dossier])
+        expect(targeted_user.dossiers.with_discarded).to match([dossier, hidden_dossier])
         expect(targeted_user.invites).to match([invite])
         expect(targeted_user.merge_logs.first).to eq(merge_log)
 


### PR DESCRIPTION
Le merge plantait lorsque l'ancien utilisateur avait des fichiers cachés.

résout https://sentry.io/organizations/demarches-simplifiees/issues/2729504350/?project=1429550&query=is%3Aunresolved