### PR TITLE
Échec de la tâche AfterParty add_traitements_from_dossiers

### DIFF
--- a/lib/tasks/deployment/20200630154829_add_traitements_from_dossiers.rake
+++ b/lib/tasks/deployment/20200630154829_add_traitements_from_dossiers.rake
@@ -6,7 +6,7 @@ namespace :after_party do
     dossiers_termines = Dossier.state_termine
     progress = ProgressReport.new(dossiers_termines.count)
     dossiers_termines.find_each do |dossier|
-      dossier.traitements.create!(state: dossier.state, motivation: dossier.motivation, processed_at: dossier.processed_at)
+      dossier.traitements.find_or_create_by!(state: dossier.state, motivation: dossier.motivation, processed_at: dossier.processed_at)
       progress.inc
     end
     progress.finish


### PR DESCRIPTION
# Résumé

<!-- décrire en quelques phrases la problématique adressée -->

La tâche de déploiement `after_party:add_traitements_from_dossiers` récemment réintroduite dans la base de code n'est pas idempotente et peut amener à la création de traitements surnuméraires.

mots-clés : after_party, task, traitement, idempotent

fixes #7034 / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`