### PR TITLE
Ajout d'un réglage pour configurer le type de stockage ActiveStorage

### DIFF
--- a/config/env.example
+++ b/config/env.example
@@ -35,7 +35,7 @@ BASIC_AUTH_PASSWORD=""
 # - "openstack": store files remotely on an OpenStack storage service
 #
 # (See config/storage.yml for the configuration of each service.)
-STORAGE_TYPE="local"
+ACTIVE_STORAGE_SERVICE="local"
 
 # Configuration for the OpenStack storage service (if enabled)
 FOG_OPENSTACK_API_KEY=""

--- a/config/env.example
+++ b/config/env.example
@@ -28,8 +28,16 @@ BASIC_AUTH_ENABLED="disabled"
 BASIC_AUTH_USERNAME=""
 BASIC_AUTH_PASSWORD=""
 
-# Object Storage for attachments
-FOG_ENABLED="disabled"
+# ActiveStorage service to use for attached files.
+# Possible values:
+# - "local": store files on the local filesystem
+# - "amazon": store files remotely on an S3 storage service
+# - "openstack": store files remotely on an OpenStack storage service
+#
+# (See config/storage.yml for the configuration of each service.)
+STORAGE_TYPE="local"
+
+# Configuration for the OpenStack storage service (if enabled)
 FOG_OPENSTACK_API_KEY=""
 FOG_OPENSTACK_USERNAME=""
 FOG_OPENSTACK_URL=""

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = ENV['FOG_ENABLED'] == 'enabled' ? :openstack : :local
+  config.active_storage.service = ENV.fetch("STORAGE_TYPE").to_sym
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = ENV.fetch("STORAGE_TYPE").to_sym
+  config.active_storage.service = ENV.fetch("ACTIVE_STORAGE_SERVICE").to_sym
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -107,7 +107,7 @@ Rails.application.configure do
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
-  config.active_storage.service = ENV.fetch("STORAGE_TYPE").to_sym
+  config.active_storage.service = ENV.fetch("ACTIVE_STORAGE_SERVICE").to_sym
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -107,7 +107,7 @@ Rails.application.configure do
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
-  config.active_storage.service = :openstack
+  config.active_storage.service = ENV.fetch("STORAGE_TYPE").to_sym
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify


### PR DESCRIPTION
# Avant de merger

- [x] 🛑 **Ajouter la variable d'environnement `ACTIVE_STORAGE_SERVICE` en dev et en prod**

# Résumé

Cette proposition concerne un petit nettoyage dans l'utilisation des variables d'environnement liées à OpenStack en systématisant l'usage de la variable `ACTIVE_STORAGE_SERVICE` en lieu et place de `FOG_ENABLED`.

mots-clés : env, fog, openstack, storage

fixes #6887 / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`