### PR TITLE
 [API Particulier] (3/4) Support de Pôle emploi

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -358,7 +358,8 @@
   }
 
   .cnaf-inputs,
-  .dgfip-inputs {
+  .dgfip-inputs,
+  .pole-emploi-inputs {
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;

--- a/app/assets/stylesheets/pole_emploi.scss
+++ b/app/assets/stylesheets/pole_emploi.scss
@@ -1,0 +1,30 @@
+@import "constants";
+@import "colors";
+
+table.pole-emploi {
+  margin: 2 * $default-padding 0 $default-padding $default-padding;
+  width: 100%;
+
+  caption {
+    font-weight: bold;
+    margin-left: - $default-padding;
+    margin-bottom: $default-spacer;
+    text-align: left;
+  }
+
+  th,
+  td {
+    font-weight: normal;
+    padding: $default-spacer;
+  }
+
+  th.text-right {
+    text-align: right;
+  }
+
+  &.horizontal {
+    th {
+      border-bottom: 1px solid $grey;
+    }
+  }
+}

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -348,8 +348,8 @@ module Users
     def champs_params
       params.permit(dossier: {
         champs_attributes: [
-          :id, :value, :value_other, :external_id, :primary_value, :secondary_value, :numero_allocataire, :code_postal, :numero_fiscal, :reference_avis, :piece_justificative_file, :departement, :code_departement, value: [],
-          champs_attributes: [:id, :_destroy, :value, :value_other, :external_id, :primary_value, :secondary_value, :numero_allocataire, :code_postal, :numero_fiscal, :reference_avis, :piece_justificative_file, :departement, :code_departement, value: []]
+          :id, :value, :value_other, :external_id, :primary_value, :secondary_value, :numero_allocataire, :code_postal, :identifiant, :numero_fiscal, :reference_avis, :piece_justificative_file, :departement, :code_departement, value: [],
+          champs_attributes: [:id, :_destroy, :value, :value_other, :external_id, :primary_value, :secondary_value, :numero_allocataire, :code_postal, :identifiant, :numero_fiscal, :reference_avis, :piece_justificative_file, :departement, :code_departement, value: []]
         ]
       })
     end

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -2009,6 +2009,11 @@ enum TypeDeChamp {
   piece_justificative
 
   """
+  Situation Pôle emploi
+  """
+  pole_emploi
+
+  """
   Régions
   """
   regions

--- a/app/lib/api_particulier/api.rb
+++ b/app/lib/api_particulier/api.rb
@@ -4,6 +4,7 @@ class APIParticulier::API
   INTROSPECT_RESOURCE_NAME = "introspect"
   COMPOSITION_FAMILIALE_RESOURCE_NAME = "v2/composition-familiale"
   AVIS_IMPOSITION_RESOURCE_NAME = "v2/avis-imposition"
+  SITUATION_POLE_EMPLOI = "v2/situations-pole-emploi"
 
   TIMEOUT = 20
 
@@ -27,6 +28,10 @@ class APIParticulier::API
     get(AVIS_IMPOSITION_RESOURCE_NAME,
         numeroFiscal: numero_fiscal.to_i.to_s.rjust(13, "0"),
         referenceAvis: reference_avis.to_i.to_s.rjust(13, "0"))
+  end
+
+  def situation_pole_emploi(identifiant)
+    get(SITUATION_POLE_EMPLOI, identifiant: identifiant)
   end
 
   private

--- a/app/lib/api_particulier/pole_emploi_adapter.rb
+++ b/app/lib/api_particulier/pole_emploi_adapter.rb
@@ -1,0 +1,46 @@
+class APIParticulier::PoleEmploiAdapter
+  class InvalidSchemaError < ::StandardError
+    def initialize(errors)
+      super(errors.map(&:to_json).join("\n"))
+    end
+  end
+
+  def initialize(api_particulier_token, identifiant, requested_sources)
+    @api = APIParticulier::API.new(api_particulier_token)
+    @identifiant = identifiant
+    @requested_sources = requested_sources
+  end
+
+  def to_params
+    @api.situation_pole_emploi(@identifiant)
+      .tap  { |d| ensure_valid_schema!(d) }
+      .then { |d| extract_requested_sources(d) }
+  end
+
+  private
+
+  def ensure_valid_schema!(data)
+    if !schemer.valid?(data)
+      errors = schemer.validate(data).to_a
+      raise InvalidSchemaError.new(errors)
+    end
+  end
+
+  def schemer
+    @schemer ||= JSONSchemer.schema(Rails.root.join('app/schemas/situation-pole-emploi.json'))
+  end
+
+  def extract_requested_sources(data)
+    @requested_sources['pole_emploi']&.map do |(scope, sources)|
+      case scope
+      when 'adresse'
+        sources.map { |source| { scope => data[scope].slice(*source) } }
+      when 'identifiant', 'contact', 'inscription'
+        sources.map { |source| { scope => data.slice(*source) } }
+      else
+        { scope => data.slice(*sources) }
+      end
+    end
+      &.flatten&.reduce(&:deep_merge) || {}
+  end
+end

--- a/app/lib/api_particulier/services/sources_service.rb
+++ b/app/lib/api_particulier/services/sources_service.rb
@@ -77,7 +77,11 @@ module APIParticulier
           'dgfip_annee_impot' => ['dgfip', 'annee_impot'],
           'dgfip_annee_revenus' => ['dgfip', 'annee_revenus'],
           'dgfip_erreur_correctif' => ['dgfip', 'erreur_correctif'],
-          'dgfip_situation_partielle' => ['dgfip', 'situation_partielle']
+          'dgfip_situation_partielle' => ['dgfip', 'situation_partielle'],
+          'pole_emploi_identite' => ['pole_emploi', 'identite'],
+          'pole_emploi_adresse' => ['pole_emploi', 'adresse'],
+          'pole_emploi_contact' => ['pole_emploi', 'contact'],
+          'pole_emploi_inscription' => ['pole_emploi', 'inscription']
         }
       end
 
@@ -114,6 +118,12 @@ module APIParticulier
             'annee_revenus' => { 'agregats_fiscaux' => ['anneeRevenus'] },
             'erreur_correctif' => { 'complements' => ['erreurCorrectif'] },
             'situation_partielle' => { 'complements' => ['situationPartielle'] }
+          },
+          'pole_emploi' => {
+            'identite' => ['identifiant', 'civilite', 'nom', 'nomUsage', 'prenom', 'sexe', 'dateNaissance'],
+            'adresse' => ['INSEECommune', 'codePostal', 'localite', 'ligneVoie', 'ligneComplementDestinataire', 'ligneComplementAdresse', 'ligneComplementDistribution', 'ligneNom'],
+            'contact' => ['email', 'telephone', 'telephone2'],
+            'inscription' => ['dateInscription', 'dateCessationInscription', 'codeCertificationCNAV', 'codeCategorieInscription', 'libelleCategorieInscription']
           }
         }
       end

