### PR TITLE
Les feature tests touchant aux emails échouent de manière aléatoire

### DIFF
--- a/spec/system/instructeurs/expert_spec.rb
+++ b/spec/system/instructeurs/expert_spec.rb
@@ -10,6 +10,10 @@ describe 'Inviting an expert:', js: true do
   let(:dossier) { create(:dossier, :en_construction, :with_dossier_link, procedure: procedure) }
   let(:linked_dossier) { Dossier.find_by(id: dossier.reload.champs.filter(&:dossier_link?).filter_map(&:value)) }
 
+  before do
+    clear_emails
+  end
+
   context 'as an Instructeur' do
     scenario 'I can invite an expert' do
       allow(ClamavService).to receive(:safe_file?).and_return(true)


### PR DESCRIPTION
# Résumé

Les _feature tests_ touchant aux emails échouent de manière aléatoire.

```
Failures:
 
  1) Inviting an expert: as an Instructeur I can invite an expert
     Failure/Error: invitation_email = open_email(expert.email.to_s)
       
Diff:
  -/procedures/2/avis/2/sign_up/email/expert1@expert.com
  +/procedures/1/avis/1/sign_up/email/expert1@expert.com
```

mots-clés : email, expert, test

ticket #6861 / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`