### PR TITLE
Matomo : désactivation du suivi des clics sur les liens externes

### DIFF
--- a/app/javascript/shared/track/matomo.js
+++ b/app/javascript/shared/track/matomo.js
@@ -7,12 +7,19 @@ if (enabled) {
   const trackerUrl = `${url}piwik.php`;
   const jsUrl = `${url}piwik.js`;
 
+  //
   // Configure Matomo analytics
+  //
+
   window._paq.push(['setCookieDomain', '*.www.demarches-simplifiees.fr']);
   window._paq.push(['setDomains', ['*.www.demarches-simplifiees.fr']]);
+  // Don’t store any cookies or send any tracking request when the "Do Not Track" browser setting is enabled.
   window._paq.push(['setDoNotTrack', true]);
+  // When enabling external link tracking, consider that it will also report links to attachments.
+  // You’ll want to exclude links to attachments from being tracked – for instance using Matomo's
+  // `setCustomRequestProcessing` callback.
+  // window._paq.push(['enableLinkTracking']);
   window._paq.push(['trackPageView']);
-  window._paq.push(['enableLinkTracking']);
 
   // Load script from Matomo
   window._paq.push(['setTrackerUrl', trackerUrl]);


### PR DESCRIPTION
Le suivi peut être rétabli pour les instances qui en ont besoin – mais par défaut c'est bien si on shippe une configuration plus restreinte.