### PR TITLE
feat(support#create): block with invisible captcha [avoid painful captcha]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem 'i18n_data'
 gem 'i18n-tasks', require: false
 gem 'iban-tools'
 gem 'image_processing'
+gem 'invisible_captcha'
 gem 'json_schemer'
 gem 'jwt'
 gem 'kaminari', '1.2.1' # Pagination

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,6 +369,8 @@ GEM
     image_processing (1.12.1)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
+    invisible_captcha (2.0.0)
+      rails (>= 5.0)
     ipaddress (0.8.3)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
@@ -838,6 +840,7 @@ DEPENDENCIES
   i18n_data
   iban-tools
   image_processing
+  invisible_captcha
   json_schemer
   jwt
   kaminari (= 1.2.1)

--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -1,4 +1,6 @@
 class SupportController < ApplicationController
+  invisible_captcha only: [:create], on_spam: :redirect_to_root
+
   def index
     setup_context
   end
@@ -91,5 +93,9 @@ class SupportController < ApplicationController
 
   def email
     current_user&.email || params[:email]
+  end
+
+  def redirect_to_root
+    redirect_to root_path, alert: t('invisible_captcha.custom_message')
   end
 end

--- a/app/views/support/index.html.haml
+++ b/app/views/support/index.html.haml
@@ -25,6 +25,9 @@
         = label_tag :type do
           = t('.your_question')
         = hidden_field_tag :type, params[:type]
+
+      = invisible_captcha
+
       %dl
         - @options.each do |(question, question_type, link)|
           %dt

--- a/config/env.example
+++ b/config/env.example
@@ -122,3 +122,5 @@ API_EDUCATION_URL="https://data.education.gouv.fr/api/records/1.0"
 
 # Clé de chriffrement des données sensibles en base
 ENCRYPTION_SERVICE_SALT=""
+
+INVISIBLE_CAPTCHA_SECRET="kikooloool"

--- a/config/initializers/invisible_captcha.rb
+++ b/config/initializers/invisible_captcha.rb
@@ -1,0 +1,12 @@
+InvisibleCaptcha.setup do |config|
+  # config.honeypots           << ['more', 'fake', 'attribute', 'names']
+  # config.visual_honeypots      = false
+  # config.timestamp_threshold   = 2
+  config.timestamp_enabled     = !Rails.env.test?
+  # config.injectable_styles     = false
+  config.spinner_enabled       = !Rails.env.test?
+
+  # Leave these unset if you want to use I18n (see below)
+  # config.sentence_for_humans     = 'If you are a human, ignore this field'
+  # config.timestamp_error_message = 'Sorry, that was too quick! Please resubmit.'
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,9 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  invisible_captcha:
+    custom_message: 'If you are a human, ignore this field'
+
   help: 'Help'
   utils:
     'yes': Yes

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -20,6 +20,9 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 fr:
+  invisible_captcha:
+    custom_message: 'Si vous êtes un humain, veuillez ignorer ce champs'
+
   help: 'Aide'
   utils:
     'yes': Oui


### PR DESCRIPTION
# contexte 
Les spams bot passent en partie par le formulaire de contact : 

<img width="1425" alt="Screen Shot 2021-12-29 at 2 04 11 PM" src="https://user-images.githubusercontent.com/125964/147665268-6ee1b92c-10e9-4cd5-9b83-16b7bb605fcc.png">

# solution 
Je propose d'essayer une solution "simple" ; l'honeypot (https://datadome.co/resources/stop-bots-without-captcha-anti-spam-honeypot/) ;

PS: en parallele ; je me suis inscrit pour le captcha souverain (https://mattermost.incubateur.net/betagouv/pl/o7jekdhxifd99cg5d9znqeex5w ; plus compliqué... sera une option supplémentaire) 

# attention
il faut ajouter une var d'env  : `INVISIBLE_CAPTCHA_SECRET` ; @tchak une idée de comment faire ? essayé via le depot ansible, pas très clair pour moi de ce coté la