### PR TITLE
Ajout d'une nouvelle variable d'environnement `SAML_IDP_ENABLED`

### DIFF
--- a/app/views/manager/application/_navigation.html.erb
+++ b/app/views/manager/application/_navigation.html.erb
@@ -25,7 +25,7 @@ as defined by the routes in the `admin/` namespace
 
   <%= link_to "Delayed Jobs", manager_delayed_job_path, class: "navigation__link" %>
   <%= link_to "Features", manager_flipper_path, class: "navigation__link" %>
-  <% if Rails.env.production? && ENV['SENDINBLUE_ENABLED'] == 'enabled'%>
+  <% if ENV["SENDINBLUE_ENABLED"] == "enabled" && ENV["SAML_IDP_ENABLED"] == "enabled" %>
     <%= link_to "Sendinblue", ENV.fetch("SENDINBLUE_LOGIN_URL"), class: "navigation__link", target: '_blank' %>
   <% end %>
 </nav>

--- a/config/env.example
+++ b/config/env.example
@@ -16,11 +16,6 @@ SECRET_KEY_BASE="05a2d479d8e412198dabd08ef0eee9d6e180f5cbb48661a35fd1cae287f0a93
 # Secret key for One-Time-Password codes, used for 2-factors authentication
 OTP_SECRET_KEY=""
 
-# SAML IdP
-
-# SAML_IDP_CERTIFICATE="billybop"
-# SAML_IDP_SECRET_KEY="-----BEGIN RSA PRIVATE KEY-----\nblabla+blabla\n-----END RSA PRIVATE KEY-----\n"
-
 # Database credentials
 DB_DATABASE="tps_development"
 DB_HOST="localhost"
@@ -40,6 +35,11 @@ FOG_OPENSTACK_USERNAME=""
 FOG_OPENSTACK_URL=""
 FOG_OPENSTACK_REGION=""
 DS_PROXY_URL=""
+
+# SAML Identity provider
+SAML_IDP_ENABLED="disabled"
+SAML_IDP_CERTIFICATE=""
+SAML_IDP_SECRET_KEY="-----BEGIN RSA PRIVATE KEY-----\nblabla+blabla\n-----END RSA PRIVATE KEY-----\n"
 
 # External service: authentication through France Connect
 FC_PARTICULIER_ID=""

--- a/config/initializers/saml_idp.rb
+++ b/config/initializers/saml_idp.rb
@@ -1,7 +1,7 @@
 # The certificate and secret key are not fetched from secrets.yml because there is a problem to set a secret key from a multiline env var"
 # So we fetch env var directly here
 
-if Rails.env.production?
+if ENV['SAML_IDP_ENABLED'] == 'enabled'
   SamlIdp.config.x509_certificate = ENV.fetch("SAML_IDP_CERTIFICATE")
   SamlIdp.config.secret_key = ENV.fetch("SAML_IDP_SECRET_KEY")
 end


### PR DESCRIPTION
En ce moment, avec l'environnement par défaut, l'app crashe au premier lancement en production, parce que les certificats SAML ne sont pas présents.

Cette PR introduit une nouvelle variable `SAML_IDP_ENABLED`, désactivée par défaut, qui permet de contrôler si l'authentification SAML est activée ou pas.

## Avant de merger et déployer

- [x] Ajouter la nouvelle variable d'environnement `SAML_IDP_ENABLED` en prod