### PR TITLE
Échec de la tâche AfterParty drop_down_list_options_to_json

### DIFF
--- a/lib/tasks/deployment/20200618121241_drop_down_list_options_to_json.rake
+++ b/lib/tasks/deployment/20200618121241_drop_down_list_options_to_json.rake
@@ -3,23 +3,33 @@ namespace :after_party do
   task drop_down_list_options_to_json: :environment do
     puts "Running deploy task 'drop_down_list_options_to_json'"
 
-    types_de_champ = TypeDeChamp.joins(:drop_down_list).where(type_champ: [
-      TypeDeChamp.type_champs.fetch(:drop_down_list),
-      TypeDeChamp.type_champs.fetch(:multiple_drop_down_list),
-      TypeDeChamp.type_champs.fetch(:linked_drop_down_list)
-    ])
-    progress = ProgressReport.new(types_de_champ.count)
-    types_de_champ.find_each do |type_de_champ|
-      type_de_champ.drop_down_list_value = type_de_champ.drop_down_list_value
-      if type_de_champ.save
-        type_de_champ.drop_down_list.destroy
-      end
-      progress.inc
-    end
-    progress.finish
+    begin
+      types_de_champ = TypeDeChamp.joins(:drop_down_list).where(type_champ: [
+        TypeDeChamp.type_champs.fetch(:drop_down_list),
+        TypeDeChamp.type_champs.fetch(:multiple_drop_down_list),
+        TypeDeChamp.type_champs.fetch(:linked_drop_down_list)
+      ])
 
-    # Update task as completed.  If you remove the line below, the task will
-    # run with every deploy (or every time you call after_party:run).
-    AfterParty::TaskRecord.create version: '20200618121241'
+      progress = ProgressReport.new(types_de_champ.count)
+
+      types_de_champ.find_each do |type_de_champ|
+        type_de_champ.drop_down_list_value = type_de_champ.drop_down_list_value
+
+        if type_de_champ.save
+          type_de_champ.drop_down_list.destroy
+        end
+
+        progress.inc
+      end
+
+      progress.finish
+    rescue ActiveRecord::ConfigurationError => e
+      warn e.message
+      puts "Skip deploy task."
+    ensure
+      # Update task as completed.  If you remove the line below, the task will
+      # run with every deploy (or every time you call after_party:run).
+      AfterParty::TaskRecord.create version: '20200618121241'
+    end
   end
 end


### PR DESCRIPTION
# Résumé

<!-- décrire en quelques phrases la problématique adressée -->

La tâche de déploiement `after_party:drop_down_list_options_to_json` récemment réintroduite dans la base de code génère une erreur 500 à l'exécution.

mots-clés : after_party, task, configuration

fixes #7030 / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`