### PR TITLE
Correction de l'ordre des mois sur la page des statistiques

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -31,7 +31,7 @@ class StatsController < ApplicationController
     @procedures_in_the_last_4_months = last_four_months_serie(procedures, :published_at)
 
     @dossiers_cumulative = stat.dossiers_cumulative
-    @dossiers_in_the_last_4_months = stat.dossiers_in_the_last_4_months
+    @dossiers_in_the_last_4_months = format_keys_as_months(stat.dossiers_in_the_last_4_months)
   end
 
   def download
@@ -136,11 +136,18 @@ class StatsController < ApplicationController
     end
   end
 
+  def format_keys_as_months(series)
+    series.transform_keys do |k|
+      date = k.is_a?(Date) ? k : (Date.parse(k) rescue k)
+      l(date, format: "%B %Y")
+    end
+  end
+
   def last_four_months_serie(association, date_attribute)
-    association
+    series = association
       .group_by_month(date_attribute, last: 4, current: super_admin_signed_in?)
       .count
-      .transform_keys { |date| l(date, format: "%B %Y") }
+    format_keys_as_months(series)
   end
 
   def cumulative_month_serie(association, date_attribute)

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -80,11 +80,7 @@ class Stat < ApplicationRecord
         association.group_by_month(date_attribute, last: 4, current: false).count
       end
 
-      month_serie(sum_hashes(*timeseries))
-    end
-
-    def month_serie(date_serie)
-      date_serie.keys.sort.each_with_object({}) { |date, h| h[I18n.l(date, format: "%B %Y")] = date_serie[date] }
+      sum_hashes(*timeseries).sort.to_h
     end
 
     def cumulative_month_serie(associations_with_date_attribute)


### PR DESCRIPTION
Before this commit, the monthly dossiers count was serialized into the Stat record using human-formatted dates, as:

```ruby
s.dossiers_in_the_last_4_months = {
  "octobre 2021"=>409592,
  "novembre 2021"=>497823,
  "décembre 2021"=>38170,
  "janvier 2022"=>0
}
```

Turns out the ordering of keys in a serialized hash is not guaranteed. After a round-trip to the database, the keys will be wrongly sorted.

Instead we want to save raw Date objects, which will preserve the ordering. The date formatting can be applied at display-time by the controller.

Fix #6848