### PR TITLE
Update zones to proc

### DIFF
--- a/app/services/update_zone_to_procedures_service.rb
+++ b/app/services/update_zone_to_procedures_service.rb
@@ -1,0 +1,21 @@
+class UpdateZoneToProceduresService
+  def self.call(lines)
+    errors = []
+    lines.each do |line|
+      zone_label = line["POL_PUB_MINISTERE RATTACHEMENT"]
+      zone = Zone.find_by(acronym: zone_label)
+      if zone.nil?
+        errors << "Zone #{zone_label} introuvable"
+      else
+        id = line["id"]
+        procedure = Procedure.find_by(id: id)
+        if procedure
+          procedure.update(zone: zone)
+        else
+          errors << "Procedure #{id} introuvable"
+        end
+      end
+    end
+    errors
+  end
+end

--- a/lib/tasks/populate_zones.rake
+++ b/lib/tasks/populate_zones.rake
@@ -1,10 +1,12 @@
-task populate_zones: :environment do
-  puts "Running deploy task 'populate_zones'"
+namespace :zones do
+  task populate_zones: :environment do
+    puts "Running deploy task 'populate_zones'"
 
-  Zone.create!(acronym: 'COLLECTIVITE', label: 'Collectivité territoriale')
-  config = Psych.safe_load(File.read(Rails.root.join("config", "zones.yml")))
-  config["ministeres"].each do |ministere|
-    acronym = ministere.keys.first
-    Zone.create!(acronym: acronym, label: ministere["label"])
+    Zone.create!(acronym: 'COLLECTIVITE', label: 'Collectivité territoriale')
+    config = Psych.safe_load(File.read(Rails.root.join("config", "zones.yml")))
+    config["ministeres"].each do |ministere|
+      acronym = ministere.keys.first
+      Zone.create!(acronym: acronym, label: ministere["label"])
+    end
   end
 end

--- a/lib/tasks/update_zone_to_procedures.rake
+++ b/lib/tasks/update_zone_to_procedures.rake
@@ -1,0 +1,23 @@
+require Rails.root.join("lib", "tasks", "task_helper")
+
+namespace :zones do
+  desc <<~EOD
+    Update zone to all procedures
+    rails zones:update_zone_to_procedures\[csv_path\]
+  EOD
+  task :update_zone_to_procedures, [:csv] => :environment do |_t, args|
+    csv = args[:csv]
+    lines = CSV.readlines(csv, headers: true)
+
+    rake_puts "Mise à jour des procédures en cours..."
+
+    errors =
+      UpdateZoneToProceduresService.call(lines)
+
+    if errors.present?
+      errors.each { |error| rake_puts error }
+    end
+
+    rake_puts "Mise à jour terminée"
+  end
+end

--- a/spec/lib/tasks/populate_zones_spec.rb
+++ b/spec/lib/tasks/populate_zones_spec.rb
@@ -1,5 +1,5 @@
 describe 'populate_zones' do
-  let(:rake_task) { Rake::Task['populate_zones'] }
+  let(:rake_task) { Rake::Task['zones:populate_zones'] }
   subject(:run_task) do
     rake_task.invoke
   end

--- a/spec/services/update_zone_to_procedures_service_spec.rb
+++ b/spec/services/update_zone_to_procedures_service_spec.rb
@@ -1,6 +1,6 @@
 describe UpdateZoneToProceduresService do
   before(:all) do
-    Rake::Task['populate_zones'].invoke
+    Rake::Task['zones:populate_zones'].invoke
   end
 
   after(:all) do

--- a/spec/services/update_zone_to_procedures_service_spec.rb
+++ b/spec/services/update_zone_to_procedures_service_spec.rb
@@ -1,0 +1,57 @@
+describe UpdateZoneToProceduresService do
+  before(:all) do
+    Rake::Task['populate_zones'].invoke
+  end
+
+  after(:all) do
+    Zone.destroy_all
+  end
+
+  describe '#call' do
+    let(:procedure1) { create(:procedure, zone: nil) }
+    let(:procedure2) { create(:procedure, zone: nil) }
+
+    subject { described_class.call(lines) }
+
+    context 'nominal case' do
+      let(:lines) do
+        [
+          { "id" => procedure1.id, "POL_PUB_MINISTERE RATTACHEMENT" => "PM" },
+          { "id" => procedure2.id, "POL_PUB_MINISTERE RATTACHEMENT" => "MI" }
+        ]
+      end
+
+      it 'updates zone to procedures' do
+        errors = subject
+
+        expect(errors).to eq []
+        expect(procedure1.reload.zone.acronym).to eq("PM")
+        expect(procedure2.reload.zone.acronym).to eq("MI")
+      end
+    end
+
+    context 'with unknown procedure' do
+      let(:lines) do
+        [
+          { "id" => procedure1.id + procedure2.id, "POL_PUB_MINISTERE RATTACHEMENT" => "PM" }
+        ]
+      end
+      it 'returns errors' do
+        errors = subject
+        expect(errors).to eq ["Procedure #{procedure1.id + procedure2.id} introuvable"]
+      end
+    end
+
+    context 'with unknown zone' do
+      let(:lines) do
+        [
+          { "id" => procedure1.id, "POL_PUB_MINISTERE RATTACHEMENT" => "YOUPI" }
+        ]
+      end
+      it 'returns errors' do
+        errors = subject
+        expect(errors).to eq ["Zone YOUPI introuvable"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Cette PR ajoute la tâche manuelle `zones:update_zone_to_procedures` qui prend en entrée un fichier CSV, et met à jour l'ensemble des procédures indiquées dans le fichier (colonne _id_) et y associent la zone (qui a pour acronyme la valeur _POL_PUB_MINISTERE RATTACHEMENT_)

Par souci de cohérence, cette PR ajoute la tâche `populate_zones` dans le namespace `zones`