### PR TITLE
Déplacer toutes les mentions à la DINUM dans des variables

### DIFF
--- a/app/assets/stylesheets/new_footer.scss
+++ b/app/assets/stylesheets/new_footer.scss
@@ -68,19 +68,12 @@ footer {
   opacity: 0.8;
 }
 
-.footer-logo-dinum {
-  @include ie-compatible-background-image("footer/logo-dinum.png");
-
-  height: 150px;
-  width: 202px;
-  margin-bottom: 14px;
-}
-
 .footer-logo-beta-gouv-fr {
   @include ie-compatible-background-image("footer/logo-beta-gouv-fr.svg");
 
   width: 150px;
   height: 25px;
+  margin-top: 14px;
 }
 
 .footer-logo-france {

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -1,6 +1,6 @@
 #footer
   %p{ class: "copyright col-md-push-#{12-main_container_size} col-md-#{main_container_size} col-lg-push-#{12-main_container_size} col-lg-#{main_container_size} text-muted small" }
-    = link_to 'DINUM', 'https://www.numerique.gouv.fr/dinum/'
+    = link_to PROVIDER_NAME, PROVIDER_URL
     = Time.zone.now.year
     \-
     = link_to 'Nouveautés', DOC_NOUVEAUTES_URL, target: '_blank'

--- a/app/views/layouts/mailers/notifications_layout.html.erb
+++ b/app/views/layouts/mailers/notifications_layout.html.erb
@@ -145,7 +145,7 @@
                       <tr>
                         <td style="word-wrap:break-word;font-size:0px;padding:0px 20px 0px 20px;padding-top:0px;padding-bottom:0px;" align="center">
                           <div class="" style="cursor:auto;color:#55575d;font-family:Helvetica, Arial, sans-serif;font-size:11px;line-height:22px;text-align:center;">
-                            <%= "#{APPLICATION_NAME}" %> est un service fourni par la DINUM
+                            <%= "#{APPLICATION_NAME}" %> est un service fourni par <%= PROVIDED_BY %>
                           </div>
                         </td>
                       </tr>

--- a/app/views/root/_footer.html.haml
+++ b/app/views/root/_footer.html.haml
@@ -5,12 +5,13 @@
       %li.footer-column
         %ul.footer-logos
           %li.footer-text
-            Un service fourni par la
-            = link_to "DINUM", "https://numerique.gouv.fr/", title: "Direction Interministérielle au Numérique"
+            Un service fourni par
+            = link_to PROVIDED_BY, PROVIDER_URL, title: PROVIDER_TITLE
             %br
           %li
-            = link_to "https://numerique.gouv.fr/", title: "DINUM", 'aria-label': 'DINUM' do
-              %span.footer-logo.footer-logo-dinum{ role: 'img', 'aria-label': 'Logo DINUM' }
+            = link_to PROVIDER_URL, title: PROVIDER_NAME, 'aria-label': PROVIDER_NAME do
+              %span.footer-logo{ role: 'img', 'aria-label': PROVIDER_LOGO_ALT }
+                = image_tag PROVIDER_LOGO_SRC, alt: PROVIDER_LOGO_ALT, width: PROVIDER_LOGO_WIDTH, height: PROVIDER_LOGO_HEIGHT, loading: 'lazy'
             = link_to "https://beta.gouv.fr", title: "le site de Beta.gouv.fr", 'aria-label': 'beta.gouv.fr' do
               %span.footer-logo.footer-logo-beta-gouv-fr{ role: 'img', 'aria-label': 'Logo beta.gouv.fr' }
 

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -89,3 +89,13 @@ DS_ENV="staging"
 
 # Admins and instructeurs can freely change their email to these domains
 # LEGIT_ADMIN_DOMAINS = "domaine_1.com;domaine_2.com"
+
+# Instance provider
+# PROVIDED_BY="la DINUM"
+# PROVIDER_NAME="DINUM"
+# PROVIDER_TITLE="Direction Interministérielle au Numérique"
+# PROVIDER_URL="https://numerique.gouv.fr/"
+# PROVIDER_LOGO_SRC="footer/logo-dinum.png"
+# PROVIDER_LOGO_ALT="Logo DINUM"
+# PROVIDER_LOGO_HEIGHT="161"
+# PROVIDER_LOGO_WIDTH="138"

--- a/config/initializers/provider.rb
+++ b/config/initializers/provider.rb
@@ -1,0 +1,10 @@
+# Instance provider
+PROVIDED_BY = ENV.fetch("PROVIDED_BY", "la DINUM")
+PROVIDER_NAME = ENV.fetch("PROVIDER_NAME", "DINUM")
+PROVIDER_TITLE = ENV.fetch("PROVIDER_TITLE", "Direction Interministérielle au Numérique")
+PROVIDER_URL = ENV.fetch("PROVIDER_URL", "https://numerique.gouv.fr/")
+
+PROVIDER_LOGO_SRC = ENV.fetch("PROVIDER_LOGO_SRC", "footer/logo-dinum.png")
+PROVIDER_LOGO_ALT = ENV.fetch("PROVIDER_LOGO_ALT", "Logo DINUM")
+PROVIDER_LOGO_HEIGHT = ENV.fetch("PROVIDER_LOGO_HEIGHT", "161")
+PROVIDER_LOGO_WIDTH = ENV.fetch("PROVIDER_LOGO_WIDTH", "138")


### PR DESCRIPTION
# Résumé

Les occurrences de la mention « DINUM » devrait être sujettes à configuration par le moyen de variables d'environnement.

mots-clés : dinum, env, provider

ticket #6873 / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`