### PR TITLE
 Un test échoue si la variable d'environnement UNIVERSIGN_API_URL est définie sans valeur

### DIFF
--- a/spec/lib/universign/api_spec.rb
+++ b/spec/lib/universign/api_spec.rb
@@ -4,6 +4,10 @@ describe Universign::API do
 
     let(:digest) { Digest::SHA256.hexdigest("CECI EST UN HASH") }
 
+    before do
+      stub_const("UNIVERSIGN_API_URL", "https://ws.universign.eu/tsa/post/")
+    end
+
     it { is_expected.not_to be_nil }
   end
 end


### PR DESCRIPTION
# Résumé

Un test échoue si la variable d'environnement UNIVERSIGN_API_URL est définie sans valeur.

mots-clés : env, test, universign

fixes #6858 / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`