### PR TITLE
Fixe la liste 'tous' des dossiers instructeurs

### DIFF
--- a/app/controllers/instructeurs/procedures_controller.rb
+++ b/app/controllers/instructeurs/procedures_controller.rb
@@ -13,7 +13,7 @@ module Instructeurs
         .order(closed_at: :desc, unpublished_at: :desc, published_at: :desc, created_at: :desc)
 
       dossiers = current_instructeur.dossiers.joins(:groupe_instructeur)
-      @dossiers_count_per_procedure = dossiers.all_state.group('groupe_instructeurs.procedure_id').reorder(nil).count
+      @dossiers_count_per_procedure = dossiers.all_state.visible_by_administration.group('groupe_instructeurs.procedure_id').reorder(nil).count
       @dossiers_a_suivre_count_per_procedure = dossiers.without_followers.en_cours.visible_by_administration.group('groupe_instructeurs.procedure_id').reorder(nil).count
       @dossiers_archived_count_per_procedure = dossiers.archived.group('groupe_instructeurs.procedure_id').count
       @dossiers_termines_count_per_procedure = dossiers.termine.visible_by_administration.group('groupe_instructeurs.procedure_id').reorder(nil).count
@@ -71,7 +71,7 @@ module Instructeurs
       @followed_dossiers_id = @followed_dossiers.pluck(:id)
 
       @termines_dossiers = dossiers_visibles.termine.visible_by_administration
-      @all_state_dossiers = dossiers_visibles.all_state
+      @all_state_dossiers = dossiers_visibles.all_state.visible_by_administration
       @archived_dossiers = dossiers_visibles.archived
       @expirant_dossiers = dossiers_visibles.termine_or_en_construction_close_to_expiration
 

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -235,7 +235,7 @@ class Instructeur < ApplicationRecord
         COUNT(DISTINCT dossiers.id) FILTER (where not archived AND NOT (dossiers.hidden_by_user_at IS NOT NULL AND state = 'en_construction') AND dossiers.state in ('en_construction', 'en_instruction') AND follows.id IS NULL) AS a_suivre,
         COUNT(DISTINCT dossiers.id) FILTER (where not archived AND dossiers.state in ('en_construction', 'en_instruction') AND follows.instructeur_id = :instructeur_id) AS suivis,
         COUNT(DISTINCT dossiers.id) FILTER (where not archived AND dossiers.state in ('accepte', 'refuse', 'sans_suite')) AS traites,
-        COUNT(DISTINCT dossiers.id) FILTER (where not archived) AS tous,
+        COUNT(DISTINCT dossiers.id) FILTER (where not archived AND NOT (dossiers.hidden_by_user_at IS NOT NULL AND state = 'en_construction')) AS tous,
         COUNT(DISTINCT dossiers.id) FILTER (where archived)     AS archives,
         COUNT(DISTINCT dossiers.id) FILTER (where
           procedures.procedure_expires_when_termine_enabled


### PR DESCRIPTION
Lorsque les dossiers `en_construction` sont cachés par l'usager, l'instructeur les voit quand même dans sa liste "tous"

Cette PR fixe cela. Lorsqu'un dossier `en_constuction` est caché par l'usager, l'instructeur ne le voit pas dans son interface.