### PR TITLE
Watermark depuis une URL distante

### DIFF
--- a/app/jobs/titre_identite_watermark_job.rb
+++ b/app/jobs/titre_identite_watermark_job.rb
@@ -12,7 +12,7 @@ class TitreIdentiteWatermarkJob < ApplicationJob
 
   MAX_IMAGE_SIZE = 1500
   SCALE = 0.9
-  WATERMARK = Rails.root.join("app/assets/images/#{WATERMARK_FILE}")
+  WATERMARK = URI.parse(WATERMARK_FILE).is_a?(URI::HTTP) ? WATERMARK_FILE : Rails.root.join("app/assets/images/#{WATERMARK_FILE}")
 
   def perform(blob)
     if blob.virus_scanner.pending? then raise FileNotScannedYetError end


### PR DESCRIPTION
# Résumé

Cette proposition offre la possibilité de disposer d'un watermark distant accessible en HTTP ou HTTPS.

mots-clés : assets, env, wartermark

ticket #6886 / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`