### PR TITLE
fix(dossier): ensure submitted dossiers always have groupe instructeur

### DIFF
--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -464,6 +464,17 @@ describe Users::DossiersController, type: :controller do
         end
       end
 
+      context "when the dossier was created on a routee procedure, but routage was later disabled" do
+        let(:dossier) { create(:dossier, groupe_instructeur: nil, user: user) }
+
+        it "sets a default groupe_instructeur" do
+          subject
+
+          expect(response).to redirect_to(merci_dossier_path(dossier))
+          expect(dossier.reload.groupe_instructeur).to eq(dossier.procedure.defaut_groupe_instructeur)
+        end
+      end
+
       context "on an closed procedure" do
         before { dossier.procedure.close! }
 


### PR DESCRIPTION
Aujourd'hui si un dossier est créé sur une démarche avec routage activé, il ne sera pas affecté à un groupe instructeur par défaut. Si plus tard le routage est désactivé, le dossier ne pourra jamais être déposé, car la validation va échouer, mais le sélecteur de groupe instructeur n'est plus affiché. Cette PR corrige ce problème.