### PR TITLE
feat(administrateur): dossiers count should only include relevant dossiers

### DIFF
--- a/app/views/administrateurs/procedures/_procedures_list.html.haml
+++ b/app/views/administrateurs/procedures/_procedures_list.html.haml
@@ -26,7 +26,7 @@
           %span.badge.baseline= procedure.instructeurs.count
 
         %span.icon.folder
-        %span.badge.baseline= procedure.dossiers.count
+        %span.badge.baseline= procedure.dossiers.state_not_brouillon.visible_by_administration.count
 
       %div
         = link_to admin_procedure_path(procedure), class: 'button mr-1 edit-procedure' do


### PR DESCRIPTION
Le compteur dans l'état inclut les dossiers en brouillon et les dossiers supprimés par les instructeurs ce qui induit en erreur et crée de la confusion