### PR TITLE
Invalide le cache d'associations d'une nouvelle révision 

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -678,7 +678,9 @@ class Procedure < ApplicationRecord
   end
 
   def create_new_revision
-    draft_revision.deep_clone(include: [:revision_types_de_champ, :revision_types_de_champ_private])
+    draft_revision
+      .deep_clone(include: [:revision_types_de_champ, :revision_types_de_champ_private])
+      .tap(&:save!)
   end
 
   def average_dossier_weight


### PR DESCRIPTION
Deep-cloned objects are created with all their relationships stale. Thus, for a newly deep-cloned revision, `revision.types_de_champs` returns `[]`, even when it actually has associated types de champ.

This causes consecutive champs creations and re-ordering to fail in subtle ways, like:

```ruby
procedure.draft_revision.add_type_de_champ(…)
procedure.publish_revision!
procedure.draft_revision.add_type_de_champ(…)
procedure.draft_revision.move_type_de_champ(…) # this will fail
```

As `publish_revision!` creates a new stale revision, moving the type de champ fails, because not all existing champs are found until the object is refreshed.

We don't hit this path in production, because usually only a single operation is made in a request. But it is hit during tests, or when adding a new validation path to the revision (see #6473).

To fix this, save the new revision before associating it as the draft procedure.

### Other option

We could also:
- Just invalidate the revision cache for this association, with `revision.types_de_champ.reset`. However we have to do this for every association we're interested in.
- Reload the revision just after saving it. This seems a bit heavy-handed though.

This is part of #6662 