### PR TITLE
Ajout de contraintes NOT NULL sur les colonnes de AdministrateursInstructeur

### DIFF
--- a/app/models/administrateurs_instructeur.rb
+++ b/app/models/administrateurs_instructeur.rb
@@ -4,8 +4,8 @@
 #
 #  created_at        :datetime
 #  updated_at        :datetime
-#  administrateur_id :integer
-#  instructeur_id    :integer
+#  administrateur_id :integer          not null
+#  instructeur_id    :integer          not null
 #
 class AdministrateursInstructeur < ApplicationRecord
   belongs_to :administrateur

--- a/db/migrate/20220322110900_add_not_null_constraints_to_administrateurs_instructeur.rb
+++ b/db/migrate/20220322110900_add_not_null_constraints_to_administrateurs_instructeur.rb
@@ -1,0 +1,10 @@
+class AddNotNullConstraintsToAdministrateursInstructeur < ActiveRecord::Migration[6.1]
+  def change
+    # We ignore strong_migrations safety warnings, because those tables are relatively small, and the null check
+    # will be very fast.
+    safety_assured do
+      change_column_null :administrateurs_instructeurs, :administrateur_id, false
+      change_column_null :administrateurs_instructeurs, :instructeur_id, false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_15_113510) do
+ActiveRecord::Schema.define(version: 2022_03_22_110900) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,9 +64,9 @@ ActiveRecord::Schema.define(version: 2022_03_15_113510) do
   end
 
   create_table "administrateurs_instructeurs", id: false, force: :cascade do |t|
-    t.integer "administrateur_id"
+    t.integer "administrateur_id", null: false
     t.datetime "created_at"
-    t.integer "instructeur_id"
+    t.integer "instructeur_id", null: false
     t.datetime "updated_at"
     t.index ["administrateur_id"], name: "index_administrateurs_instructeurs_on_administrateur_id"
     t.index ["instructeur_id", "administrateur_id"], name: "unique_couple_administrateur_instructeur", unique: true


### PR DESCRIPTION
Petit correctif sur une PR précédente (#7001) : on avait rajouté des foreign keys sur les colonnes de AdministrateursInstructeur, mais en oubliant la contrainte NOT NULL.

Cette PR répare cet oubli, en rajoutant les bonnes contraintes.

C'est indépendant des autres PRs en cours sur les colonnes User <-> rôles.