### PR TITLE
fix(dossier): use depose_at instead of en_construction_at

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -57,8 +57,8 @@ class StatsController < ApplicationController
           "procedures.libelle",
           "users.id",
           "dossiers.state",
-          "dossiers.en_construction_at - dossiers.created_at",
-          "dossiers.en_instruction_at - dossiers.en_construction_at",
+          "dossiers.depose_at - dossiers.created_at",
+          "dossiers.en_instruction_at - dossiers.depose_at",
           "dossiers.processed_at - dossiers.en_instruction_at"
         )
     end
@@ -121,7 +121,7 @@ class StatsController < ApplicationController
         end_date = monthly_report[:end_date].to_time.localtime
         replies_count = monthly_report[:replies_sent]
 
-        dossiers_count = Dossier.where(en_construction_at: start_date..end_date).count
+        dossiers_count = Dossier.where(depose_at: start_date..end_date).count
 
         monthly_contact_percentage = replies_count.fdiv(dossiers_count || 1) * 100
         [I18n.l(start_date, format: '%b %y'), monthly_contact_percentage.round(1)]

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -689,22 +689,27 @@ type Dossier {
   champs(id: ID): [Champ!]!
 
   """
+  Date de dépôt.
+  """
+  dateDepot: ISO8601DateTime!
+
+  """
   Date de la dernière modification.
   """
   dateDerniereModification: ISO8601DateTime!
 
   """
-  Date de dépôt.
+  Date du dernier passage en construction.
   """
   datePassageEnConstruction: ISO8601DateTime!
 
   """
-  Date de passage en instruction.
+  Date du dernier passage en instruction.
   """
   datePassageEnInstruction: ISO8601DateTime
 
   """
-  Date de traitement.
+  Date du dernier traitement.
   """
   dateTraitement: ISO8601DateTime
   demandeur: Demandeur!

--- a/app/graphql/types/dossier_type.rb
+++ b/app/graphql/types/dossier_type.rb
@@ -14,9 +14,10 @@ module Types
 
     field :demarche, Types::DemarcheDescriptorType, null: false, method: :procedure
 
-    field :date_passage_en_construction, GraphQL::Types::ISO8601DateTime, "Date de dépôt.", null: false, method: :en_construction_at
-    field :date_passage_en_instruction, GraphQL::Types::ISO8601DateTime, "Date de passage en instruction.", null: true, method: :en_instruction_at
-    field :date_traitement, GraphQL::Types::ISO8601DateTime, "Date de traitement.", null: true, method: :processed_at
+    field :date_depot, GraphQL::Types::ISO8601DateTime, "Date de dépôt.", null: false, method: :depose_at
+    field :date_passage_en_construction, GraphQL::Types::ISO8601DateTime, "Date du dernier passage en construction.", null: false, method: :en_construction_at
+    field :date_passage_en_instruction, GraphQL::Types::ISO8601DateTime, "Date du dernier passage en instruction.", null: true, method: :en_instruction_at
+    field :date_traitement, GraphQL::Types::ISO8601DateTime, "Date du dernier traitement.", null: true, method: :processed_at
     field :date_derniere_modification, GraphQL::Types::ISO8601DateTime, "Date de la dernière modification.", null: false, method: :updated_at
 
     field :archived, Boolean, null: false

--- a/app/models/concerns/procedure_stats_concern.rb
+++ b/app/models/concerns/procedure_stats_concern.rb
@@ -67,14 +67,14 @@ module ProcedureStatsConcern
   def traitement_times(date_range)
     Traitement.for_traitement_time_stats(self)
       .where(processed_at: date_range)
-      .pluck('dossiers.en_construction_at', :processed_at)
-      .map { |en_construction_at, processed_at| { en_construction_at: en_construction_at, processed_at: processed_at } }
+      .pluck('dossiers.depose_at', :processed_at)
+      .map { |depose_at, processed_at| { depose_at: depose_at, processed_at: processed_at } }
   end
 
   def usual_traitement_time_by_month_in_days
     traitement_times(first_processed_at..last_considered_processed_at)
       .group_by { |t| t[:processed_at].beginning_of_month }
-      .transform_values { |month| month.map { |h| h[:processed_at] - h[:en_construction_at] } }
+      .transform_values { |month| month.map { |h| h[:processed_at] - h[:depose_at] } }
       .transform_values { |traitement_times_for_month| traitement_times_for_month.percentile(USUAL_TRAITEMENT_TIME_PERCENTILE).ceil }
       .transform_values { |seconds| seconds == 0 ? nil : seconds }
       .transform_values { |seconds| convert_seconds_in_days(seconds) }
@@ -85,7 +85,7 @@ module ProcedureStatsConcern
     now = Time.zone.now
     traitement_time =
       traitement_times((now - nb_days.days)..now)
-        .map { |times| times[:processed_at] - times[:en_construction_at] }
+        .map { |times| times[:processed_at] - times[:depose_at] }
         .percentile(USUAL_TRAITEMENT_TIME_PERCENTILE)
         .ceil
 

--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -13,8 +13,8 @@ module TagsSubstitutionConcern
     },
     {
       libelle: 'date de dépôt',
-      description: 'Date du passage en construction du dossier par l’usager',
-      lambda: -> (d) { format_date(d.en_construction_at) },
+      description: 'Date de dépôt du dossier par l’usager',
+      lambda: -> (d) { format_date(d.depose_at) },
       available_for_states: Dossier::SOUMIS
     },
     {

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -208,9 +208,9 @@ class Dossier < ApplicationRecord
   scope :not_hidden_by_user, -> { where(hidden_by_user_at: nil) }
 
   scope :order_by_updated_at, -> (order = :desc) { order(updated_at: order) }
-  scope :order_by_created_at, -> (order = :asc) { order(en_construction_at: order, created_at: order, id: order) }
+  scope :order_by_created_at, -> (order = :asc) { order(depose_at: order, created_at: order, id: order) }
   scope :updated_since,       -> (since) { where('dossiers.updated_at >= ?', since) }
-  scope :created_since,       -> (since) { where('dossiers.en_construction_at >= ?', since) }
+  scope :created_since,       -> (since) { where('dossiers.depose_at >= ?', since) }
 
   scope :with_type_de_champ, -> (stable_id) {
     joins('INNER JOIN champs ON champs.dossier_id = dossiers.id INNER JOIN types_de_champ ON types_de_champ.id = champs.type_de_champ_id')
@@ -249,7 +249,7 @@ class Dossier < ApplicationRecord
         ],
         avis: [:claimant, :expert],
         etablissement: :champ
-      ).order(en_construction_at: 'asc')
+      ).order(depose_at: 'asc')
   }
   scope :en_cours,                    -> { not_archived.state_en_construction_ou_instruction }
   scope :without_followers,           -> { left_outer_joins(:follows).where(follows: { id: nil }) }
