### PR TITLE
Fix attestation templates again

### DIFF
--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -32,7 +32,7 @@ module Instructeurs
     end
 
     def apercu_attestation
-      @attestation = dossier.procedure.attestation_template.render_attributes_for(dossier: dossier)
+      @attestation = dossier.attestation_template.render_attributes_for(dossier: dossier)
 
       render 'administrateurs/attestation_templates/show', formats: [:pdf]
     end

--- a/app/models/attestation_template.rb
+++ b/app/models/attestation_template.rb
@@ -15,7 +15,6 @@ class AttestationTemplate < ApplicationRecord
   include ActionView::Helpers::NumberHelper
   include TagsSubstitutionConcern
 
-  belongs_to :procedure, optional: true
   has_many :revisions, class_name: 'ProcedureRevision', inverse_of: :attestation_template, dependent: :nullify
 
   has_one_attached :logo
@@ -120,7 +119,7 @@ class AttestationTemplate < ApplicationRecord
   end
 
   def procedure
-    revisions.last&.procedure || super
+    revisions.last&.procedure
   end
 
   private

--- a/app/models/attestation_template.rb
+++ b/app/models/attestation_template.rb
@@ -122,6 +122,22 @@ class AttestationTemplate < ApplicationRecord
     revisions.last&.procedure
   end
 
+  def logo_checksum
+    logo.attached? ? logo.checksum : nil
+  end
+
+  def signature_checksum
+    signature.attached? ? signature.checksum : nil
+  end
+
+  def logo_filename
+    logo.attached? ? logo.filename : nil
+  end
+
+  def signature_filename
+    signature.attached? ? signature.filename : nil
+  end
+
   private
 
   def used_tags

--- a/app/models/attestation_template.rb
+++ b/app/models/attestation_template.rb
@@ -103,17 +103,19 @@ class AttestationTemplate < ApplicationRecord
     }
   end
 
-  def revise!
-    if revisions.size > 1
+  def find_or_revise!
+    if revisions.size > 1 && procedure.feature_enabled?(:procedure_revisions)
+      # If attestation template belongs to more then one revision
+      # and procedure has revisions enabled – revise attestation template.
       attestation_template = dup
       attestation_template.save!
-      revisions
-        .last
-        .procedure
-        .draft_revision
-        .update!(attestation_template: attestation_template)
+      procedure.draft_revision.update!(attestation_template: attestation_template)
       attestation_template
     else
+      # If procedure has only one revision or revisions are not supported
+      # apply updates directly to the attestation template.
+      # If it is a published procedure with revisions disabled,
+      # draft and published attestation template will be the same.
       self
     end
   end

--- a/app/models/concerns/dossier_rebase_concern.rb
+++ b/app/models/concerns/dossier_rebase_concern.rb
@@ -14,7 +14,9 @@ module DossierRebaseConcern
   def rebase
     attachments_to_purge = []
     geo_areas_to_delete = []
-    changes_by_type_de_champ = revision.compare(procedure.published_revision).group_by { |change| change[:stable_id] }
+    changes_by_type_de_champ = revision.compare(procedure.published_revision)
+      .filter { |change| change[:model] == :type_de_champ }
+      .group_by { |change| change[:stable_id] }
 
     changes_by_type_de_champ.each do |stable_id, changes|
       type_de_champ = find_type_de_champ_by_stable_id(stable_id)

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -137,6 +137,7 @@ class Dossier < ApplicationRecord
   belongs_to :user, optional: true
   has_one :france_connect_information, through: :user
 
+  has_one :attestation_template, through: :revision
   has_one :procedure, through: :revision
   has_many :types_de_champ, through: :revision
   has_many :types_de_champ_private, through: :revision
@@ -384,7 +385,7 @@ class Dossier < ApplicationRecord
       .where.not(user: users_who_submitted)
   end
 
-  scope :for_api_v2, -> { includes(procedure: [:administrateurs, :attestation_template], etablissement: [], individual: [], traitement: []) }
+  scope :for_api_v2, -> { includes(procedure: [:administrateurs], revision: [:attestation_template], etablissement: [], individual: [], traitement: []) }
 
   scope :with_notifications, -> do
     joins(:follows)
@@ -721,10 +722,6 @@ class Dossier < ApplicationRecord
     { lon: lon, lat: lat, zoom: zoom }
   end
 
