### PR TITLE
Corrige l'authentification de l'API GraphQL, pour utiliser les nouvelles relations sur les rôles

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -214,7 +214,7 @@ Rails.application.routes.draw do
   # API
   #
 
-  authenticated :user, lambda { |user| user.administrateur_id } do
+  authenticated :user, lambda { |user| user.administrateur? } do
     mount GraphqlPlayground::Rails::Engine, at: "/graphql", graphql_path: "/api/v2/graphql"
   end
 


### PR DESCRIPTION
Corrige une régression introduite dans #7050, qui fait échouer les requêtes à l'API GraphQL.

(Voir https://sentry.io/organizations/demarches-simplifiees/issues/2866044669/)