### PR TITLE
Nettoyage des dépendances de Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,15 +1,15 @@
 require:
+  - rubocop-performance
+  - rubocop-rails
   - rubocop/rspec/focused
   - ./lib/cops/add_concurrent_index.rb
   - ./lib/cops/application_name.rb
   - ./lib/cops/unscoped.rb
 
-inherit_gem:
-  rubocop-rails_config:
-    - config/rails.yml
-
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
+  DisabledByDefault: true
+  SuggestExtensions: false
   Exclude:
     - "db/schema.rb"
     - "db/migrate/20190730153555_recreate_structure.rb"
@@ -643,6 +643,9 @@ Performance/RedundantMatch:
 
 Performance/RedundantMerge:
   Enabled: true
+
+Style/HashTransformValues:
+    Enabled: true
 
 Style/RedundantSortBy:
   Enabled: true
@@ -1373,4 +1376,3 @@ Style/YodaCondition:
 
 Style/ZeroLengthPredicate:
   Enabled: true
-

--- a/Gemfile
+++ b/Gemfile
@@ -111,7 +111,8 @@ group :development do
   gem 'rack-mini-profiler'
   gem 'rails-erd', require: false # generates `doc/database_models.pdf`
   gem 'rubocop', require: false
-  gem 'rubocop-rails_config'
+  gem 'rubocop-performance', require: false
+  gem 'rubocop-rails', require: false
   gem 'rubocop-rspec-focused', require: false
   gem 'scss_lint', require: false
   gem 'web-console'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -620,8 +620,6 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
-    rubocop-packaging (0.5.1)
-      rubocop (>= 0.89, < 2.0)
     rubocop-performance (1.9.2)
       rubocop (>= 0.90.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -629,13 +627,6 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 0.90.0, < 2.0)
-    rubocop-rails_config (1.3.1)
-      railties (>= 5.0)
-      rubocop (>= 1.8)
-      rubocop-ast (>= 1.0.1)
-      rubocop-packaging (~> 0.5)
-      rubocop-performance (~> 1.3)
-      rubocop-rails (~> 2.0)
     rubocop-rspec-focused (1.0.0)
       rubocop (>= 0.51)
     ruby-graphviz (1.2.5)
@@ -874,7 +865,8 @@ DEPENDENCIES
   rspec-rails
   rspec_junit_formatter
   rubocop
-  rubocop-rails_config
+  rubocop-performance
+  rubocop-rails
   rubocop-rspec-focused
   ruby-saml-idp
   sanitize-url

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
     administrateurs { administrateur.present? ? [administrateur] : [association(:administrateur)] }
 
     transient do
-      administrateur { }
+      administrateur {}
       instructeurs { [] }
       types_de_champ { [] }
       types_de_champ_private { [] }


### PR DESCRIPTION
# Résumé

Proposition de nettoyage des dépendances de Rubocop.

mots-clés : config, minitest, rails, rubocop

ticket #6866 / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`