### PR TITLE
Support de MailCatcher dans l'environnement de production

### DIFF
--- a/config/env.example
+++ b/config/env.example
@@ -90,10 +90,16 @@ SENDINBLUE_BALANCING="disabled"
 SENDINBLUE_BALANCING_VALUE="50"
 
 # Alternate SMTP Provider: Mailtrap (mail catcher for staging environments)
-# When enabled, all emails will be sent using this provided
+# When enabled, all emails will be sent using this provider
 MAILTRAP_ENABLED="disabled"
 MAILTRAP_USERNAME=""
 MAILTRAP_PASSWORD=""
+
+# Alternative SMTP Provider: Mailcatcher (Catches mail and serves it through a dream.)
+# When enabled, all emails will be sent using this provider
+MAILCATCHER_ENABLED="disabled"
+MAILCATCHER_HOST=""
+MAILCATCHER_PORT=""
 
 # External service: live chat for admins (specific to démarches-simplifiées.fr)
 CRISP_ENABLED="disabled"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -89,7 +89,8 @@ Rails.application.configure do
 
   elsif ENV['SENDINBLUE_ENABLED'] == 'enabled'
     config.action_mailer.delivery_method = :sendinblue
-
+  elsif ENV['MAILCATCHER_ENABLED'] == 'enabled'
+    config.action_mailer.delivery_method = :mailcatcher
   else
     config.action_mailer.delivery_method = :mailjet
   end

--- a/config/initializers/mailcatcher.rb
+++ b/config/initializers/mailcatcher.rb
@@ -1,0 +1,13 @@
+if ENV.fetch('MAILCATCHER_ENABLED') == 'enabled'
+  ActiveSupport.on_load(:action_mailer) do
+    module Mailcatcher
+      class SMTP < ::Mail::SMTP; end
+    end
+
+    ActionMailer::Base.add_delivery_method :mailcatcher, Mailcatcher::SMTP
+    ActionMailer::Base.mailcatcher_settings = {
+      address: ENV.fetch("MAILCATCHER_HOST"),
+      port: ENV.fetch("MAILCATCHER_PORT")
+    }
+  end
+end


### PR DESCRIPTION
# Avant de mettre en production

- [x]  **🛑 Ajouter la nouvelle variable d'environnement `MAILCATCHER_ENABLED` en production**
- [x]  **🛑 Ajouter la nouvelle variable d'environnement `MAILCATCHER_HOST` en production**
- [x]  **🛑 Ajouter la nouvelle variable d'environnement `MAILCATCHER_PORT` en production**

# Résumé

Proposition du support de MailCatcher dans l'environnement de production.

documentation : https://mailcatcher.me/

mots-clés : env, mailcatcher, smtp

fixes #6871 / @adullact & @synbioz

PR liée : #6821 

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`