### PR TITLE
Restauration des anciennes tâches after_party supprimée du code

### DIFF
--- a/lib/tasks/deployment/20200326133630_cleanup_deleted_dossiers.rake
+++ b/lib/tasks/deployment/20200326133630_cleanup_deleted_dossiers.rake
@@ -1,0 +1,10 @@
+namespace :after_party do
+  desc 'Deployment task: cleanup_deleted_dossiers'
+  task cleanup_deleted_dossiers: :environment do
+    puts "Running deploy task 'cleanup_deleted_dossiers'"
+
+    DeletedDossier.where(state: :brouillon).destroy_all
+
+    AfterParty::TaskRecord.create version: '20200326133630'
+  end
+end

--- a/lib/tasks/deployment/20200401123317_process_expired_dossiers_en_construction.rake
+++ b/lib/tasks/deployment/20200401123317_process_expired_dossiers_en_construction.rake
@@ -1,0 +1,27 @@
+namespace :after_party do
+  desc 'Deployment task: process_expired_dossiers_en_construction'
+  task process_expired_dossiers_en_construction: :environment do
+    puts "Running deploy task 'process_expired_dossiers_en_construction'"
+
+    if ENV['APP_NAME'] == 'tps'
+      dossiers_close_to_expiration = Dossier
+        .en_construction_close_to_expiration
+        .without_en_construction_expiration_notice_sent
+
+      ExpiredDossiersDeletionService.send_expiration_notices(dossiers_close_to_expiration)
+
+      BATCH_SIZE = 1000
+
+      ((dossiers_close_to_expiration.count / BATCH_SIZE).ceil + 1).times do |n|
+        dossiers_close_to_expiration
+          .offset(n * BATCH_SIZE)
+          .limit(BATCH_SIZE)
+          .update_all(en_construction_close_to_expiration_notice_sent_at: Time.zone.now + n.days)
+      end
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord.create version: '20200401123317'
+  end
+end

--- a/lib/tasks/deployment/20200527124112_fix_champ_etablissement.rake
+++ b/lib/tasks/deployment/20200527124112_fix_champ_etablissement.rake
@@ -1,0 +1,35 @@
+namespace :after_party do
+  desc 'Deployment task: fix_champ_etablissement'
+  task fix_champ_etablissement: :environment do
+    puts "Running deploy task 'fix_champ_etablissement'"
+
+    etablissements = Etablissement.joins(:champ).where.not(dossier_id: nil).where('etablissements.created_at > ?', 1.month.ago)
+    dossiers_modif = []
+    etablissements.find_each do |e|
+      if e.dossier
+        user = e.dossier.user
+        dossier = e.dossier
+        if user.dossiers.count == 1 && user.siret == e.champ.value
+          e.update!(dossier_id: nil)
+          dossier.reload.etablissement = e.reload.dup
+          dossier.save!
+          dossiers_modif << dossier.id
+          fetch_api_entreprise_infos(dossier.etablissement.id, dossier.procedure.id, user.id)
+        end
+      end
+    end
+    puts "Nb dossiers modifiés: #{dossiers_modif.size}"
+    AfterParty::TaskRecord.create version: '20200527124112'
+  end
+
+  def fetch_api_entreprise_infos(etablissement_id, procedure_id, user_id)
+    [
+      APIEntreprise::EntrepriseJob, APIEntreprise::AssociationJob, APIEntreprise::ExercicesJob,
+      APIEntreprise::EffectifsJob, APIEntreprise::EffectifsAnnuelsJob, APIEntreprise::AttestationSocialeJob,
+      APIEntreprise::BilansBdfJob
+    ].each do |job|
+      job.perform_later(etablissement_id, procedure_id)
+    end
+    APIEntreprise::AttestationFiscaleJob.perform_later(etablissement_id, procedure_id, user_id)
+  end
+end

