### PR TITLE
Ajout de colonnes référençant le User à Administrateur, Instructeur et Expert

### DIFF
--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -7,6 +7,7 @@
 #  encrypted_token :string
 #  created_at      :datetime
 #  updated_at      :datetime
+#  user_id         :bigint
 #
 class Administrateur < ApplicationRecord
   include ActiveRecord::SecureToken

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -5,6 +5,7 @@
 #  id         :bigint           not null, primary key
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  user_id    :bigint
 #
 class Expert < ApplicationRecord
   has_one :user

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -9,6 +9,7 @@
 #  created_at               :datetime
 #  updated_at               :datetime
 #  agent_connect_id         :string
+#  user_id                  :bigint
 #
 class Instructeur < ApplicationRecord
   has_and_belongs_to_many :administrateurs

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -2,11 +2,11 @@
 #
 # Table name: procedure_revisions
 #
-#  id                      :bigint           not null, primary key
-#  published_at            :datetime
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  attestation_template_id :bigint
+#  id                           :bigint           not null, primary key
+#  published_at                 :datetime
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
+#  attestation_template_id      :bigint
 #  dossier_submitted_message_id :bigint
 #  procedure_id                 :bigint           not null
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -221,6 +221,7 @@ class User < ApplicationRecord
       old_user.invites.update_all(user_id: id)
       old_user.merge_logs.update_all(user_id: id)
 
+      # Move or merge old user's roles to the user
       [
         [old_user.instructeur, instructeur],
         [old_user.expert, expert],
@@ -232,6 +233,8 @@ class User < ApplicationRecord
           targeted_role.merge(old_role)
         end
       end
+      # (Ensure the old user doesn't reference its former roles anymore)
+      old_user.reload
 
       merge_logs.create(from_user_id: old_user.id, from_user_email: old_user.email)
       old_user.destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,6 +65,21 @@ class User < ApplicationRecord
 
   validate :does_not_merge_on_self, if: :requested_merge_into_id_changed?
 
+  # Temporary code for double writing the admin, instructeur and expert id to the foreign key
+  after_save do
+    if saved_change_to_attribute?(:administrateur_id) && administrateur_id.present?
+      Administrateur.find(administrateur_id).update!(user_id: id)
+    end
+
+    if saved_change_to_attribute?(:instructeur_id) && instructeur_id.present?
+      Instructeur.find(instructeur_id).update!(user_id: id)
+    end
+
+    if saved_change_to_attribute?(:expert_id) && expert_id.present?
+      Expert.find(expert_id).update!(user_id: id)
+    end
+  end
+
   def validate_password_complexity?
     administrateur?
   end

--- a/db/migrate/20220315113510_add_foreign_keys_to_user_related_models.rb
+++ b/db/migrate/20220315113510_add_foreign_keys_to_user_related_models.rb
@@ -1,0 +1,11 @@
+class AddForeignKeysToUserRelatedModels < ActiveRecord::Migration[6.1]
+  def change
+    # options = { type: :bigint, index: { unique: true }, foreign_key: true, null: true }
+    # add_reference :administrateurs, :user, **options
+    # add_reference :instructeurs,    :user, **options
+    # add_reference :experts,         :user, **options
+    add_column :administrateurs, :user_id, :bigint
+    add_column :instructeurs, :user_id, :bigint
+    add_column :experts, :user_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_08_110720) do
+ActiveRecord::Schema.define(version: 2022_03_15_113510) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,6 +60,7 @@ ActiveRecord::Schema.define(version: 2022_03_08_110720) do
     t.datetime "updated_at"
     t.boolean "active", default: false
     t.string "encrypted_token"
+    t.bigint "user_id"
   end
 
   create_table "administrateurs_instructeurs", id: false, force: :cascade do |t|
@@ -411,6 +412,7 @@ ActiveRecord::Schema.define(version: 2022_03_08_110720) do
   create_table "experts", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id"
   end
 
   create_table "experts_procedures", force: :cascade do |t|
@@ -539,6 +541,7 @@ ActiveRecord::Schema.define(version: 2022_03_08_110720) do
     t.datetime "login_token_created_at"
     t.boolean "bypass_email_login_token", default: false, null: false
     t.string "agent_connect_id"
+    t.bigint "user_id"
     t.index ["agent_connect_id"], name: "index_instructeurs_on_agent_connect_id", unique: true
   end
 

--- a/lib/tasks/deployment/20220310115522_copy_user_association_to_user_related_models.rake
+++ b/lib/tasks/deployment/20220310115522_copy_user_association_to_user_related_models.rake
@@ -1,0 +1,32 @@
+namespace :after_party do
+  desc 'Deployment task: copy user id to administrateurs.user_id, instructeurs.user_id and experts.user_id'
+  task copy_user_association_to_user_related_models: :environment do
+    rake_puts "Running deploy task 'copy_user_association_to_user_related_models'"
+
+    copy_user_id_to(Administrateur)
+    copy_user_id_to(Instructeur)
+    copy_user_id_to(Expert)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+
+  def copy_user_id_to(model)
+    table_name = model.table_name
+    rake_print "Copying user.#{table_name.singularize}_id to #{table_name}.user_id"
+
+    records_to_update = model.where(user_id: nil)
+    progress = ProgressReport.new(records_to_update.count)
+
+    records_to_update.where(user_id: nil).in_batches do |relation|
+      count = relation.update_all("user_id = (SELECT id FROM users WHERE #{table_name}.id = users.#{table_name.singularize}_id)")
+      progress.inc(count)
+      sleep(0.01) # throttle
+    end
+
+    progress.finish
+    rake_puts
+  end
+end

--- a/lib/tasks/task_helper.rb
+++ b/lib/tasks/task_helper.rb
@@ -33,8 +33,8 @@ class ProgressReport
     set_progress(total: total, count: 0)
   end
 
-  def inc
-    set_progress(count: @count + 1)
+  def inc(amount = 1)
+    set_progress(count: @count + amount)
     if @per_10_000 % 10 == 0
       print_progress
     end


### PR DESCRIPTION
Cette PR continue le travail de #6976.

Maintenant que les tables de jointures de Administrateur, Instructeur et Expert sont nettoyées, on peut commencer à basculer les foreigns keys de `User` vers les modèles associés. (Pour mémoire, l'objectif final est de pouvoir mettre une contrainte 'foreign key NOT NULL` sur `Administrateur.user_id` et les autres modèles, ce qui garantira qu'un Admin, Instructeur ou Expert ne peut exister sans User associé.)

On commence donc par la première partie :

- Création de trois colonnes : administrateurs.user_id, instructeurs.user_id, experts.user_id,
- Ajout d'une moulinette qui backporte les anciennes données dans les nouvelles colonnes,
- Plus un callback `after_save` pour écrire la donnée à la fois dans les anciennes et dans les nouvelles colonnes.