### PR TITLE
Permet de voir les zones des procédures dans le manager

### DIFF
--- a/app/controllers/manager/zones_controller.rb
+++ b/app/controllers/manager/zones_controller.rb
@@ -12,9 +12,13 @@ module Manager
     # This will be used to set the resource for the `show`, `edit`, and `update`
     # actions.
     #
-    # def find_resource(param)
-    #   Foo.find_by!(slug: param)
-    # end
+    def find_resource(param)
+      if param == "nil"
+        NullZone.new
+      else
+        Zone.find(param)
+      end
+    end
 
     # The result of this lookup will be available as `requested_resource`
 

--- a/app/controllers/manager/zones_controller.rb
+++ b/app/controllers/manager/zones_controller.rb
@@ -1,0 +1,46 @@
+module Manager
+  class ZonesController < Manager::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/app/dashboards/procedure_dashboard.rb
+++ b/app/dashboards/procedure_dashboard.rb
@@ -16,6 +16,7 @@ class ProcedureDashboard < Administrate::BaseDashboard
     id: Field::Number.with_options(searchable: true),
     libelle: Field::String,
     description: Field::String,
+    zone: Field::BelongsTo,
     lien_site_web: Field::String, # TODO: use Field::Url when administrate-v0.12 will be released
     organisation: Field::String,
     direction: Field::String,
@@ -47,6 +48,7 @@ class ProcedureDashboard < Administrate::BaseDashboard
     :id,
     :created_at,
     :libelle,
+    :zone,
     :service,
     :dossiers,
     :published_at,
@@ -64,6 +66,7 @@ class ProcedureDashboard < Administrate::BaseDashboard
     :lien_site_web,
     :organisation,
     :direction,
+    :zone,
     :service,
     :created_at,
     :updated_at,

--- a/app/dashboards/zone_dashboard.rb
+++ b/app/dashboards/zone_dashboard.rb
@@ -1,0 +1,53 @@
+require "administrate/base_dashboard"
+
+class ZoneDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    procedures: Field::HasMany,
+    id: Field::Number,
+    acronym: Field::String,
+    label: Field::String,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = [:procedures, :id, :acronym, :label].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = [:procedures, :id, :acronym, :label, :created_at, :updated_at].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = [:procedures, :acronym, :label].freeze
+
+  # COLLECTION_FILTERS
+  # a hash that defines filters that can be used while searching via the search
+  # field of the dashboard.
+  #
+  # For example to add an option to search for open resources by typing "open:"
+  # in the search field:
+  #
+  #   COLLECTION_FILTERS = {
+  #     open: ->(resources) { resources.where(open: true) }
+  #   }.freeze
+  COLLECTION_FILTERS = {}.freeze
+
+  # Overwrite this method to customize how zones are displayed
+  # across all pages of the admin dashboard.
+  #
+  def display_resource(zone)
+    "Zone #{zone.label}"
+  end
+end

--- a/app/models/null_zone.rb
+++ b/app/models/null_zone.rb
@@ -1,0 +1,31 @@
+class NullZone
+  include ActiveModel::Model
+
+  def procedures
+    Procedure.where(zone: nil).where.not(published_at: nil).order(published_at: :desc)
+  end
+
+  def self.reflect_on_association(association)
+    OpenStruct.new(class_name: "Procedure") if association == :procedures
+  end
+
+  def label
+    "non renseignée"
+  end
+
+  def id
+    -1
+  end
+
+  def acronym
+    "NA"
+  end
+
+  def created_at
+    "NA"
+  end
+
+  def updated_at
+    "NA"
+  end
+end

--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -10,4 +10,5 @@
 #
 class Zone < ApplicationRecord
   validates :acronym, presence: true, uniqueness: true
+  has_many :procedures, -> { order(published_at: :desc) }, inverse_of: :zone
 end

--- a/app/views/manager/zones/index.html.erb
+++ b/app/views/manager/zones/index.html.erb
@@ -1,0 +1,70 @@
+<%#
+# Index
+
+This view is the template for the index page.
+It is responsible for rendering the search bar, header and pagination.
+It renders the `_table` partial to display details about the resources.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Collection][1].
+  Contains helper methods to help display a table,
+  and knows which attributes should be displayed in the resource's table.
+- `resources`:
+  An instance of `ActiveRecord::Relation` containing the resources
+  that match the user's search criteria.
+  By default, these resources are passed to the table partial to be displayed.
+- `search_term`:
+  A string containing the term the user has searched for, if any.
+- `show_search_bar`:
+  A boolean that determines if the search bar should be shown.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
+%>
+
+<% content_for(:title) do %>
+  <%= display_resource_name(page.resource_name) %>
+<% end %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title" id="page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <div>
+    <%= link_to "Procedures sans zone renseignée", manager_zone_path(id: 'nil') %>
+  </div>
+
+  <% if show_search_bar %>
+    <%= render(
+      "search",
+      search_term: search_term,
+      resource_name: display_resource_name(page.resource_name)
+    ) %>
+  <% end %>
+
+  <div>
+    <%= link_to(
+      t(
+        "administrate.actions.new_resource",
+        name: display_resource_name(page.resource_name, singular: true).downcase
+      ),
+      [:new, namespace, page.resource_path.to_sym],
+      class: "button",
+    ) if valid_action?(:new) && show_action?(:new, new_resource) %>
+  </div>
+</header>
+
+<section class="main-content__body main-content__body--flush">
+  <%= render(
+    "collection",
+    collection_presenter: page,
+    collection_field_name: resource_name,
+    page: page,
+    resources: resources,
+    table_title: "page-title"
+  ) %>
+
+  <%= paginate resources, param_name: '_page' %>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,7 @@ Rails.application.routes.draw do
 
     resources :super_admins, only: [:index, :show, :destroy]
 
-    resources :zones
+    resources :zones, only: [:index, :show]
 
     post 'demandes/create_administrateur'
     post 'demandes/refuse_administrateur'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,8 @@ Rails.application.routes.draw do
 
     resources :super_admins, only: [:index, :show, :destroy]
 
+    resources :zones
+
     post 'demandes/create_administrateur'
     post 'demandes/refuse_administrateur'
 


### PR DESCRIPTION
Cette PR apporte les modifications suivantes au manager :

- ajoute la liste de zones (à partir de laquelle on pourra pour chaque zone voir ses démarches)
![zones_index](https://user-images.githubusercontent.com/1111966/147274614-bf943505-7dac-45cb-8101-57c4456ea58a.png)

- la liste des démarches pour une zone donnée
![zone-details](https://user-images.githubusercontent.com/1111966/147274630-51197659-46bc-4503-8735-78f4a4f1f0b6.png)

- indique dans la vue d'une démarche la zone associée
![zone_procedure](https://user-images.githubusercontent.com/1111966/147274650-e1668000-6b31-460c-8b80-87703299f64b.png)

