### PR TITLE
Rend l'environnement de développement accessible depuis un hôte autre que localhost:3000 

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -77,15 +77,12 @@ Rails.application.configure do
   # Action Mailer settings
   config.action_mailer.delivery_method = :letter_opener
 
-  config.action_mailer.default_url_options = {
-    host: 'localhost',
-    port: 3000
-  }
-  config.action_mailer.asset_host = "http://" + ENV['APP_HOST']
+  config.action_mailer.default_url_options = { host: ENV.fetch("APP_HOST") }
+  config.action_mailer.asset_host = "http://" + ENV.fetch("APP_HOST")
 
   Rails.application.routes.default_url_options = {
-    host: 'localhost',
-    port: 3000
+    host: ENV.fetch("APP_HOST"),
+    protocol: :http
   }
 
   # Use Content-Security-Policy-Report-Only headers
@@ -111,4 +108,6 @@ Rails.application.configure do
   if ENV['IGN_CARTE_REFERER']
     config.hosts << ENV['IGN_CARTE_REFERER']
   end
+
+  config.hosts << ENV.fetch("APP_HOST")
 end


### PR DESCRIPTION
# Résumé

L'environnement de développement peut être accessible depuis un hôte autre que `localhost:3000` ; c'est par exemple le cas lors de l'utilisation de Démarches Simplifiées dans un environnement dockerisé.

Pour un parfait support de l'hôte personnalisé, il convient d'utiliser la variable d'environnement `APP_HOST` lors de la configuration de l'environnement de développement. Notamment, au niveau des routes, d'ActiveMailer, et de la liste blanche des hôtes.

Cela afin de prévenir, entre autres, ce type d'erreur :

```
*** ArgumentError Exception: Missing host to link to! Please
provide the :host parameter, set default_url_options[:host],
or set :only_path to true
```

mots-clés : ActiveMailer, env, dev, host, mailer, routes

fixes #6860 / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`