### PR TITLE
Petites améliorations sur les textes de la page "Statistiques"

### DIFF
--- a/app/assets/stylesheets/stats.scss
+++ b/app/assets/stylesheets/stats.scss
@@ -60,6 +60,7 @@ $stat-card-half-horizontal-spacing: 4 * $default-space;
   font-size: 26px;
   font-weight: bold;
   width: 200px;
+  text-transform: uppercase;
 }
 
 .stat-card-details {
@@ -132,6 +133,7 @@ $big-number-card-padding: 2 * $segmented-control-item-border-radius;
   margin: 0 auto;
   margin-bottom: 20px;
   color: $light-grey;
+  text-transform: uppercase;
 
   &.long-title {
     margin-left: -30px;

--- a/app/views/shared/procedures/_stats.html.haml
+++ b/app/views/shared/procedures/_stats.html.haml
@@ -7,45 +7,45 @@
   .stat-cards
     - if @usual_traitement_time.present?
       .stat-card.big-number-card
-        %span.big-number-card-title TEMPS DE TRAITEMENT USUEL
+        %span.big-number-card-title= t('.usual_processing_time')
         %span.big-number-card-number
           = distance_of_time_in_words(@usual_traitement_time)
         %span.big-number-card-detail
-          #{ProcedureStatsConcern::USUAL_TRAITEMENT_TIME_PERCENTILE}% des demandes des #{ProcedureStatsConcern::NB_DAYS_RECENT_DOSSIERS} derniers jours ont été traitées en moins de #{distance_of_time_in_words(@usual_traitement_time)}.
+          = t('.processing_time_description', percentile: ProcedureStatsConcern::USUAL_TRAITEMENT_TIME_PERCENTILE, span: ProcedureStatsConcern::NB_DAYS_RECENT_DOSSIERS, days: distance_of_time_in_words(@usual_traitement_time))
 
   .stat-cards
     .stat-card.stat-card-half.pull-left
-      %span.stat-card-title TEMPS DE TRAITEMENT
-      .stat-card-details depuis le lancement de la procédure
+      %span.stat-card-title= t('.processing_time')
+      .stat-card-details= t('.since_procedure_creation')
       .chart-container
         .chart
           - colors = %w(#C3D9FF #0069CC #1C7EC9) # from _colors.scss
-          = column_chart @usual_traitement_time_by_month, ytitle: "Nb Jours", legend: "bottom", label: "Temps de traitement entre le passage en instruction et la réponse (accepté, refusé, ou classé sans suite) pour 90% des dossiers"
+          = column_chart @usual_traitement_time_by_month, ytitle: t('.nb_days'), legend: "bottom", label: t('.processing_time_graph_description')
 
     .stat-card.stat-card-half.pull-left
-      %span.stat-card-title AVANCÉE DES DOSSIERS
-      .stat-card-details depuis le lancement de la procédure
+      %span.stat-card-title= t('.status_evolution')
+      .stat-card-details= t('.status_evolution_details')
       .chart-container
         .chart
-          = area_chart @dossiers_funnel, ytitle: 'Nb dossiers', label: 'Nb dossiers'
+          = area_chart @dossiers_funnel, ytitle: t('.dossiers_count'), label: t('.dossiers_count')
 
   .stat-cards
     .stat-card.stat-card-half.pull-left
-      %span.stat-card-title TAUX D’ACCEPTATION
-      .stat-card-details depuis le lancement de la procédure
+      %span.stat-card-title= t('.acceptance_rate')
+      .stat-card-details= t('.acceptance_rate_details')
       .chart-container
         .chart
           = pie_chart @termines_states,
             code: true,
             colors: %w(#387EC3 #AE2C2B #FAD859),
-            label: 'Taux',
+            label: t('.rate'),
             suffix: '%',
             library: { plotOptions: { pie: {  dataLabels: { enabled: true, format: '{point.name} : {point.percentage: .1f}%' } } } }
 
 
     .stat-card.stat-card-half.pull-left
-      %span.stat-card-title RÉPARTITION PAR SEMAINE
-      .stat-card-details au cours des 6 derniers mois
+      %span.stat-card-title= t('.weekly_distribution')
+      .stat-card-details= t('.weekly_distribution_details')
       .chart-container
         .chart
-          = line_chart @termines_by_week, colors: ["#387EC3", "#AE2C2B", "#FAD859"], ytitle: 'Nb dossiers'
+          = line_chart @termines_by_week, colors: ["#387EC3", "#AE2C2B", "#FAD859"], ytitle: t('.dossiers_count')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -418,3 +418,20 @@ en:
           invalid_password: "The password is not correct."
           connection_done: "The accounts for FranceConnect and %{application_name} are now merged."
           merger_token_expired: "Le delay to merge your FranceConnect and %{application_name} accounts is expired. Please retry."
+  shared:
+    procedures:
+      stats:
+        usual_processing_time: "Usual processing time"
+        processing_time_description: "%{percentile}% of submitted files in the last %{span} days were processed in less than %{days} days."
+        processing_time: "Processing time"
+        since_procedure_creation: "since the procedure was created"
+        nb_days: "Nb Days"
+        processing_time_graph_description: "Processing time between instruction and final answer (accepted, rejected or closed) for 90% of files."
+        status_evolution_details: "since the procedure launch"
+        status_evolution: "Evolution of file statuses"
+        acceptance_rate: "Acceptance rate"
+        acceptance_rate_details: "since the procedure launch"
+        rate: "Rate"
+        dossiers_count: "Nb files"
+        weekly_distribution: "Weekly distribution"
+        weekly_distribution_details: "in the last 6 months"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -462,3 +462,20 @@ fr:
         invalid_password: "Mauvais mot de passe"
         connection_done: "Les comptes FranceConnect et %{application_name} sont à présent fusionnés"
         merger_token_expired: "Le délai pour fusionner les comptes FranceConnect et %{application_name} est expirée. Veuillez recommencer la procédure pour vous fusionner les comptes."
+  shared:
+    procedures:
+      stats:
+        usual_processing_time: "Temps de traitement usuel"
+        processing_time_description: "%{percentile}% des demandes des %{span} derniers jours ont été traitées en moins de %{days} jours."
+        processing_time: "Temps de traitement"
+        since_procedure_creation: "depuis le lancement de la démarche"
+        nb_days: "Nb Jours"
+        processing_time_graph_description: "Temps de traitement entre le passage en instruction et la réponse (accepté, refusé, ou classé sans suite) pour 90% des dossiers"
+        status_evolution_details: "depuis le lancement de la démarche"
+        status_evolution: "Avancée des dossiers"
+        acceptance_rate: "Taux d’acceptation"
+        acceptance_rate_details: "depuis le lancement de la démarche"
+        rate: "Taux"
+        dossiers_count: "Nb dossiers"
+        weekly_distribution: "Répartition par semaine"
+        weekly_distribution_details: "au cours des 6 derniers mois"

--- a/spec/views/users/statistiques/show.html.haml_spec.rb
+++ b/spec/views/users/statistiques/show.html.haml_spec.rb
@@ -8,9 +8,9 @@ describe 'users/statistiques/show.html.haml', type: :view do
   subject { render }
 
   it "display stats" do
-    expect(subject).to have_text("RÉPARTITION PAR SEMAINE")
-    expect(subject).to have_text("AVANCÉE DES DOSSIERS")
-    expect(subject).to have_text("TAUX D’ACCEPTATION")
+    expect(subject).to have_text("Répartition par semaine")
+    expect(subject).to have_text("Avancée des dossiers")
+    expect(subject).to have_text("Taux d’acceptation")
     expect(subject).to have_text(procedure.libelle)
   end
 end


### PR DESCRIPTION
- Internationalisation,
- Traduction des textes de la page en anglais,
- Renommage de 'procédure' en 'démarches'.


## Avant
![avant](https://user-images.githubusercontent.com/179923/146008959-18ad050a-f629-4072-89ca-79a12d1a47f4.png)

## Après
![après](https://user-images.githubusercontent.com/179923/146008975-89d2e9ff-96b9-4b37-aa6a-ee8c64a700c9.png)

