### PR TITLE
Suppression des AdministrateursProcedure quand une Procedure est supprimée

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -176,7 +176,7 @@ class Procedure < ApplicationRecord
     end
   end
 
-  has_many :administrateurs_procedures
+  has_many :administrateurs_procedures, dependent: :delete_all
   has_many :administrateurs, through: :administrateurs_procedures, after_remove: -> (procedure, _admin) { procedure.validate! }
   has_many :groupe_instructeurs, dependent: :destroy
   has_many :instructeurs, through: :groupe_instructeurs

--- a/db/migrate/20220302110720_add_procedure_foreign_key_to_administrateurs_procedure.rb
+++ b/db/migrate/20220302110720_add_procedure_foreign_key_to_administrateurs_procedure.rb
@@ -1,0 +1,25 @@
+class AddProcedureForeignKeyToAdministrateursProcedure < ActiveRecord::Migration[6.1]
+  def up
+    say_with_time 'Removing AdministrateursProcedures where the associated Procedure no longer exists ' do
+      # Find procedure_ids in AdministrateursProcedure that don't have an existing Procedure attached
+      deleted_procedure_ids = query_values <<~SQL1
+        SELECT administrateurs_procedures.procedure_id
+        FROM administrateurs_procedures
+        LEFT OUTER JOIN procedures on procedures.id = administrateurs_procedures.procedure_id
+        WHERE procedures.id IS NULL
+      SQL1
+
+      # Delete the AdministrateursProcedure having those procedure_ids
+      exec_delete <<~SQL2
+        DELETE FROM administrateurs_procedures
+        WHERE administrateurs_procedures.procedure_id IN (#{deleted_procedure_ids.uniq.join(', ')})
+      SQL2
+    end
+
+    add_foreign_key :administrateurs_procedures, :procedures
+  end
+
+  def down
+    remove_foreign_key :administrateurs_procedures, :procedures
+  end
+end


### PR DESCRIPTION
Et on continue le boulot de rectification du schéma de base de données (#6976).

Cette fois ci, on continue sur AdministrateursProcedure, en rajoutant une contrainte pour que la Procedure pointée soit toujours valide.

## Migration des données

En ce moment en prod on ne supprime pas les AdministrateursProcedure quand on supprime une Procedure.

On a donc environ 20 000 records AdministrateursProcedure qui pointent vers des Procedures qui n'existent pas. La migration supprimme ces records avant de supprimer la clef.