### PR TITLE
fix(users/champs/piece_justificative#update): ensure to bump dossier.last_champ_updated_at otherwise instructeurs are not notified when user update their piece_justificative

### DIFF
--- a/app/controllers/champs/piece_justificative_controller.rb
+++ b/app/controllers/champs/piece_justificative_controller.rb
@@ -14,7 +14,9 @@ class Champs::PieceJustificativeController < ApplicationController
   def attach_piece_justificative
     @champ = policy_scope(Champ).find(params[:champ_id])
     @champ.piece_justificative_file.attach(params[:blob_signed_id])
-    @champ.save
+    save_succeed = @champ.save
+    @champ.dossier.update(last_champ_updated_at: Time.zone.now.utc) if save_succeed
+    save_succeed
   end
 
   def attach_piece_justificative_or_retry

--- a/spec/controllers/champs/piece_justificative_controller_spec.rb
+++ b/spec/controllers/champs/piece_justificative_controller_spec.rb
@@ -31,6 +31,10 @@ describe Champs::PieceJustificativeController, type: :controller do
         expect(response.status).to eq(200)
         expect(response.body).to include("##{champ.input_group_id}")
       end
+
+      it 'updates dossier.last_champ_updated_at' do
+        expect { subject }.to change { dossier.reload.last_champ_updated_at }
+      end
     end
 
     context 'when the file is invalid' do


### PR DESCRIPTION
### contexte 
ETQ instructeur, quand un de mes utilisateur modifie la piece justificative de son dossier, je n'ai pas la vignette dans mon interface listant les dossiers
cf: https://secure.helpscout.net/conversation/1745986907/1958203/

<img width="728" alt="Screen Shot 2022-01-05 at 6 06 47 PM" src="https://user-images.githubusercontent.com/125964/148258837-84d47dc6-f96d-46d7-8534-f80f8c795fb0.png">

### resolution
mettre a jour le dossier.last_champ_updated_at 

### questions
je ne cherche pas l'exactitude sur cette PR ; que pensez-vous d'ouvrir un bug pour voir si on a pas d'autres trous ds la raquette ? (ex: https://github.com/betagouv/demarches-simplifiees.fr/blob/main/app/controllers/users/dossiers_controller.rb#L89)