### PR TITLE
Renommage de STORAGE_TYPE en ACTIVE_STORAGE_SERVICE

### DIFF
--- a/config/env.example
+++ b/config/env.example
@@ -28,12 +28,13 @@ BASIC_AUTH_ENABLED="disabled"
 BASIC_AUTH_USERNAME=""
 BASIC_AUTH_PASSWORD=""
 
-# Object Storage for attachments
-FOG_ENABLED="disabled"
+# Object Storage for attachments. Used if ACTIVE_STORAGE_SERVICE is not "local"
+ACTIVE_STORAGE_SERVICE="local"
 FOG_OPENSTACK_API_KEY=""
-FOG_OPENSTACK_USERNAME=""
-FOG_OPENSTACK_URL=""
+FOG_OPENSTACK_AUTH_URL="https://auth.cloud.ovh.net"
 FOG_OPENSTACK_REGION=""
+FOG_OPENSTACK_URL=""
+FOG_OPENSTACK_USERNAME=""
 DS_PROXY_URL=""
 
 # SAML Identity provider

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = ENV['FOG_ENABLED'] == 'enabled' ? :openstack : :local
+  config.active_storage.service = ENV.fetch("ACTIVE_STORAGE_SERVICE").to_sym
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -106,7 +106,7 @@ Rails.application.configure do
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
-  config.active_storage.service = :openstack
+  config.active_storage.service = ENV.fetch("ACTIVE_STORAGE_SERVICE").to_sym
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify


### PR DESCRIPTION
# Avant de merger

- [x] 🛑 **Ajouter la variable d'environnement `ACTIVE_STORAGE_SERVICE` en dev et en prod**

# Résumé

@kemenaran propose de renommer la variable `STORAGE_TYPE` en `ACTIVE_STORAGE_SERVICE`

Cf. https://github.com/betagouv/demarches-simplifiees.fr/pull/6929#discussion_r801700035

mots-clés : env, storage, variable

PR liée : #6929

fixes #6942  / @adullact & @synbioz & @betagouv

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`