### PR TITLE
Suppression du code obsolète pour l'auto-validation du chemin des démarches

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -235,7 +235,6 @@ class Procedure < ApplicationRecord
   validates :description, presence: true, allow_blank: false, allow_nil: false
   validates :administrateurs, presence: true
   validates :lien_site_web, presence: true, if: :publiee?
-  validate :validate_for_publication, on: :publication
   validate :check_juridique
   validates :path, presence: true, format: { with: /\A[a-z0-9_\-]{3,200}\z/ }, uniqueness: { scope: [:path, :closed_at, :hidden_at, :unpublished_at], case_sensitive: false }
   validates :duree_conservation_dossiers_dans_ds, allow_nil: false, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: MAX_DUREE_CONSERVATION }
@@ -323,18 +322,6 @@ class Procedure < ApplicationRecord
     if !locked? || draft_changed?
       draft_revision.dossiers.destroy_all
     end
-  end
-
-  def validate_for_publication
-    old_attributes = self.slice(:aasm_state, :closed_at)
-    self.aasm_state = :publiee
-    self.closed_at = nil
-
-    is_valid = validate
-
-    self.attributes = old_attributes
-
-    is_valid
   end
 
   def suggested_path(administrateur)

--- a/app/views/new_administrateur/procedures/_publication_form.html.haml
+++ b/app/views/new_administrateur/procedures/_publication_form.html.haml
@@ -30,14 +30,5 @@
                           autocomplete: 'off',
                           placeholder: 'https://exemple.gouv.fr/ma_demarche')
 
-    - procedure.validate(:publication)
-    - errors = procedure.errors
-    -# Ignore the :taken error if the path can be claimed
-    - if errors.details[:path]&.pluck(:error)&.include?(:taken) && procedure.path_available?(administrateur, procedure.path)
-      - errors.delete(:path)
-
-    - options = { class: "button primary", id: 'publish' }
-    - if errors.details[:path].present?
-      - options[:disabled] = :disabled
     .flex.justify-end
-      = submit_tag procedure_publish_label(procedure, :submit), options
+      = submit_tag procedure_publish_label(procedure, :submit), { class: "button primary", id: 'publish' }


### PR DESCRIPTION
Il y a longtemps, lors de la publication, on validait la disponibilité du chemin d'une démarche instantanément, en faisant une requête en arrière-plan.

Ce dispositif a sauté lors du redesign de la page de publication il y a environ un an. On a décidé de le désactiver complètement, en attendant de le recoder proprement un jour au besoin.

Cette PR supprime les derniers bouts restants de ce code (qui par ailleurs était nécessaire, mais pas bien beau à voir).

Fait partie de #6662 