### PR TITLE
Fix csv download of stats

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -57,9 +57,9 @@ class StatsController < ApplicationController
           "procedures.libelle",
           "users.id",
           "dossiers.state",
-          "dossiers.depose_at - dossiers.created_at",
-          "dossiers.en_instruction_at - dossiers.depose_at",
-          "dossiers.processed_at - dossiers.en_instruction_at"
+          Arel.sql("dossiers.depose_at - dossiers.created_at"),
+          Arel.sql("dossiers.en_instruction_at - dossiers.depose_at"),
+          Arel.sql("dossiers.processed_at - dossiers.en_instruction_at")
         )
     end
 


### PR DESCRIPTION
Le telechargement du csv déclenche une exception ActiveRecord::UnknownAttributeReference. 
cf https://medium.com/@mitsun.chieh/activerecord-relation-with-raw-sql-argument-returns-a-warning-exception-raising-8999f1b9898a