@@ -459,11 +459,6 @@ class Dossier < ApplicationRecord
     traitement&.motivation || read_attribute(:motivation)
   end
 
-  def processed_at
-    return nil if !termine?
-    traitement&.processed_at || read_attribute(:processed_at)
-  end
-
   def update_search_terms
     self.search_terms = [
       user&.email,
@@ -636,7 +631,7 @@ class Dossier < ApplicationRecord
     else
       parts = [
         "Dossier déposé le ",
-        en_construction_at.strftime("%d/%m/%Y"),
+        depose_at.strftime("%d/%m/%Y"),
         " sur la démarche ",
         procedure.libelle,
         " gérée par l'organisme ",
@@ -1040,7 +1035,7 @@ class Dossier < ApplicationRecord
       ['Archivé', :archived],
       ['État du dossier', Dossier.human_attribute_name("state.#{state}")],
       ['Dernière mise à jour le', :updated_at],
-      ['Déposé le', :en_construction_at],
+      ['Déposé le', :depose_at],
       ['Passé en instruction le', :en_instruction_at],
       ['Traité le', :processed_at],
       ['Motivation de la décision', :motivation],

--- a/app/models/dossier_operation_log.rb
+++ b/app/models/dossier_operation_log.rb
@@ -111,9 +111,9 @@ class DossierOperationLog < ApplicationRecord
       nil
     elsif operation == operations.fetch(:supprimer)
       {
-        date_de_depot: subject.en_construction_at,
+        date_de_depot: subject.depose_at,
         date_de_mise_en_instruction: subject.en_instruction_at,
-        date_de_decision: subject.termine? ? subject.traitements.last.processed_at : nil
+        date_de_decision: subject.processed_at
       }.as_json
     else
       case subject

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -99,7 +99,7 @@ class Export < ApplicationRecord
   def io(since: nil)
     dossiers = Dossier.where(groupe_instructeur: groupe_instructeurs)
     if since.present?
-      dossiers = dossiers.where('dossiers.en_construction_at > ?', since)
+      dossiers = dossiers.where('dossiers.depose_at > ?', since)
     end
     service = ProcedureExportService.new(procedure, dossiers)
 

--- a/app/models/procedure_overview.rb
+++ b/app/models/procedure_overview.rb
@@ -20,7 +20,7 @@ class ProcedureOverview
     @dossiers_en_construction_count = dossiers.state_en_construction.count
     @old_dossiers_en_construction = dossiers
       .state_en_construction
-      .where('en_construction_at < ?', 1.week.ago)
+      .where('depose_at < ?', 1.week.ago)
 
     @created_dossiers_count = dossiers
       .where(created_at: start_date..Time.zone.now)

--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -38,6 +38,7 @@ class ProcedurePresentation < ApplicationRecord
     fields = [
       field_hash('Créé le', 'self', 'created_at'),
       field_hash('En construction le', 'self', 'en_construction_at'),
+      field_hash('Déposé le', 'self', 'depose_at'),
       field_hash('Mis à jour le', 'self', 'updated_at'),
       field_hash('Demandeur', 'user', 'email'),
       field_hash('Email instructeur', 'followers_instructeurs', 'email'),

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -31,11 +31,11 @@ class Stat < ApplicationRecord
         dossiers_not_brouillon: states['not_brouillon'],
         dossiers_termines: states['termines'],
         dossiers_cumulative: cumulative_hash([
-          [Dossier.state_not_brouillon, :en_construction_at],
+          [Dossier.state_not_brouillon, :depose_at],
           [DeletedDossier.where.not(state: :brouillon), :deleted_at]
         ]),
         dossiers_in_the_last_4_months: last_four_months_hash([
-          [Dossier.state_not_brouillon, :en_construction_at],
+          [Dossier.state_not_brouillon, :depose_at],
           [DeletedDossier.where.not(state: :brouillon), :deleted_at]
         ]),
         administrations_partenaires: AdministrateursProcedure.joins(:procedure).merge(Procedure.publiees_ou_closes).select('distinct administrateur_id').count
@@ -48,8 +48,8 @@ class Stat < ApplicationRecord
       sanitize_and_exec(Dossier, <<-EOF
         SELECT
           COUNT(*) FILTER ( WHERE state != 'brouillon' ) AS "not_brouillon",
-          COUNT(*) FILTER ( WHERE state != 'brouillon' and en_construction_at BETWEEN :one_month_ago AND :now ) AS "dossiers_depose_avant_30_jours",
-          COUNT(*) FILTER ( WHERE state != 'brouillon' and en_construction_at BETWEEN :two_months_ago AND :one_month_ago ) AS "dossiers_deposes_entre_60_et_30_jours",
+          COUNT(*) FILTER ( WHERE state != 'brouillon' and depose_at BETWEEN :one_month_ago AND :now ) AS "dossiers_depose_avant_30_jours",
+          COUNT(*) FILTER ( WHERE state != 'brouillon' and depose_at BETWEEN :two_months_ago AND :one_month_ago ) AS "dossiers_deposes_entre_60_et_30_jours",
           COUNT(*) FILTER ( WHERE state = 'brouillon' ) AS "brouillon",
           COUNT(*) FILTER ( WHERE state = 'en_construction' ) AS "en_construction",
           COUNT(*) FILTER ( WHERE state = 'en_instruction' ) AS "en_instruction",

--- a/app/models/traitement.rb
+++ b/app/models/traitement.rb
@@ -22,7 +22,7 @@ class Traitement < ApplicationRecord
     includes(:dossier)
       .termine
       .where(dossier: procedure.dossiers)
-      .where.not('dossiers.en_construction_at' => nil, :processed_at => nil)
+      .where.not('dossiers.depose_at' => nil, processed_at: nil)
       .order(:processed_at)
   end
 

--- a/app/serializers/dossier_serializer.rb
+++ b/app/serializers/dossier_serializer.rb
@@ -87,7 +87,7 @@ class DossierSerializer < ActiveModel::Serializer
   end
 
   def initiated_at
-    object.en_construction_at&.in_time_zone('UTC')
+    object.depose_at&.in_time_zone('UTC')
   end
 
   def received_at

--- a/app/serializers/dossiers_serializer.rb
+++ b/app/serializers/dossiers_serializer.rb
@@ -11,7 +11,7 @@ class DossiersSerializer < ActiveModel::Serializer
   end
 
   def initiated_at
-    object.en_construction_at&.in_time_zone('UTC')
+    object.depose_at&.in_time_zone('UTC')
   end
 
   def state

--- a/app/views/commencer/show.html.haml
+++ b/app/views/commencer/show.html.haml
@@ -30,7 +30,7 @@
       - dossier = not_drafts.first
       %h2.huge-title= t('views.commencer.show.already_not_draft')
       %p
-        = t('views.commencer.show.already_not_draft_detail_html', time_ago: time_ago_in_words(dossier.en_construction_at), procedure: dossier.procedure.libelle)
+        = t('views.commencer.show.already_not_draft_detail_html', time_ago: time_ago_in_words(dossier.depose_at), procedure: dossier.procedure.libelle)
       = link_to t('views.commencer.show.show_my_submitted_file'), dossier_path(dossier), class: ['button large expand primary']
       = link_to t('views.commencer.show.start_new_file'), url_for_new_dossier(@revision), class: ['button large expand']
 

--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -193,8 +193,8 @@ def add_etat_dossier(pdf, dossier)
 end
 
 def add_etats_dossier(pdf, dossier)
-  if dossier.en_construction_at.present?
-    format_in_2_columns(pdf, "Déposé le", try_format_date(dossier.en_construction_at))
+  if dossier.depose_at.present?
+    format_in_2_columns(pdf, "Déposé le", try_format_date(dossier.depose_at))
   end
   if dossier.en_instruction_at.present?
     format_in_2_columns(pdf, "En instruction le", try_format_date(dossier.en_instruction_at))

--- a/app/views/shared/dossiers/_demande.html.haml
+++ b/app/views/shared/dossiers/_demande.html.haml
@@ -1,5 +1,5 @@
 .container
-  - if dossier.en_construction_at.present?
+  - if dossier.depose_at.present?
     .card
       = render partial: "shared/dossiers/infos_generales", locals: { dossier: dossier }
 

--- a/app/views/shared/dossiers/_infos_generales.html.haml
+++ b/app/views/shared/dossiers/_infos_generales.html.haml
@@ -2,7 +2,7 @@
   %tbody
     %tr
       %th.libelle Déposé le :
-      %td= l(dossier.en_construction_at, format: '%d %B %Y')
+      %td= l(dossier.depose_at, format: '%d %B %Y')
   - if dossier.justificatif_motivation.attached?
     %tr
       %th.libelle Justificatif :

--- a/app/views/users/dossiers/_transfered_dossiers_list.html.haml
+++ b/app/views/users/dossiers/_transfered_dossiers_list.html.haml
@@ -19,7 +19,7 @@
                   = dossier.id
                 %td= dossier.procedure.libelle
                 %td= status_badge(dossier.state)
-                %td{ style: 'padding: 18px;' }= (dossier.en_construction_at || dossier.created_at).strftime('%d/%m/%Y')
+                %td{ style: 'padding: 18px;' }= (dossier.depose_at || dossier.created_at).strftime('%d/%m/%Y')
 
         .transfer-actions.mt-4
           = link_to "Accepter", transfer_path(transfer), class: "button primary", method: :put

--- a/app/views/users/dossiers/show/_header.html.haml
+++ b/app/views/users/dossiers/show/_header.html.haml
@@ -7,8 +7,8 @@
       %h1= dossier.procedure.libelle
       %h2
         = t('views.users.dossiers.show.header.dossier_number', dossier_id: dossier.id)
-        - if dossier.en_construction_at.present?
-          = t('views.users.dossiers.show.header.submit_date', date_du_dossier: I18n.l(dossier.en_construction_at))
+        - if dossier.depose_at.present?
+          = t('views.users.dossiers.show.header.submit_date', date_du_dossier: I18n.l(dossier.depose_at))
 
       = render(partial: 'users/dossiers/expiration_banner', locals: {dossier: dossier})
 

--- a/spec/controllers/api/v2/graphql_controller_spec.rb
+++ b/spec/controllers/api/v2/graphql_controller_spec.rb
@@ -319,6 +319,7 @@ describe API::V2::GraphqlController do
               datePassageEnConstruction
               datePassageEnInstruction
               dateTraitement
+              dateDepot
               motivation
               motivationAttachment {
                 url
@@ -396,6 +397,7 @@ describe API::V2::GraphqlController do
             state: 'en_construction',
             dateDerniereModification: dossier.updated_at.iso8601,
             datePassageEnConstruction: dossier.en_construction_at.iso8601,
+            dateDepot: dossier.depose_at.iso8601,
             datePassageEnInstruction: nil,
             dateTraitement: nil,
             motivation: nil,

--- a/spec/models/concern/procedure_stats_concern_spec.rb
+++ b/spec/models/concern/procedure_stats_concern_spec.rb
@@ -89,6 +89,6 @@ describe ProcedureStatsConcern do
   private
 
   def create_dossier(construction_date:, instruction_date:, processed_date:)
-    dossier = create(:dossier, :accepte, procedure: procedure, en_construction_at: construction_date, en_instruction_at: instruction_date, processed_at: processed_date)
+    dossier = create(:dossier, :accepte, procedure: procedure, depose_at: construction_date, en_instruction_at: instruction_date, processed_at: processed_date)
   end
 end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -356,15 +356,15 @@ describe Dossier do
     let(:service) { create(:service, nom: 'nom du service') }
     let(:procedure) { create(:procedure, libelle: "Démarche", organisation: "Organisme", service: service) }
 
-    context 'when the dossier has been en_construction' do
-      let(:dossier) { create :dossier, procedure: procedure, state: Dossier.states.fetch(:en_construction), en_construction_at: "31/12/2010".to_date }
+    context 'when the dossier has been submitted' do
+      let(:dossier) { create :dossier, procedure: procedure, state: Dossier.states.fetch(:en_construction), depose_at: "31/12/2010".to_date }
 
       subject { dossier.text_summary }
 
       it { is_expected.to eq("Dossier déposé le 31/12/2010 sur la démarche Démarche gérée par l'organisme nom du service") }
     end
 
-    context 'when the dossier has not been en_construction' do
+    context 'when the dossier has not been submitted' do
       let(:dossier) { create :dossier, procedure: procedure, state: Dossier.states.fetch(:brouillon) }
 
       subject { dossier.text_summary }
@@ -538,9 +538,9 @@ describe Dossier do
   describe '.downloadable_sorted' do
     let(:procedure) { create(:procedure) }
     let!(:dossier) { create(:dossier, :with_entreprise, procedure: procedure, state: Dossier.states.fetch(:brouillon)) }
-    let!(:dossier2) { create(:dossier, :with_entreprise, procedure: procedure, state: Dossier.states.fetch(:en_construction), en_construction_at: Time.zone.parse('03/01/2010')) }
-    let!(:dossier3) { create(:dossier, :with_entreprise, procedure: procedure, state: Dossier.states.fetch(:en_instruction), en_construction_at: Time.zone.parse('01/01/2010')) }
-    let!(:dossier4) { create(:dossier, :with_entreprise, procedure: procedure, state: Dossier.states.fetch(:en_instruction), archived: true, en_construction_at: Time.zone.parse('02/01/2010')) }
+    let!(:dossier2) { create(:dossier, :with_entreprise, procedure: procedure, state: Dossier.states.fetch(:en_construction), depose_at: Time.zone.parse('03/01/2010')) }
+    let!(:dossier3) { create(:dossier, :with_entreprise, procedure: procedure, state: Dossier.states.fetch(:en_instruction), depose_at: Time.zone.parse('01/01/2010')) }
+    let!(:dossier4) { create(:dossier, :with_entreprise, procedure: procedure, state: Dossier.states.fetch(:en_instruction), archived: true, depose_at: Time.zone.parse('02/01/2010')) }
 
     subject { procedure.dossiers.downloadable_sorted }
 

--- a/spec/models/procedure_presentation_spec.rb
+++ b/spec/models/procedure_presentation_spec.rb
@@ -60,6 +60,7 @@ describe ProcedurePresentation do
         [
           { "label" => 'Créé le', "table" => 'self', "column" => 'created_at' },
           { "label" => 'En construction le', "table" => 'self', "column" => 'en_construction_at' },
+          { "label" => 'Déposé le', "table" => 'self', "column" => 'depose_at' },
           { "label" => 'Mis à jour le', "table" => 'self', "column" => 'updated_at' },
           { "label" => 'Demandeur', "table" => 'user', "column" => 'email' },
           { "label" => 'Email instructeur', "table" => 'followers_instructeurs', "column" => 'email' },

--- a/spec/models/stat_spec.rb
+++ b/spec/models/stat_spec.rb
@@ -54,11 +54,11 @@ describe Stat do
   describe '.cumulative_hash' do
     it 'works count and cumulate counters by month for both dossier and deleted dossiers' do
       12.downto(1).map do |i|
-        create(:dossier, state: :en_construction, en_construction_at: i.months.ago)
+        create(:dossier, state: :en_construction, depose_at: i.months.ago)
         create(:deleted_dossier, dossier_id: i + 100, state: :en_construction, deleted_at: i.month.ago)
       end
       rs = Stat.send(:cumulative_hash, [
-        [Dossier.state_not_brouillon, :en_construction_at],
+        [Dossier.state_not_brouillon, :depose_at],
         [DeletedDossier.where.not(state: :brouillon), :deleted_at]
       ])
       expect(rs).to eq({
@@ -82,11 +82,11 @@ describe Stat do
     it 'works count and cumulate counters by month for both dossier and deleted dossiers' do
       travel_to Time.zone.local(2021, 11, 25) do
         4.downto(1).map do |i|
-          create(:dossier, state: :en_construction, en_construction_at: i.months.ago)
+          create(:dossier, state: :en_construction, depose_at: i.months.ago)
           create(:deleted_dossier, dossier_id: i + 100, state: :en_construction, deleted_at: i.month.ago)
         end
         rs = Stat.send(:last_four_months_hash, [
-          [Dossier.state_not_brouillon, :en_construction_at],
+          [Dossier.state_not_brouillon, :depose_at],
           [DeletedDossier.where.not(state: :brouillon), :deleted_at]
         ])
         expect(rs).to eq([

--- a/spec/serializers/dossier_serializer_spec.rb
+++ b/spec/serializers/dossier_serializer_spec.rb
@@ -5,7 +5,7 @@ describe DossierSerializer do
     context 'when the dossier is en_construction' do
       let(:dossier) { create(:dossier, :en_construction) }
 
-      it { is_expected.to include(initiated_at: dossier.en_construction_at) }
+      it { is_expected.to include(initiated_at: dossier.depose_at) }
       it { is_expected.to include(state: 'initiated') }
     end
 

--- a/spec/serializers/dossiers_serializer_spec.rb
+++ b/spec/serializers/dossiers_serializer_spec.rb
@@ -5,7 +5,7 @@ describe DossiersSerializer do
     context 'when the dossier is en_construction' do
       let(:dossier) { create(:dossier, :en_construction) }
 
-      it { is_expected.to include(initiated_at: dossier.en_construction_at) }
+      it { is_expected.to include(initiated_at: dossier.depose_at) }
       it { is_expected.to include(state: 'initiated') }
     end
   end

--- a/spec/services/dossier_projection_service_spec.rb
+++ b/spec/services/dossier_projection_service_spec.rb
@@ -70,6 +70,13 @@ describe DossierProjectionService do
           it { is_expected.to eq('17/10/2018') }
         end
 
+        context 'for depose_at column' do
+          let(:column) { 'depose_at' }
+          let(:dossier) { create(:dossier, :en_construction, depose_at: Time.zone.local(2018, 10, 17)) }
+
+          it { is_expected.to eq('17/10/2018') }
+        end
+
         context 'for updated_at column' do
           let(:column) { 'updated_at' }
           let(:dossier) { create(:dossier) }

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -91,10 +91,10 @@ describe ProcedureExportService do
         expect(etablissements_sheet.data.size).to eq(1)
 
         # SimpleXlsxReader is transforming datetimes in utc... It is only used in test so we just hack around.
-        offset = dossier.en_construction_at.utc_offset
-        en_construction_at = Time.zone.at(dossiers_sheet.data[0][8] - offset.seconds)
+        offset = dossier.depose_at.utc_offset
+        depose_at = Time.zone.at(dossiers_sheet.data[0][8] - offset.seconds)
         en_instruction_at = Time.zone.at(dossiers_sheet.data[0][9] - offset.seconds)
-        expect(en_construction_at).to eq(dossier.en_construction_at.round)
+        expect(depose_at).to eq(dossier.depose_at.round)
         expect(en_instruction_at).to eq(dossier.en_instruction_at.round)
       end
 

--- a/spec/system/users/dossier_details_spec.rb
+++ b/spec/system/users/dossier_details_spec.rb
@@ -17,7 +17,7 @@ describe 'Dossier details:' do
   end
 
   describe "the user can see the mean time they are expected to wait" do
-    let(:other_dossier) { create(:dossier, :accepte, :with_individual, procedure: procedure, en_construction_at: 10.days.ago, en_instruction_at: 9.days.ago, processed_at: Time.zone.now) }
+    let(:other_dossier) { create(:dossier, :accepte, :with_individual, procedure: procedure, depose_at: 10.days.ago, en_instruction_at: 9.days.ago, processed_at: Time.zone.now) }
 
     context "when the dossier is in construction" do
       it "displays the estimated wait duration" do

--- a/spec/views/commencer/show.html.haml_spec.rb
+++ b/spec/views/commencer/show.html.haml_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'commencer/show.html.haml', type: :view do
 
       it 'renders a link to the submitted dossier' do
         subject
-        expect(rendered).to have_text(time_ago_in_words(dossier.en_construction_at))
+        expect(rendered).to have_text(time_ago_in_words(dossier.depose_at))
         expect(rendered).to have_link('Voir mon dossier', href: dossier_path(dossier))
       end
     end

--- a/spec/views/users/dossiers/demande.html.haml_spec.rb
+++ b/spec/views/users/dossiers/demande.html.haml_spec.rb
@@ -28,7 +28,7 @@ describe 'users/dossiers/demande.html.haml', type: :view do
     it { is_expected.not_to have_link('Modifier le dossier') }
   end
 
-  context 'when the dossier has no en_construction_at date' do
+  context 'when the dossier has no depose_at date' do
     let(:dossier) { create(:dossier, :with_entreprise, procedure: procedure) }
 
     it { expect(rendered).not_to have_text('Déposé le') }


### PR DESCRIPTION
On utilise `depose_at` au lieu de `en_construction_at` partout maintenant, sauf pour le calcul d'expiration qui se base sur `en_construction_at` qui est la date du dernier passage `en_construction`