### PR TITLE
Utilisation des variables d'environnement lors de la déclaration des Content Security Policies (à nouveau)

### DIFF
--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -93,6 +93,9 @@ DS_ENV="staging"
 # External service: Matomo web analytics
 MATOMO_IFRAME_URL="https://matomo.example.org/index.php?module=CoreAdminHome&action=optOut&language=fr&&fontColor=333333&fontSize=16px&fontFamily=Muli"
 
+# An URI used to report requests breaking the Content Security Policy
+# CSP_REPORT_URI="https://myappname.report-uri.com/r/d/csp/reportOnly"
+
 # Instance provider
 # PROVIDED_BY="la DINUM"
 # PROVIDER_NAME="DINUM"

--- a/config/initializers/02_urls.rb
+++ b/config/initializers/02_urls.rb
@@ -1,7 +1,9 @@
 # rubocop:disable DS/ApplicationName
 # API URLs
+API_ADRESSE_URL = ENV.fetch("API_ADRESSE_URL", "https://api-adresse.data.gouv.fr")
 API_ENTREPRISE_URL = ENV.fetch("API_ENTREPRISE_URL", "https://entreprise.api.gouv.fr/v2")
 API_EDUCATION_URL = ENV.fetch("API_EDUCATION_URL", "https://data.education.gouv.fr/api/records/1.0")
+API_GEO_URL = ENV.fetch("API_GEO_URL", "https://geo.api.gouv.fr")
 API_PARTICULIER_URL = ENV.fetch("API_PARTICULIER_URL", "https://particulier.api.gouv.fr/api")
 HELPSCOUT_API_URL = ENV.fetch("HELPSCOUT_API_URL", "https://api.helpscout.net/v2")
 PIPEDRIVE_API_URL = ENV.fetch("PIPEDRIVE_API_URL", "https://api.pipedrive.com/v1")