--- a/lib/tasks/deployment/20200528124044_fix_dossier_etablissement.rake
+++ b/lib/tasks/deployment/20200528124044_fix_dossier_etablissement.rake
@@ -1,0 +1,20 @@
+namespace :after_party do
+  desc 'Deployment task: fix_dossier_etablissement'
+  task fix_dossier_etablissement: :environment do
+    puts "Running deploy task 'fix_dossier_etablissement'"
+
+    etablissements = Etablissement.joins(:champ).where.not(dossier_id: nil).where('etablissements.created_at > ?', 1.month.ago)
+    dossiers_modif = []
+    etablissements.find_each do |e|
+      if e.dossier
+        dossier = e.dossier
+        e.update!(dossier_id: nil)
+        dossier.reload.etablissement = e.reload.dup
+        dossier.save!
+        dossiers_modif << dossier.id
+      end
+    end
+    puts "Nb dossiers modifiés: #{dossiers_modif.size}"
+    AfterParty::TaskRecord.create version: '20200528124044'
+  end
+end

--- a/lib/tasks/deployment/20200618121241_drop_down_list_options_to_json.rake
+++ b/lib/tasks/deployment/20200618121241_drop_down_list_options_to_json.rake
@@ -1,0 +1,25 @@
+namespace :after_party do
+  desc 'Deployment task: drop_down_list_options_to_json'
+  task drop_down_list_options_to_json: :environment do
+    puts "Running deploy task 'drop_down_list_options_to_json'"
+
+    types_de_champ = TypeDeChamp.joins(:drop_down_list).where(type_champ: [
+      TypeDeChamp.type_champs.fetch(:drop_down_list),
+      TypeDeChamp.type_champs.fetch(:multiple_drop_down_list),
+      TypeDeChamp.type_champs.fetch(:linked_drop_down_list)
+    ])
+    progress = ProgressReport.new(types_de_champ.count)
+    types_de_champ.find_each do |type_de_champ|
+      type_de_champ.drop_down_list_value = type_de_champ.drop_down_list_value
+      if type_de_champ.save
+        type_de_champ.drop_down_list.destroy
+      end
+      progress.inc
+    end
+    progress.finish
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord.create version: '20200618121241'
+  end
+end

--- a/lib/tasks/deployment/20200625113026_migrate_revisions.rake
+++ b/lib/tasks/deployment/20200625113026_migrate_revisions.rake
@@ -1,0 +1,22 @@
+namespace :after_party do
+  desc 'Deployment task: migrate_revisions'
+  task migrate_revisions: :environment do
+    puts "Running deploy task 'migrate_revisions'"
+
+    procedures = Procedure.with_discarded.where(draft_revision_id: nil)
+    progress = ProgressReport.new(procedures.count)
+
+    puts "Processing procedures"
+    procedures.find_each do |procedure|
+      RevisionsMigration.add_revisions(procedure)
+      progress.inc
+    end
+    progress.finish
+
+    TmpDossiersMigrateRevisionsJob.perform_later([])
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord.create version: '20200625113026'
+  end
+end

--- a/lib/tasks/deployment/20200630154829_add_traitements_from_dossiers.rake
+++ b/lib/tasks/deployment/20200630154829_add_traitements_from_dossiers.rake
@@ -1,0 +1,18 @@
+namespace :after_party do
+  desc 'Deployment task: add_traitements_from_dossiers'
+  task add_traitements_from_dossiers: :environment do
+    puts "Running deploy task 'add_traitements_from_dossiers'"
+
+    dossiers_termines = Dossier.state_termine
+    progress = ProgressReport.new(dossiers_termines.count)
+    dossiers_termines.find_each do |dossier|
+      dossier.traitements.create!(state: dossier.state, motivation: dossier.motivation, processed_at: dossier.processed_at)
+      progress.inc
+    end
+    progress.finish
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord.create version: '20200630154829'
+  end
+end

