### PR TITLE
Échec de la tâche AfterParty process_expired_dossiers_en_construction

### DIFF
--- a/lib/tasks/deployment/20200401123317_process_expired_dossiers_en_construction.rake
+++ b/lib/tasks/deployment/20200401123317_process_expired_dossiers_en_construction.rake
@@ -8,7 +8,7 @@ namespace :after_party do
         .en_construction_close_to_expiration
         .without_en_construction_expiration_notice_sent
 
-      ExpiredDossiersDeletionService.send_expiration_notices(dossiers_close_to_expiration)
+      ExpiredDossiersDeletionService.send_expiration_notices(dossiers_close_to_expiration, :en_construction_close_to_expiration_notice_sent_at)
 
       BATCH_SIZE = 1000
 

--- a/lib/tasks/deployment/20200401123317_process_expired_dossiers_en_construction.rake
+++ b/lib/tasks/deployment/20200401123317_process_expired_dossiers_en_construction.rake
@@ -3,21 +3,19 @@ namespace :after_party do
   task process_expired_dossiers_en_construction: :environment do
     puts "Running deploy task 'process_expired_dossiers_en_construction'"
 
-    if ENV['APP_NAME'] == 'tps'
-      dossiers_close_to_expiration = Dossier
-        .en_construction_close_to_expiration
-        .without_en_construction_expiration_notice_sent
+    dossiers_close_to_expiration = Dossier
+      .en_construction_close_to_expiration
+      .without_en_construction_expiration_notice_sent
 
-      ExpiredDossiersDeletionService.send_expiration_notices(dossiers_close_to_expiration, :en_construction_close_to_expiration_notice_sent_at)
+    ExpiredDossiersDeletionService.send_expiration_notices(dossiers_close_to_expiration, :en_construction_close_to_expiration_notice_sent_at)
 
-      BATCH_SIZE = 1000
+    BATCH_SIZE = 1000
 
-      ((dossiers_close_to_expiration.count / BATCH_SIZE).ceil + 1).times do |n|
-        dossiers_close_to_expiration
-          .offset(n * BATCH_SIZE)
-          .limit(BATCH_SIZE)
-          .update_all(en_construction_close_to_expiration_notice_sent_at: Time.zone.now + n.days)
-      end
+    ((dossiers_close_to_expiration.count / BATCH_SIZE).ceil + 1).times do |n|
+      dossiers_close_to_expiration
+        .offset(n * BATCH_SIZE)
+        .limit(BATCH_SIZE)
+        .update_all(en_construction_close_to_expiration_notice_sent_at: Time.zone.now + n.days)
     end
 
     # Update task as completed.  If you remove the line below, the task will


### PR DESCRIPTION
# Résumé

<!-- décrire en quelques phrases la problématique adressée -->

La tâche de déploiement after_party:process_expired_dossiers_en_construction récemment réintroduite dans la base de code génère une erreur 500 en production.

mots-clés : after_party, task, env

fixes #7028  / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`