### PR TITLE
Correction de la requête de notification quotidienne des Instructeurs

### DIFF
--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -2,7 +2,7 @@ class NotificationService
   class << self
     def send_instructeur_email_notification
       Instructeur
-        .includes(assign_to: { procedure: :dossiers })
+        .includes(assign_to: [:procedure])
         .where(assign_tos: { daily_email_notifications_enabled: true })
         .find_in_batches { |instructeurs| send_batch_of_instructeurs_email_notification(instructeurs) }
     end


### PR DESCRIPTION
En ce moment la requête pour envoyer les notifications quotidiennes aux Instructeurs timeoute toutes les nuits en prod (https://sentry.io/organizations/demarches-simplifiees/issues/2632987852)

Ce commit accélère la requête initiale, pour qu'elle ne timeoute pas.

> This request currently times out almost every night in production.
>
> It's because although Instructeurs are loaded in batches (default batch size is 1000), loading all dossiers for 1000 instructeurs is slow.
>
> Turns out the code executed after this query to compute notifications doesn't even use these dossiers. Indeed it is faster not to preload them: both the initial query and the total treatment time are shorter.
>
> Here's a quick benchmark made locally (but using production data):
>
> ### Before this commit:
> ```ruby
> Benchmark.measure { pp Instructeur.includes(assign_to: { procedure: :dossiers }).where(assign_tos: { daily_email_notifications_enabled: true }).limit(100).map(&:email_notification_data) }
> ```
>
> - Only the initial query : 35s
> - Total time : 97s
>
> ### Without preloading dossiers:
> ```ruby
> Benchmark.measure { pp Instructeur.includes(assign_to: :procedure).where(assign_tos: { daily_email_notifications_enabled: true }).limit(100).map(&:email_notification_data) }
> ```
>
> - Only the initial query : 0.08s (400x faster)
> - Total time : 29s (3,3x faster)
>
> Plus it doesn't timeout, of course.

## Notes complémentaires

Après il faut aussi que le temps de traitement total du job ne timeoute pas la durée maximale d'un job. Mais on va déjà commencer par ça.