--- a/lib/tasks/deployment/20200708101123_add_default_skip_validation_to_piece_justificative.rake
+++ b/lib/tasks/deployment/20200708101123_add_default_skip_validation_to_piece_justificative.rake
@@ -1,0 +1,18 @@
+namespace :after_party do
+  desc 'Deployment task: add_default_skip_validation_to_piece_justificative'
+  task add_default_skip_validation_to_piece_justificative: :environment do
+    puts "Running deploy task 'add_default_skip_validation_to_piece_justificative'"
+
+    tdcs = TypeDeChamp.where(type_champ: TypeDeChamp.type_champs.fetch(:piece_justificative))
+    progress = ProgressReport.new(tdcs.count)
+    tdcs.find_each do |tdc|
+      tdc.update(skip_pj_validation: true)
+      progress.inc
+    end
+    progress.finish
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord.create version: '20200708101123'
+  end
+end

--- a/lib/tasks/deployment/20200728150458_fix_cloned_revisions.rake
+++ b/lib/tasks/deployment/20200728150458_fix_cloned_revisions.rake
@@ -1,0 +1,25 @@
+namespace :after_party do
+  desc 'Deployment task: fix_cloned_revisions'
+  task fix_cloned_revisions: :environment do
+    puts "Running deploy task 'fix_cloned_revisions'"
+
+    Procedure.with_discarded.where(aasm_state: :brouillon).where.not(published_revision_id: nil).update_all(published_revision_id: nil)
+
+    types_de_champ = TypeDeChamp.joins(:revision).where('types_de_champ.procedure_id != procedure_revisions.procedure_id')
+    progress = ProgressReport.new(types_de_champ.count)
+
+    types_de_champ.find_each do |type_de_champ|
+      procedure = type_de_champ.procedure ? type_de_champ.procedure : Procedure.with_discarded.find(type_de_champ.procedure_id)
+      revision_id = procedure.published_revision_id || procedure.draft_revision_id
+      type_de_champ.update_column(:revision_id, revision_id)
+      progress.inc
+    end
+
+    progress.finish
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20200813111957_fix_geo_areas_geometry.rake
+++ b/lib/tasks/deployment/20200813111957_fix_geo_areas_geometry.rake
@@ -1,0 +1,71 @@
+namespace :after_party do
+  desc 'Deployment task: fix_geo_areas_geometry'
+  task fix_geo_areas_geometry: :environment do
+    puts "Running deploy task 'fix_geo_areas_geometry'"
+
+    geometry_collections = GeoArea.where("geometry -> 'type' = '\"GeometryCollection\"'")
+    multi_polygons = GeoArea.where("geometry -> 'type' = '\"MultiPolygon\"'")
+    multi_line_strings = GeoArea.where("geometry -> 'type' = '\"MultiLineString\"'")
+
+    def valid_geometry?(geometry)
+      RGeo::GeoJSON.decode(geometry.to_json, geo_factory: RGeo::Geographic.simple_mercator_factory)
+      true
+    rescue
+      false
+    end
+
+    progress = ProgressReport.new(geometry_collections.count)
+    geometry_collections.find_each do |geometry_collection|
+      geometry_collection.geometry['geometries'].each do |geometry|
+        if valid_geometry?(geometry)
+          geometry_collection.champ.geo_areas.create!(geometry: geometry, source: 'selection_utilisateur')
+        end
+      end
+
+      geometry_collection.destroy
+      progress.inc
+    end
+    progress.finish
+
+    progress = ProgressReport.new(multi_line_strings.count)
+    multi_line_strings.find_each do |multi_line_string|
+      multi_line_string.geometry['coordinates'].each do |coordinates|
+        geometry = {
+          type: 'LineString',
+          coordinates: coordinates
+        }
+
+        if valid_geometry?(geometry)
+          multi_line_string.champ.geo_areas.create!(geometry: geometry, source: 'selection_utilisateur')
+        end
+      end
+
+      multi_line_string.destroy
+      progress.inc
+    end
+    progress.finish
+
+    progress = ProgressReport.new(multi_polygons.count)
+    multi_polygons.find_each do |multi_polygon|
+      multi_polygon.geometry['coordinates'].each do |coordinates|
+        geometry = {
+          type: 'Polygon',
+          coordinates: coordinates
+        }
+
+        if valid_geometry?(geometry)
+          multi_polygon.champ.geo_areas.create!(geometry: geometry, source: 'selection_utilisateur')
+        end
+      end
+
+      multi_polygon.destroy
+      progress.inc
+    end
+    progress.finish
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20201001161931_migrate_filters_to_use_stable_id.rake
+++ b/lib/tasks/deployment/20201001161931_migrate_filters_to_use_stable_id.rake
@@ -1,0 +1,50 @@
+namespace :after_party do
+  desc 'Deployment task: migrate_filters_to_use_stable_id'
+  task migrate_filters_to_use_stable_id: :environment do
+    puts "Running deploy task 'migrate_filters_to_use_stable_id'"
+
+    procedure_presentations = ProcedurePresentation.where("filters -> 'migrated' IS NULL")
+    progress = ProgressReport.new(procedure_presentations.count)
+    procedure_presentations.find_each do |procedure_presentation|
+      filters = procedure_presentation.filters
+      sort = procedure_presentation.sort
+      displayed_fields = procedure_presentation.displayed_fields
+
+      ['tous', 'suivis', 'traites', 'a-suivre', 'archives'].each do |statut|
+        filters[statut] = filters[statut].map do |filter|
+          table, column = filter.values_at('table', 'column')
+          if table && (table == 'type_de_champ' || table == 'type_de_champ_private')
+            type_de_champ = TypeDeChamp.find_by(id: column)
+            filter['column'] = type_de_champ&.stable_id&.to_s
+          end
+          filter
+        end
+      end
+
+      table, column = sort.values_at('table', 'column')
+      if table && (table == 'type_de_champ' || table == 'type_de_champ_private')
+        type_de_champ = TypeDeChamp.find_by(id: column)
+        sort['column'] = type_de_champ&.stable_id&.to_s
+      end
+
+      displayed_fields = displayed_fields.map do |displayed_field|
+        table, column = displayed_field.values_at('table', 'column')
+        if table && (table == 'type_de_champ' || table == 'type_de_champ_private')
+          type_de_champ = TypeDeChamp.find_by(id: column)
+          displayed_field['column'] = type_de_champ&.stable_id&.to_s
+        end
+        displayed_field
+      end
+
+      filters['migrated'] = true
+      procedure_presentation.update_columns(filters: filters, sort: sort, displayed_fields: displayed_fields)
+      progress.inc
+    end
+    progress.finish
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20201006123842_setup_first_stats.rake
+++ b/lib/tasks/deployment/20201006123842_setup_first_stats.rake
@@ -1,0 +1,11 @@
+namespace :after_party do
+  desc 'Deployment task: setup_first_stats'
+  task setup_first_stats: :environment do
+    Stat.update_stats
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/lib/tasks/deployment/20201218163035_fix_types_de_champ_revisions.rake
+++ b/lib/tasks/deployment/20201218163035_fix_types_de_champ_revisions.rake
@@ -1,0 +1,19 @@
+namespace :after_party do
+  desc 'Deployment task: fix_types_de_champ_revisions'
+  task fix_types_de_champ_revisions: :environment do
+    puts "Running deploy task 'fix_types_de_champ_revisions'"
+
+    types_de_champ = TypeDeChamp.joins(:parent).where('types_de_champ.revision_id != parents_types_de_champ.revision_id')
+    progress = ProgressReport.new(types_de_champ.count)
+    types_de_champ.find_each do |type_de_champ|
+      type_de_champ.update_column(:revision_id, type_de_champ.parent.revision_id)
+      progress.inc
+    end
+    progress.finish
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/lib/tasks/deployment/20200708101123_add_default_skip_validation_to_piece_justificative.rake_spec.rb
+++ b/spec/lib/tasks/deployment/20200708101123_add_default_skip_validation_to_piece_justificative.rake_spec.rb
@@ -1,0 +1,25 @@
+describe '20200708101123_add_default_skip_validation_to_piece_justificative.rake' do
+  let(:rake_task) { Rake::Task['after_party:add_default_skip_validation_to_piece_justificative'] }
+  let!(:pj_type_de_champ) { create(:type_de_champ_piece_justificative) }
+  let!(:text_type_de_champ) { create(:type_de_champ_text) }
+
+  before do
+    rake_task.invoke
+    text_type_de_champ.reload
+    pj_type_de_champ.reload
+  end
+
+  after { rake_task.reenable }
+
+  context 'on a piece_justificative type de champ' do
+    it 'sets the skip_pj_validation option' do
+      expect(pj_type_de_champ.skip_pj_validation).to be_truthy
+    end
+  end
+
+  context 'on a non piece_justificative type de champ' do
+    it 'does not set the skip_pj_validation option' do
+      expect(text_type_de_champ.skip_pj_validation).to be_blank
+    end
+  end
+end

