### PR TITLE
Dépendances : suppression des mentions de commits spécifiques pour les gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@ gem 'spreadsheet_architect'
 gem 'typhoeus'
 gem 'warden'
 gem 'webpacker'
-gem 'zipline', github: 'fringd/zipline', ref: 'd637bbff2' # Unreleased 1.3.0, with a fix for Ruby 3.0 kwargs
+gem 'zipline'
 gem 'zxcvbn-ruby', require: 'zxcvbn'
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -120,7 +120,7 @@ end
 
 group :development, :test do
   gem 'graphql-schema_comparator'
-  gem 'mina', git: 'https://github.com/mina-deploy/mina.git', require: false # Deploy
+  gem 'mina', require: false # Deploy
   gem 'pry-byebug' # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'rspec-rails'
   gem 'simple_xlsx_reader'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/mina-deploy/mina.git
-  revision: 84fa84c7f7f94f9518ef9b7099396ab6676b5881
-  specs:
-    mina (1.2.3)
-      open4 (~> 1.3.4)
-      rake
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -423,6 +415,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0212)
+    mina (1.2.4)
+      open4 (~> 1.3.4)
+      rake
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     mini_portile2 (2.7.1)
@@ -838,7 +833,7 @@ DEPENDENCIES
   lograge
   logstash-event
   mailjet
-  mina!
+  mina
   openid_connect
   pg
   phonelib

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/fringd/zipline.git
-  revision: d637bbff262f59718d23a65f50b50163b8ba749f
-  ref: d637bbff2
-  specs:
-    zipline (1.3.0)
-      actionpack (>= 3.2.1, < 7.0)
-      zip_tricks (>= 4.2.1, < 6.0)
-
-GIT
   remote: https://github.com/mina-deploy/mina.git
   revision: 84fa84c7f7f94f9518ef9b7099396ab6676b5881
   specs:
@@ -183,6 +174,7 @@ GEM
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.1.9)
     connection_pool (2.2.3)
+    content_disposition (1.0.0)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -770,6 +762,10 @@ GEM
       nokogiri (~> 1.8)
     zeitwerk (2.5.4)
     zip_tricks (5.6.0)
+    zipline (1.4.1)
+      actionpack (>= 6.0, < 8.0)
+      content_disposition (~> 1.0)
+      zip_tricks (>= 4.2.1, < 6.0)
     zxcvbn-ruby (1.2.0)
 
 PLATFORMS
@@ -892,7 +888,7 @@ DEPENDENCIES
   webdrivers (~> 4.0)
   webmock
   webpacker
-  zipline!
+  zipline
   zxcvbn-ruby
 
 BUNDLED WITH


### PR DESCRIPTION
Plus aucune des gems qu'on utilise n'a besoin d'une mention explicite d'un repo git ou d'un commit pas encore taggé. Cette PR revient donc à la déclaration standard pour toutes les gems.

/cc @akarzim ;)