### PR TITLE
Échec de la tâche AfterParty fix_geo_areas_geometry

### DIFF
--- a/lib/tasks/deployment/20200813111957_fix_geo_areas_geometry.rake
+++ b/lib/tasks/deployment/20200813111957_fix_geo_areas_geometry.rake
@@ -18,7 +18,7 @@ namespace :after_party do
     geometry_collections.find_each do |geometry_collection|
       geometry_collection.geometry['geometries'].each do |geometry|
         if valid_geometry?(geometry)
-          geometry_collection.champ.geo_areas.create!(geometry: geometry, source: 'selection_utilisateur')
+          geometry_collection.champ.geo_areas.find_or_create_by!(geometry: geometry, source: 'selection_utilisateur')
         end
       end
 
@@ -36,7 +36,7 @@ namespace :after_party do
         }
 
         if valid_geometry?(geometry)
-          multi_line_string.champ.geo_areas.create!(geometry: geometry, source: 'selection_utilisateur')
+          multi_line_string.champ.geo_areas.find_or_create_by!(geometry: geometry, source: 'selection_utilisateur')
         end
       end
 
@@ -54,7 +54,7 @@ namespace :after_party do
         }
 
         if valid_geometry?(geometry)
-          multi_polygon.champ.geo_areas.create!(geometry: geometry, source: 'selection_utilisateur')
+          multi_polygon.champ.geo_areas.find_or_create_by!(geometry: geometry, source: 'selection_utilisateur')
         end
       end
 


### PR DESCRIPTION
# Résumé

<!-- décrire en quelques phrases la problématique adressée -->

La tâche de déploiement `after_party:fix_geo_areas_geometry` récemment réintroduite dans la base de code n'est pas idempotente et peut amener à la création d'aires géométriques surnuméraires.

mots-clés : after_party, task, geo_area, idempotent

mots-clés :

fixes #7038 / @adullact & @synbioz

--- 

> - L'ADULLACT a mandaté le prestataire @synbioz pour développer plusieurs fonctionnalités (tickets et PR à venir).
> - C'est dans ce cadre que @synbioz nous propose certains correctifs annexes comme celui-ci.
> - Si c'est nécessaire, @akarzim et @jobygoude de @synbioz pourront interagir avec l'équipe @betagouv sur ce ticket et sur la PR (répondre aux commentaires, pousser des commits…).

## Rebase du code (si nécessaire)

Si besoin nous pouvons faire les rebases et/ou ajouter un utilisateur @betagouv pour intervenir directement sur notre dépôt.

---

`trackingAdullactContrib`