--- a/spec/lib/tasks/deployment/20201001161931_migrate_filters_to_use_stable_id_spec.rb
+++ b/spec/lib/tasks/deployment/20201001161931_migrate_filters_to_use_stable_id_spec.rb
@@ -1,0 +1,60 @@
+describe '20201001161931_migrate_filters_to_use_stable_id' do
+  let(:rake_task) { Rake::Task['after_party:migrate_filters_to_use_stable_id'] }
+
+  let(:procedure) { create(:procedure, :with_instructeur, :with_type_de_champ) }
+  let(:type_de_champ) { procedure.types_de_champ.first }
+  let(:sort) do
+    {
+      "table" => "type_de_champ",
+      "column" => type_de_champ.id.to_s,
+      "order" => "asc"
+    }
+  end
+  let(:filters) do
+    {
+      'tous' => [
+        {
+          "label" => "test",
+          "table" => "type_de_champ",
+          "column" => type_de_champ.id.to_s,
+          "value" => "test"
+        }
+      ],
+      'suivis' => [],
+      'traites' => [],
+      'a-suivre' => [],
+      'archives' => []
+    }
+  end
+  let(:displayed_fields) do
+    [
+      {
+        "label" => "test",
+        "table" => "type_de_champ",
+        "column" => type_de_champ.id.to_s
+      }
+    ]
+  end
+  let!(:procedure_presentation) do
+    type_de_champ.update_column(:stable_id, 13)
+    procedure_presentation = create(:procedure_presentation, procedure: procedure, assign_to: procedure.groupe_instructeurs.first.assign_tos.first)
+    procedure_presentation.update_columns(sort: sort, filters: filters, displayed_fields: displayed_fields)
+    procedure_presentation
+  end
+
+  before do
+    rake_task.invoke
+    procedure_presentation.reload
+  end
+
+  after { rake_task.reenable }
+
+  context "should migrate procedure_presentation" do
+    it "columns are updated" do
+      expect(procedure_presentation.sort['column']).to eq(type_de_champ.stable_id.to_s)
+      expect(procedure_presentation.filters['tous'][0]['column']).to eq(type_de_champ.stable_id.to_s)
+      expect(procedure_presentation.displayed_fields[0]['column']).to eq(type_de_champ.stable_id.to_s)
+      expect(procedure_presentation.filters['migrated']).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
Dans #6177, on a supprimé les tâches after_party de 2020. Il s'avère que les instances qui déploient genre une fois l'an ont besoin de ces tâches.

Je propose de les remettre dans le code pour l'instant, et de voir plus tard quelle politique d'éviction des anciennes tâches on veut définir.

Ça permettra aussi de supprimer une note de la doc de déploiement (#6971), qui dit "Houlà à une époque des tâches ont été supprimées").

## Notes de déploiement

Comme on rajoute des tâches, elles pourraient se mettre à tourner en prod. Mais en prod le timestamp indiquant qu'elles ont tourné est toujours être présent, donc les tâches sont ignorées.

J'ai testé en local, et effectivement les tâches sont bien ignorées.

/cc @akarzim 