### PR TITLE
Masquage de sections de la landing page administration

### DIFF
--- a/app/views/root/_testimonials.html.haml
+++ b/app/views/root/_testimonials.html.haml
@@ -1,0 +1,51 @@
+.landing-panel
+  .container
+    %h2.landing-panel-title Ce que les utilisateurs pensent du service
+
+    %ul.quotes
+      %li.quote
+        %img.quote-quotation-mark{ :src => image_url("landing/testimonials/quotation-mark.svg"), alt: "" }
+        .quote-content-wrapper
+          %p.quote-content
+            Les échanges avec les usagers sont facilités, ce qui permet de réduire les délais d’instructions et de gagner en efficacité.
+
+          %p.quote-author
+            %span.quote-author-name Elodie Le Rhun
+            %br
+            Cheffe de bureau, DRIEA Ile-de-France
+
+      %li.quote
+        %img.quote-quotation-mark{ :src => image_url("landing/testimonials/quotation-mark.svg"), alt: "" }
+        .quote-content-wrapper
+          %p.quote-content
+            Un service qui garantit une économie de temps et beaucoup moins de manipulations des dossiers.
+
+          %p.quote-author
+            %span.quote-author-name Nadja Briki
+            %br
+            Déléguée de la Préfète du Pas-de-Calais
+
+    %ul.quotes
+      %li.quote
+        %img.quote-quotation-mark{ :src => image_url("landing/testimonials/quotation-mark.svg"), alt: "" }
+        .quote-content-wrapper
+          %p.quote-content
+            Parfait, cela fonctionne très bien ! Merci encore pour votre réactivité.
+
+          %p.quote-author
+            %span.quote-author-name Max A.
+            %br
+            à notre service support
+
+      %li.quote
+        %img.quote-quotation-mark{ :src => image_url("landing/testimonials/quotation-mark.svg"), alt: "" }
+        .quote-content-wrapper
+          %p.quote-content
+            ★★★★★
+            %br
+            Eh les cocos, il y a la télé-procédure
+
+          %p.quote-author
+            %span.quote-author-name Hisham M.
+            %br
+            sur le site de la DRIEA

--- a/app/views/root/_users.html.haml
+++ b/app/views/root/_users.html.haml
@@ -1,0 +1,37 @@
+.landing-panel.users-panel
+  .container
+    %h2.landing-panel-title Ils utilisent déjà #{APPLICATION_NAME}
+
+    %ul.users
+      %li.user
+        = link_to "https://www.ecologique-solidaire.gouv.fr/", target: :blank, rel: "noopener noreferrer" do
+          %img.user-image{ :src => image_url("landing/users/mtes.jpg"), alt: "Ministère de la Transition Écologique et Solidaire" }
+      %li.user
+        = link_to "https://www.iledefrance.fr/", target: :blank, rel: "noopener noreferrer" do
+          %img.user-image{ :src => image_url("landing/users/region-idf.jpg"), alt: "Région Île-de-France" }
+      %li.user
+        = link_to "http://www.artisanat.fr/", target: :blank, rel: "noopener noreferrer" do
+          %img.user-image{ :src => image_url("landing/users/chambres-de-metiers.jpg"), alt: "Chambres des Métiers et de l'Artisanat" }
+      %li.user
+        = link_to "http://www.cci.fr/", target: :blank, rel: "noopener noreferrer" do
+          %img.user-image{ :src => image_url("landing/users/cci.jpg"), alt: "CCI de France" }
+      %li.user
+        = link_to "http://www.driea.ile-de-france.developpement-durable.gouv.fr/", target: :blank, rel: "noopener noreferrer" do
+          %img.user-image{ :src => image_url("landing/users/driea-idf.jpg"), alt: "Direction Régionale et Interdépartementale de l'Équipement et de l'Aménagement" }
+
+    %ul.users
+      %li.user
+        = link_to "https://www.debatpublic.fr/", target: :blank, rel: "noopener noreferrer" do
+          %img.user-image{ :src => image_url("landing/users/cndp.jpg"), alt: "Commission Nationale du Débat Public" }
+      %li.user
+        = link_to "https://www.iledefrance.ars.sante.fr/", target: :blank, rel: "noopener noreferrer" do
+          %img.user-image{ :src => image_url("landing/users/ars-idf.jpg"), alt: "Agence Régionale de Santé d’Île-de-France" }
+      %li.user
+        = link_to "http://www.franceagrimer.fr/", target: :blank, rel: "noopener noreferrer" do
+          %img.user-image{ :src => image_url("landing/users/france-agrimer.jpg"), alt: "FranceAgrimer" }
+      %li.user
+        = link_to "http://www.rhone.gouv.fr/", target: :blank, rel: "noopener noreferrer" do
+          %img.user-image{ :src => image_url("landing/users/prefecture-rhone.jpg"), alt: "Préfecture de la région Rhône-Alpes" }
+      %li.user
+        = link_to "http://www.lillemetropole.fr/", target: :blank, rel: "noopener noreferrer" do
+          %img.user-image{ :src => image_url("landing/users/mel.jpg"), alt: "Métropole Européenne de Lille" }

