### PR TITLE
[FranceConnect] les tests échouent quand la variable d'env APPLICATION_NAME a une autre valeur que celle par défaut

### DIFF
--- a/spec/controllers/france_connect/particulier_controller_spec.rb
+++ b/spec/controllers/france_connect/particulier_controller_spec.rb
@@ -149,6 +149,7 @@ describe FranceConnect::ParticulierController, type: :controller do
   RSpec.shared_examples "a method that needs a valid merge token" do
     context 'when the merge token is invalid' do
       before do
+        stub_const("APPLICATION_NAME", "demarches-simplifiees.fr")
         merge_token
         fci.update(merge_token_created_at: 2.years.ago)
       end
@@ -180,6 +181,10 @@ describe FranceConnect::ParticulierController, type: :controller do
 
     context 'when the merge token does not exist' do
       let(:merge_token) { 'i do not exist' }
+
+      before do
+        stub_const("APPLICATION_NAME", "demarches-simplifiees.fr")
+      end
 
       it do
         expect(subject).to redirect_to root_path


### PR DESCRIPTION
# Résumé


Les tests de contrôleurs de FranceConnect partent du postulat que le nom de l'application est `demarches-simplifiees.fr`. Or, la variable d'environnement `APPLICATION_NAME` peut prendre toute autre valeur. Et le cas échéant, lesdits tests échouent.

mots-clés : env, FranceConnect, test

ticket #6864 / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`