### PR TITLE
Suppression des AdministrateursInstructeur quand un Instructeur est supprimé

### DIFF
--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -11,8 +11,7 @@
 #  agent_connect_id         :string
 #
 class Instructeur < ApplicationRecord
-  has_many :administrateurs_instructeurs
-  has_many :administrateurs, through: :administrateurs_instructeurs
+  has_and_belongs_to_many :administrateurs
 
   has_many :assign_to, dependent: :destroy
   has_many :groupe_instructeurs, through: :assign_to

--- a/db/migrate/20220302101337_add_foreign_keys_to_administrateurs_instructeurs.rb
+++ b/db/migrate/20220302101337_add_foreign_keys_to_administrateurs_instructeurs.rb
@@ -1,0 +1,22 @@
+class AddForeignKeysToAdministrateursInstructeurs < ActiveRecord::Migration[6.1]
+  def up
+    # Sanity check
+    say_with_time 'Removing AdministrateursInstructeur where the associated Administrateur no longer exists ' do
+      deleted_administrateurs_ids = AdministrateursInstructeur.where.missing(:administrateur).pluck(:administrateur_id)
+      AdministrateursInstructeur.where(administrateur_id: deleted_administrateurs_ids).delete_all
+    end
+
+    say_with_time 'Removing AdministrateursInstructeur where the associated Instructeur no longer exists ' do
+      deleted_instructeurs_ids = AdministrateursInstructeur.where.missing(:instructeur).pluck(:instructeur_id)
+      AdministrateursInstructeur.where(instructeur_id: deleted_instructeurs_ids).delete_all
+    end
+
+    add_foreign_key :administrateurs_instructeurs, :administrateurs
+    add_foreign_key :administrateurs_instructeurs, :instructeurs
+  end
+
+  def down
+    remove_foreign_key :administrateurs_instructeurs, :administrateurs
+    remove_foreign_key :administrateurs_instructeurs, :instructeurs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_04_130722) do
+ActiveRecord::Schema.define(version: 2022_03_02_101337) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -852,6 +852,8 @@ ActiveRecord::Schema.define(version: 2022_02_04_130722) do
   end
 
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "administrateurs_instructeurs", "administrateurs"
+  add_foreign_key "administrateurs_instructeurs", "instructeurs"
   add_foreign_key "archives_groupe_instructeurs", "archives"
   add_foreign_key "archives_groupe_instructeurs", "groupe_instructeurs"
   add_foreign_key "assign_tos", "groupe_instructeurs"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -854,6 +854,7 @@ ActiveRecord::Schema.define(version: 2022_03_02_101337) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "administrateurs_instructeurs", "administrateurs"
   add_foreign_key "administrateurs_instructeurs", "instructeurs"
+  add_foreign_key "administrateurs_procedures", "administrateurs"
   add_foreign_key "archives_groupe_instructeurs", "archives"
   add_foreign_key "archives_groupe_instructeurs", "groupe_instructeurs"
   add_foreign_key "assign_tos", "groupe_instructeurs"

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -12,6 +12,10 @@ describe Instructeur, type: :model do
     procedure_3
   end
 
+  describe 'associations' do
+    it { is_expected.to have_and_belong_to_many(:administrateurs) }
+  end
+
   describe 'follow' do
     let(:dossier) { create :dossier }
     let(:already_followed_dossier) { create :dossier }


### PR DESCRIPTION
On poursuit le travail sur #6976.

Ça continue avec AdministrateursInstructeur, en rajoutant des contraintes pour que l'Instructeur et l'Administrateur pointés soient toujours valides.

## Implémentation

Pareil que dans #6992, j'ai mis la suppression des records AdministrateursInstructeur directement dans la tâche de migration du schéma - parce que c'est très rapide, et pour la localité du code.