### PR TITLE
Add parent to procedure revision type de champ

### DIFF
--- a/app/models/procedure_revision_type_de_champ.rb
+++ b/app/models/procedure_revision_type_de_champ.rb
@@ -6,6 +6,7 @@
 #  position         :integer          not null
 #  created_at       :datetime         not null
 #  updated_at       :datetime         not null
+#  parent_id        :bigint
 #  revision_id      :bigint           not null
 #  type_de_champ_id :bigint           not null
 #
@@ -13,6 +14,8 @@ class ProcedureRevisionTypeDeChamp < ApplicationRecord
   belongs_to :revision, class_name: 'ProcedureRevision'
   belongs_to :type_de_champ
 
+  belongs_to :parent, class_name: 'ProcedureRevisionTypeDeChamp', optional: true
+  has_many :revision_types_de_champ, -> { ordered }, foreign_key: :parent_id, class_name: 'ProcedureRevisionTypeDeChamp', inverse_of: :parent, dependent: :destroy
   scope :ordered, -> { order(:position) }
   scope :public_only, -> { joins(:type_de_champ).where(types_de_champ: { private: false }) }
   scope :private_only, -> { joins(:type_de_champ).where(types_de_champ: { private: true }) }

--- a/app/models/procedure_revision_type_de_champ.rb
+++ b/app/models/procedure_revision_type_de_champ.rb
@@ -16,7 +16,9 @@ class ProcedureRevisionTypeDeChamp < ApplicationRecord
 
   belongs_to :parent, class_name: 'ProcedureRevisionTypeDeChamp', optional: true
   has_many :revision_types_de_champ, -> { ordered }, foreign_key: :parent_id, class_name: 'ProcedureRevisionTypeDeChamp', inverse_of: :parent, dependent: :destroy
+  scope :root, -> { where(parent: nil) }
   scope :ordered, -> { order(:position) }
+  scope :revision_ordered, -> { order(:revision_id) }
   scope :public_only, -> { joins(:type_de_champ).where(types_de_champ: { private: false }) }
   scope :private_only, -> { joins(:type_de_champ).where(types_de_champ: { private: true }) }
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -2,19 +2,20 @@
 #
 # Table name: types_de_champ
 #
-#  id          :integer          not null, primary key
-#  description :text
-#  libelle     :string
-#  mandatory   :boolean          default(FALSE)
-#  options     :jsonb
-#  order_place :integer
-#  private     :boolean          default(FALSE), not null
-#  type_champ  :string
-#  created_at  :datetime
-#  updated_at  :datetime
-#  parent_id   :bigint
-#  revision_id :bigint
-#  stable_id   :bigint
+#  id              :integer          not null, primary key
+#  description     :text
+#  libelle         :string
+#  mandatory       :boolean          default(FALSE)
+#  migrated_parent :boolean
+#  options         :jsonb
+#  order_place     :integer
+#  private         :boolean          default(FALSE), not null
+#  type_champ      :string
+#  created_at      :datetime
+#  updated_at      :datetime
+#  parent_id       :bigint
+#  revision_id     :bigint
+#  stable_id       :bigint
 #
 class TypeDeChamp < ApplicationRecord
   enum type_champs: {
@@ -59,8 +60,9 @@ class TypeDeChamp < ApplicationRecord
   has_many :types_de_champ, -> { ordered }, foreign_key: :parent_id, class_name: 'TypeDeChamp', inverse_of: :parent, dependent: :destroy
 
   store_accessor :options, :cadastres, :old_pj, :drop_down_options, :skip_pj_validation, :skip_content_type_pj_validation, :drop_down_secondary_libelle, :drop_down_secondary_description, :drop_down_other
-  has_many :revision_types_de_champ, class_name: 'ProcedureRevisionTypeDeChamp', dependent: :destroy, inverse_of: :type_de_champ
-  has_many :revisions, through: :revision_types_de_champ
+  has_many :revision_types_de_champ, -> { revision_ordered }, class_name: 'ProcedureRevisionTypeDeChamp', dependent: :destroy, inverse_of: :type_de_champ
+  has_one :revision_type_de_champ, -> { revision_ordered }, class_name: 'ProcedureRevisionTypeDeChamp', inverse_of: false
+  has_many :revisions, -> { ordered }, through: :revision_types_de_champ
 
   delegate :tags_for_template, :libelle_for_export, to: :dynamic_type
 
@@ -371,6 +373,17 @@ class TypeDeChamp < ApplicationRecord
     else
       super
     end
+  end
+
+  def migrate_parent!
+    if parent_id.present? && migrated_parent.nil?
+      ProcedureRevisionTypeDeChamp.create(parent: parent.revision_type_de_champ,
+        type_de_champ: self,
+        revision_id: parent.revision_type_de_champ.revision_id,
+        position: order_place)
+      update_column(:migrated_parent, true)
+    end
+    self
   end
 
   private

--- a/db/migrate/20210630101808_add_parent_id_to_procedure_revision_type_de_champ.rb
+++ b/db/migrate/20210630101808_add_parent_id_to_procedure_revision_type_de_champ.rb
@@ -1,0 +1,5 @@
+class AddParentIdToProcedureRevisionTypeDeChamp < ActiveRecord::Migration[6.1]
+  def change
+    add_belongs_to :procedure_revision_types_de_champ, :parent, index: true, foreign_key: { to_table: :procedure_revision_types_de_champ }
+  end
+end

--- a/db/migrate/20211124134220_add_migrated_parent_to_types_de_champ.rb
+++ b/db/migrate/20211124134220_add_migrated_parent_to_types_de_champ.rb
@@ -1,0 +1,5 @@
+class AddMigratedParentToTypesDeChamp < ActiveRecord::Migration[6.1]
+  def change
+    add_column :types_de_champ, :migrated_parent, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_01_135804) do
+ActiveRecord::Schema.define(version: 2021_12_02_135804) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -581,6 +581,8 @@ ActiveRecord::Schema.define(version: 2021_12_01_135804) do
     t.integer "position", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "parent_id"