@@ -11,7 +13,7 @@ UNIVERSIGN_API_URL = ENV.fetch("UNIVERSIGN_API_URL", "https://ws.universign.eu/t
 FEATURE_UPVOTE_URL = ENV.fetch("FEATURE_UPVOTE_URL", "https://demarches-simplifiees.featureupvote.com")
 
 # Internal URLs
-FOG_BASE_URL = "https://static.demarches-simplifiees.fr"
+FOG_OPENSTACK_URL = ENV.fetch("FOG_OPENSTACK_URL", "https://auth.cloud.ovh.net")
 
 # External services URLs
 WEBINAIRE_URL = "https://app.livestorm.co/demarches-simplifiees"

--- a/config/initializers/02_urls.rb
+++ b/config/initializers/02_urls.rb
@@ -14,6 +14,7 @@ FEATURE_UPVOTE_URL = ENV.fetch("FEATURE_UPVOTE_URL", "https://demarches-simplifi
 
 # Internal URLs
 FOG_OPENSTACK_URL = ENV.fetch("FOG_OPENSTACK_URL", "https://auth.cloud.ovh.net")
+DS_PROXY_URL = ENV.fetch("DS_PROXY_URL", "")
 
 # External services URLs
 WEBINAIRE_URL = "https://app.livestorm.co/demarches-simplifiees"

--- a/config/initializers/02_urls.rb
+++ b/config/initializers/02_urls.rb
@@ -47,5 +47,6 @@ FAQ_ERREUR_SIRET_URL = [FAQ_URL, "article", "4-erreur-siret"].join("/")
 STATUS_PAGE_URL = ENV.fetch("STATUS_PAGE_URL", "https://status.demarches-simplifiees.fr")
 DEMANDE_INSCRIPTION_ADMIN_PAGE_URL = ENV.fetch("DEMANDE_INSCRIPTION_ADMIN_PAGE_URL", "https://www.demarches-simplifiees.fr/commencer/demande-d-inscription-a-demarches-simplifiees")
 MATOMO_IFRAME_URL = ENV.fetch("MATOMO_IFRAME_URL", "https://#{ENV.fetch('MATOMO_HOST', 'stats.data.gouv.fr')}/index.php?module=CoreAdminHome&action=optOut&language=fr&&fontColor=333333&fontSize=16px&fontFamily=Muli")
+CSP_REPORT_URI = ENV.fetch("CSP_REPORT_URI", "")
 
 # rubocop:enable DS/ApplicationName

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -42,6 +42,8 @@ Rails.application.config.content_security_policy do |policy|
     policy.report_uri "http://#{ENV.fetch('APP_HOST')}/csp/"
     # En développement, quand bin/webpack-dev-server est utilisé, on autorise les requêtes faites par le live-reload
     policy.connect_src(*policy.connect_src, "ws://localhost:3035", "http://localhost:3035")
+  else
+    policy.report_uri CSP_REPORT_URI if CSP_REPORT_URI.present?
   end
 end
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -7,7 +7,7 @@
 Rails.application.config.content_security_policy do |policy|
   # Whitelist image
   images_whitelist = ["*.openstreetmap.org", "*.cloud.ovh.net", "*"]
-  images_whitelist << URI(FOG_OPENSTACK_URL).host if FOG_OPENSTACK_URL.present?
+  images_whitelist << URI(DS_PROXY_URL).host if DS_PROXY_URL.present?
   images_whitelist << URI(MATOMO_IFRAME_URL).host if MATOMO_IFRAME_URL.present?
   policy.img_src(:self, :data, :blob, *images_whitelist)
 
@@ -23,16 +23,17 @@ Rails.application.config.content_security_policy do |policy|
   policy.style_src(:self, "*.crisp.chat", "crisp.chat", 'cdn.jsdelivr.net', 'maxcdn.bootstrapcdn.com', :unsafe_inline)
 
   connect_whitelist = ["wss://*.crisp.chat", "*.crisp.chat", "in-automate.sendinblue.com", "app.franceconnect.gouv.fr", "sentry.io", "openmaptiles.geo.data.gouv.fr", "openmaptiles.github.io", "tiles.geo.api.gouv.fr", "wxs.ign.fr"]
+  connect_whitelist << ENV.fetch('APP_HOST')
+  connect_whitelist << URI(DS_PROXY_URL).host if DS_PROXY_URL.present?
   connect_whitelist << URI(API_ADRESSE_URL).host if API_ADRESSE_URL.present?
   connect_whitelist << URI(API_EDUCATION_URL).host if API_EDUCATION_URL.present?
   connect_whitelist << URI(API_GEO_URL).host if API_GEO_URL.present?
-  connect_whitelist << "*.#{ENV.fetch('APP_HOST', 'localhost:3000')}"
   policy.connect_src(:self, *connect_whitelist)
 
   # Pour tout le reste, par défaut on accepte uniquement ce qui vient de chez nous
   # et dans la notification on inclue la source de l'erreur
   default_whitelist = ["fonts.gstatic.com", "in-automate.sendinblue.com", "player.vimeo.com", "app.franceconnect.gouv.fr", "sentry.io", "*.crisp.chat", "crisp.chat", "*.crisp.help", "*.sibautomation.com", "sibautomation.com", "data"]
-  default_whitelist << URI(FOG_OPENSTACK_URL).host if FOG_OPENSTACK_URL.present?
+  default_whitelist << URI(DS_PROXY_URL).host if DS_PROXY_URL.present?
   policy.default_src(:self, :data, :blob, :report_sample, *default_whitelist)
 
   if Rails.env.development?

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,30 +4,45 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# rubocop:disable DS/ApplicationName
 Rails.application.config.content_security_policy do |policy|
   # Whitelist image
-  policy.img_src :self, "*.openstreetmap.org", "static.demarches-simplifiees.fr", "*.cloud.ovh.net", "stats.data.gouv.fr", "*", :data, :blob
+  images_whitelist = ["*.openstreetmap.org", "*.cloud.ovh.net", "*"]
+  images_whitelist << URI(FOG_OPENSTACK_URL).host if FOG_OPENSTACK_URL.present?
+  images_whitelist << URI(MATOMO_IFRAME_URL).host if MATOMO_IFRAME_URL.present?
+  policy.img_src(:self, :data, :blob, *images_whitelist)
+
   # Whitelist JS: nous, sendinblue et matomo
   # miniprofiler et nous avons quelques boutons inline :(
-  policy.script_src :self, "stats.data.gouv.fr", "*.sendinblue.com", "*.crisp.chat", "crisp.chat", "*.sibautomation.com", "sibautomation.com", 'cdn.jsdelivr.net', 'maxcdn.bootstrapcdn.com', 'code.jquery.com', :unsafe_eval, :unsafe_inline, :blob
+  scripts_whitelist = ["*.sendinblue.com", "*.crisp.chat", "crisp.chat", "*.sibautomation.com", "sibautomation.com", "cdn.jsdelivr.net", "maxcdn.bootstrapcdn.com", "code.jquery.com"]
+  scripts_whitelist << URI(MATOMO_IFRAME_URL).host if MATOMO_IFRAME_URL.present?
+  policy.script_src(:self, :unsafe_eval, :unsafe_inline, :blob, *scripts_whitelist)
+
   # Pour les CSS, on a beaucoup de style inline et quelques balises <style>
   # c'est trop compliqué pour être rectifié immédiatement (et sans valeur ajoutée:
   # c'est hardcodé dans les vues, donc pas injectable).
-  policy.style_src :self, "*.crisp.chat", "crisp.chat", 'cdn.jsdelivr.net', 'maxcdn.bootstrapcdn.com', :unsafe_inline
-  policy.connect_src :self, "wss://*.crisp.chat", "*.crisp.chat", "*.demarches-simplifiees.fr", "in-automate.sendinblue.com", "app.franceconnect.gouv.fr", "sentry.io", "geo.api.gouv.fr", "api-adresse.data.gouv.fr", "openmaptiles.geo.data.gouv.fr", "openmaptiles.github.io", "tiles.geo.api.gouv.fr", "wxs.ign.fr", "data.education.gouv.fr"
+  policy.style_src(:self, "*.crisp.chat", "crisp.chat", 'cdn.jsdelivr.net', 'maxcdn.bootstrapcdn.com', :unsafe_inline)
+
+  connect_whitelist = ["wss://*.crisp.chat", "*.crisp.chat", "in-automate.sendinblue.com", "app.franceconnect.gouv.fr", "sentry.io", "openmaptiles.geo.data.gouv.fr", "openmaptiles.github.io", "tiles.geo.api.gouv.fr", "wxs.ign.fr"]
+  connect_whitelist << URI(API_ADRESSE_URL).host if API_ADRESSE_URL.present?
+  connect_whitelist << URI(API_EDUCATION_URL).host if API_EDUCATION_URL.present?
+  connect_whitelist << URI(API_GEO_URL).host if API_GEO_URL.present?
+  connect_whitelist << "*.#{ENV.fetch('APP_HOST', 'localhost:3000')}"
+  policy.connect_src(:self, *connect_whitelist)
+
   # Pour tout le reste, par défaut on accepte uniquement ce qui vient de chez nous
   # et dans la notification on inclue la source de l'erreur
-  policy.default_src :self, :data, :blob, :report_sample, "fonts.gstatic.com", "in-automate.sendinblue.com", "player.vimeo.com", "app.franceconnect.gouv.fr", "sentry.io", "static.demarches-simplifiees.fr", "*.crisp.chat", "crisp.chat", "*.crisp.help", "*.sibautomation.com", "sibautomation.com", "data"
+  default_whitelist = ["fonts.gstatic.com", "in-automate.sendinblue.com", "player.vimeo.com", "app.franceconnect.gouv.fr", "sentry.io", "*.crisp.chat", "crisp.chat", "*.crisp.help", "*.sibautomation.com", "sibautomation.com", "data"]
+  default_whitelist << URI(FOG_OPENSTACK_URL).host if FOG_OPENSTACK_URL.present?
+  policy.default_src(:self, :data, :blob, :report_sample, *default_whitelist)
+
   if Rails.env.development?
     # Les CSP ne sont pas appliquées en dev: on notifie cependant une url quelconque de la violation
     # pour détecter les erreurs lors de l'ajout d'une nouvelle brique externe durant le développement
-    policy.report_uri "http://#{ENV['APP_HOST']}/csp/"
+    policy.report_uri "http://#{ENV.fetch('APP_HOST')}/csp/"
     # En développement, quand bin/webpack-dev-server est utilisé, on autorise les requêtes faites par le live-reload
     policy.connect_src(*policy.connect_src, "ws://localhost:3035", "http://localhost:3035")
   end
 end
-# rubocop:enable DS/ApplicationName
 
 # If you are using UJS then enable automatic nonce generation
 # Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }


### PR DESCRIPTION
## Avant de merger

- [x]  **🛑 Ajouter la nouvelle variable d'environnement `CSP_REPORT_URI` en production**

## Description

Cette PR reprend #6933 (qui a dû être revertée parce qu'elle bloquait les envois de fichiers vers static.demarches-simplifiees.fr en prod).

Effectivement l'hôte du DS-proxy (si activé) n'était pas présent dans les différentes directives CSP.

## Correctif

J'ai modifié les CSP pour qu'elles correspondent à ce qu'on a en prod en ce moment. L'ancienne et la nouvelle sont donc maintenant identiques.

Juste une différence : à un endroit on avait un accès `*.demarches-simplifiees.fr`. Cet accès est difficile à reproduire sans hardcoder : comme variables d'env on a `APP_HOST=www.demarches-simplifiees.fr` et `DS_PROXY_URL=static.demarches-simplifiees.fr`. J'ai donc remplacé le `*` par les deux domaines concernés.

<img width="1218" alt="Capture d’écran 2022-02-09 à 12 18 59" src="https://user-images.githubusercontent.com/179923/153190215-72f7a6d8-d6c6-4f5d-9a54-c3881743e742.png">
_Le diff entre la CSP en prod et celle de cette PR_

## Reporting

J'ai également remis le reporting des violations CSP en prod, pour qu'on puisse détecter si d'autres domaines sont bloqués.

@LeSim @tchak @akarzim vous en pensez quoi ?

