### PR TITLE
Remplacement de la feature Flipper `instructeur_bypass_email_login_token` (3/3)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -224,7 +224,7 @@ class ApplicationController < ActionController::Base
   def redirect_if_untrusted
     if instructeur_signed_in? &&
         sensitive_path &&
-        !feature_enabled?(:instructeur_bypass_email_login_token) &&
+        !current_instructeur.bypass_email_login_token &&
         !IPService.ip_trusted?(request.headers['X-Forwarded-For']) &&
         !trusted_device?
 

--- a/app/controllers/manager/instructeurs_controller.rb
+++ b/app/controllers/manager/instructeurs_controller.rb
@@ -1,23 +1,5 @@
 module Manager
   class InstructeursController < Manager::ApplicationController
-    # Temporary code: synchronize Flipper's instructeur_bypass_email_login_token
-    # when Instructeur.bypass_email_login_token is modified.
-    #
-    # This will be removed when the migration of this feature flag out of Flipper will be complete.
-    def update
-      super
-
-      instructeur = requested_resource
-      saved_successfully = !requested_resource.changed?
-      if saved_successfully
-        if instructeur.bypass_email_login_token
-          Flipper.enable_actor(:instructeur_bypass_email_login_token, instructeur.user)
-        else
-          Flipper.disable_actor(:instructeur_bypass_email_login_token, instructeur.user)
-        end
-      end
-    end
-
     def reinvite
       instructeur = Instructeur.find(params[:id])
       instructeur.user.invite!

--- a/config/application.rb
+++ b/config/application.rb
@@ -63,8 +63,8 @@ module TPS
     end
 
     config.middleware.use Rack::Attack
-    config.middleware.use Flipper::Middleware::Memoizer,
-      preload: [:instructeur_bypass_email_login_token]
+    # Ensure we make maximum one call per feature per request.
+    config.middleware.use Flipper::Middleware::Memoizer
 
     config.ds_env = ENV.fetch('DS_ENV', Rails.env)
 

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -30,7 +30,6 @@ features = [
   :dossier_pdf_vide,
   :expert_not_allowed_to_invite,
   :hide_instructeur_email,
-  :instructeur_bypass_email_login_token,
   :procedure_revisions,
   :procedure_routage_api,
   :procedure_process_expired_dossiers_termine

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -165,7 +165,7 @@ describe ApplicationController, type: :controller do
       let(:sensitive_path) { true }
 
       before do
-        Flipper.disable(:instructeur_bypass_email_login_token)
+        current_instructeur.update!(bypass_email_login_token: false)
       end
 
       context 'when the instructeur is signed_in' do

--- a/spec/factories/instructeur.rb
+++ b/spec/factories/instructeur.rb
@@ -2,6 +2,8 @@ FactoryBot.define do
   sequence(:instructeur_email) { |n| "inst#{n}@inst.com" }
 
   factory :instructeur do
+    bypass_email_login_token { true }
+
     user { association :user, email: email, password: password }
 
     transient do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -89,10 +89,6 @@ RSpec.configure do |config|
     Geocoder.configure(lookup: :test)
   end
 
-  config.before(:each) do
-    Flipper.enable(:instructeur_bypass_email_login_token)
-  end
-
   # By default, forgery protection is disabled in the test environment.
   # (See `config.action_controller.allow_forgery_protection` in `config/test.rb`)
   #

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -17,7 +17,7 @@ module SystemHelpers
     fill_in :user_password, with: password
 
     if sign_in_by_link
-      Flipper.disable(:instructeur_bypass_email_login_token)
+      User.find_by(email: email)&.instructeur&.update!(bypass_email_login_token: false)
     end
 
     perform_enqueued_jobs do


### PR DESCRIPTION
Fix #6679

## Vue d'ensemble

- ~~Partie 1 : ajouter la colonne sur Instructeur en base (#6082)~~
- ~~Partie 2 : écrire les données à la fois dans Flipper et dans la nouvelle colonne en base (#6680)~~
- **Partie 3 : supprimer le flag Flipper, et ne plus lire que la colonne (cette PR)**

## Description

Cette PR :
- utilise la colonne `Instructeur.bypass_email_login_token` dans le code et les tests,
- supprime la feature Flipper.

## À faire

- [x] Attendre que #6680 soit mergée et déployée en production