### PR TITLE
Correction des requêtes Matomo bloquées par la Content Security Policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -31,6 +31,10 @@ Rails.application.config.content_security_policy do |policy|
   connect_whitelist << Rails.application.secrets.matomo[:host] if Rails.application.secrets.matomo[:enabled]
   policy.connect_src(:self, *connect_whitelist)
 
+  frame_whitelist = []
+  frame_whitelist << URI(MATOMO_IFRAME_URL).host if Rails.application.secrets.matomo[:enabled]
+  policy.frame_src(:self, *frame_whitelist)
+
   # Pour tout le reste, par défaut on accepte uniquement ce qui vient de chez nous
   # et dans la notification on inclue la source de l'erreur
   default_whitelist = ["fonts.gstatic.com", "in-automate.sendinblue.com", "player.vimeo.com", "app.franceconnect.gouv.fr", "sentry.io", "*.crisp.chat", "crisp.chat", "*.crisp.help", "*.sibautomation.com", "sibautomation.com", "data"]

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -28,6 +28,7 @@ Rails.application.config.content_security_policy do |policy|
   connect_whitelist << URI(API_ADRESSE_URL).host if API_ADRESSE_URL.present?
   connect_whitelist << URI(API_EDUCATION_URL).host if API_EDUCATION_URL.present?
   connect_whitelist << URI(API_GEO_URL).host if API_GEO_URL.present?
+  connect_whitelist << Rails.application.secrets.matomo[:host] if Rails.application.secrets.matomo[:enabled]
   policy.connect_src(:self, *connect_whitelist)
 
   # Pour tout le reste, par défaut on accepte uniquement ce qui vient de chez nous


### PR DESCRIPTION
En ce moment les requêtes de suivi Matomo et l'iframe affichée sur la page `/suivi` sont bloquées par la Content Security Policy.

En pratique, Matomo détecte l'échec de connexion, et fallback sur un pixel de tracking (qui ne nécessite pas de Javascript). Mais ça fait des avertissements dans la console, et un suivi qui est bien plus limité.

Cette PR rajoute les règles qui vont bien pour corriger ces deux problèmes.

Fix #5868, #6949 (cc @dzc34 @akarzim)