### PR TITLE
Correction d'une erreur dans le formulaire de contact

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,7 +13,7 @@ module ApplicationHelper
     case level
     when 'notice'
       class_names << 'alert-success'
-    when 'alert'
+    when 'alert', 'error'
       class_names << 'alert-danger'
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,12 +8,15 @@ module ApplicationHelper
   end
 
   def flash_class(level, sticky: false, fixed: false)
-    class_names = case level
+    class_names = []
+
+    case level
     when 'notice'
-      ['alert-success']
+      class_names << 'alert-success'
     when 'alert'
-      ['alert-danger']
+      class_names << 'alert-danger'
     end
+
     if sticky
       class_names << 'sticky'
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -18,6 +18,12 @@ describe ApplicationHelper do
     end
   end
 
+  describe "#flash_class" do
+    it { expect(flash_class('notice')).to eq 'alert-success' }
+    it { expect(flash_class('alert', sticky: true, fixed: true)).to eq 'alert-danger sticky alert-fixed' }
+    it { expect(flash_class('unknown-level')).to eq '' }
+  end
+
   describe "#try_format_date" do
     subject { try_format_date(date) }
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -21,6 +21,7 @@ describe ApplicationHelper do
   describe "#flash_class" do
     it { expect(flash_class('notice')).to eq 'alert-success' }
     it { expect(flash_class('alert', sticky: true, fixed: true)).to eq 'alert-danger sticky alert-fixed' }
+    it { expect(flash_class('error')).to eq 'alert-danger' }
     it { expect(flash_class('unknown-level')).to eq '' }
   end
 


### PR DESCRIPTION
En ce moment invisible_captcha génère des erreurs qui font planter le formulaire de contact.

Corrige https://sentry.io/organizations/demarches-simplifiees/issues/2908720093/