### PR TITLE
[RGeo] les tests échouent sur macOS

### DIFF
--- a/app/validators/geo_json_validator.rb
+++ b/app/validators/geo_json_validator.rb
@@ -1,7 +1,7 @@
 class GeoJSONValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     begin
-      RGeo::GeoJSON.decode(value.to_json, geo_factory: RGeo::Geographic.simple_mercator_factory)
+      RGeo::GeoJSON.decode(value.to_json, geo_factory: RGeo::Geographic.spherical_factory)
     rescue RGeo::Error::InvalidGeometry
       record.errors[attribute] << (options[:message] || "n'est pas un GeoJSON valide")
     end


### PR DESCRIPTION
# Résumé

La _factory_ _simple mercator_ utilisée par `RGeo` dans `GeoJSONValidator` présente un comportement suspect lors des tests.

```
Failures:

  1) GeoArea#valid? hourglass_polygon is expected to be falsey
     Failure/Error: it { expect(geo_area.valid?).to be_falsey }

       expected: falsey value
            got: true

  2) GeoArea#valid? invalid_right_hand_rule_polygon
     Failure/Error: RGeo::GeoJSON.decode(value.to_json, geo_factory: RGeo::Geographic.simple_mercator_factory)


	NoMethodError:
	  undefined method `is_simple?'' for nil:NilClass
	  Did you mean?  is_haml?
````

Il semble que cela ne se produise que sur macOS. Le probème n'est apparemment pas lié à la gemme rgeo mais plutôt à la bibliothèque geos sous-jacente sur macOS.

Il semble y avoir une différence dans la façon dont geos 3.8.x (3.10.2 étant la version présente dans Homebrew au 01/02/2022) et les versions antérieures de la bibliothèque geos gèrent le calcul `is_simple` qui détermine la validité des polygones. Ceci affecte la plupart des _factories_ RGeo, mais pas `RGeo::Geographic.spherical_factory` ni `RGeo::Cartesian.simple_factory` soutenues par l'API C.

mots-clés : api, factory, mercator, rgeo, spherical, test

fixes #6862 / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`