### PR TITLE
Remplissage de la colonne `bypass_email_login_token` (2/3)

### DIFF
--- a/app/controllers/manager/instructeurs_controller.rb
+++ b/app/controllers/manager/instructeurs_controller.rb
@@ -1,5 +1,23 @@
 module Manager
   class InstructeursController < Manager::ApplicationController
+    # Temporary code: synchronize Flipper's instructeur_bypass_email_login_token
+    # when Instructeur.bypass_email_login_token is modified.
+    #
+    # This will be removed when the migration of this feature flag out of Flipper will be complete.
+    def update
+      super
+
+      instructeur = requested_resource
+      saved_successfully = !requested_resource.changed?
+      if saved_successfully
+        if instructeur.bypass_email_login_token
+          Flipper.enable_actor(:instructeur_bypass_email_login_token, instructeur.user)
+        else
+          Flipper.disable_actor(:instructeur_bypass_email_login_token, instructeur.user)
+        end
+      end
+    end
+
     def reinvite
       instructeur = Instructeur.find(params[:id])
       instructeur.user.invite!

--- a/app/dashboards/instructeur_dashboard.rb
+++ b/app/dashboards/instructeur_dashboard.rb
@@ -14,7 +14,7 @@ class InstructeurDashboard < Administrate::BaseDashboard
     updated_at: Field::DateTime,
     dossiers: Field::HasMany,
     procedures: Field::HasMany,
-    features: FeaturesField
+    bypass_email_login_token: Field::Boolean
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -35,13 +35,15 @@ class InstructeurDashboard < Administrate::BaseDashboard
     :id,
     :user,
     :created_at,
-    :features
+    :bypass_email_login_token
   ].freeze
 
   # FORM_ATTRIBUTES
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
-  FORM_ATTRIBUTES = [].freeze
+  FORM_ATTRIBUTES = [
+    :bypass_email_login_token
+  ].freeze
 
   # Overwrite this method to customize how users are displayed
   # across all pages of the admin dashboard.

--- a/app/views/manager/instructeurs/show.html.erb
+++ b/app/views/manager/instructeurs/show.html.erb
@@ -26,7 +26,7 @@ as well as a link to its edit page.
 
   <div>
     <%= link_to(
-      t("administrate.actions.edit_resource", name: page.page_title),
+      'Modifier',
       [:edit, namespace, page.resource],
       class: "button",
     ) if valid_action?(:edit) && show_action?(:edit, page.resource) %>

--- a/config/locales/models/instructeur/fr.yml
+++ b/config/locales/models/instructeur/fr.yml
@@ -4,3 +4,10 @@ fr:
       instructeur:
         one: Instructeur
         other: Instructeurs
+    attributes:
+      instructeur:
+        bypass_email_login_token: Autoriser la connexion sans confirmer l’email
+  helpers:
+    label:
+      instructeur:
+        bypass_email_login_token: Autoriser la connexion sans confirmer l’email

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,7 @@ Rails.application.routes.draw do
       put 'unblock_email'
     end
 
-    resources :instructeurs, only: [:index, :show] do
+    resources :instructeurs, only: [:index, :show, :edit, :update] do
       post 'reinvite', on: :member
       delete 'delete', on: :member
     end

--- a/lib/tasks/deployment/20211259131949_populate_bypass_email_login_again.rake
+++ b/lib/tasks/deployment/20211259131949_populate_bypass_email_login_again.rake
@@ -1,0 +1,18 @@
+namespace :after_party do
+  desc 'Deployment task: populate_bypass_email_login'
+  task populate_bypass_email_login: :environment do
+    user_ids = Flipper::Adapters::ActiveRecord::Gate
+      .where(feature_key: 'instructeur_bypass_email_login_token')
+      .pluck(:value)
+      .filter { |s| s.start_with?('User:') }
+      .map { |s| s.gsub('User:', '') }
+      .map(&:to_i)
+
+    Instructeur
+      .where(user: { id: user_ids })
+      .update_all(bypass_email_login_token: true)
+
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
_Fait partie de #6679_

## Vue d'ensemble

- Partie 1 : ajouter la colonne sur Instructeur en base (#6082)
- **Partie 2 : écrire les données à la fois dans Flipper et dans la nouvelle colonne en base** (cette PR)
- Partie 3 : supprimer le flag Flipper, et ne plus lire que la colonne (#6681)

## Description

Cette PR :
- fait en sorte que la colonne `Instructeur.bypass_email_login_token` soit remplie quand on active la feature dans le Manager,
- active le flag pour les Instructeurs existants qui ont déjà la feature dans Flipper.

## Notes

Le processus pour activer la feature change légèrement.

### ~~Avant~~

On cochait la case directement.

<img width="799" alt="avant" src="https://user-images.githubusercontent.com/179923/143457850-6bdf12a9-8ecc-4f46-ae77-18811649ba10.png">

### Après

Il faut cliquer sur "Modifier", puis cocher la case.

<img width="794" alt="après 1" src="https://user-images.githubusercontent.com/179923/143457097-5457510c-f9ae-4017-a27b-6d4cbfbe4fd0.png">

<img width="797" alt="après 2" src="https://user-images.githubusercontent.com/179923/143457128-cb69f7f3-90c8-4fe4-b5c1-f2c0eee5a008.png">

