### PR TITLE
Ajout d'un réglage pour pouvoir désactiver ClamAV

### DIFF
--- a/app/services/clamav_service.rb
+++ b/app/services/clamav_service.rb
@@ -1,18 +1,18 @@
 class ClamavService
   def self.safe_file?(file_path)
-    if Rails.env.development?
-      return true
-    end
+    return true if !Rails.configuration.x.clamav.enabled
 
     FileUtils.chmod(0666, file_path)
 
     client = ClamAV::Client.new
     response = client.execute(ClamAV::Commands::ScanCommand.new(file_path)).first
-    if response.class == ClamAV::SuccessResponse
+
+    case response
+    when ClamAV::SuccessResponse
       true
-    elsif response.class == ClamAV::VirusResponse
+    when ClamAV::VirusResponse
       false
-    elsif response.class == ClamAV::ErrorResponse
+    when ClamAV::ErrorResponse
       raise "ClamAV ErrorResponse : #{response.error_str}"
     else
       raise "ClamAV unkown response #{response.class.name}"

--- a/config/application.rb
+++ b/config/application.rb
@@ -76,5 +76,9 @@ module TPS
     }
 
     config.skylight.probes += [:graphql]
+
+    # Custom Configuration
+    # @see https://guides.rubyonrails.org/configuring.html#custom-configuration
+    config.x.clamav.enabled = ENV.fetch("CLAMAV_ENABLED", "enabled") == "enabled"
   end
 end

--- a/config/env.example
+++ b/config/env.example
@@ -138,3 +138,6 @@ ENCRYPTION_SERVICE_SALT=""
 # Salt for invisible_captcha session data.
 # Must be the same value for all app instances behind a load-balancer.
 INVISIBLE_CAPTCHA_SECRET="kikooloool"
+
+# Clamav antivirus usage
+CLAMAV_ENABLED="disabled"

--- a/spec/services/clamav_service_spec.rb
+++ b/spec/services/clamav_service_spec.rb
@@ -4,25 +4,51 @@ describe ClamavService do
 
     subject { ClamavService.safe_file?(path_file) }
 
-    before do
-      client = double("ClamAV::Client", execute: [response])
-      allow(ClamAV::Client).to receive(:new).and_return(client)
-      allow(FileUtils).to receive(:chmod).with(0666, path_file).and_return(true)
+    context "when ClamAV is enabled" do
+      before do
+        @saved_clamav = Rails.configuration.x.clamav.enabled
+        Rails.configuration.x.clamav.enabled = true
+
+        client = double("ClamAV::Client", execute: [response])
+        allow(ClamAV::Client).to receive(:new).and_return(client)
+        allow(FileUtils).to receive(:chmod).with(0666, path_file).and_return(true)
+      end
+
+      after do
+        Rails.configuration.x.clamav.enabled = @saved_clamav
+      end
+
+      context 'When response type is ClamAV::SuccessResponse' do
+        let(:response) { ClamAV::SuccessResponse.new("OK") }
+        it { expect(subject).to eq(true) }
+      end
+
+      context 'When response type is ClamAV::VirusResponse' do
+        let(:response) { ClamAV::VirusResponse.new("KO", "VirusN4ame") }
+        it { expect(subject).to eq(false) }
+      end
+
+      context 'When response type is ClamAV::ErrorResponse' do
+        let(:response) { ClamAV::ErrorResponse.new("File not found") }
+        it { expect { subject }.to raise_error("ClamAV ErrorResponse : File not found") }
+      end
     end
 
-    context 'When response type is ClamAV::SuccessResponse' do
-      let(:response) { ClamAV::SuccessResponse.new("OK") }
-      it { expect(subject).to eq(true) }
-    end
+    context "when ClamAV is disabled" do
+      before do
+        @saved_clamav = Rails.configuration.x.clamav.enabled
+        Rails.configuration.x.clamav.enabled = false
+      end
 
-    context 'When response type is ClamAV::VirusResponse' do
-      let(:response) { ClamAV::VirusResponse.new("KO", "VirusN4ame") }
-      it { expect(subject).to eq(false) }
-    end
+      after do
+        Rails.configuration.x.clamav.enabled = @saved_clamav
+      end
 
-    context 'When response type is ClamAV::ErrorResponse' do
-      let(:response) { ClamAV::ErrorResponse.new("File not found") }
-      it { expect { subject }.to raise_error("ClamAV ErrorResponse : File not found") }
+      it do
+        expect(ClamAV::Client).not_to receive(:new)
+        expect(FileUtils).not_to receive(:chmod)
+        expect(subject).to eq(true)
+      end
     end
   end
 end


### PR DESCRIPTION
# Avant de merger

- [x] 🛑 **Ajouter la variable d'environnement `CLAMAV_ENABLED` en dev et en prod**

# Résumé

Cette proposition offre la possibilité de désactiver ClamAV.

mots-clés : antivirus, clamav, docker, env

fixes #6885 / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`