--- a/app/views/root/administration.html.haml
+++ b/app/views/root/administration.html.haml
@@ -82,57 +82,7 @@
             %br
             à l'ensemble des services de l'État plateforme
 
-  .landing-panel
-    .container
-      %h2.landing-panel-title Ce que les utilisateurs pensent du service
-
-      %ul.quotes
-        %li.quote
-          %img.quote-quotation-mark{ :src => image_url("landing/testimonials/quotation-mark.svg"), alt: "" }
-          .quote-content-wrapper
-            %p.quote-content
-              Les échanges avec les usagers sont facilités, ce qui permet de réduire les délais d’instructions et de gagner en efficacité.
-
-            %p.quote-author
-              %span.quote-author-name Elodie Le Rhun
-              %br
-              Cheffe de bureau, DRIEA Ile-de-France
-
-        %li.quote
-          %img.quote-quotation-mark{ :src => image_url("landing/testimonials/quotation-mark.svg"), alt: "" }
-          .quote-content-wrapper
-            %p.quote-content
-              Un service qui garantit une économie de temps et beaucoup moins de manipulations des dossiers.
-
-            %p.quote-author
-              %span.quote-author-name Nadja Briki
-              %br
-              Déléguée de la Préfète du Pas-de-Calais
-
-      %ul.quotes
-        %li.quote
-          %img.quote-quotation-mark{ :src => image_url("landing/testimonials/quotation-mark.svg"), alt: "" }
-          .quote-content-wrapper
-            %p.quote-content
-              Parfait, cela fonctionne très bien ! Merci encore pour votre réactivité.
-
-            %p.quote-author
-              %span.quote-author-name Max A.
-              %br
-              à notre service support
-
-        %li.quote
-          %img.quote-quotation-mark{ :src => image_url("landing/testimonials/quotation-mark.svg"), alt: "" }
-          .quote-content-wrapper
-            %p.quote-content
-              ★★★★★
-              %br
-              Eh les cocos, il y a la télé-procédure
-
-            %p.quote-author
-              %span.quote-author-name Hisham M.
-              %br
-              sur le site de la DRIEA
+  = render partial: "root/testimonials" if LANDING_TESTIMONIALS_ENABLED
 
   - cache "numbers-panel", :expires_in => 3.hours do
     .landing-panel.numbers-panel
@@ -161,43 +111,7 @@
               %br<>
               des délais de traitement
 
