### PR TITLE
Correction d'un problème d'accessibilité sur la page de contact

### DIFF
--- a/app/assets/stylesheets/contact.scss
+++ b/app/assets/stylesheets/contact.scss
@@ -12,4 +12,9 @@ $contact-padding: $default-space * 2;
   .hidden {
     display: none;
   }
+
+  ul {
+    margin-bottom: $default-space;
+  }
+
 }

--- a/config/locales/views/support/en.yml
+++ b/config/locales/views/support/en.yml
@@ -21,8 +21,8 @@ en:
       product:
         question: I have an idea to improve the website
         answer_html: "<p>Got an idea? Please check our <strong>enhancement dashboard</strong></p>
-              <p><ul><li>Vote for your priority improvements</li>
-              <li>Share your own ideas</li></ul></p>
+              <ul><li>Vote for your priority improvements</li>
+              <li>Share your own ideas</li></ul>
               <p><strong><a href=%{link_product}>➡ Access the enhancement dashboard</a></strong></p>"
       lost_user:
         question: I am having trouble finding the procedure I am looking for

--- a/config/locales/views/support/fr.yml
+++ b/config/locales/views/support/fr.yml
@@ -21,8 +21,8 @@ fr:
       product:
         question: J’ai une idée d’amélioration pour votre site
         answer_html: "<p>Une idée ? Pensez à consulter notre <strong>tableau de bord des améliorations</strong></p>
-        <p><ul><li>Votez pour vos améliorations prioritaires;</li>
-        <li>Proposez votre propre idée.</li></ul></p>
+        <ul><li>Votez pour vos améliorations prioritaires;</li>
+        <li>Proposez votre propre idée.</li></ul>
         <p><strong><a href=%{link_product}>➡ Accéder au tableau des améliorations</a></strong></p>"
       lost_user:
         question: Je ne trouve pas la démarche que je veux faire


### PR DESCRIPTION
L'interpolation de `support.index.product.answer_html` produisait des
balises p vides, ce qui contrevenait au critère 8.9.1 RGAA
(https://www.numerique.gouv.fr/publications/rgaa-accessibilite/methode/criteres/#test-8-9-1)