--- a/app/lib/api_particulier/services/sources_service.rb
+++ b/app/lib/api_particulier/services/sources_service.rb
@@ -7,8 +7,7 @@ module APIParticulier
 
       def available_sources
         @procedure.api_particulier_scopes
-          .map { |provider_and_scope| raw_scopes[provider_and_scope] }
-          .compact
+          .filter_map { |provider_and_scope| raw_scopes[provider_and_scope] }
           .map { |provider, scope| extract_sources(provider, scope) }
           .reduce({}) { |acc, el| acc.deep_merge(el) { |_, this_val, other_val| this_val + other_val } }
       end

--- a/app/models/champs/pole_emploi_champ.rb
+++ b/app/models/champs/pole_emploi_champ.rb
@@ -1,0 +1,47 @@
+# == Schema Information
+#
+# Table name: champs
+#
+#  id                             :integer          not null, primary key
+#  data                           :jsonb
+#  fetch_external_data_exceptions :string           is an Array
+#  private                        :boolean          default(FALSE), not null
+#  rebased_at                     :datetime
+#  row                            :integer
+#  type                           :string
+#  value                          :string
+#  value_json                     :jsonb
+#  created_at                     :datetime
+#  updated_at                     :datetime
+#  dossier_id                     :integer
+#  etablissement_id               :integer
+#  external_id                    :string
+#  parent_id                      :bigint
+#  type_de_champ_id               :integer
+#
+class Champs::PoleEmploiChamp < Champs::TextChamp
+  # see https://github.com/betagouv/api-particulier/blob/master/src/presentation/middlewares/pole-emploi-input-validation.middleware.ts
+  store_accessor :value_json, :identifiant
+
+  def blank?
+    external_id.nil?
+  end
+
+  def fetch_external_data?
+    true
+  end
+
+  def fetch_external_data
+    return if !valid?
+
+    APIParticulier::PoleEmploiAdapter.new(
+      procedure.api_particulier_token,
+      identifiant,
+      procedure.api_particulier_sources
+    ).to_params
+  end
+
+  def external_id
+    { identifiant: identifiant }.to_json if identifiant.present?
+  end
+end

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -730,6 +730,10 @@ class Procedure < ApplicationRecord
     api_particulier_sources['dgfip'].present?
   end
 
+  def pole_emploi_enabled?
+    api_particulier_sources['pole_emploi'].present?
+  end
+
   private
 
   def validate_for_publication?

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -51,7 +51,8 @@ class TypeDeChamp < ApplicationRecord
     iban: 'iban',
     annuaire_education: 'annuaire_education',
     cnaf: 'cnaf',
-    dgfip: 'dgfip'
+    dgfip: 'dgfip',
+    pole_emploi: 'pole_emploi'
   }
 
   belongs_to :revision, class_name: 'ProcedureRevision', optional: true
@@ -327,6 +328,8 @@ class TypeDeChamp < ApplicationRecord
         procedure.cnaf_enabled?
       when TypeDeChamp.type_champs.fetch(:dgfip)
         procedure.dgfip_enabled?
+      when TypeDeChamp.type_champs.fetch(:pole_emploi)
+        procedure.pole_emploi_enabled?
       else
         true
       end

--- a/app/models/types_de_champ/pole_emploi_type_de_champ.rb
+++ b/app/models/types_de_champ/pole_emploi_type_de_champ.rb
@@ -1,0 +1,2 @@
+class TypesDeChamp::PoleEmploiTypeDeChamp < TypesDeChamp::TextTypeDeChamp
+end

