### PR TITLE
[AfterParty] échec de la tâche 20210429172327_rename_conservation_extension

### DIFF
--- a/lib/tasks/deployment/20210429172327_rename_conservation_extension.rake
+++ b/lib/tasks/deployment/20210429172327_rename_conservation_extension.rake
@@ -5,6 +5,9 @@ namespace :after_party do
 
     BATCH_SIZE = 20_000
 
+    ignored_columns = Dossier.ignored_columns.dup
+    Dossier.ignored_columns -= ["en_construction_conservation_extension"]
+
     dossiers = Dossier.state_en_construction.where.not(en_construction_conservation_extension: 0.days)
     progress = ProgressReport.new((dossiers.count.to_f / BATCH_SIZE).round)
     dossiers.in_batches(of: BATCH_SIZE) do |relation|
@@ -12,6 +15,8 @@ namespace :after_party do
       progress.inc
     end
     progress.finish
+
+    Dossier.ignored_columns = ignored_columns
 
     dossiers_without_conservation_extension = Dossier.where(conservation_extension: nil)
     progress = ProgressReport.new((dossiers_without_conservation_extension.count.to_f / BATCH_SIZE).round)


### PR DESCRIPTION
# Résumé

La tâche de déploiement `20210429172327_rename_conservation_extension`  ne peut être jouée avec succès lors d'une montée de version depuis le tag `2020-10-30-02`.

mots-clés : after party, déploiement, dossier, tâche

ticket #6884 / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`