### PR TITLE
Remplacement de la gem rubocop-rspec-focused dépréciée

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 require:
   - rubocop-performance
   - rubocop-rails
-  - rubocop/rspec/focused
+  - rubocop-rspec
   - ./lib/cops/add_concurrent_index.rb
   - ./lib/cops/application_name.rb
   - ./lib/cops/unscoped.rb
@@ -877,7 +877,7 @@ Rails/WhereExists:
 Rails/WhereNot:
   Enabled: true
 
-RSpec/Focused:
+RSpec/Focus:
   Enabled: true
 
 Security/Eval:

--- a/Gemfile
+++ b/Gemfile
@@ -113,7 +113,7 @@ group :development do
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
-  gem 'rubocop-rspec-focused', require: false
+  gem 'rubocop-rspec', require: false
   gem 'scss_lint', require: false
   gem 'web-console'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -627,8 +627,9 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 0.90.0, < 2.0)
-    rubocop-rspec-focused (1.0.0)
-      rubocop (>= 0.51)
+    rubocop-rspec (2.4.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
     ruby-graphviz (1.2.5)
       rexml
     ruby-progressbar (1.11.0)
@@ -867,7 +868,7 @@ DEPENDENCIES
   rubocop
   rubocop-performance
   rubocop-rails
-  rubocop-rspec-focused
+  rubocop-rspec
   ruby-saml-idp
   sanitize-url
   sassc-rails


### PR DESCRIPTION
# Résumé

La gem `rubocop-rspec-focused` est dépréciée et ses auteurs recommandent l'utilisation de `rubocop-rspec` en remplacement de celle-ci.

```
WARNING: We are no longer maintaining this gem, and will eventually
archive this repo. We recommend you use rubocop-rspec instead.
```

documentation : https://github.com/CarooDev/rubocop-rspec-focused

mots-clés : rspec, rubocop, test

fixes #6863 / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`