### PR TITLE
Javascript : correction de la gestion d'erreur dans OperationQueue.js

### DIFF
--- a/app/javascript/components/TypesDeChampEditor/OperationsQueue.js
+++ b/app/javascript/components/TypesDeChampEditor/OperationsQueue.js
@@ -45,7 +45,7 @@ async function handleError({ response, message }, reject) {
     try {
       const {
         errors: [message]
-      } = await response.json();
+      } = await response.clone().json();
       reject(message);
     } catch {
       reject(await response.text());


### PR DESCRIPTION
When an exception is raised, `response.json()` may have been called already. In that case, when accessing `response.text()` in the error handler, a "Response.text: Body has already been consumed." error will be raised.

Fix https://sentry.io/organizations/demarches-simplifiees/issues/3003113694/