### PR TITLE
Amélioration de la fiabilité du test automatisé "Remplir un dossier"

### DIFF
--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -23,6 +23,7 @@ describe 'The user' do
     choose('Madame')
     fill_in('email', with: 'loulou@yopmail.com')
     fill_in('phone', with: '0123456789')
+    scroll_to(find_field('Non'), align: :center)
     choose('Non')
     choose('val2')
     check('val1')


### PR DESCRIPTION
In the "Dossier brouillon" spec, the "Yes/No" radio buttons may be under the sticky bottom bar, and thus not register the click – which somitomes makes the test fail.

Fix the issue by manually scrolling to the radio buttons.