--- a/app/schemas/situation-pole-emploi.json
+++ b/app/schemas/situation-pole-emploi.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://demarches-simplifiees.fr/situation-pole-emploi.schema.json",
+  "title": "situation pole emploi",
+  "type": "object",
+  "properties": {
+    "identifiant": {
+      "type": "string"
+    },
+    "civilite": {
+      "type": "string"
+    },
+    "nom": {
+      "type": "string"
+    },
+    "nomUsage": {
+      "type": "string"
+    },
+    "prenom": {
+      "type": "string"
+    },
+    "sexe": {
+      "enum": ["F", "M"]
+    },
+    "dateNaissance": {
+      "format": "date",
+      "type": "string"
+    },
+    "codeCertificationCNAV": {
+      "type": "string"
+    },
+    "telephone": {
+      "type": "string"
+    },
+    "telephone2": {
+      "type": "string"
+    },
+    "email": {
+      "type": "string"
+    },
+    "$defs": {
+      "adresse": {
+        "type": "object",
+        "properties": {
+          "codePostal": {
+            "type": "string"
+          },
+          "INSEECommune": {
+            "type": "string"
+          },
+          "localite": {
+            "type": "string"
+          },
+          "ligneVoie": {
+            "type": "string"
+          },
+          "ligneComplementDestinataire": {
+            "type": "string"
+          },
+          "ligneComplementAdresse": {
+            "type": "string"
+          },
+          "ligneComplementDistribution": {
+            "type": "string"
+          },
+          "ligneNom": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "dateInscription": {
+      "format": "date",
+      "type": "string"
+    },
+    "dateCessationInscription": {
+      "format": "date",
+      "type": "string"
+    },
+    "codeCategorieInscription": {
+      "type": "integer"
+    },
+    "libelleCategroiieInscription": {
+      "type": "string"
+    }
+  }
+}

--- a/app/views/administrateurs/sources_particulier/show.html.haml
+++ b/app/views/administrateurs/sources_particulier/show.html.haml
@@ -16,7 +16,7 @@
 
       - scopes.each do |scope_key, sources|
         %h3.explication-libelle= t("api_particulier.providers.#{provider_key}.scopes.#{scope_key}.libelle")
-        %ul.procedure-admin-api-particulier-sources{ id: scope_key }
+        %ul.procedure-admin-api-particulier-sources{ id: "#{provider_key}-#{scope_key}" }
           - sources.each do |source_key, enabled_hash|
             - enabled = (@procedure.api_particulier_sources.dig(provider_key, scope_key)&.include?(source_key)).present?
             %li

--- a/app/views/shared/champs/pole_emploi/_adresse.html.haml
+++ b/app/views/shared/champs/pole_emploi/_adresse.html.haml
@@ -1,0 +1,6 @@
+%table.pole-emploi
+  %caption #{t("api_particulier.providers.pole_emploi.scopes.#{scope}.libelle")} :
+  - adresse.slice('INSEECommune', 'codePostal', 'localite', 'ligneVoie', 'ligneComplementDestinataire', 'ligneComplementAdresse', 'ligneComplementDistribution', 'ligneNom').keys.each do |key|
+    %tr
+      %th= t("api_particulier.providers.pole_emploi.scopes.#{scope}.#{key}")
+      %td= adresse[key]

--- a/app/views/shared/champs/pole_emploi/_contact.html.haml
+++ b/app/views/shared/champs/pole_emploi/_contact.html.haml
@@ -1,0 +1,6 @@
+%table.pole-emploi
+  %caption #{t("api_particulier.providers.pole_emploi.scopes.#{scope}.libelle")} :
+  - contact.slice('email', 'telephone', 'telephone2').keys.each do |key|
+    %tr
+      %th= t("api_particulier.providers.pole_emploi.scopes.#{scope}.#{key}")
+      %td= contact[key]

--- a/app/views/shared/champs/pole_emploi/_identite.html.haml
+++ b/app/views/shared/champs/pole_emploi/_identite.html.haml
@@ -1,0 +1,12 @@
+%table.pole-emploi
+  %caption #{t("api_particulier.providers.pole_emploi.scopes.#{scope}.libelle")} :
+  - identite.slice('identifiant', 'civilite', 'nom', 'nomUsage', 'prenom', 'sexe', 'dateNaissance').keys.each do |key|
+    %tr
+      %th= t("api_particulier.providers.pole_emploi.scopes.#{scope}.#{key}")
+      - case key
+      - when 'dateNaissance'
+        %td= try_format_date(Date.strptime(identite[key], "%Y-%m-%d"))
+      - when 'sexe'
+        %td= t("api_particulier.providers.pole_emploi.scopes.#{scope}.#{identite[key]}")
+      - else
+        %td= identite[key]

--- a/app/views/shared/champs/pole_emploi/_inscription.html.haml
+++ b/app/views/shared/champs/pole_emploi/_inscription.html.haml
@@ -1,0 +1,10 @@
+%table.pole-emploi
+  %caption #{t("api_particulier.providers.pole_emploi.scopes.#{scope}.libelle")} :
+  - inscription.slice('dateInscription', 'dateCessationInscription', 'codeCertificationCNAV', 'codeCategorieInscription', 'libelleCategorieInscription').keys.each do |key|
+    %tr
+      %th= t("api_particulier.providers.pole_emploi.scopes.#{scope}.#{key}")
+      - case key
+      - when 'dateInscription', 'dateCessationInscription'
+        %td= try_format_date(Date.strptime(inscription[key], "%Y-%m-%d"))
+      - else
+        %td= inscription[key]

--- a/app/views/shared/champs/pole_emploi/_show.html.haml
+++ b/app/views/shared/champs/pole_emploi/_show.html.haml
@@ -1,0 +1,24 @@
+- if champ.blank?
+  %p= t('.not_filled')
+- elsif champ.data.blank?
+  %p= t('.fetching_data',
+    identifiant: champ.identifiant)
+- else
+  - if profile == 'usager'
+    - sources = champ.procedure.api_particulier_sources['pole_emploi'].keys
+    - i18n_sources = sources.map { |s| I18n.t("#{s}.libelle", scope: 'api_particulier.providers.pole_emploi.scopes') }
+    %p= t('.data_fetched', sources: i18n_sources.to_sentence, identifiant: champ.identifiant)
+
+  - if profile == 'instructeur'
+    %p= t('.data_fetched_title')
+
+    - champ.data.slice('identite', 'adresse', 'contact', 'inscription').keys.each do |scope|
+      - case scope
+      - when 'identite'
+        = render partial: 'shared/champs/pole_emploi/identite', locals: { scope: scope, identite: champ.data[scope] }
+      - when 'adresse'
+        = render partial: 'shared/champs/pole_emploi/adresse', locals: { scope: scope, adresse: champ.data[scope] }
+      - when 'contact'
+        = render partial: 'shared/champs/pole_emploi/contact', locals: { scope: scope, contact: champ.data[scope] }
+      - when 'inscription'
+        = render partial: 'shared/champs/pole_emploi/inscription', locals: { scope: scope, inscription: champ.data[scope] }

--- a/app/views/shared/dossiers/_champ_row.html.haml
+++ b/app/views/shared/dossiers/_champ_row.html.haml
@@ -40,6 +40,8 @@
               = render partial: "shared/champs/cnaf/show", locals: { champ: c, profile: profile }
             - when TypeDeChamp.type_champs.fetch(:dgfip)
               = render partial: "shared/champs/dgfip/show", locals: { champ: c, profile: profile }
+            - when TypeDeChamp.type_champs.fetch(:pole_emploi)
+              = render partial: "shared/champs/pole_emploi/show", locals: { champ: c, profile: profile }
             - when TypeDeChamp.type_champs.fetch(:address)
               = render partial: "shared/champs/address/show", locals: { champ: c }
             - when TypeDeChamp.type_champs.fetch(:communes)

--- a/app/views/shared/dossiers/editable_champs/_pole_emploi.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_pole_emploi.html.haml
@@ -1,0 +1,7 @@
+.pole_emploi-inputs
+  %div
+    = form.label :identifiant, t('.identifiant_label')
+    %p.notice= t('.identifiant_notice')
+    = form.text_field :identifiant,
+      required: champ.mandatory?,
+      aria: { describedby: describedby_id(champ) }

--- a/config/locales/api_particulier.en.yml
+++ b/config/locales/api_particulier.en.yml
@@ -68,3 +68,39 @@ en:
             libelle: supplements
             erreurCorrectif: error correction
             situationPartielle: partial status
+      pole_emploi:
+        libelle: Pôle emploi
+        scopes:
+          identite:
+            libelle: Identity
+            identifiant: identifier
+            civilite: civility
+            nom: name
+            nomUsage: common name
+            prenom: first name
+            sexe: gender
+            M: male
+            F: female
+            dateNaissance: date of birth
+          adresse:
+            libelle: Address
+            INSEECommune: INSEE code of the commune
+            codePostal: postcode
+            localite: city
+            ligneVoie: route
+            ligneComplementDestinataire: recipient
+            ligneComplementAdresse: address
+            ligneComplementDistribution: distribution
+            ligneNom: name
+          contact:
+            libelle: Contact
+            email: email
+            telephone: phone number
+            telephone2: phone number 2
+          inscription:
+            libelle: Registration
+            dateInscription: registration date
+            dateCessationInscription: date of deregistration
+            codeCertificationCNAV: CNAV certification code
+            codeCategorieInscription: registration category code
+            libelleCategorieInscription: registration category label

--- a/config/locales/api_particulier.fr.yml
+++ b/config/locales/api_particulier.fr.yml
@@ -68,3 +68,39 @@ fr:
             libelle: compléments
             erreurCorrectif: erreur correctif
             situationPartielle: situation partielle
+      pole_emploi:
+        libelle: Pôle emploi
+        scopes:
+          identite:
+            libelle: Identité
+            identifiant: identifiant
+            civilite: civilité
+            nom: nom
+            nomUsage: nom d’usage
+            prenom: prénom
+            sexe: sexe
+            M: masculin
+            F: féminin
+            dateNaissance: date de naissance
+          adresse:
+            libelle: Adresse
+            INSEECommune: code INSEE de la commune
+            codePostal: code postal
+            localite: localité
+            ligneVoie: voie
+            ligneComplementDestinataire: destinataire
+            ligneComplementAdresse: adresse
+            ligneComplementDistribution: distribution
+            ligneNom: nom
+          contact:
+            libelle: Contact
+            email: email
+            telephone: téléphone
+            telephone2: téléphone 2
+          inscription:
+            libelle: Inscription
+            dateInscription: date d’inscription
+            dateCessationInscription: date de cessation d’inscription
+            codeCertificationCNAV: code de certification CNAV
+            codeCategorieInscription: code de catégorie d’inscription
+            libelleCategorieInscription: libellé de catégorie d’inscription

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -420,7 +420,7 @@ fr:
     jeton_particulier:
       show:
         configure_token: "Configurer le jeton API Particulier"
-        api_particulier_description_html: "%{app_name} utilise <a href=\"https://api.gouv.fr/les-api/api-particulier\">API Particulier</a> qui permet de récupérer les données fiscales (DGFiP) et familiales (CAF).<br />Renseignez ici le <a href=\"https://api.gouv.fr/les-api/api-particulier/demande-acces\">jeton API Particulier</a> propre à votre démarche."
+        api_particulier_description_html: "%{app_name} utilise <a href=\"https://api.gouv.fr/les-api/api-particulier\">API Particulier</a> qui permet d'accéder aux données familiales (CAF), aux données fiscales (DGFiP) et au statut pôle-emploi d'un citoyen.<br />Renseignez ici le <a href=\"https://api.gouv.fr/les-api/api-particulier/demande-acces\">jeton API Particulier</a> propre à votre démarche."
         token_description: "Il doit contenir au minimum 15 caractères."
       update:
         token_ok: "Le jeton a bien été mis à jour"
@@ -434,7 +434,7 @@ fr:
       show:
         title: "Définir les sources de données"
         data_sources: "Sources de données"
-        explication_html: "<p>API Particulier facilite l’accès des administrations aux données fiscales (DGFiP) et familiales (CAF) pour simplifier les démarches administratives mises en œuvre par les collectivités et les administrations.<br> Cela permet aux administrations d’accéder à des informations certifiées à la source et ainsi : </p> <ul> <li>de s’affranchir des pièces justificatives lors des démarches en ligne,</li> <li>de réduire le nombre d’erreurs de saisie,</li> <li>d’écarter le risque de fraude documentaire.</li> </ul> <p> <strong>Important&nbsp;:</strong> les disposition de l'article <a href='https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000031366350&amp;idArticle=LEGIARTI000031367412&amp;dateTexte=&amp;categorieLien=cid'>L144-8</a> n’autorisent que l’échange des informations strictement nécessaires pour traiter une démarche.<br /><br />En conséquence, ne sélectionnez ici que les données auxquelles vous aurez accès d’un point de vue légal.</p>"
+        explication_html: "<p>API Particulier facilite l’accès des administrations aux données familiales (CAF), aux données fiscales (DGFiP) et au statut pôle-emploi d'un citoyen pour simplifier les démarches administratives mises en œuvre par les collectivités et les administrations.<br> Cela permet aux administrations d’accéder à des informations certifiées à la source et ainsi : </p> <ul> <li>de s’affranchir des pièces justificatives lors des démarches en ligne,</li> <li>de réduire le nombre d’erreurs de saisie,</li> <li>d’écarter le risque de fraude documentaire.</li> </ul> <p> <strong>Important&nbsp;:</strong> les disposition de l'article <a href='https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000031366350&amp;idArticle=LEGIARTI000031367412&amp;dateTexte=&amp;categorieLien=cid'>L144-8</a> n’autorisent que l’échange des informations strictement nécessaires pour traiter une démarche.<br /><br />En conséquence, ne sélectionnez ici que les données auxquelles vous aurez accès d’un point de vue légal.</p>"
       update:
         sources_ok: 'Mise à jour effectuée'
     procedures:

--- a/config/locales/models/type_de_champ/fr.yml
+++ b/config/locales/models/type_de_champ/fr.yml
@@ -38,3 +38,4 @@ fr:
           annuaire_education: 'Annuaire de l’éducation'
           cnaf: 'Données de la Caisse nationale des allocations familiales'
           dgfip: 'Données de la Direction générale des Finances publiques'
+          pole_emploi: 'Situation Pôle emploi'

--- a/config/locales/shared.en.yml
+++ b/config/locales/shared.en.yml
@@ -12,6 +12,9 @@ en:
           numero_fiscal_notice: It is usually composed of 13 to 14 characters.
           reference_avis_label: Tax notice reference
           reference_avis_notice: It is usually composed of 13 to 14 characters.
+        pole_emploi:
+          identifiant_label: Identifier
+          identifiant_notice: It is usually composed of alphanumeric characters.
       header:
         expires_at:
           brouillon: "Expires at %{date} (%{duree_conservation_totale} months after the creation of this file)"
@@ -33,3 +36,9 @@ en:
           fetching_data: "Fetching data for declarant No. %{numero_fiscal} with tax notice reference %{reference_avis}."
           data_fetched: "Data concerning %{sources} linked to the declarant Nº %{numero_fiscal} with tax notice reference %{reference_avis} has been received from the DGFiP."
           data_fetched_title: "Data received from la Direction générale des Finances publiques"
+      pole_emploi:
+        show:
+          not_filled: not filled
+          fetching_data: "Fetching data for identifier %{identifiant}."
+          data_fetched: "Data concerning %{sources} linked to the identifier %{identifiant} has been received from Pôle emploi."
+          data_fetched_title: "Data received from Pôle emploi"

--- a/config/locales/shared.fr.yml
+++ b/config/locales/shared.fr.yml
@@ -12,6 +12,9 @@ fr:
           numero_fiscal_notice: Il est généralement composé de 13 ou 14 caractères.
           reference_avis_label: La référence d'avis d'imposition
           reference_avis_notice: Elle est généralement composée de 13 ou 14 caractères.
+        pole_emploi:
+          identifiant_label: Identifiant
+          identifiant_notice: Il est généralement composé de caractères alphanumériques.
       header:
         expires_at:
           brouillon: "Expirera le %{date} (%{duree_conservation_totale} mois après la création du dossier)"
@@ -35,3 +38,9 @@ fr:
           fetching_data: "La récupération automatique des données pour le déclarant Nº %{numero_fiscal} avec la référence d'avis %{reference_avis} est en cours."
           data_fetched: "Des données concernant %{sources} liées au déclarant Nº %{numero_fiscal} avec la référence d'avis %{reference_avis} ont été reçues depuis la DGFiP."
           data_fetched_title: "Données obtenues de la Direction générale des Finances publiques"
+      pole_emploi:
+        show:
+          not_filled: non renseigné
+          fetching_data: "La récupération automatique des données pour l'identifiant %{identifiant} est en cours."
+          data_fetched: "Des données concernant %{sources} liées à l'identifiant %{identifiant} ont été reçues depuis Pôle emploi."
+          data_fetched_title: "Données obtenues de Pôle emploi"

--- a/spec/controllers/administrateurs/jeton_particulier_controller_spec.rb
+++ b/spec/controllers/administrateurs/jeton_particulier_controller_spec.rb
@@ -75,7 +75,11 @@ describe Administrateurs::JetonParticulierController, type: :controller do
             'dgfip_revenu_fiscal_reference',
             'dgfip_revenu_imposable',
             'dgfip_situation_familiale',
-            'dgfip_situation_partielle'
+            'dgfip_situation_partielle',
+            'pole_emploi_identite',
+            'pole_emploi_adresse',
+            'pole_emploi_contact',
+            'pole_emploi_inscription'
           )
           expect(procedure.api_particulier_sources).to be_empty
         end

--- a/spec/factories/champ.rb
+++ b/spec/factories/champ.rb
@@ -193,6 +193,10 @@ FactoryBot.define do
       type_de_champ { association :type_de_champ_dgfip, procedure: dossier.procedure }
     end
 
+    factory :champ_pole_emploi, class: 'Champs::PoleEmploiChamp' do
+      type_de_champ { association :type_de_champ_pole_emploi, procedure: dossier.procedure }
+    end
+
     factory :champ_siret, class: 'Champs::SiretChamp' do
       type_de_champ { association :type_de_champ_siret, procedure: dossier.procedure }
       association :etablissement, factory: [:etablissement]

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -206,6 +206,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_pole_emploi do
+      after(:build) do |procedure, _evaluator|
+        build(:type_de_champ_pole_emploi, procedure: procedure)
+      end
+    end
+
     trait :with_explication do
       after(:build) do |procedure, _evaluator|
         build(:type_de_champ_explication, procedure: procedure)

--- a/spec/factories/type_de_champ.rb
+++ b/spec/factories/type_de_champ.rb
@@ -160,6 +160,9 @@ FactoryBot.define do
     factory :type_de_champ_dgfip do
       type_champ { TypeDeChamp.type_champs.fetch(:dgfip) }
     end
+    factory :type_de_champ_pole_emploi do
+      type_champ { TypeDeChamp.type_champs.fetch(:pole_emploi) }
+    end
     factory :type_de_champ_carte do
       type_champ { TypeDeChamp.type_champs.fetch(:carte) }
     end

--- a/spec/fixtures/cassettes/api_particulier/success/introspect.yml
+++ b/spec/fixtures/cassettes/api_particulier/success/introspect.yml
@@ -25,7 +25,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '228'
+      - '257'
       Connection:
       - keep-alive
       Keep-Alive:
@@ -38,6 +38,6 @@ http_interactions:
       - max-age=15552000
     body:
       encoding: UTF-8
-      string: '{"_id":"1d99db5a-a099-4314-ad2f-2707c6b505a6","name":"Application de sandbox","scopes":["cnaf_allocataires","cnaf_enfants","cnaf_adresse","cnaf_quotient_familial","dgfip_declarant1_nom","dgfip_declarant1_nom_naissance","dgfip_declarant1_prenoms","dgfip_declarant1_date_naissance","dgfip_declarant2_nom","dgfip_declarant2_nom_naissance","dgfip_declarant2_prenoms","dgfip_declarant2_date_naissance","dgfip_date_recouvrement","dgfip_date_etablissement","dgfip_adresse_fiscale_taxation","dgfip_adresse_fiscale_annee","dgfip_nombre_parts","dgfip_nombre_personnes_a_charge","dgfip_situation_familiale","dgfip_revenu_brut_global","dgfip_revenu_imposable","dgfip_impot_revenu_net_avant_corrections","dgfip_montant_impot","dgfip_revenu_fiscal_reference","dgfip_annee_impot","dgfip_annee_revenus","dgfip_erreur_correctif","dgfip_situation_partielle"]}'
+      string: '{"_id":"1d99db5a-a099-4314-ad2f-2707c6b505a6","name":"Application de sandbox","scopes":["cnaf_allocataires","cnaf_enfants","cnaf_adresse","cnaf_quotient_familial","dgfip_declarant1_nom","dgfip_declarant1_nom_naissance","dgfip_declarant1_prenoms","dgfip_declarant1_date_naissance","dgfip_declarant2_nom","dgfip_declarant2_nom_naissance","dgfip_declarant2_prenoms","dgfip_declarant2_date_naissance","dgfip_date_recouvrement","dgfip_date_etablissement","dgfip_adresse_fiscale_taxation","dgfip_adresse_fiscale_annee","dgfip_nombre_parts","dgfip_nombre_personnes_a_charge","dgfip_situation_familiale","dgfip_revenu_brut_global","dgfip_revenu_imposable","dgfip_impot_revenu_net_avant_corrections","dgfip_montant_impot","dgfip_revenu_fiscal_reference","dgfip_annee_impot","dgfip_annee_revenus","dgfip_erreur_correctif","dgfip_situation_partielle", "pole_emploi_identite","pole_emploi_adresse","pole_emploi_contact","pole_emploi_inscription"]}'
   recorded_at: Tue, 16 Mar 2021 15:25:24 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/cassettes/api_particulier/success/situation_pole_emploi.yml
+++ b/spec/fixtures/cassettes/api_particulier/success/situation_pole_emploi.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://particulier.api.gouv.fr/api/v2/situations-pole-emploi?identifiant=georges_moustaki_77
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - demarches-simplifiees.fr
+      Accept:
+      - application/json
+      X-Api-Key:
+      - 06fd8675601267d2988cbbdef56ecb0de1d45223
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Mar 2021 17:01:19 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '651'
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - timeout=5
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Expose-Headers:
+      - Range,Content-Range,X-Content-Range,X-API-Key
+      Etag:
+      - W/"2eb-A0NiRd+gbJKIAT0y4tR4j9tjXb0"
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15552000
+      - max-age=15552000
+      Vary:
+      - Origin, Accept
+      X-Gravitee-Request-Id:
+      - 7bfb7f99-ac2d-4443-bb7f-99ac2d0443c5
+      X-Gravitee-Transaction-Id:
+      - f5dca8b3-2ab7-4c9a-9ca8-b32ab70c9a2b
+    body:
+      encoding: ASCII-8BIT
+      string: '{
+        "identifiant": "georges_moustaki_77",
+        "civilite": "M.",
+        "nom": "Moustaki",
+        "nomUsage": "Moustaki",
+        "prenom": "Georges",
+        "sexe": "M",
+        "dateNaissance": "1934-05-03",
+        "adresse": {
+          "INSEECommune": "75118",
+          "codePostal": "75018",
+          "localite": "75018 Paris",
+          "ligneVoie": "3 rue des Huttes",
+          "ligneNom": "MOUSTAKI"
+        },
+        "email": "georges@moustaki.fr",
+        "telephone": "0629212921",
+        "dateInscription": "1965-05-03",
+        "dateCessationInscription": "1966-05-03",
+        "codeCertificationCNAV": "VC",
+        "codeCategorieInscription": 1,
+        "libelleCategorieInscription": "PERSONNE SANS EMPLOI DISPONIBLE DUREE INDETERMINEE PLEIN TPS"
+      }'
+  recorded_at: Tue, 16 Mar 2021 17:01:18 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/cassettes/api_particulier/success/situation_pole_emploi_invalid.yml
+++ b/spec/fixtures/cassettes/api_particulier/success/situation_pole_emploi_invalid.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://particulier.api.gouv.fr/api/v2/situations-pole-emploi?identifiant=georges_moustaki_77
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - demarches-simplifiees.fr
+      Accept:
+      - application/json
+      X-Api-Key:
+      - 06fd8675601267d2988cbbdef56ecb0de1d45223
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 16 Mar 2021 17:01:19 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '747'
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - timeout=5
+      Access-Control-Allow-Credentials:
+      - '651'
+      Access-Control-Expose-Headers:
+      - Range,Content-Range,X-Content-Range,X-API-Key
+      Etag:
+      - W/"2eb-A0NiRd+gbJKIAT0y4tR4j9tjXb0"
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=15552000
+      - max-age=15552000
+      Vary:
+      - Origin, Accept
+      X-Gravitee-Request-Id:
+      - 7bfb7f99-ac2d-4443-bb7f-99ac2d0443c5
+      X-Gravitee-Transaction-Id:
+      - f5dca8b3-2ab7-4c9a-9ca8-b32ab70c9a2b
+    body:
+      encoding: ASCII-8BIT
+      string: '{
+        "identifiant": "georges_moustaki_77",
+        "civilite": "M.",
+        "nom": "Moustaki",
+        "nomUsage": "Moustaki",
+        "prenom": "Georges",
+        "sexe": "X",
+        "dateNaissance": "1934-05-03",
+        "adresse": {
+          "INSEECommune": "75118",
+          "codePostal": "75018",
+          "localite": "75018 Paris",
+          "ligneVoie": "3 rue des Huttes",
+          "ligneNom": "MOUSTAKI"
+        },
+        "email": "georges@moustaki.fr",
+        "telephone": "0629212921",
+        "dateInscription": "1965-05-03",
+        "dateCessationInscription": "1966-05-03",
+        "codeCertificationCNAV": "VC",
+        "codeCategorieInscription": 1,
+        "libelleCategorieInscription": "PERSONNE SANS EMPLOI DISPONIBLE DUREE INDETERMINEE PLEIN TPS"
+      }'
+  recorded_at: Tue, 16 Mar 2021 17:01:18 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/files/api_particulier/situation_pole_emploi.json
+++ b/spec/fixtures/files/api_particulier/situation_pole_emploi.json
@@ -1,0 +1,29 @@
+{
+  "identite": {
+    "identifiant": "georges_moustaki_77",
+    "civilite": "M.",
+    "nom": "Moustaki",
+    "nomUsage": "Moustaki",
+    "prenom": "Georges",
+    "sexe": "M",
+    "dateNaissance": "1934-05-03"
+  },
+  "adresse": {
+    "INSEECommune": "75118",
+    "codePostal": "75018",
+    "localite": "75018 Paris",
+    "ligneVoie": "3 rue des Huttes",
+    "ligneNom": "MOUSTAKI"
+  },
+  "contact": {
+    "email": "georges@moustaki.fr",
+    "telephone": "0629212921"
+  },
+  "inscription": {
+    "dateInscription": "1965-05-03",
+    "dateCessationInscription": "1966-05-03",
+    "codeCertificationCNAV": "VC",
+    "codeCategorieInscription": 1,
+    "libelleCategorieInscription": "PERSONNE SANS EMPLOI DISPONIBLE DUREE INDETERMINEE PLEIN TPS"
+  }
+}

