### PR TITLE
Corrige le controller ping (health check)

### DIFF
--- a/app/controllers/ping_controller.rb
+++ b/app/controllers/ping_controller.rb
@@ -4,7 +4,7 @@ class PingController < ApplicationController
       status_code = if File.file?(Rails.root.join("maintenance"))
         # See https://cbonte.github.io/haproxy-dconv/2.0/configuration.html#4.2-http-check%20disable-on-404
         :not_found
-      elsif (ActiveRecord::Base.connected?)
+      elsif (ActiveRecord::Base.connection.execute('select 1 as test;').first['test'] == 1)
         :ok
       else
         :internal_server_error

--- a/spec/controllers/ping_controller_spec.rb
+++ b/spec/controllers/ping_controller_spec.rb
@@ -6,10 +6,10 @@ describe PingController, type: :controller do
 
     context 'when base is un-plug' do
       before do
-        allow(ActiveRecord::Base).to receive(:connected?).and_return(false)
+        allow(ActiveRecord::Base).to receive(:connected?).and_raise(ActiveRecord::ConnectionTimeoutError)
       end
 
-      it { expect(subject.status).to eq 500 }
+      it { expect { subject }.to raise_error(ActiveRecord::ConnectionTimeoutError) }
     end
 
     context 'when a maintenance file is present' do


### PR DESCRIPTION
For an unknown reason, ActiveRecord::Base.connected? does not work anymore in dev. It returns false negative.

This simple workaround can timeout. The caller has to monitor the response time.