### PR TITLE
Des tests sur les instructeurs échouent aléatoirement

### DIFF
--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -164,7 +164,7 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
       it { expect(gi_1_2.dossiers.with_discarded.count).to be(2) }
       it { expect(gi_1_2.dossiers.last.id).to be(dossier12.id) }
       it { expect(dossier12.groupe_instructeur.id).to be(gi_1_2.id) }
-      it { expect(bulk_message.groupe_instructeurs).to eq([gi_1_2, gi_1_3]) }
+      it { expect(bulk_message.groupe_instructeurs).to contain_exactly(gi_1_2, gi_1_3) }
     end
 
     describe 'when the target group is not a possible group' do


### PR DESCRIPTION
# Résumé

Il arrive que les tests de contrôleurs des groupes d'instructeurs échouent aléatoirement.

mots-clés : instructeur, rspec, test

ticket #6865 / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`