### PR TITLE
Revert "refactor date_trunc queries using groupdate gem"

### DIFF
--- a/spec/controllers/stats_controller_spec.rb
+++ b/spec/controllers/stats_controller_spec.rb
@@ -1,4 +1,7 @@
 describe StatsController, type: :controller do
+  before { Timecop.travel(Date.parse("2021/12/15")) }
+  after { Timecop.return }
+
   describe "#last_four_months_hash" do
     context "while a regular user is logged in" do
       before do


### PR DESCRIPTION
This reverts commit 0a31c8bc7936bf6abc842be52614594b993ed9c5.

Ce commit corrige le test qui fail de temps en temps `./spec/controllers/stats_controller_spec.rb:45`