### PR TITLE
Ajout d'un réglage pour configurer le domaine de Matomo

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -276,6 +276,8 @@ class ApplicationController < ActionController::Base
     matomo = Rails.application.secrets.matomo
 
     {
+      cookie_domain: matomo[:cookie_domain],
+      domain: matomo[:domain],
       enabled: matomo[:enabled],
       host: matomo[:host],
       key: matomo[:client_key]

--- a/app/javascript/shared/track/matomo.js
+++ b/app/javascript/shared/track/matomo.js
@@ -1,4 +1,4 @@
-const { enabled, host, key } = gon.matomo || {};
+const { cookieDomain, domain, enabled, host, key } = gon.matomo || {};
 
 if (enabled) {
   window._paq = window._paq || [];
@@ -10,8 +10,8 @@ if (enabled) {
   // Configure Matomo analytics
   //
 
-  window._paq.push(['setCookieDomain', '*.www.demarches-simplifiees.fr']);
-  window._paq.push(['setDomains', ['*.www.demarches-simplifiees.fr']]);
+  window._paq.push(['setCookieDomain', cookieDomain]);
+  window._paq.push(['setDomains', [domain]]);
   // Don’t store any cookies or send any tracking request when the "Do Not Track" browser setting is enabled.
   window._paq.push(['setDoNotTrack', true]);
   // When enabling external link tracking, consider that it will also report links to attachments.

--- a/config/env.example
+++ b/config/env.example
@@ -67,6 +67,8 @@ SENTRY_DSN_JS=""
 
 # External service: Matomo web analytics
 MATOMO_ENABLED="disabled"
+MATOMO_COOKIE_DOMAIN="*.www.demarches-simplifiees.fr"
+MATOMO_DOMAIN="*.www.demarches-simplifiees.fr"
 MATOMO_ID=""
 MATOMO_HOST="matomo.example.org"
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -54,6 +54,8 @@ defaults: &defaults
     smtp_key: <%= ENV['SENDINBLUE_SMTP_KEY'] %>
     api_v3_key: <%= ENV['SENDINBLUE_API_V3_KEY'] %>
   matomo:
+    cookie_domain: "<%= ENV['MATOMO_COOKIE_DOMAIN'] %>"
+    domain: "<%= ENV['MATOMO_DOMAIN'] %>"
     enabled: <%= ENV['MATOMO_ENABLED'] == 'enabled' %>
     host: <%= ENV['MATOMO_HOST'] %>
     client_key: <%= ENV['MATOMO_ID'] %>


### PR DESCRIPTION
## Avant de merger et déployer

- [x]  **🛑 Ajouter la nouvelle variable d'environnement `MATOMO_DOMAIN` en production**
- [x]  **🛑 Ajouter la nouvelle variable d'environnement `MATOMO_COOKIE_DOMAIN` en production**

# Résumé

Le domaine considéré par Matomo devrait pouvoir être configurable par le moyen de variables d'environnement.

mots-clés : cookie, domain, env, gon, javascript, matomo

fixes #6872 / @adullact & @synbioz



--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`