### PR TITLE
Correction du réglage "cookieDomain" de Matomo

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -276,7 +276,7 @@ class ApplicationController < ActionController::Base
     matomo = Rails.application.secrets.matomo
 
     {
-      cookie_domain: matomo[:cookie_domain],
+      cookieDomain: matomo[:cookie_domain],
       domain: matomo[:domain],
       enabled: matomo[:enabled],
       host: matomo[:host],


### PR DESCRIPTION
It was exported to the GON as `cookie_domain`, but imported by the tracking code as `cookieDomain`.