### PR TITLE
6194 add zone to procedure

### DIFF
--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -251,7 +251,7 @@ module Administrateurs
     end
 
     def procedure_params
-      editable_params = [:libelle, :description, :organisation, :direction, :lien_site_web, :cadre_juridique, :deliberation, :notice, :web_hook_url, :declarative_with_state, :logo, :auto_archive_on, :monavis_embed, :api_entreprise_token, :duree_conservation_dossiers_dans_ds]
+      editable_params = [:libelle, :description, :organisation, :direction, :lien_site_web, :cadre_juridique, :deliberation, :notice, :web_hook_url, :declarative_with_state, :logo, :auto_archive_on, :monavis_embed, :api_entreprise_token, :duree_conservation_dossiers_dans_ds, :zone_id]
       permited_params = if @procedure&.locked?
         params.require(:procedure).permit(*editable_params)
       else

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -48,6 +48,7 @@
 #  parent_procedure_id                       :bigint
 #  published_revision_id                     :bigint
 #  service_id                                :bigint
+#  zone_id                                   :bigint
 #
 
 class Procedure < ApplicationRecord
@@ -85,6 +86,7 @@ class Procedure < ApplicationRecord
   belongs_to :parent_procedure, class_name: 'Procedure', optional: true
   belongs_to :canonical_procedure, class_name: 'Procedure', optional: true
   belongs_to :service, optional: true
+  belongs_to :zone, optional: true
 
   def active_revision
     brouillon? ? draft_revision : published_revision

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -1,0 +1,13 @@
+# == Schema Information
+#
+# Table name: zones
+#
+#  id         :bigint           not null, primary key
+#  acronym    :string
+#  label      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class Zone < ApplicationRecord
+  validates :acronym, presence: true, uniqueness: true
+end

--- a/app/views/administrateurs/procedures/_informations.html.haml
+++ b/app/views/administrateurs/procedures/_informations.html.haml
@@ -14,7 +14,7 @@
 = f.text_area :description, rows: '6', placeholder: 'Description de la démarche, destinataires, etc. ', class: 'form-control'
 
 = f.label :zone do
-  Organisme qui met en oeuvre la démarche
+  = t('zone', scope: 'activerecord.attributes.procedure')
   %span.mandatory *
 = f.collection_select :zone_id, Zone.order(:label), :id, :label, prompt: true
 

--- a/app/views/administrateurs/procedures/_informations.html.haml
+++ b/app/views/administrateurs/procedures/_informations.html.haml
@@ -13,6 +13,11 @@
   %span.mandatory *
 = f.text_area :description, rows: '6', placeholder: 'Description de la démarche, destinataires, etc. ', class: 'form-control'
 
+= f.label :zone do
+  Organisme qui met en oeuvre la démarche
+  %span.mandatory *
+= f.collection_select :zone_id, Zone.order(:label), :id, :label, prompt: true
+
 %h3.header-subsection Logo de la démarche
 = image_upload_and_render f, @procedure.logo
 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -248,6 +248,8 @@ fr:
         << : *default_attributes
       super_admin:
         << : *default_attributes
+      procedure:
+        zone: Organisme qui met en œuvre la démarche
     errors:
       messages:
         not_a_phone: 'Numéro de téléphone invalide'

--- a/config/zones.yml
+++ b/config/zones.yml
@@ -1,0 +1,37 @@
+ministeres:
+  - MAA:
+    label: "Ministère de l'Agriculture et de l'Alimentation"
+  - MC:
+    label: "Ministère de la Culture"
+  - MAS:
+    label: "Ministère des Solidarités et de la Santé"
+  - MTEI:
+    label: "Ministère du Travail"
+  - MEAE:
+    label: "Ministère de l'Europe et des Affaires étrangères"
+  - MEF:
+    label: "Ministère de l'Économie, des Finances et de la Relance"
+  - MJS:
+    label: "Ministère de la Jeunesse et des Sports"
+  - EN:
+    label: "Ministère de l'Éducation nationale, de la Jeunesse et des Sports"
+  - ESR:
+    label: "Ministère de l'Enseignement supérieur, de la Recherche et de l'Innovation"
+  - MI:
+    label: "Ministère de l'Intérieur"
+  - MInArm:
+    label: "Ministère des Armées"
+  - MJ:
+    label: "Ministère de la Justice"
+  - MTES:
+    label: "Ministère de la Transition écologique"
+  - MCTRCT:
+    label: "Ministère de la Cohésion des territoires et des Relations avec les collectivités territoriales"
+  - SPM:
+    label: "Premier ministre"
+  - MER:
+    label: "Ministère de la Mer"
+  - MTFP:
+    label: "Ministère de la Transformation et de la Fonction publiques"
+  - OM:
+    label: "Ministère des Outre-mer"