--- a/spec/lib/api_particulier/api_spec.rb
+++ b/spec/lib/api_particulier/api_spec.rb
@@ -37,7 +37,11 @@ describe APIParticulier::API do
           'dgfip_revenu_fiscal_reference',
           'dgfip_revenu_imposable',
           'dgfip_situation_familiale',
-          'dgfip_situation_partielle'
+          'dgfip_situation_partielle',
+          'pole_emploi_identite',
+          'pole_emploi_adresse',
+          'pole_emploi_contact',
+          'pole_emploi_inscription'
         )
       end
     end

--- a/spec/lib/api_particulier/pole_emploi_adapter_spec.rb
+++ b/spec/lib/api_particulier/pole_emploi_adapter_spec.rb
@@ -1,0 +1,63 @@
+describe APIParticulier::PoleEmploiAdapter do
+  let(:adapter) { described_class.new(api_particulier_token, identifiant, requested_sources) }
+
+  before { stub_const('API_PARTICULIER_URL', 'https://particulier.api.gouv.fr/api') }
+
+  describe '#to_params' do
+    let(:api_particulier_token) { '06fd8675601267d2988cbbdef56ecb0de1d45223' }
+    let(:identifiant) { 'georges_moustaki_77' }
+
+    subject { VCR.use_cassette(cassette) { adapter.to_params } }
+
+    context 'when the api answer is valid' do
+      let(:cassette) { 'api_particulier/success/situation_pole_emploi' }
+
+      context 'when the token has all the pole emploi scopes' do
+        context 'and all the sources are requested' do
+          let(:requested_sources) do
+            {
+              'pole_emploi' => {
+                'identite' => ['identifiant', 'civilite', 'nom', 'nomUsage', 'prenom', 'sexe', 'dateNaissance'],
+                'adresse' => ['INSEECommune', 'codePostal', 'localite', 'ligneVoie', 'ligneComplementDestinataire', 'ligneComplementAdresse', 'ligneComplementDistribution', 'ligneNom'],
+                'contact' => ['email', 'telephone', 'telephone2'],
+                'inscription' => ['dateInscription', 'dateCessationInscription', 'codeCertificationCNAV', 'codeCategorieInscription', 'libelleCategorieInscription']
+              }
+            }
+          end
+
+          let(:result) { JSON.parse(File.read('spec/fixtures/files/api_particulier/situation_pole_emploi.json')) }
+
+          it { is_expected.to eq(result) }
+        end
+
+        context 'when no sources is requested' do
+          let(:requested_sources) { {} }
+
+          it { is_expected.to eq({}) }
+        end
+
+        context 'when an address name is requested' do
+          let(:requested_sources) { { 'pole_emploi' => { 'adresse' => ['ligneNom'] } } }
+
+          it { is_expected.to eq('adresse' => { 'ligneNom' => 'MOUSTAKI' }) }
+        end
+
+        context 'when a first name is requested' do
+          let(:requested_sources) { { 'pole_emploi' => { 'identite' => ['prenom'] } } }
+
+          it { is_expected.to eq('identite' => { 'prenom' => 'Georges' }) }
+        end
+      end
+    end
+
+    context 'when the api answer is invalid' do
+      let(:cassette) { 'api_particulier/success/situation_pole_emploi_invalid' }
+
+      context 'when no sources is requested' do
+        let(:requested_sources) { {} }
+
+        it { expect { subject }.to raise_error(APIParticulier::PoleEmploiAdapter::InvalidSchemaError) }
+      end
+    end
+  end
+end

