### PR TITLE
Affichage d'un message clair en cas d'erreur `APIEntreprise::API::Error::ServiceUnavailable`

### DIFF
--- a/app/controllers/champs/siret_controller.rb
+++ b/app/controllers/champs/siret_controller.rb
@@ -17,7 +17,7 @@ class Champs::SiretController < ApplicationController
 
     begin
       etablissement = find_etablissement_with_siret
-    rescue APIEntreprise::API::Error::RequestFailed, APIEntreprise::API::Error::ServiceUnavailable
+    rescue APIEntreprise::API::Error::RequestFailed, APIEntreprise::API::Error::BadGateway, APIEntreprise::API::Error::TimedOut, APIEntreprise::API::Error::ServiceUnavailable
       # i18n-tasks-use t('errors.messages.siret_network_error')
       return siret_error(:network_error)
     end

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -106,7 +106,7 @@ module Users
       sanitized_siret = siret_model.siret
       begin
         etablissement = APIEntrepriseService.create_etablissement(@dossier, sanitized_siret, current_user.id)
-      rescue APIEntreprise::API::Error::RequestFailed, APIEntreprise::API::Error::BadGateway, APIEntreprise::API::Error::TimedOut
+      rescue APIEntreprise::API::Error::RequestFailed, APIEntreprise::API::Error::BadGateway, APIEntreprise::API::Error::TimedOut, APIEntreprise::API::Error::ServiceUnavailable
         return render_siret_error(t('errors.messages.siret_network_error'))
       end
       if etablissement.nil?


### PR DESCRIPTION
Dans beaucoup d'endroit on attrape les erreurs de l'API Entreprise, pour soit réessayer plus tard (les jobs asynchrones), soit afficher un joli message d'erreur à l'usager.

Petit trous dans la raquette : 
- Quand on essaie de commencer un dossier avec un n° SIRET, si l'API Entreprise lève une erreur `APIEntreprise::API::Error::ServiceUnavailable`, l'usager prend une Erreur 500 générique.
- Quand on utilise un champ SIRET, si l'API Entreprise timeoute, l'application plante.

Cette PR fait en sorte d'afficher dans ces cas un message d'erreur clair à l'usager.

Fix https://sentry.io/organizations/demarches-simplifiees/issues/2875490403/, https://sentry.io/organizations/demarches-simplifiees/issues/2815765655/activity/