### PR TITLE
fix a11y-8.9.1

### DIFF
--- a/app/helpers/string_to_html_helper.rb
+++ b/app/helpers/string_to_html_helper.rb
@@ -1,5 +1,6 @@
 module StringToHtmlHelper
   def string_to_html(str, wrapper_tag = 'p')
+    return nil if str.blank?
     html_formatted = simple_format(str, {}, { wrapper_tag: wrapper_tag })
     with_links = Anchored::Linker.auto_link(html_formatted, target: '_blank', rel: 'noopener')
     sanitize(with_links, attributes: ['target', 'rel', 'href'])

--- a/app/views/shared/attachment/_edit.html.haml
+++ b/app/views/shared/attachment/_edit.html.haml
@@ -29,6 +29,7 @@
       %p.attachment-error-title
         Une erreur s’est produite pendant l’envoi du fichier.
       %p.attachment-error-description
+        Une erreur inconnue s'est produite pendant l'envoi du fichier
     = button_tag type: 'button', class: 'button attachment-error-retry', data: { 'input-target': ".attachment-input-#{attachment_id}" } do
       %span.icon.retry
       Ré-essayer

--- a/app/views/shared/dossiers/_champ_row.html.haml
+++ b/app/views/shared/dossiers/_champ_row.html.haml
@@ -57,7 +57,7 @@
             - when TypeDeChamp.type_champs.fetch(:number)
               = number_with_html_delimiter(c.to_s)
             - else
-              = format_text_value(c.to_s)
+              = format_text_value(c.to_s) unless c.blank?
 
       - if c.type_champ != TypeDeChamp.type_champs.fetch(:header_section)
         %td.updated-at

--- a/spec/helpers/string_to_html_helper_spec.rb
+++ b/spec/helpers/string_to_html_helper_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe StringToHtmlHelper, type: :helper do
     context "with empty decription" do
       let(:description) { nil }
 
-      it { is_expected.to eq('<p></p>') }
+      it { is_expected.to eq nil }
     end
 
     context "with a bad script" do


### PR DESCRIPTION
Les balises p ne doivent pas être utilisées uniquement à des fins de
présentation.
Cette PR supprime les balises p sans contenu.

lié à #6788 