--- a/spec/lib/api_particulier/services/sources_service_spec.rb
+++ b/spec/lib/api_particulier/services/sources_service_spec.rb
@@ -47,6 +47,21 @@ describe APIParticulier::Services::SourcesService do
       it { is_expected.to match(dgfip_avis_imposition_et_adresse) }
     end
 
+    context 'when a procedure has a pole_emploi_identite and a pole_emploi_adresse scopes' do
+      let(:api_particulier_scopes) { ['pole_emploi_identite', 'pole_emploi_adresse'] }
+
+      let(:pole_emploi_identite_et_adresse) do
+        {
+          'pole_emploi' => {
+            'identite' => ['identifiant', 'civilite', 'nom', 'nomUsage', 'prenom', 'sexe', 'dateNaissance'],
+            'adresse' => ['INSEECommune', 'codePostal', 'localite', 'ligneVoie', 'ligneComplementDestinataire', 'ligneComplementAdresse', 'ligneComplementDistribution', 'ligneNom']
+          }
+        }
+      end
+
+      it { is_expected.to match(pole_emploi_identite_et_adresse) }
+    end
+
     context 'when a procedure has an unknown scope' do
       let(:api_particulier_scopes) { ['unknown_scope'] }
 

--- a/spec/models/champs/pole_emploi_champ_spec.rb
+++ b/spec/models/champs/pole_emploi_champ_spec.rb
@@ -1,0 +1,56 @@
+describe Champs::PoleEmploiChamp, type: :model do
+  let(:champ) { described_class.new }
+
+  describe 'identifiant' do
+    before do
+      champ.identifiant = 'georges_moustaki_77'
+    end
+
+    it 'saves identifiant' do
+      expect(champ.identifiant).to eq('georges_moustaki_77')
+    end
+  end
+
+  describe 'external_id' do
+    context 'when no data is given' do
+      before do
+        champ.identifiant = ''
+        champ.save
+      end
+
+      it { expect(champ.external_id).to be_nil }
+    end
+
+    context 'when all data required for an external fetch are given' do
+      before do
+        champ.identifiant = 'georges_moustaki_77'
+        champ.save
+      end
+
+      it { expect(JSON.parse(champ.external_id)).to eq("identifiant" => "georges_moustaki_77") }
+    end
+  end
+
+  describe '#validate' do
+    let(:champ) { described_class.new(dossier: create(:dossier), type_de_champ: create(:type_de_champ_pole_emploi)) }
+    let(:validation_context) { :create }
+
+    subject { champ.valid?(validation_context) }
+
+    before do
+      champ.identifiant = identifiant
+    end
+
+    context 'when identifiant is valid' do
+      let(:identifiant) { 'georges_moustaki_77' }
+
+      it { is_expected.to be true }
+    end
+
+    context 'when identifiant is nil' do
+      let(:identifiant) { nil }
+
+      it { is_expected.to be true }
+    end
+  end
+end

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -79,6 +79,7 @@ describe ProcedureExportService do
           "annuaire_education",
           "cnaf",
           "dgfip",
