### PR TITLE
fix(react): remove register component cache

### DIFF
--- a/app/javascript/shared/register-react-components.jsx
+++ b/app/javascript/shared/register-react-components.jsx
@@ -9,9 +9,6 @@ const CLASS_NAME_ATTR = 'data-react-class';
 // example: `data-react-props="{\"item\": { \"id\": 1, \"name\": \"My Item\"} }"`
 const PROPS_ATTR = 'data-react-props';
 
-// A unique identifier to identify a node
-const CACHE_ID_ATTR = 'data-react-cache-id';
-
 const CLASS_NAME_SELECTOR = `[${CLASS_NAME_ATTR}]`;
 
 // helper method for the mount and unmount methods to find the
@@ -40,7 +37,6 @@ function getSelector(searchSelector) {
 }
 
 class ReactComponentRegistry {
-  #cache = {};
   #components;
 
   constructor(components) {
@@ -59,7 +55,6 @@ class ReactComponentRegistry {
       const ComponentClass = this.getConstructor(className);
       const propsJson = node.getAttribute(PROPS_ATTR);
       const props = propsJson && JSON.parse(propsJson);
-      const cacheId = node.getAttribute(CACHE_ID_ATTR);
 
       if (!ComponentClass) {
         const message = `Cannot find component: "${className}"`;
@@ -73,15 +68,7 @@ class ReactComponentRegistry {
           `${message}. Make sure your component is available to render.`
         );
       } else {
-        let component = this.#cache[cacheId];
-        if (!component) {
-          this.#cache[cacheId] = component = createElement(
-            ComponentClass,
-            props
-          );
-        }
-
-        render(component, node);
+        render(createElement(ComponentClass, props), node);
       }
     }
   }


### PR DESCRIPTION
Pour instancier les composants React sur la page on utilise la gem `react-rails`. Elle fournit un helper ruby `react_component` qui permet d'insérer une balise `div` avec le nom de la class du composant et les properties sérialisé dans des data attributes. La gem fournis aussi un bout de js qui fait le job d’instancier les composants. Le problème c'est que ce code js se base sur une fonctionnalité de Webpack qu'on voulait supprimée. Du coup, j'ai importé le bout de js chez nous en le simplifiant pour notre usage. Mais visiblement il y a un truc que mon code fait de différent avec le cache des instances des composants. Et on se retrouve avec un bug ou les composants utilisés plusieurs fois sur la page partagent les properties. Dans le doute, je vire ce cache, car de toute façon dans notre cas d'usage on n’y gagne pas grand-chose.