### PR TITLE
Suppression des AdministrateursProcedure quand un Administrateur est supprimé

### DIFF
--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -12,8 +12,7 @@ class Administrateur < ApplicationRecord
   include ActiveRecord::SecureToken
 
   has_and_belongs_to_many :instructeurs
-  has_many :administrateurs_procedures
-  has_many :procedures, through: :administrateurs_procedures
+  has_and_belongs_to_many :procedures
   has_many :services
 
   has_one :user, dependent: :nullify

--- a/db/migrate/20220301160753_add_administrateur_foreign_key_to_administrateurs_procedure.rb
+++ b/db/migrate/20220301160753_add_administrateur_foreign_key_to_administrateurs_procedure.rb
@@ -1,0 +1,15 @@
+class AddAdministrateurForeignKeyToAdministrateursProcedure < ActiveRecord::Migration[6.1]
+  def up
+    # Sanity check
+    say_with_time 'Removing AdministrateursProcedures where the associated Administrateur no longer exists ' do
+      deleted_administrateur_ids = AdministrateursProcedure.where.missing(:administrateur).pluck(:administrateur_id)
+      AdministrateursProcedure.where(administrateur_id: deleted_administrateur_ids).delete_all
+    end
+
+    add_foreign_key :administrateurs_procedures, :administrateurs
+  end
+
+  def down
+    remove_foreign_key :administrateurs_procedures, :administrateurs
+  end
+end

--- a/spec/models/administrateur_spec.rb
+++ b/spec/models/administrateur_spec.rb
@@ -3,7 +3,7 @@ describe Administrateur, type: :model do
 
   describe 'associations' do
     it { is_expected.to have_and_belong_to_many(:instructeurs) }
-    it { is_expected.to have_many(:procedures) }
+    it { is_expected.to have_and_belong_to_many(:procedures) }
   end
 
   describe "#renew_api_token" do


### PR DESCRIPTION
Bonjour, c'est le début du travail sur #6976, avec beaucoup d'ajout de contraintes et de rectification de bad data ✨ 

On commence par `AdministrateursProcedure`, en rajoutant une contrainte pour que l'Administrateur pointé soit toujours valide.

## Détails

Je recopie le message de commit :

> By default, `has_and_belongs_to_many` properly deletes the record in the join table.
>
> However, as the Administrateur->AdministrateursProcedure association is declared manually with a `has_many / through`, it doesn't delete the joined record automatically.
>
> As we also lack a foreign-key contraint on the join table, that means a dangling record remains in the join table.
>
> To fix this:
> 1. declare it a proper `has_and_belongs_to_many` association, which will let the join record be deleted automatically on destroy,
> 2. add a foreign key, to ensure the same situation will be blocked at the database level. 