### PR TITLE
Fix add depose_at to dossiers

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -10,6 +10,7 @@
 #  conservation_extension                             :interval         default(0 seconds)
 #  declarative_triggered_at                           :datetime
 #  deleted_user_email_never_send                      :string
+#  depose_at                                          :datetime
 #  en_construction_at                                 :datetime
 #  en_construction_close_to_expiration_notice_sent_at :datetime
 #  en_instruction_at                                  :datetime
@@ -776,7 +777,7 @@ class Dossier < ApplicationRecord
 
   def after_passer_en_construction
     self.conservation_extension = 0.days
-    self.en_construction_at = self.traitements
+    self.depose_at = self.en_construction_at = self.traitements
       .passer_en_construction
       .processed_at
     save!
@@ -1095,6 +1096,7 @@ class Dossier < ApplicationRecord
   def create_missing_traitemets
     if en_construction_at.present? && traitements.en_construction.empty?
       self.traitements.passer_en_construction(processed_at: en_construction_at)
+      self.depose_at ||= en_construction_at
     end
     if en_instruction_at.present? && traitements.en_instruction.empty?
       self.traitements.passer_en_instruction(processed_at: en_instruction_at)

--- a/db/migrate/20211124111429_add_depose_at_to_dossiers.rb
+++ b/db/migrate/20211124111429_add_depose_at_to_dossiers.rb
@@ -1,0 +1,5 @@
+class AddDeposeAtToDossiers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :dossiers, :depose_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_19_112046) do
+ActiveRecord::Schema.define(version: 2021_11_24_111429) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -323,6 +323,7 @@ ActiveRecord::Schema.define(version: 2021_11_19_112046) do
     t.index "to_tsvector('french'::regconfig, search_terms)", name: "index_dossiers_on_search_terms", using: :gin
     t.bigint "dossier_transfer_id"
     t.datetime "identity_updated_at"
+    t.datetime "depose_at"
     t.index ["archived"], name: "index_dossiers_on_archived"
     t.index ["dossier_transfer_id"], name: "index_dossiers_on_dossier_transfer_id"
     t.index ["groupe_instructeur_id"], name: "index_dossiers_on_groupe_instructeur_id"

--- a/lib/tasks/deployment/20211124112843_add_depose_at_to_dossiers.rake
+++ b/lib/tasks/deployment/20211124112843_add_depose_at_to_dossiers.rake
@@ -1,0 +1,22 @@
+namespace :after_party do
+  desc 'Deployment task: add_depose_at_to_dossiers'
+  task add_depose_at_to_dossiers: :environment do
+    puts "Running deploy task 'add_depose_at_to_dossiers'"
+
+    dossiers = Dossier.includes(:traitements).where(depose_at: nil).where.not(en_construction_at: nil)
+    progress = ProgressReport.new(dossiers.count)
+
+    dossiers.find_each do |dossier|
+      traitement = dossier.traitements.find { |traitement| traitement.state == :en_construction }
+      depose_at = traitement&.processed_at || dossier.en_construction_at
+      dossier.update_column(:depose_at, depose_at)
+      progress.inc
+    end
+    progress.finish
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -456,6 +456,7 @@ describe Dossier do
 
       it { expect(dossier.state).to eq(Dossier.states.fetch(:en_construction)) }
       it { expect(dossier.en_construction_at).to eq(beginning_of_day) }
+      it { expect(dossier.depose_at).to eq(beginning_of_day) }
       it { expect(dossier.traitement.state).to eq(Dossier.states.fetch(:en_construction)) }
       it { expect(dossier.traitement.processed_at).to eq(beginning_of_day) }
 
@@ -467,6 +468,7 @@ describe Dossier do
         expect(dossier.traitements.size).to eq(3)
         expect(dossier.traitements.first.processed_at).to eq(beginning_of_day)
         expect(dossier.traitement.processed_at.round).to eq(dossier.en_construction_at.round)
+        expect(dossier.depose_at).to eq(beginning_of_day)
         expect(dossier.en_construction_at).to be > beginning_of_day
       end
     end
@@ -490,8 +492,9 @@ describe Dossier do
         dossier.repasser_en_construction!(instructeur)
         dossier.passer_en_instruction!(instructeur)
 
-        expect(dossier.traitements.size).to eq(3)
-        expect(dossier.traitements.first.processed_at).to eq(beginning_of_day)
+        expect(dossier.traitements.size).to eq(4)
+        expect(dossier.traitements.en_construction.first.processed_at).to eq(dossier.depose_at)
+        expect(dossier.traitements.en_instruction.first.processed_at).to eq(beginning_of_day)
         expect(dossier.traitement.processed_at.round).to eq(dossier.en_instruction_at.round)
         expect(dossier.en_instruction_at).to be > beginning_of_day
       end


### PR DESCRIPTION
Depuis que j’ai ajouté l’historique des traitements à tout les états, nous avons un problème sur l’affichage de la data de dépôt. On affiche maintenant la dernière date de passage en_construction à la place de la première. Je propose d’ajouter un nouveau timestamp sur dossier ‘depose_at’ plutôt que de faire des joins avec les traitements. Je souhaite garder `en_construction_at` car on s’en sert dans des scopes.