### PR TITLE
Correction du formulaire de contact lorsqu'un un numéro de téléphone est fourni

### DIFF
--- a/app/lib/helpscout/api.rb
+++ b/app/lib/helpscout/api.rb
@@ -43,7 +43,7 @@ class Helpscout::API
   end
 
   def add_phone_number(email, phone)
-    query = URI.encode("(email:#{email})")
+    query = CGI.escape("(email:#{email})")
     response = call_api(:get, "#{CUSTOMERS}?mailbox=#{user_support_mailbox_id}&query=#{query}")
     if response.success?
       body = parse_response_body(response)


### PR DESCRIPTION
Depuis le passage à Ruby 3 `URI.encode` n'existe plus. Ça cause une erreur quand on envoie un formulaire de contact avec un n° de téléphone.

Corrige https://sentry.io/organizations/demarches-simplifiees/issues/2826494165/