### PR TITLE
Blocage des connexions vers des services externes pendant les tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -66,8 +66,8 @@ Rails.application.configure do
     protocol: :http
   }
 
-  # Use Content-Security-Policy-Report-Only headers
-  config.content_security_policy_report_only = true
+  # Disallow all connections to external domains during tests
+  config.content_security_policy_report_only = false
 
   config.active_job.queue_adapter = :test
   config.active_storage.service = :test


### PR DESCRIPTION
Pendant les tests, on bloque déjà les connexions de l'appli Rails vers des domaines externes.

Mais pendant tests d'intégration système, le navigateur lui-même peut faire des requêtes à des services externes (Crisp, IGN, Matomo, etc)

Ça cause divers problèmes :
- C'est lent (on attend les connexions externes),
- Ça leake nos tests à des services externes,
- Ça peut causer des erreurs de tests lié au timing (#6982).

Cette PR fait en sorte que le navigateur ne puisse se connecter qu'au domaine local pendant les tests.

Fix #6982 