--- a/db/migrate/20211127133549_create_zones.rb
+++ b/db/migrate/20211127133549_create_zones.rb
@@ -1,0 +1,10 @@
+class CreateZones < ActiveRecord::Migration[6.1]
+  def change
+    create_table :zones do |t|
+      t.string :acronym
+      t.string :label
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211127133549_create_zones.rb
+++ b/db/migrate/20211127133549_create_zones.rb
@@ -1,7 +1,7 @@
 class CreateZones < ActiveRecord::Migration[6.1]
   def change
     create_table :zones do |t|
-      t.string :acronym
+      t.string :acronym, null: false, index: { unique: true }
       t.string :label
 
       t.timestamps

--- a/db/migrate/20211127143736_add_zone_to_procedures.rb
+++ b/db/migrate/20211127143736_add_zone_to_procedures.rb
@@ -1,0 +1,5 @@
+class AddZoneToProcedures < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :procedures, :zone, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -554,6 +554,14 @@ ActiveRecord::Schema.define(version: 2021_11_27_143736) do
     t.index ["user_id"], name: "index_merge_logs_on_user_id"
   end
 
+  create_table "zones", force: :cascade do |t|
+    t.string "acronym", null: false
+    t.string "label"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["acronym"], name: "index_zones_on_acronym", unique: true
+  end
+
   create_table "module_api_cartos", id: :serial, force: :cascade do |t|
     t.integer "procedure_id"
     t.boolean "use_api_carto", default: false
@@ -823,13 +831,6 @@ ActiveRecord::Schema.define(version: 2021_11_27_143736) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["procedure_id"], name: "index_without_continuation_mails_on_procedure_id"
-  end
-
-  create_table "zones", force: :cascade do |t|
-    t.string "acronym"
-    t.string "label"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
   end
 
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_26_150915) do
+ActiveRecord::Schema.define(version: 2021_11_27_133549) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -821,6 +821,13 @@ ActiveRecord::Schema.define(version: 2021_11_26_150915) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["procedure_id"], name: "index_without_continuation_mails_on_procedure_id"
+  end
+
+  create_table "zones", force: :cascade do |t|
+    t.string "acronym"
+    t.string "label"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_27_133549) do
+ActiveRecord::Schema.define(version: 2021_11_27_143736) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -638,6 +638,7 @@ ActiveRecord::Schema.define(version: 2021_11_27_133549) do
     t.text "api_particulier_scopes", default: [], array: true
     t.jsonb "api_particulier_sources", default: {}
     t.boolean "instructeurs_self_management_enabled"
+    t.bigint "zone_id"
     t.index ["api_particulier_sources"], name: "index_procedures_on_api_particulier_sources", using: :gin
     t.boolean "routing_enabled"
     t.index ["declarative_with_state"], name: "index_procedures_on_declarative_with_state"
@@ -648,6 +649,7 @@ ActiveRecord::Schema.define(version: 2021_11_27_133549) do
     t.index ["path", "closed_at", "hidden_at"], name: "index_procedures_on_path_and_closed_at_and_hidden_at", unique: true
     t.index ["published_revision_id"], name: "index_procedures_on_published_revision_id"
     t.index ["service_id"], name: "index_procedures_on_service_id"
+    t.index ["zone_id"], name: "index_procedures_on_zone_id"
   end
 
   create_table "received_mails", id: :serial, force: :cascade do |t|
