### PR TITLE
Correction de Administrateurs::ProcedureAdministrateursController#destroy

### DIFF
--- a/app/controllers/administrateurs/procedure_administrateurs_controller.rb
+++ b/app/controllers/administrateurs/procedure_administrateurs_controller.rb
@@ -32,7 +32,8 @@ module Administrateurs
 
       # Prevent self-removal (Also enforced in the UI)
       if administrateur == current_administrateur
-        flash.error = "Vous ne pouvez pas vous retirer vous-même d’une démarche."
+        flash.alert = "Vous ne pouvez pas vous retirer vous-même d’une démarche."
+        return
       end
 
       # Actually remove the admin

--- a/spec/controllers/administrateurs/procedure_administrateurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedure_administrateurs_controller_spec.rb
@@ -1,0 +1,26 @@
+describe Administrateurs::ProcedureAdministrateursController, type: :controller do
+  let(:signed_in_admin) { create(:administrateur) }
+  let(:other_admin) { create(:administrateur) }
+  let(:procedure) { create(:procedure, administrateurs: [signed_in_admin, other_admin]) }
+
+  before do
+    sign_in(signed_in_admin.user)
+  end
+
+  describe '#destroy' do
+    subject do
+      delete :destroy, params: { procedure_id: procedure.id, id: admin_to_remove.id }, format: :js, xhr: true
+    end
+
+    context 'when removing another admin' do
+      let(:admin_to_remove) { other_admin }
+
+      it 'removes the admin from the procedure' do
+        subject
+        expect(response.status).to eq(200)
+        expect(signed_in_admin.procedures.reload).to include(procedure)
+        expect(other_admin.procedures.reload).not_to include(procedure)
+      end
+    end
+  end
+end

--- a/spec/controllers/administrateurs/procedure_administrateurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedure_administrateurs_controller_spec.rb
@@ -18,8 +18,19 @@ describe Administrateurs::ProcedureAdministrateursController, type: :controller 
       it 'removes the admin from the procedure' do
         subject
         expect(response.status).to eq(200)
-        expect(signed_in_admin.procedures.reload).to include(procedure)
-        expect(other_admin.procedures.reload).not_to include(procedure)
+        expect(flash[:notice]).to be_present
+        expect(admin_to_remove.procedures.reload).not_to include(procedure)
+      end
+    end
+
+    context 'when removing oneself from a procedure' do
+      let(:admin_to_remove) { signed_in_admin }
+
+      it 'denies the right for an admin to remove itself' do
+        subject
+        expect(response.status).to eq(200)
+        expect(flash[:alert]).to be_present
+        expect(admin_to_remove.procedures.reload).to include(procedure)
       end
     end
   end


### PR DESCRIPTION
- The "Don't remove yourself" rule wasn't actually enforced
- `flash.error` is not a flash category