### PR TITLE
Configuration de l'URL de l'iframe Matomo

### DIFF
--- a/config/env.example
+++ b/config/env.example
@@ -68,7 +68,7 @@ SENTRY_DSN_JS=""
 # External service: Matomo web analytics
 MATOMO_ENABLED="disabled"
 MATOMO_ID=""
-MATOMO_HOST="matomo.organisme.fr"
+MATOMO_HOST="matomo.example.org"
 
 # Default SMTP Provider: Mailjet
 MAILJET_API_KEY=""

--- a/config/env.example
+++ b/config/env.example
@@ -2,8 +2,8 @@
 #
 # Examples:
 # * For local development: localhost:3000
-# * For preproduction: staging.ds.organisme.fr
-# * For production: ds.organisme.fr
+# * For preproduction: staging.ds.example.org
+# * For production: ds.example.org
 APP_HOST="localhost:3000"
 
 # Rails key for signing sensitive data

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -90,6 +90,9 @@ DS_ENV="staging"
 # Admins and instructeurs can freely change their email to these domains
 # LEGIT_ADMIN_DOMAINS = "domaine_1.com;domaine_2.com"
 
+# External service: Matomo web analytics
+MATOMO_IFRAME_URL="https://matomo.example.org/index.php?module=CoreAdminHome&action=optOut&language=fr&&fontColor=333333&fontSize=16px&fontFamily=Muli"
+
 # Instance provider
 # PROVIDED_BY="la DINUM"
 # PROVIDER_NAME="DINUM"

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -88,7 +88,7 @@ DS_ENV="staging"
 # API_PARTICULIER_URL="https://particulier.api.gouv.fr/api"
 
 # Admins and instructeurs can freely change their email to these domains
-# LEGIT_ADMIN_DOMAINS = "domaine_1.com;domaine_2.com"
+# LEGIT_ADMIN_DOMAINS = "example.org;example.net"
 
 # External service: Matomo web analytics
 MATOMO_IFRAME_URL="https://matomo.example.org/index.php?module=CoreAdminHome&action=optOut&language=fr&&fontColor=333333&fontSize=16px&fontFamily=Muli"

--- a/config/initializers/urls.rb
+++ b/config/initializers/urls.rb
@@ -43,6 +43,6 @@ FAQ_ERREUR_SIRET_URL = [FAQ_URL, "article", "4-erreur-siret"].join("/")
 
 STATUS_PAGE_URL = ENV.fetch("STATUS_PAGE_URL", "https://status.demarches-simplifiees.fr")
 DEMANDE_INSCRIPTION_ADMIN_PAGE_URL = ENV.fetch("DEMANDE_INSCRIPTION_ADMIN_PAGE_URL", "https://www.demarches-simplifiees.fr/commencer/demande-d-inscription-a-demarches-simplifiees")
-MATOMO_IFRAME_URL = "https://stats.data.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=fr&&fontColor=333333&fontSize=16px&fontFamily=Muli"
+MATOMO_IFRAME_URL = ENV.fetch("MATOMO_IFRAME_URL", "https://#{ENV.fetch('MATOMO_HOST', 'stats.data.gouv.fr')}/index.php?module=CoreAdminHome&action=optOut&language=fr&&fontColor=333333&fontSize=16px&fontFamily=Muli")
 
 # rubocop:enable DS/ApplicationName


### PR DESCRIPTION
# Résumé

Configuration de l'URL de l'iframe Matomo par le moyen d'une variable d'environnement.

mots-clés : env, iframe, matomo

fixes #6889 / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`