-  .landing-panel.users-panel
-    .container
-      %h2.landing-panel-title Ils utilisent déjà #{APPLICATION_NAME}
-
-      %ul.users
-        %li.user
-          = link_to "https://www.ecologique-solidaire.gouv.fr/", target: :blank, rel: "noopener noreferrer" do
-            %img.user-image{ :src => image_url("landing/users/mtes.jpg"), alt: "Ministère de la Transition Écologique et Solidaire" }
-        %li.user
-          = link_to "https://www.iledefrance.fr/", target: :blank, rel: "noopener noreferrer" do
-            %img.user-image{ :src => image_url("landing/users/region-idf.jpg"), alt: "Région Île-de-France" }
-        %li.user
-          = link_to "http://www.artisanat.fr/", target: :blank, rel: "noopener noreferrer" do
-            %img.user-image{ :src => image_url("landing/users/chambres-de-metiers.jpg"), alt: "Chambres des Métiers et de l'Artisanat" }
-        %li.user
-          = link_to "http://www.cci.fr/", target: :blank, rel: "noopener noreferrer" do
-            %img.user-image{ :src => image_url("landing/users/cci.jpg"), alt: "CCI de France" }
-        %li.user
-          = link_to "http://www.driea.ile-de-france.developpement-durable.gouv.fr/", target: :blank, rel: "noopener noreferrer" do
-            %img.user-image{ :src => image_url("landing/users/driea-idf.jpg"), alt: "Direction Régionale et Interdépartementale de l'Équipement et de l'Aménagement" }
-
-      %ul.users
-        %li.user
-          = link_to "https://www.debatpublic.fr/", target: :blank, rel: "noopener noreferrer" do
-            %img.user-image{ :src => image_url("landing/users/cndp.jpg"), alt: "Commission Nationale du Débat Public" }
-        %li.user
-          = link_to "https://www.iledefrance.ars.sante.fr/", target: :blank, rel: "noopener noreferrer" do
-            %img.user-image{ :src => image_url("landing/users/ars-idf.jpg"), alt: "Agence Régionale de Santé d’Île-de-France" }
-        %li.user
-          = link_to "http://www.franceagrimer.fr/", target: :blank, rel: "noopener noreferrer" do
-            %img.user-image{ :src => image_url("landing/users/france-agrimer.jpg"), alt: "FranceAgrimer" }
-        %li.user
-          = link_to "http://www.rhone.gouv.fr/", target: :blank, rel: "noopener noreferrer" do
-            %img.user-image{ :src => image_url("landing/users/prefecture-rhone.jpg"), alt: "Préfecture de la région Rhône-Alpes" }
-        %li.user
-          = link_to "http://www.lillemetropole.fr/", target: :blank, rel: "noopener noreferrer" do
-            %img.user-image{ :src => image_url("landing/users/mel.jpg"), alt: "Métropole Européenne de Lille" }
+  = render partial: "root/users" if  LANDING_USERS_ENABLED
 
   .landing-panel.cta-panel-2
     .container

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -102,3 +102,7 @@ MATOMO_IFRAME_URL="https://matomo.example.org/index.php?module=CoreAdminHome&act
 # PROVIDER_LOGO_ALT="Logo DINUM"
 # PROVIDER_LOGO_HEIGHT="161"
 # PROVIDER_LOGO_WIDTH="138"
+
+# Landing page sections
+# LANDING_TESTIMONIALS_ENABLED="enabled"
+# LANDING_USERS_ENABLED="enabled"

--- a/config/initializers/landing.rb
+++ b/config/initializers/landing.rb
@@ -1,0 +1,3 @@
+# Hide or show the landing page sections
+LANDING_TESTIMONIALS_ENABLED = ENV.fetch("LANDING_TESTIMONIALS_ENABLED", "enabled") == "enabled"
+LANDING_USERS_ENABLED = ENV.fetch("LANDING_USERS_ENABLED", "enabled") == "enabled"


### PR DESCRIPTION
# Résumé

La présente proposition permet de configurer par le moyen de variables d'instance, l'affichage ou non des sections « Ce que les utilisateurs pensent du service » & « Ils utilisent déjà  » sur la landing page administration.

mots-clés : administration, env, landing, testimonial

fixes #6874 / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`