### PR TITLE
Correction de la migration 20210402163003_exports_key_not_null

### DIFF
--- a/lib/tasks/deployment/20210402000000_null_export_keys_to_uuid.rake
+++ b/lib/tasks/deployment/20210402000000_null_export_keys_to_uuid.rake
@@ -1,0 +1,13 @@
+namespace :after_party do
+  desc 'Deployment task: null_exports_key_to_uuid'
+  task null_exports_key_to_uuid: :environment do
+    puts "Running deploy task 'null_exports_key_to_uuid'"
+
+    Export.where(key: nil).update_all(key: SecureRandom.uuid)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
# Résumé

La migration `20210402163003_exports_key_not_null.rb` échoue si des exports préexistent en base avec une valeur nulle sur le champ `key`.

mots-clés : export, migration, null

fixes #6870 / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`