### PR TITLE
 ETQ développeur, je voudrais pouvoir influer sur l'option --no-sandbox du pilote Selenium Chrome lors des tests

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -9,6 +9,7 @@ end
 
 Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument('--no-sandbox') unless ENV['SANDBOX']
   options.add_argument('--headless') unless ENV['NO_HEADLESS']
   options.add_argument('--window-size=1440,900')
 


### PR DESCRIPTION
# Résumé

<!-- décrire en quelques phrases la problématique adressée -->

Des erreurs surviennent lorsque l'environnement de test est exécuté avec l'utilisateur root. Ce cas de figure a peu de chances de se produire dans un environnement de test standard, mais est déjà beaucoup plus probable dans un environnement Dockerisé où il est très courant que l'utilisateur par défaut soit root, du fait qu'il soit confiné à son seul container.

Unable to open browser with url: 'https://www.demarches-simplifiees.fr'
(Root cause: org.openqa.selenium.WebDriverException: unknown error: DevToolsActivePort file doesn't exist)

documentation : https://stackoverflow.com/questions/50642308/

mots-clés : capybara, chrome, driver, sandbox, selenium, test

ticket #6857 / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`