### PR TITLE
Correction de la tâche de migration `after_party:set_dossiers_processed_at`, et suppression des correctifs temporaires

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -564,7 +564,8 @@ class Dossier < ApplicationRecord
   end
 
   def close_to_expiration?
-    return false
+    return false if en_instruction?
+    approximative_expiration_date < Time.zone.now
   end
 
   def expiration_date

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -560,7 +560,7 @@ class Dossier < ApplicationRecord
       approximative_expiration_date_reference,
       conservation_extension,
       procedure.duree_conservation_dossiers_dans_ds.months
-    ].compact.sum - REMAINING_WEEKS_BEFORE_EXPIRATION.weeks
+    ].sum - REMAINING_WEEKS_BEFORE_EXPIRATION.weeks
   end
 
   def close_to_expiration?

--- a/lib/tasks/deployment/20211110093332_set_dossiers_processed_at.rake
+++ b/lib/tasks/deployment/20211110093332_set_dossiers_processed_at.rake
@@ -7,7 +7,7 @@ namespace :after_party do
     progress = ProgressReport.new(dossiers.count)
 
     dossiers.find_each do |dossier|
-      if dossier.processed_at != dossier.traitement.processed_at
+      if dossier.read_attribute(:processed_at) != dossier.traitement.processed_at
         dossier.update_column(:processed_at, dossier.traitement.processed_at)
       end
       progress.inc


### PR DESCRIPTION
Une fois la tache `rake after_party:set_dossiers_processed_at` est rejoué on peut rollback les "fix"

J'ai corrigé la task pour que les autres instances n'ai pas le problem lors de leur deploy