### PR TITLE
Amélioration du contraste de la landing page administration

### DIFF
--- a/app/assets/stylesheets/landing.scss
+++ b/app/assets/stylesheets/landing.scss
@@ -295,7 +295,6 @@ $users-breakpoint: 950px;
   font-size: 24px;
   font-weight: bold;
   margin-top: 13px;
-  color: #FFFFFF;
 
   &.grey {
     color: $g700;
@@ -303,13 +302,17 @@ $users-breakpoint: 950px;
 }
 
 .cta-panel-explanation {
-  font-size: 24px;
+  font-size: 22px;
   margin-bottom: 10px;
-  color: #FFFFFF;
 
   &.grey {
     color: $g700;
   }
+}
+
+.half .cta-panel-title,
+.half .cta-panel-explanation {
+  text-align: center;
 }
 
 .role-panel-title {
@@ -357,7 +360,7 @@ $cta-panel-button-border-size: 2px;
   @include vertical-padding(15px);
   display: block;
   border-radius: 100px;
-  font-size: 24px;
+  font-size: 22px;
   text-align: center;
   cursor: pointer;
   margin-top: 20px;


### PR DESCRIPTION
# Résumé

Certains textes apparaissent blanc sur fond blanc sur la landing page administration.

mots-clés : administration, contraste, css, landing

ticket #6875 / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`