### PR TITLE
GraphQL : affiche la cause des erreurs de syntaxe des requêtes

### DIFF
--- a/app/controllers/api/v2/graphql_controller.rb
+++ b/app/controllers/api/v2/graphql_controller.rb
@@ -8,6 +8,8 @@ class API::V2::GraphqlController < API::V2::BaseController
       operation_name: params[:operationName])
 
     render json: result
+  rescue GraphQL::ParseError => exception
+    handle_parse_error(exception)
   rescue => exception
     if Rails.env.production?
       handle_error_in_production(exception)
@@ -86,6 +88,15 @@ class API::V2::GraphqlController < API::V2::BaseController
     else
       raise ArgumentError, "Unexpected parameter: #{ambiguous_param}"
     end
+  end
+
+  def handle_parse_error(exception)
+    render json: {
+      errors: [
+        { message: exception.message }
+      ],
+      data: nil
+    }, status: 400
   end
 
   def handle_error_in_development(exception)


### PR DESCRIPTION
Currently, when a query can't be parsed, the error is:
- logged to Sentry (which is useless to us),
- returned as a generic '500 Internal Server Error' (which is useless to the user who made the query).

With this commit, the error is instead ignored from our logs (because it is a user error), and the parse error details are returned to the user, with the following format:

> HTTP Status: 400
> {'errors': [{'message': 'Parse error on ")" (RPAREN) at [3, 23]'}]}

Fix https://sentry.io/organizations/demarches-simplifiees/issues/2779240458/