+    t.index ["parent_id"], name: "index_procedure_revision_types_de_champ_on_parent_id"
     t.index ["revision_id"], name: "index_procedure_revision_types_de_champ_on_revision_id"
     t.index ["type_de_champ_id"], name: "index_procedure_revision_types_de_champ_on_type_de_champ_id"
   end
@@ -865,6 +867,7 @@ ActiveRecord::Schema.define(version: 2021_12_01_135804) do
   add_foreign_key "initiated_mails", "procedures"
   add_foreign_key "merge_logs", "users"
   add_foreign_key "procedure_presentations", "assign_tos"
+  add_foreign_key "procedure_revision_types_de_champ", "procedure_revision_types_de_champ", column: "parent_id"
   add_foreign_key "procedure_revision_types_de_champ", "procedure_revisions", column: "revision_id"
   add_foreign_key "procedure_revision_types_de_champ", "types_de_champ"
   add_foreign_key "procedure_revisions", "procedures"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -768,6 +768,7 @@ ActiveRecord::Schema.define(version: 2021_12_02_135804) do
     t.bigint "stable_id"
     t.bigint "parent_id"
     t.bigint "revision_id"
+    t.boolean "migrated_parent"
     t.index ["parent_id"], name: "index_types_de_champ_on_parent_id"
     t.index ["private"], name: "index_types_de_champ_on_private"
     t.index ["revision_id"], name: "index_types_de_champ_on_revision_id"

--- a/lib/tasks/deployment/20210630101910_migrate_type_de_champ_parent.rake
+++ b/lib/tasks/deployment/20210630101910_migrate_type_de_champ_parent.rake
@@ -1,0 +1,23 @@
+namespace :after_party do
+  desc 'Deployment task: migrate_type_de_champ_parent'
+  task migrate_type_de_champ_parent: :environment do
+    puts "Running deploy task 'migrate_type_de_champ_parent'"
+
+    types_de_champ = TypeDeChamp
+      .where.not(parent_id: nil)
+      .where(migrated_parent: nil)
+      .includes(:revisions, parent: :revision_type_de_champ)
+
+    progress = ProgressReport.new(types_de_champ.count)
+    types_de_champ.find_each do |type_de_champ|
+      type_de_champ.migrate_parent!
+      progress.inc
+    end
+    progress.finish
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -437,7 +437,7 @@ describe Procedure do
       end
 
       TypeDeChamp.where(parent: procedure.draft_types_de_champ.repetition).zip(TypeDeChamp.where(parent: subject.draft_types_de_champ.repetition)).each do |ptc, stc|
-        expect(stc).to have_same_attributes_as(ptc, except: ["revision_id", "parent_id"])
+        expect(stc).to have_same_attributes_as(ptc, except: ["revision_id", "parent_id", "migrated_parent"])
         expect(stc.revision).to eq(subject.draft_revision)
       end
 
@@ -447,7 +447,7 @@ describe Procedure do
       end
 
       TypeDeChamp.where(parent: procedure.draft_types_de_champ_private.repetition).zip(TypeDeChamp.where(parent: subject.draft_types_de_champ_private.repetition)).each do |ptc, stc|
-        expect(stc).to have_same_attributes_as(ptc, except: ["revision_id", "parent_id"])
+        expect(stc).to have_same_attributes_as(ptc, except: ["revision_id", "parent_id", "migrated_parent"])
         expect(stc.revision).to eq(subject.draft_revision)
       end
 


### PR DESCRIPTION
Cette PR ajoute les `ProcedureRevisionTypeDeChamp` sur les champs contenus dans les revisions. Cette PR contient juste la migration et le code minimal pour faire du double read/write. Le but est de faire porter l'information de la parenté sur la table de jointure plutôt que sur le type de champ lui-même. Ça nous permettra de clarifier le code des revisions en général, mais surtout de reviser proprement les “champ répétition” sans cloner systématiquement toute l'arborescence.