+          "pole_emploi",
           "text"
         ]
       end
@@ -168,6 +169,7 @@ describe ProcedureExportService do
           "annuaire_education",
           "cnaf",
           "dgfip",
+          "pole_emploi",
           "text"
         ]
       end
@@ -253,6 +255,7 @@ describe ProcedureExportService do
             "annuaire_education",
             "cnaf",
             "dgfip",
+            "pole_emploi",
             "text"
           ]
         end


### PR DESCRIPTION
Cette PR ajoute le support de Pôle emploi à travers l'API Particulier.

Sur la base des travaux de réécriture de la PR #6024, initiés par @LeSim (voir PR #6483 et #6488), voici l'implémentation du support de Pôle emploi. Cette MR comprend un nouveau champ Pôle emploi, ainsi que l'adaptateur Pôle emploi, le tout avec les tests qui vont avec et un support complet des locales.

# Captures d'écran
![Screenshot 2021-12-01 at 14-26-14 demarches-simplifiees syn](https://user-images.githubusercontent.com/130560/144256192-e033a499-c1c0-4dcc-a8c6-edef56966a19.png)

![Screenshot 2021-12-01 at 14-30-29 demarches-simplifiees syn](https://user-images.githubusercontent.com/130560/144256189-8756d5b2-678c-4978-89b8-3c9f0b22a2ff.png)

![Screenshot 2021-12-01 at 14-30-40 demarches-simplifiees syn](https://user-images.githubusercontent.com/130560/144256186-ba84f9cb-fc03-4251-be99-741551c1e42d.png)

![Screenshot 2021-12-01 at 14-31-40 Modification du brouillon nº 19 (Ma démarche) · demarches-simplifiees syn](https://user-images.githubusercontent.com/130560/144256183-fec6d1ca-7e08-495f-afc7-429bbbaa884c.png)

![Screenshot 2021-12-01 at 14-32-12 Demande · Dossier nº19 (Ma démarche) · demarches-simplifiees syn](https://user-images.githubusercontent.com/130560/144256180-55031c5f-7957-41ea-89e5-26d84f847002.png)

![Screenshot 2021-12-01 at 14-36-27 Demande · Dossier nº 19 (Moustaki Georges) · demarches-simplifiees syn](https://user-images.githubusercontent.com/130560/144256176-fa96939c-06df-431d-a0bf-e367bbfdc327.png)