-  def attestation_template
-    revision.attestation_template
-  end
-
   def unspecified_attestation_champs
     if attestation_template&.activated?
       attestation_template.unspecified_champs_for_dossier(self)
@@ -828,7 +825,7 @@ class Dossier < ApplicationRecord
   end
 
   def attestation_activated?
-    termine? && procedure.attestation_template&.activated?
+    termine? && attestation_template&.activated?
   end
 
   def after_passer_en_construction

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -84,7 +84,7 @@ class Procedure < ApplicationRecord
   has_many :experts, through: :experts_procedures
 
   has_one :module_api_carto, dependent: :destroy
-  has_one :attestation_template, dependent: :destroy
+  has_one :legacy_attestation_template, class_name: 'AttestationTemplate', dependent: :destroy
   has_many :attestation_templates, through: :revisions, source: :attestation_template
 
   belongs_to :parent_procedure, class_name: 'Procedure', optional: true
@@ -434,7 +434,6 @@ class Procedure < ApplicationRecord
 
     populate_champ_stable_ids
     include_list = {
-      attestation_template: [],
       draft_revision: {
         revision_types_de_champ: {
           type_de_champ: :types_de_champ
@@ -580,7 +579,7 @@ class Procedure < ApplicationRecord
     touch(:whitelisted_at)
   end
 
-  def active_attestation_template
+  def attestation_template
     published_attestation_template || draft_attestation_template
   end
 
@@ -588,9 +587,9 @@ class Procedure < ApplicationRecord
     # As an optimization, don’t check the predefined templates (they are presumed correct)
     if closed_mail.present?
       tag_present = closed_mail.body.to_s.include?("--lien attestation--")
-      if active_attestation_template&.activated? && !tag_present
+      if attestation_template&.activated? && !tag_present
         :missing_tag
-      elsif !active_attestation_template&.activated? && tag_present
+      elsif !attestation_template&.activated? && tag_present
         :extraneous_tag
       end
     end

--- a/app/views/administrateurs/procedures/_revision_change_attestation_template.html.haml
+++ b/app/views/administrateurs/procedures/_revision_change_attestation_template.html.haml
@@ -1,0 +1,15 @@
+- case change[:op]
+- when :add
+  %li.mb-1= t(:add, scope: [:administrateurs, :revision_changes, :attestation_template])
+- when :update
+  - case change[:attribute]
+  - when :title
+    %li.mb-1= t(:update_title, scope: [:administrateurs, :revision_changes, :attestation_template], to: change[:to])
+  - when :body
+    %li.mb-1= t(:update_body, scope: [:administrateurs, :revision_changes, :attestation_template])
+  - when :footer
+    %li.mb-1= t(:update_footer, scope: [:administrateurs, :revision_changes, :attestation_template])
+  - when :logo
+    %li.mb-1= t(:update_logo, scope: [:administrateurs, :revision_changes, :attestation_template], to: change[:to])
+  - when :signature
+    %li.mb-1= t(:update_signature, scope: [:administrateurs, :revision_changes, :attestation_template], to: change[:to])

--- a/app/views/administrateurs/procedures/_revision_change_type_de_champ.html.haml
+++ b/app/views/administrateurs/procedures/_revision_change_type_de_champ.html.haml
@@ -1,0 +1,56 @@
+- postfix = change[:private] ? '_private' : ''
+- case change[:op]
+- when :add
+  %li.mb-1= t("add#{postfix}", label: change[:label], scope: [:administrateurs, :revision_changes])
+- when :remove
+  %li.mb-1= t("remove#{postfix}", label: change[:label], scope: [:administrateurs, :revision_changes])
+- when :update
+  - case change[:attribute]
+  - when :libelle
+    %li.mb-1= t("update_libelle#{postfix}", label: change[:label], to: change[:to], scope: [:administrateurs, :revision_changes])
+  - when :type_champ
+    %li.mb-1= t("update_type_champ#{postfix}", label: change[:label], to: t("activerecord.attributes.type_de_champ.type_champs.#{change[:to]}"), scope: [:administrateurs, :revision_changes])
+  - when :description
+    %li.mb-1= t("update_description#{postfix}", label: change[:label], to: change[:to], scope: [:administrateurs, :revision_changes])
+  - when :drop_down_secondary_libelle
+    %li.mb-1= t("update_drop_down_secondary_libelle#{postfix}", label: change[:label], to: change[:to], scope: [:administrateurs, :revision_changes])
+  - when :drop_down_secondary_description
+    %li.mb-1= t("update_drop_down_secondary_description#{postfix}", label: change[:label], to: change[:to], scope: [:administrateurs, :revision_changes])
+  - when :mandatory
+    - if change[:from] == false
+      -# i18n-tasks-use t('administrateurs.revision_changes.update_mandatory.enabled')
+      -# i18n-tasks-use t('administrateurs.revision_changes.update_mandatory_private.enabled')
+      %li.mb-1= t("administrateurs.revision_changes.update_mandatory#{postfix}.enabled", label: change[:label])
+    - else
+      -# i18n-tasks-use t('administrateurs.revision_changes.update_mandatory.disabled')
+      -# i18n-tasks-use t('administrateurs.revision_changes.update_mandatory_private.disabled')
+      %li.mb-1= t("administrateurs.revision_changes.update_mandatory#{postfix}.disabled", label: change[:label])
+  - when :piece_justificative_template
+    -# i18n-tasks-use t('administrateurs.revision_changes.update_piece_justificative_template')
+    -# i18n-tasks-use t('administrateurs.revision_changes.update_piece_justificative_template_private')
+    %li.mb-1= t("administrateurs.revision_changes.update_piece_justificative_template#{postfix}", label: change[:label])
+  - when :drop_down_options
+    - added = change[:to].sort - change[:from].sort
+    - removed = change[:from].sort - change[:to].sort
+    %li.mb-1
+      = t("update_drop_down_options#{postfix}", scope: [:administrateurs, :revision_changes], label: change[:label])
+      %ul
+        - if added.present?
+          %li= t(:add_option, scope: [:administrateurs, :revision_changes], items: added.map{ |term| "« #{term.strip} »" }.join(", "))
+        - if removed.present?
+          %li= t(:remove_option, scope: [:administrateurs, :revision_changes], items: removed.map{ |term| "« #{term.strip} »" }.join(", "))
+  - when :drop_down_other
+    - if change[:from] == false
+      %li.mb-1= t("administrateurs.revision_changes.update_drop_down_other#{postfix}.enabled", label: change[:label])
+    - else
+      %li.mb-1= t("administrateurs.revision_changes.update_drop_down_other#{postfix}.disabled", label: change[:label])
+  - when :carte_layers
+    - added = change[:to].sort - change[:from].sort
+    - removed = change[:from].sort - change[:to].sort
+    %li.mb-1
+      = t("update_carte_layers#{postfix}", scope: [:administrateurs, :revision_changes], label: change[:label])
+      %ul
+        - if added.present?
+          %li= t(:add_option, scope: [:administrateurs, :revision_changes], items: added.map{ |term| "« #{t(term, scope: [:administrateurs, :carte_layers])} »" }.join(", "))
+        - if removed.present?
+          %li= t(:remove_option, scope: [:administrateurs, :revision_changes], items: removed.map{ |term| "« #{t(term, scope: [:administrateurs, :carte_layers])} »" }.join(", "))

--- a/app/views/administrateurs/procedures/_revision_changes.html.haml
+++ b/app/views/administrateurs/procedures/_revision_changes.html.haml
@@ -1,61 +1,8 @@
 %ul.revision-changes
-  - changes.each do |change|
-    - postfix = change[:private] ? '_private' : ''
-    - case change[:op]
-    - when :add
-      %li.mb-1= t("add#{postfix}", label: change[:label], scope: [:administrateurs, :revision_changes])
-    - when :remove
-      %li.mb-1= t("remove#{postfix}", label: change[:label], scope: [:administrateurs, :revision_changes])
-    - when :update
-      - case change[:attribute]
-      - when :libelle
-        %li.mb-1= t("update_libelle#{postfix}", label: change[:label], to: change[:to], scope: [:administrateurs, :revision_changes])
-      - when :type_champ
-        %li.mb-1= t("update_type_champ#{postfix}", label: change[:label], to: t("activerecord.attributes.type_de_champ.type_champs.#{change[:to]}"), scope: [:administrateurs, :revision_changes])
-      - when :description
-        %li.mb-1= t("update_description#{postfix}", label: change[:label], to: change[:to], scope: [:administrateurs, :revision_changes])
-      - when :drop_down_secondary_libelle
-        %li.mb-1= t("update_drop_down_secondary_libelle#{postfix}", label: change[:label], to: change[:to], scope: [:administrateurs, :revision_changes])
-      - when :drop_down_secondary_description
-        %li.mb-1= t("update_drop_down_secondary_description#{postfix}", label: change[:label], to: change[:to], scope: [:administrateurs, :revision_changes])
-      - when :mandatory
-        - if change[:from] == false
-          -# i18n-tasks-use t('administrateurs.revision_changes.update_mandatory.enabled')
-          -# i18n-tasks-use t('administrateurs.revision_changes.update_mandatory_private.enabled')
-          %li.mb-1= t("administrateurs.revision_changes.update_mandatory#{postfix}.enabled", label: change[:label])
-        - else
-          -# i18n-tasks-use t('administrateurs.revision_changes.update_mandatory.disabled')
-          -# i18n-tasks-use t('administrateurs.revision_changes.update_mandatory_private.disabled')
-          %li.mb-1= t("administrateurs.revision_changes.update_mandatory#{postfix}.disabled", label: change[:label])
-      - when :piece_justificative_template
-        -# i18n-tasks-use t('administrateurs.revision_changes.update_piece_justificative_template')
-        -# i18n-tasks-use t('administrateurs.revision_changes.update_piece_justificative_template_private')
-        %li.mb-1= t("administrateurs.revision_changes.update_piece_justificative_template#{postfix}", label: change[:label])
-      - when :drop_down_options
-        - added = change[:to].sort - change[:from].sort
-        - removed = change[:from].sort - change[:to].sort
-        %li.mb-1
-          = t("update_drop_down_options#{postfix}", scope: [:administrateurs, :revision_changes], label: change[:label])
-          %ul
-            - if added.present?
-              %li= t(:add_option, scope: [:administrateurs, :revision_changes], items: added.map{ |term| "« #{term.strip} »" }.join(", "))
-            - if removed.present?
-              %li= t(:remove_option, scope: [:administrateurs, :revision_changes], items: removed.map{ |term| "« #{term.strip} »" }.join(", "))
-      - when :drop_down_other
-        - if change[:from] == false
-          %li.mb-1= t("administrateurs.revision_changes.update_drop_down_other#{postfix}.enabled", label: change[:label])
-        - else
-          %li.mb-1= t("administrateurs.revision_changes.update_drop_down_other#{postfix}.disabled", label: change[:label])
-      - when :carte_layers
-        - added = change[:to].sort - change[:from].sort
-        - removed = change[:from].sort - change[:to].sort
-        %li.mb-1
-          = t("update_carte_layers#{postfix}", scope: [:administrateurs, :revision_changes], label: change[:label])
-          %ul
-            - if added.present?
-              %li= t(:add_option, scope: [:administrateurs, :revision_changes], items: added.map{ |term| "« #{t(term, scope: [:administrateurs, :carte_layers])} »" }.join(", "))
-            - if removed.present?
-              %li= t(:remove_option, scope: [:administrateurs, :revision_changes], items: removed.map{ |term| "« #{t(term, scope: [:administrateurs, :carte_layers])} »" }.join(", "))
+  - changes.filter { |change| change[:model] == :attestation_template }.each do |change|
+    = render partial: 'administrateurs/procedures/revision_change_attestation_template', locals: { change: change }
+  - changes.filter { |change| change[:model] == :type_de_champ }.each do |change|
+    = render partial: 'administrateurs/procedures/revision_change_type_de_champ', locals: { change: change }
   - move_changes, move_private_changes = changes.filter { |change| change[:op] == :move }.partition { |change| !change[:private] }
   - if move_changes.size != 0
     %li.mb-1= t(:move, scope: [:administrateurs, :revision_changes], count: move_changes.size)

--- a/config/locales/views/administrateurs/revision_changes/fr.yml
+++ b/config/locales/views/administrateurs/revision_changes/fr.yml
@@ -1,6 +1,13 @@
 fr:
   administrateurs:
     revision_changes:
+      attestation_template:
+        add: Un model d’attestation à été ajouté
+        update_title: Le titre de l’attestation à été modifié. Le nouveau titre est « %{to} »
+        update_body: Le corps du document de l’attestation à été modifié
+        update_footer: Le pied de page de l’attestation à été modifié
+        update_logo: Le logo de l’attestation à été modifié. Le nouveau logo est « %{to} »
+        update_signature: La signature de l’attestation à été modifié. La nouvelle signature est « %{to} »
       has_changes: Modifications en cours (appliqué à la prochaine publication)
       add: Le champ « %{label} » a été ajouté
       remove: Le champ « %{label} » a été supprimé

--- a/lib/tasks/deployment/20220112184331_revise_attestation_templates.rake
+++ b/lib/tasks/deployment/20220112184331_revise_attestation_templates.rake
@@ -4,13 +4,13 @@ namespace :after_party do
     rake_puts "Running deploy task 'revise_attestation_templates'"
 
     revisions = ProcedureRevision
-      .joins(procedure: :attestation_template)
+      .joins(procedure: :legacy_attestation_template)
       .where(attestation_template_id: nil)
 
     progress = ProgressReport.new(revisions.count)
 
     revisions.find_each do |revision|
-      attestation_template_id = revision.procedure.attestation_template.id
+      attestation_template_id = revision.procedure.legacy_attestation_template.id
       revision.update_column(:attestation_template_id, attestation_template_id)
 
       progress.inc

--- a/lib/tasks/deployment/20220211090402_reassign_redundant_attestation_templates.rake
+++ b/lib/tasks/deployment/20220211090402_reassign_redundant_attestation_templates.rake
@@ -1,0 +1,28 @@
+namespace :after_party do
+  desc 'Deployment task: reassign_redundant_attestation_templates'
+  task reassign_redundant_attestation_templates: :environment do
+    rake_puts "Running deploy task 'reassign_redundant_attestation_templates'"
+
+    procedures = Procedure.publiees_ou_closes.joins(:draft_attestation_template, :published_attestation_template)
+    progress = ProgressReport.new(procedures.count)
+
+    # On all published procedures with disabled revisions draft_attestation_template should be the same as published_attestation_template
+    # Let's not destroy redundant attestation_templates for now. We can clean orphans later.
+    procedures.find_each do |procedure|
+      progress.inc
+      if !procedure.feature_enabled?(:procedure_revisions)
+        draft_attestation_template = procedure.draft_attestation_template
+        published_attestation_template = procedure.published_attestation_template
+        if draft_attestation_template && published_attestation_template && draft_attestation_template != published_attestation_template
+          procedure.published_revision.update(attestation_template_id: draft_attestation_template.id)
+        end
+      end
+    end
+    progress.finish
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/factories/dossier.rb
+++ b/spec/factories/dossier.rb
@@ -188,9 +188,8 @@ FactoryBot.define do
 
     trait :with_attestation do
       after(:build) do |dossier, _evaluator|
-        if dossier.procedure.attestation_template.blank?
-          dossier.procedure.attestation_template = build(:attestation_template)
-        end
+        dossier.revision.attestation_template ||= build(:attestation_template)
+        dossier.association(:attestation_template).target = dossier.revision.attestation_template
         dossier.attestation = dossier.build_attestation
       end
     end

--- a/spec/factories/procedure_revision.rb
+++ b/spec/factories/procedure_revision.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
         original = evaluator.from_original
 
         revision.procedure = original.procedure
+        revision.attestation_template_id = original.attestation_template_id
         original.revision_types_de_champ.each do |r_tdc|
           revision.revision_types_de_champ << build(:procedure_revision_type_de_champ, from_original: r_tdc)
         end

--- a/spec/jobs/cron/declarative_procedures_job_spec.rb
+++ b/spec/jobs/cron/declarative_procedures_job_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Cron::DeclarativeProceduresJob, type: :job do
 
     let(:state) { nil }
     let(:procedure) { create(:procedure, :published, :for_individual, :with_instructeur, declarative_with_state: state) }
-    let(:nouveau_dossier1) { create(:dossier, :en_construction, :with_individual, procedure: procedure) }
-    let(:nouveau_dossier2) { create(:dossier, :en_construction, :with_individual, procedure: procedure) }
+    let(:nouveau_dossier1) { create(:dossier, :en_construction, :with_individual, :with_attestation, procedure: procedure) }
+    let(:nouveau_dossier2) { create(:dossier, :en_construction, :with_individual, :with_attestation, procedure: procedure) }
     let(:dossier_recu) { create(:dossier, :en_instruction, :with_individual, procedure: procedure) }
     let(:dossier_brouillon) { create(:dossier, procedure: procedure) }
     let(:dossier_repasse_en_construction) { create(:dossier, :en_construction, :with_individual, procedure: procedure) }
@@ -22,7 +22,6 @@ RSpec.describe Cron::DeclarativeProceduresJob, type: :job do
         dossier_repasse_en_construction
       ]
 
-      create(:attestation_template, procedure: procedure)
       Cron::DeclarativeProceduresJob.new.perform
 
       dossiers.each(&:reload)

--- a/spec/lib/tasks/deployment/20220112184331_revise_attestation_templates_spec.rb
+++ b/spec/lib/tasks/deployment/20220112184331_revise_attestation_templates_spec.rb
@@ -1,7 +1,7 @@
 describe '20220112184331_revise_attestation_templates' do
   let(:rake_task) { Rake::Task['after_party:revise_attestation_templates'] }
   let(:procedure) { create(:procedure) }
-  let(:attestation_template) { create(:attestation_template, procedure: procedure) }
+  let(:attestation_template) { create(:attestation_template, procedure_id: procedure.id) }
 
   subject(:run_task) do
     attestation_template
@@ -13,10 +13,10 @@ describe '20220112184331_revise_attestation_templates' do
 
   describe 'revise_attestation_templates' do
     it 'attaches the attestation_template to the latest revision (without removing the link between attestation_template and procedure for now)' do
-      expect(attestation_template.procedure.revisions.first.attestation_template_id).to be_nil
+      expect(procedure.revisions.first.attestation_template_id).to be_nil
       run_task
       expect(attestation_template.procedure_id).to eq(procedure.id)
-      expect(attestation_template.procedure.revisions.first.attestation_template_id).to eq(attestation_template.id)
+      expect(procedure.revisions.first.attestation_template_id).to eq(attestation_template.id)
     end
   end
 end

--- a/spec/lib/tasks/deployment/20220211090402_reassign_redundant_attestation_templates_spec.rb
+++ b/spec/lib/tasks/deployment/20220211090402_reassign_redundant_attestation_templates_spec.rb
@@ -1,0 +1,51 @@
+describe '20220211090402_reassign_redundant_attestation_templates' do
+  let(:rake_task) { Rake::Task['after_party:reassign_redundant_attestation_templates'] }
+  let(:procedure) { create(:procedure, :published) }
+  let(:procedure_with_revisions) { create(:procedure, :published) }
+
+  before do
+    procedure.published_revision.update(attestation_template: create(:attestation_template))
+    procedure.draft_revision.update(attestation_template: procedure.published_attestation_template.dup)
+
+    Flipper.enable(:procedure_revisions, procedure_with_revisions)
+    procedure_with_revisions.published_revision.update(attestation_template: create(:attestation_template))
+    procedure_with_revisions.draft_revision.update(attestation_template: procedure_with_revisions.published_attestation_template.dup)
+  end
+
+  subject(:run_task) do
+    rake_task.invoke
+    procedure.reload
+    procedure_with_revisions.reload
+  end
+
+  after { rake_task.reenable }
+
+  describe 'reassign_redundant_attestation_templates' do
+    it 'reassign draft attestation template as published attestation template on procedures without revisions' do
+      expect(procedure.published_attestation_template).not_to be_nil
+      expect(procedure.draft_attestation_template).not_to be_nil
+      expect(procedure.draft_attestation_template).not_to eq(procedure.published_attestation_template)
+
+      expect(procedure_with_revisions.published_attestation_template).not_to be_nil
+      expect(procedure_with_revisions.draft_attestation_template).not_to be_nil
+      expect(procedure_with_revisions.draft_attestation_template).not_to eq(procedure_with_revisions.published_attestation_template)
+
+      orphans = AttestationTemplate.where(procedure_id: nil).left_outer_joins(:revisions).filter { |a| a.revisions.empty? }
+      expect(orphans).to eq([])
+      to_be_orphan = procedure.published_attestation_template
+
+      run_task
+
+      expect(procedure.published_attestation_template).not_to be_nil
+      expect(procedure.draft_attestation_template).not_to be_nil
+      expect(procedure.draft_attestation_template).to eq(procedure.published_attestation_template)
+
+      expect(procedure_with_revisions.published_attestation_template).not_to be_nil
+      expect(procedure_with_revisions.draft_attestation_template).not_to be_nil
+      expect(procedure_with_revisions.draft_attestation_template).not_to eq(procedure_with_revisions.published_attestation_template)
+
+      orphans = AttestationTemplate.where(procedure_id: nil).left_outer_joins(:revisions).filter { |a| a.revisions.empty? }
+      expect(orphans).to eq([to_be_orphan])
+    end
+  end
+end

--- a/spec/models/attestation_template_spec.rb
+++ b/spec/models/attestation_template_spec.rb
@@ -95,7 +95,8 @@ describe AttestationTemplate, type: :model do
       create(:procedure,
         types_de_champ: types_de_champ,
         types_de_champ_private: types_de_champ_private,
-        for_individual: for_individual)
+        for_individual: for_individual,
+        attestation_template: attestation_template)
     end
     let(:for_individual) { false }
     let(:individual) { nil }
@@ -106,7 +107,7 @@ describe AttestationTemplate, type: :model do
     let(:template_title) { 'title' }
     let(:template_body) { 'body' }
     let(:attestation_template) do
-      build(:attestation_template, procedure: procedure,
+      build(:attestation_template,
         title: template_title,
         body: template_body,
         logo: @logo,

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -172,6 +172,7 @@ describe ProcedureRevision do
         expect(procedure.active_revision.different_from?(new_revision)).to be_truthy
         expect(procedure.active_revision.compare(new_revision)).to eq([
           {
+            model: :type_de_champ,
             op: :add,
             label: "Un champ text",
             private: false,
@@ -182,6 +183,7 @@ describe ProcedureRevision do
         new_revision.find_or_clone_type_de_champ(new_revision.types_de_champ.first.stable_id).update(libelle: 'modifier le libelle')
         expect(procedure.active_revision.compare(new_revision.reload)).to eq([
           {
+            model: :type_de_champ,
             op: :update,
             attribute: :libelle,
             label: type_de_champ_first.libelle,
@@ -191,6 +193,7 @@ describe ProcedureRevision do
             stable_id: type_de_champ_first.stable_id
           },
           {
+            model: :type_de_champ,
             op: :add,
             label: "Un champ text",
             private: false,
@@ -202,6 +205,7 @@ describe ProcedureRevision do
         new_revision.move_type_de_champ(new_revision.types_de_champ.second.stable_id, 2)
         expect(procedure.active_revision.compare(new_revision.reload)).to eq([
           {
+            model: :type_de_champ,
             op: :update,
             attribute: :libelle,
             label: type_de_champ_first.libelle,
@@ -211,12 +215,14 @@ describe ProcedureRevision do
             stable_id: type_de_champ_first.stable_id
           },
           {
+            model: :type_de_champ,
             op: :add,
             label: "Un champ text",
             private: false,
             stable_id: new_type_de_champ.stable_id
           },
           {
+            model: :type_de_champ,
             op: :move,
             label: type_de_champ_second.libelle,
             private: false,
@@ -230,12 +236,14 @@ describe ProcedureRevision do
         new_revision.remove_type_de_champ(new_revision.types_de_champ.first.stable_id)
         expect(procedure.active_revision.compare(new_revision.reload)).to eq([
           {
+            model: :type_de_champ,
             op: :remove,
             label: type_de_champ_first.libelle,
             private: false,
             stable_id: type_de_champ_first.stable_id
           },
           {
+            model: :type_de_champ,
             op: :add,
             label: "Un champ text",
             private: false,
@@ -247,18 +255,21 @@ describe ProcedureRevision do
         new_revision.find_or_clone_type_de_champ(new_revision.types_de_champ.last.stable_id).update(mandatory: true)
         expect(procedure.active_revision.compare(new_revision.reload)).to eq([
           {
+            model: :type_de_champ,
             op: :remove,
             label: type_de_champ_first.libelle,
             private: false,
             stable_id: type_de_champ_first.stable_id
           },
           {
+            model: :type_de_champ,
             op: :add,
             label: "Un champ text",
             private: false,
             stable_id: new_type_de_champ.stable_id
           },
           {
+            model: :type_de_champ,
             op: :update,
             attribute: :description,
             label: type_de_champ_second.libelle,
@@ -268,6 +279,7 @@ describe ProcedureRevision do
             stable_id: type_de_champ_second.stable_id
           },
           {
+            model: :type_de_champ,
             op: :update,
             attribute: :mandatory,
             label: type_de_champ_second.libelle,
@@ -282,18 +294,21 @@ describe ProcedureRevision do
         new_revision.find_or_clone_type_de_champ(new_revision.types_de_champ.last.types_de_champ.first.stable_id).update(drop_down_options: ['one', 'two'])
         expect(procedure.active_revision.compare(new_revision.reload)).to eq([
           {
+            model: :type_de_champ,
             op: :remove,
             label: type_de_champ_first.libelle,
             private: false,
             stable_id: type_de_champ_first.stable_id
           },
           {
+            model: :type_de_champ,
             op: :add,
             label: "Un champ text",
             private: false,
             stable_id: new_type_de_champ.stable_id
           },
           {
+            model: :type_de_champ,
             op: :update,
             attribute: :description,
             label: type_de_champ_second.libelle,
@@ -303,6 +318,7 @@ describe ProcedureRevision do
             stable_id: type_de_champ_second.stable_id
           },
           {
+            model: :type_de_champ,
             op: :update,
             attribute: :mandatory,
             label: type_de_champ_second.libelle,
@@ -312,6 +328,7 @@ describe ProcedureRevision do
             stable_id: type_de_champ_second.stable_id
           },
           {
+            model: :type_de_champ,
             op: :update,
             attribute: :type_champ,
             label: "sub type de champ",
@@ -321,6 +338,7 @@ describe ProcedureRevision do
             stable_id: new_revision.types_de_champ.last.types_de_champ.first.stable_id
           },
           {
+            model: :type_de_champ,
             op: :update,
             attribute: :drop_down_options,
             label: "sub type de champ",
@@ -335,18 +353,21 @@ describe ProcedureRevision do
         new_revision.find_or_clone_type_de_champ(new_revision.types_de_champ.last.types_de_champ.first.stable_id).update(options: { cadastres: true, znieff: true })
         expect(procedure.active_revision.compare(new_revision.reload)).to eq([
           {
+            model: :type_de_champ,
             op: :remove,
             label: type_de_champ_first.libelle,
             private: false,
             stable_id: type_de_champ_first.stable_id
           },
           {
+            model: :type_de_champ,
             op: :add,
             label: "Un champ text",
             private: false,
             stable_id: new_type_de_champ.stable_id
           },
           {
+            model: :type_de_champ,
             op: :update,
             attribute: :description,
             label: type_de_champ_second.libelle,
@@ -356,6 +377,7 @@ describe ProcedureRevision do
             stable_id: type_de_champ_second.stable_id
           },
           {
+            model: :type_de_champ,
             op: :update,
             attribute: :mandatory,
             label: type_de_champ_second.libelle,
@@ -365,6 +387,7 @@ describe ProcedureRevision do
             stable_id: type_de_champ_second.stable_id
           },
           {
+            model: :type_de_champ,
             op: :update,
             attribute: :type_champ,
             label: "sub type de champ",
@@ -374,6 +397,7 @@ describe ProcedureRevision do
             stable_id: new_revision.types_de_champ.last.types_de_champ.first.stable_id
           },
           {
+            model: :type_de_champ,
             op: :update,
             attribute: :carte_layers,
             label: "sub type de champ",


### PR DESCRIPTION
Cette PR corrige deux problèmes :
* sur les démarches sans les revisions activées, on rétablit le comportement précédent. La modification du modèle d'attestation prend effet immédiatement sur tous les dossiers.
* sur les démarches avec les revisions activées, on ajoute les modifications sur le template dans la diff de la révision et on invite l'administrateur à publier une nouvelle revision qui prendra en compte le nouveau modèle d'attestation.

Pour l'instant, il n'est pas possible de modifier les modèles des attestations des révisions précédentes. Je vais ajouter la possibilité de le faire dans une PR ultérieur.