### PR TITLE
feat(MonAvisEmbedValidator): allow mon avis button without title

### DIFF
--- a/app/validators/mon_avis_embed_validator.rb
+++ b/app/validators/mon_avis_embed_validator.rb
@@ -1,7 +1,7 @@
 class MonAvisEmbedValidator < ActiveModel::Validator
   def validate(record)
     # We need to ensure the embed code is not any random string in order to avoid injections
-    r = Regexp.new('<a href="https://monavis|voxusagers.numerique.gouv.fr/Demarches/\d+.*key=[[:alnum:]]+.*">\s*<img src="https://monavis|voxusagers.numerique.gouv.fr/(monavis-)?static/bouton-blanc|bleu.png|svg" alt="Je donne mon avis" title="Je donne mon avis sur cette démarche" />\s*</a>', Regexp::MULTILINE)
+    r = Regexp.new('<a href="https://monavis|voxusagers.numerique.gouv.fr/Demarches/\d+.*key=[[:alnum:]]+.*">\s*<img src="https://monavis|voxusagers.numerique.gouv.fr/(monavis-)?static/bouton-blanc|bleu.png|svg" alt="Je donne mon avis" (title="Je donne mon avis sur cette démarche" )?/>\s*</a>', Regexp::MULTILINE)
     if record.monavis_embed.present? && !r.match?(record.monavis_embed)
       record.errors[:base] << "Le code fourni ne correspond pas au format des codes MonAvis reconnus par la plateforme."
     end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -268,6 +268,16 @@ describe Procedure do
         let(:procedure) { build(:procedure, monavis_embed: monavis_issue_phillipe) }
         it { expect(procedure.valid?).to eq(true) }
       end
+
+      context 'Monavis embed code without title allowed' do
+        monavis_issue_bouchra = <<-MSG
+          <a href="https://voxusagers.numerique.gouv.fr/Demarches/3193?&view-mode=formulaire-avis&nd_mode=en-ligne-enti%C3%A8rement&nd_source=button&key=58e099a09c02abe629c14905ed2b055d">
+            <img src="https://voxusagers.numerique.gouv.fr/static/bouton-bleu.svg" alt="Je donne mon avis" />
+          </a>
+        MSG
+        let(:procedure) { build(:procedure, monavis_embed: monavis_issue_bouchra) }
+        it { expect(procedure.valid?).to eq(true) }
+      end
     end
 
     shared_examples 'duree de conservation' do


### PR DESCRIPTION
crisp : https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_5cfa9fa2-890a-4348-b444-fbe936c12a55/
semblerait que voxusagers puisse ne pas inclure le "title" sur une balise <img> (semble pertinent d'ailleurs). donc on ajoute ceci en option au validateur
![monavis2png_izlk0g](https://user-images.githubusercontent.com/125964/150800204-e4bce6c3-c76a-4c41-bcda-8044073187d9.png)