@@ -865,6 +867,7 @@ ActiveRecord::Schema.define(version: 2021_11_27_133549) do
   add_foreign_key "procedures", "procedure_revisions", column: "draft_revision_id"
   add_foreign_key "procedures", "procedure_revisions", column: "published_revision_id"
   add_foreign_key "procedures", "services"
+  add_foreign_key "procedures", "zones"
   add_foreign_key "received_mails", "procedures"
   add_foreign_key "refused_mails", "procedures"
   add_foreign_key "services", "administrateurs"

--- a/lib/tasks/deployment/20211116140232_populate_zones.rake
+++ b/lib/tasks/deployment/20211116140232_populate_zones.rake
@@ -1,0 +1,17 @@
+namespace :after_party do
+  desc 'Deployment task: populate_zones'
+  task populate_zones: :environment do
+    puts "Running deploy task 'populate_zones'"
+
+    Zone.create!(acronym: 'COLLECTIVITE', label: 'Collectivité territoriale')
+    config = Psych.safe_load(File.read(Rails.root.join("config", "zones.yml")))
+    config["ministeres"].each do |ministere|
+      acronym = ministere.keys.first
+      Zone.create!(acronym: acronym, label: ministere["label"])
+    end
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -7,6 +7,7 @@ describe Administrateurs::ProceduresController, type: :controller do
   let(:description) { 'Description de test' }
   let(:organisation) { 'Organisation de test' }
   let(:direction) { 'Direction de test' }
+  let(:ministere) { create(:zone) }
   let(:cadre_juridique) { 'cadre juridique' }
   let(:duree_conservation_dossiers_dans_ds) { 3 }
   let(:monavis_embed) { nil }
@@ -30,6 +31,7 @@ describe Administrateurs::ProceduresController, type: :controller do
       description: description,
       organisation: organisation,
       direction: direction,
+      ministere: ministere,
       cadre_juridique: cadre_juridique,
       duree_conservation_dossiers_dans_ds: duree_conservation_dossiers_dans_ds,
       monavis_embed: monavis_embed,

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
     ask_birthday { false }
     lien_site_web { "https://mon-site.gouv" }
     path { SecureRandom.uuid }
+    association :zone
 
     groupe_instructeurs { [association(:groupe_instructeur, :default, procedure: instance, strategy: :build)] }
     administrateurs { administrateur.present? ? [administrateur] : [association(:administrateur)] }

--- a/spec/factories/zone.rb
+++ b/spec/factories/zone.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :zone do
+    sequence(:acronym) { |n| "MA#{n}" }
+    sequence(:label) { |n| "Ministère de l'Education Populaire #{n}" }
+  end
+end

--- a/spec/lib/tasks/deployment/20211116140232_populate_zones_spec.rb
+++ b/spec/lib/tasks/deployment/20211116140232_populate_zones_spec.rb
@@ -1,0 +1,11 @@
+describe '20211116140232_populate_zones' do
+  let(:rake_task) { Rake::Task['after_party:populate_zones'] }
+  subject(:run_task) do
+    rake_task.invoke
+  end
+
+  it 'populates zones' do
+    run_task
+    expect(Zone.find_by(acronym: 'SPM').label).to eq "Premier ministre"
+  end
+end


### PR DESCRIPTION
v0 de #6194 

Cette PR n'est pas en l'état livrable

# Ce que fait cette PR
Elle permet à un administrateur d'indiquer quel ministère met en oeuvre sa démarche.

![edit-ministere](https://user-images.githubusercontent.com/1111966/143083084-d68677ad-1145-40ab-84ae-827a271076ac.png)

# Ce qu'il reste à faire
Il reste pour que cette PR soit livrable à traiter le cas où c'est une collectivité territoriale et non un ministère qui met en oeuvre sa démarche.

Mon plan est de proposer un bouton radio permettant à l'administrateur que la démarche est mise en oeuvre par une collectivité ou par un ministère. Et si c'est un ministère, la select box apparait.

Mais vous voyez peut-être un moyen plus simple ?

