### PR TITLE
Changement du sens de la relation des Users aux rôles

### DIFF
--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -16,7 +16,7 @@ class Administrateur < ApplicationRecord
   has_and_belongs_to_many :procedures
   has_many :services
 
-  has_one :user, dependent: :nullify
+  belongs_to :user
 
   default_scope { eager_load(:user) }
 

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -8,7 +8,7 @@
 #  user_id    :bigint
 #
 class Expert < ApplicationRecord
-  has_one :user
+  belongs_to :user
   has_many :experts_procedures
   has_many :procedures, through: :experts_procedures
   has_many :avis, through: :experts_procedures

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -31,7 +31,7 @@ class Instructeur < ApplicationRecord
   has_many :archives
   has_many :bulk_messages, dependent: :destroy
 
-  has_one :user, dependent: :nullify
+  belongs_to :user
 
   scope :with_instant_email_message_notifications, -> {
     includes(:assign_to).where(assign_tos: { instant_email_message_notifications_enabled: true })

--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -121,7 +121,7 @@ class ProcedurePresentation < ApplicationRecord
       end
     when 'followers_instructeurs'
       assert_supported_column(table, column)
-      # LEFT OUTER JOIN allows to keep dossiers without assignated instructeurs yet
+      # LEFT OUTER JOIN allows to keep dossiers without assigned instructeurs yet
       dossiers
         .includes(:followers_instructeurs)
         .joins('LEFT OUTER JOIN users instructeurs_users ON instructeurs_users.id = instructeurs.user_id')

--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -124,7 +124,7 @@ class ProcedurePresentation < ApplicationRecord
       # LEFT OUTER JOIN allows to keep dossiers without assignated instructeurs yet
       dossiers
         .includes(:followers_instructeurs)
-        .joins('LEFT OUTER JOIN users instructeurs_users ON instructeurs_users.instructeur_id = instructeurs.id')
+        .joins('LEFT OUTER JOIN users instructeurs_users ON instructeurs_users.id = instructeurs.user_id')
         .order("instructeurs_users.email #{order}")
         .pluck(:id)
         .uniq
@@ -167,7 +167,7 @@ class ProcedurePresentation < ApplicationRecord
         assert_supported_column(table, column)
         dossiers
           .includes(:followers_instructeurs)
-          .joins('INNER JOIN users instructeurs_users ON instructeurs_users.instructeur_id = instructeurs.id')
+          .joins('INNER JOIN users instructeurs_users ON instructeurs_users.id = instructeurs.user_id')
           .filter_ilike('instructeurs_users', :email, values)
       when 'user', 'individual'
         dossiers

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,21 +65,6 @@ class User < ApplicationRecord
 
   validate :does_not_merge_on_self, if: :requested_merge_into_id_changed?
 
-  # Temporary code for double writing the admin, instructeur and expert id to the foreign key
-  after_save do
-    if saved_change_to_attribute?(:administrateur_id) && administrateur_id.present?
-      Administrateur.find(administrateur_id).update!(user_id: id)
-    end
-
-    if saved_change_to_attribute?(:instructeur_id) && instructeur_id.present?
-      Instructeur.find(instructeur_id).update!(user_id: id)
-    end
-
-    if saved_change_to_attribute?(:expert_id) && expert_id.present?
-      Expert.find(expert_id).update!(user_id: id)
-    end
-  end
-
   def validate_password_complexity?
     administrateur?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,9 +25,6 @@
 #  unlock_token                 :string
 #  created_at                   :datetime
 #  updated_at                   :datetime
-#  administrateur_id            :bigint
-#  expert_id                    :bigint
-#  instructeur_id               :bigint
 #  requested_merge_into_id      :bigint
 #
 class User < ApplicationRecord
@@ -52,9 +49,9 @@ class User < ApplicationRecord
   has_many :requested_merge_from, class_name: 'User', dependent: :nullify, inverse_of: :requested_merge_into, foreign_key: :requested_merge_into_id
 
   has_one :france_connect_information, dependent: :destroy
-  belongs_to :instructeur, optional: true, dependent: :destroy
-  belongs_to :administrateur, optional: true, dependent: :destroy
-  belongs_to :expert, optional: true, dependent: :destroy
+  has_one :instructeur, dependent: :destroy
+  has_one :administrateur, dependent: :destroy
+  has_one :expert, dependent: :destroy
   belongs_to :requested_merge_into, class_name: 'User', optional: true
 
   accepts_nested_attributes_for :france_connect_information
@@ -120,7 +117,7 @@ class User < ApplicationRecord
       .find_or_create_by(email: email)
 
     if user.valid?
-      if user.instructeur_id.nil?
+      if user.instructeur.nil?
         user.create_instructeur!
         user.update(france_connect_information: nil)
       end
@@ -134,7 +131,7 @@ class User < ApplicationRecord
   def self.create_or_promote_to_administrateur(email, password)
     user = User.create_or_promote_to_instructeur(email, password)
 
-    if user.valid? && user.administrateur_id.nil?
+    if user.valid? && user.administrateur.nil?
       user.create_administrateur!
       user.update(france_connect_information: nil)
     end
@@ -148,7 +145,7 @@ class User < ApplicationRecord
       .find_or_create_by(email: email)
 
     if user.valid?
-      if user.expert_id.nil?
+      if user.expert.nil?
         user.create_expert!
       end
     end
@@ -165,15 +162,15 @@ class User < ApplicationRecord
   end
 
   def administrateur?
-    administrateur_id.present?
+    administrateur.present?
   end
 
   def instructeur?
-    instructeur_id.present?
+    instructeur.present?
   end
 
   def expert?
-    expert_id.present?
+    expert.present?
   end
 
   def can_france_connect?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,6 +41,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable, :async,
     :recoverable, :rememberable, :trackable, :validatable, :confirmable, :lockable
 
+  self.ignored_columns = [:administrateur_id, :instructeur_id, :expert_id]
+
   has_many :dossiers, dependent: :destroy
   has_many :invites, dependent: :destroy
   has_many :dossiers_invites, through: :invites, source: :dossier

--- a/spec/models/procedure_presentation_spec.rb
+++ b/spec/models/procedure_presentation_spec.rb
@@ -347,14 +347,14 @@ describe ProcedurePresentation do
       let(:table) { 'followers_instructeurs' }
       let(:order) { 'asc' } # Desc works the same, no extra test required
 
-      let!(:dossier_a) { create(:dossier, :en_construction, procedure: procedure) }
       let!(:dossier_z) { create(:dossier, :en_construction, procedure: procedure) }
+      let!(:dossier_a) { create(:dossier, :en_construction, procedure: procedure) }
       let!(:dossier_without_instructeur) { create(:dossier, :en_construction, procedure: procedure) }
 
       before do
+        create(:follow, dossier: dossier_z, instructeur: create(:instructeur, email: 'zythum@exemple.fr'))
         create(:follow, dossier: dossier_a, instructeur: create(:instructeur, email: 'abaca@exemple.fr'))
         create(:follow, dossier: dossier_a, instructeur: create(:instructeur, email: 'abaca2@exemple.fr'))
-        create(:follow, dossier: dossier_z, instructeur: create(:instructeur, email: 'zythum@exemple.fr'))
       end
 
       context 'for email column' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -372,7 +372,7 @@ describe User, type: :model do
     end
 
     context 'for administrateurs' do
-      let(:user) { build(:user, email: 'admin@exemple.fr', password: password, administrateur: create(:administrateur, user: nil)) }
+      let(:user) { build(:user, email: 'admin@exemple.fr', password: password, administrateur: build(:administrateur, user: nil)) }
 
       context 'when the password is too short' do
         let(:password) { 's' * (PASSWORD_MIN_LENGTH - 1) }
@@ -453,8 +453,8 @@ describe User, type: :model do
         targeted_user.reload
 
         expect(targeted_user.instructeur).to match(instructeur)
-        expect(targeted_user.expert).to match(expert)
         expect(targeted_user.administrateur).to match(administrateur)
+        expect(targeted_user.expert).to match(expert)
       end
 
       context 'and the targeted account owns an instructeur and expert as well' do


### PR DESCRIPTION
Suite de #6976 :

Avant, le User était responsable de référencer les rôles (Administrateur, Instructeur, Expert). 
Problème : on pouvait se retrouver avec des rôles référencés par aucun User.

La [PR précédente](https://github.com/betagouv/demarches-simplifiees.fr/pull/7019) a rajouté des colonnes pour inverser le sens de la relation, mis en place un double-write, et mouliné les données existantes.

Maintenant que les nouvelles colonnes sont prêtes et remplies, on peut :

1. Basculer les relations dans l'autre sens (pour qu'elles utilisent les nouvelles colonnes),
2. Retirer le double-write.

(Une fois qu'on aura fait tout ça, la dernière PR à venir rajoutera des contraintes fortes aux nouvelles relations.)