### PR TITLE
Administrateur : empêche la publication d'une démarche comportant un champ "Choix" sans valeur sélectionnable

### DIFF
--- a/app/javascript/components/TypesDeChampEditor/typeDeChampsReducer.js
+++ b/app/javascript/components/TypesDeChampEditor/typeDeChampsReducer.js
@@ -110,7 +110,7 @@ function updateTypeDeChamp(
         break;
       case 'drop_down_list':
       case 'multiple_drop_down_list':
-        typeDeChamp.drop_down_list_value = '--Premier élément du menu--\n';
+        typeDeChamp.drop_down_list_value = 'Premier choix\nDeuxième choix';
     }
   }
 

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -234,7 +234,7 @@ class Procedure < ApplicationRecord
   validates :description, presence: true, allow_blank: false, allow_nil: false
   validates :administrateurs, presence: true
   validates :lien_site_web, presence: true, if: :publiee?
-  validates :draft_revision, 'revisions/no_empty_repetitions': true, if: :validate_for_publication?
+  validates :draft_revision, 'revisions/no_empty_repetition': true, if: :validate_for_publication?
   validate :check_juridique
   validates :path, presence: true, format: { with: /\A[a-z0-9_\-]{3,200}\z/ }, uniqueness: { scope: [:path, :closed_at, :hidden_at, :unpublished_at], case_sensitive: false }
   validates :duree_conservation_dossiers_dans_ds, allow_nil: false, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: MAX_DUREE_CONSERVATION }

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -234,7 +234,10 @@ class Procedure < ApplicationRecord
   validates :description, presence: true, allow_blank: false, allow_nil: false
   validates :administrateurs, presence: true
   validates :lien_site_web, presence: true, if: :publiee?
-  validates :draft_revision, 'revisions/no_empty_repetition': true, if: :validate_for_publication?
+  validates :draft_revision,
+    'revisions/no_empty_repetition': true,
+    'revisions/no_empty_drop_down': true,
+    if: :validate_for_publication?
   validate :check_juridique
   validates :path, presence: true, format: { with: /\A[a-z0-9_\-]{3,200}\z/ }, uniqueness: { scope: [:path, :closed_at, :hidden_at, :unpublished_at], case_sensitive: false }
   validates :duree_conservation_dossiers_dans_ds, allow_nil: false, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: MAX_DUREE_CONSERVATION }

--- a/app/validators/revisions/no_empty_drop_down_validator.rb
+++ b/app/validators/revisions/no_empty_drop_down_validator.rb
@@ -1,0 +1,22 @@
+class Revisions::NoEmptyDropDownValidator < ActiveModel::EachValidator
+  def validate_each(procedure, attribute, revision)
+    return if revision.nil?
+
+    tdcs = revision.types_de_champ + revision.types_de_champ_private
+    drop_downs = tdcs.filter(&:drop_down_list?)
+    drop_downs.each do |drop_down|
+      validate_drop_down_not_empty(procedure, attribute, drop_down)
+    end
+  end
+
+  private
+
+  def validate_drop_down_not_empty(procedure, attribute, drop_down)
+    if drop_down.drop_down_list_enabled_non_empty_options.empty?
+      procedure.errors.add(
+        attribute,
+        procedure.errors.generate_message(attribute, :empty_drop_down, { value: drop_down.libelle })
+      )
+    end
+  end
+end

--- a/app/validators/revisions/no_empty_repetition_validator.rb
+++ b/app/validators/revisions/no_empty_repetition_validator.rb
@@ -1,4 +1,4 @@
-class Revisions::NoEmptyRepetitionsValidator < ActiveModel::EachValidator
+class Revisions::NoEmptyRepetitionValidator < ActiveModel::EachValidator
   def validate_each(procedure, attribute, revision)
     return if revision.nil?
 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -311,6 +311,7 @@ fr:
         forbidden_html: "Seul-e-s les usagers peuvent se connecter via France Connect. En tant qu’instructeur ou administrateur, nous vous invitons à <a href='%{reset_link}'>réininitialiser votre mot de passe</a>."
       procedure_archived: "Cette démarche en ligne a été close, il n’est plus possible de déposer de dossier."
       empty_repetition: 'Le bloc répétable « %{value} » doit comporter au moins un champ'
+      empty_drop_down: 'La liste de choix « %{value} » doit comporter au moins un choix sélectionnable'
       # procedure_not_draft: "Cette démarche n’est maintenant plus en brouillon."
       cadastres_empty:
         one: "Aucune parcelle cadastrale sur la zone sélectionnée"

--- a/spec/factories/type_de_champ.rb
+++ b/spec/factories/type_de_champ.rb
@@ -89,6 +89,9 @@ FactoryBot.define do
       trait :long do
         drop_down_list_value { "alpha\r\nbravo\r\n--separateur--\r\ncharly\r\ndelta\r\necho\r\nfox-trot\r\ngolf" }
       end
+      trait :without_selectable_values do
+        drop_down_list_value { "\r\n--separateur--\r\n--separateur 2--\r\n \r\n" }
+      end
     end
     factory :type_de_champ_multiple_drop_down_list do
       type_champ { TypeDeChamp.type_champs.fetch(:multiple_drop_down_list) }


### PR DESCRIPTION
Empêche de publier une révision qui contient un choix d'options obligatoire avec que des titres, et pas d'option sélectionnable.

(Dans ce cas les titres ne seraient pas affichés, et seule l'option "Non renseignée" serait visible, ce qui est absurde.)

Fix #6662