### PR TITLE
[OpenStack] nettoyage des variables d'environnement

### DIFF
--- a/config/env.example
+++ b/config/env.example
@@ -28,8 +28,9 @@ BASIC_AUTH_ENABLED="disabled"
 BASIC_AUTH_USERNAME=""
 BASIC_AUTH_PASSWORD=""
 
-# Object Storage for attachments
-FOG_ENABLED="disabled"
+# Object Storage for attachments. Used if STORAGE_TYPE is not "local"
+STORAGE_TYPE="openstack"
+FOG_OPENSTACK_AUTH_URL="https://auth.cloud.ovh.net"
 FOG_OPENSTACK_API_KEY=""
 FOG_OPENSTACK_USERNAME=""
 FOG_OPENSTACK_URL=""

--- a/config/env.example
+++ b/config/env.example
@@ -28,9 +28,8 @@ BASIC_AUTH_ENABLED="disabled"
 BASIC_AUTH_USERNAME=""
 BASIC_AUTH_PASSWORD=""
 
-# Object Storage for attachments. Used if STORAGE_TYPE is not "local"
-STORAGE_TYPE="openstack"
-FOG_OPENSTACK_AUTH_URL="https://auth.cloud.ovh.net"
+# Object Storage for attachments
+FOG_ENABLED="disabled"
 FOG_OPENSTACK_API_KEY=""
 FOG_OPENSTACK_USERNAME=""
 FOG_OPENSTACK_URL=""

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,7 +8,7 @@ openstack:
   service: OpenStack
   container: "<%= ENV['FOG_ACTIVESTORAGE_DIRECTORY'] %>"
   credentials:
-    openstack_auth_url: "https://auth.cloud.ovh.net"
+    openstack_auth_url: "<%= ENV['FOG_OPENSTACK_AUTH_URL'] %>"
     openstack_api_key: "<%= ENV['FOG_OPENSTACK_API_KEY'] %>"
     openstack_username: "<%= ENV['FOG_OPENSTACK_USERNAME'] %>"
     openstack_region: "<%= ENV['FOG_OPENSTACK_REGION'] %>"

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,7 +8,7 @@ openstack:
   service: OpenStack
   container: "<%= ENV['FOG_ACTIVESTORAGE_DIRECTORY'] %>"
   credentials:
-    openstack_auth_url: "<%= ENV['FOG_OPENSTACK_AUTH_URL'] %>"
+    openstack_auth_url: "<%= ENV['FOG_OPENSTACK_URL'] %>"
     openstack_api_key: "<%= ENV['FOG_OPENSTACK_API_KEY'] %>"
     openstack_username: "<%= ENV['FOG_OPENSTACK_USERNAME'] %>"
     openstack_region: "<%= ENV['FOG_OPENSTACK_REGION'] %>"


### PR DESCRIPTION
# Avant de merger

- [x] 🛑 **Ajouter la variable d'environnement `FOG_OPENSTACK_URL` en dev et en prod**

# Résumé

Cette proposition concerne un petit nettoyage dans l'utilisation des variables d'environnement liées à OpenStack en systématisant l'usage de la variable `FOG_OPENSTACK_URL` en lieu et place de `FOG_BASE_URL`.

mots-clés : env, openstack, url

fixes #6890 / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`