### PR TITLE
Ajout de contraintes sur les colonnes des rôles en base

### DIFF
--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -7,7 +7,7 @@
 #  encrypted_token :string
 #  created_at      :datetime
 #  updated_at      :datetime
-#  user_id         :bigint
+#  user_id         :bigint           not null
 #
 class Administrateur < ApplicationRecord
   include ActiveRecord::SecureToken

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -5,7 +5,7 @@
 #  id         :bigint           not null, primary key
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  user_id    :bigint
+#  user_id    :bigint           not null
 #
 class Expert < ApplicationRecord
   belongs_to :user

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -9,7 +9,7 @@
 #  created_at               :datetime
 #  updated_at               :datetime
 #  agent_connect_id         :string
-#  user_id                  :bigint
+#  user_id                  :bigint           not null
 #
 class Instructeur < ApplicationRecord
   has_and_belongs_to_many :administrateurs

--- a/db/migrate/20220323064705_add_not_null_constraints_to_role_tables.rb
+++ b/db/migrate/20220323064705_add_not_null_constraints_to_role_tables.rb
@@ -1,0 +1,18 @@
+class AddNotNullConstraintsToRoleTables < ActiveRecord::Migration[6.1]
+  include Database::MigrationHelpers
+
+  def change
+    # If this migration fails, that means you need to run the matching data migration task first.
+    # Please run:
+    #   bin/rake after_party:copy_user_association_to_user_related_models
+    #   bin/rake after_party:delete_roles_without_users
+    #
+    # (We ignore strong_migrations safety warnings, because those tables are relatively small, and the null check
+    # will be very fast.)
+    safety_assured do
+      change_column_null :administrateurs, :user_id, false
+      change_column_null :instructeurs, :user_id, false
+      change_column_null :experts, :user_id, false
+    end
+  end
+end

--- a/db/migrate/20220323113048_add_foreign_keys_to_role_tables.rb
+++ b/db/migrate/20220323113048_add_foreign_keys_to_role_tables.rb
@@ -1,0 +1,10 @@
+class AddForeignKeysToRoleTables < ActiveRecord::Migration[6.1]
+  def change
+    # Add foreign keys constraints to role tables.
+    #
+    # (We don't validate foreign keys right now, to avoid blocking writes to these tables for too long.)
+    add_foreign_key :administrateurs, :users, validate: false
+    add_foreign_key :instructeurs, :users, validate: false
+    add_foreign_key :experts, :users, validate: false
+  end
+end

--- a/db/migrate/20220323113152_validate_foreign_keys_to_role_tables.rb
+++ b/db/migrate/20220323113152_validate_foreign_keys_to_role_tables.rb
@@ -1,0 +1,10 @@
+class ValidateForeignKeysToRoleTables < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    # Now that the foreign keys are added, we can validate them safely without blocking writes.
+    validate_foreign_key :administrateurs, :users
+    validate_foreign_key :instructeurs, :users
+    validate_foreign_key :experts, :users
+  end
+end

--- a/db/migrate/20220323113327_add_index_to_role_tables.rb
+++ b/db/migrate/20220323113327_add_index_to_role_tables.rb
@@ -1,0 +1,9 @@
+class AddIndexToRoleTables < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :administrateurs, :user_id, algorithm: :concurrently
+    add_index :instructeurs, :user_id, algorithm: :concurrently
+    add_index :experts, :user_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20220323120846_remove_role_columns_on_user.rb
+++ b/db/migrate/20220323120846_remove_role_columns_on_user.rb
@@ -1,0 +1,10 @@
+class RemoveRoleColumnsOnUser < ActiveRecord::Migration[6.1]
+  def change
+    # (The safety_assured block validates that the columns to remove are ignored in the model, which is the case.)
+    safety_assured do
+      remove_column :users, :administrateur_id
+      remove_column :users, :instructeur_id
+      remove_column :users, :expert_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_23_113327) do
+ActiveRecord::Schema.define(version: 2022_03_23_120846) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -791,7 +791,6 @@ ActiveRecord::Schema.define(version: 2022_03_23_113327) do
   end
 
   create_table "users", id: :serial, force: :cascade do |t|
-    t.bigint "administrateur_id"
     t.datetime "confirmation_sent_at"
     t.string "confirmation_token"
     t.datetime "confirmed_at"
@@ -800,9 +799,7 @@ ActiveRecord::Schema.define(version: 2022_03_23_113327) do
     t.string "current_sign_in_ip"
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
-    t.bigint "expert_id"
     t.integer "failed_attempts", default: 0, null: false
-    t.bigint "instructeur_id"
     t.datetime "last_sign_in_at"
     t.string "last_sign_in_ip"
     t.string "locale"
@@ -817,11 +814,8 @@ ActiveRecord::Schema.define(version: 2022_03_23_113327) do
     t.text "unconfirmed_email"
     t.string "unlock_token"
     t.datetime "updated_at"
-    t.index ["administrateur_id"], name: "index_users_on_administrateur_id"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["expert_id"], name: "index_users_on_expert_id"
-    t.index ["instructeur_id"], name: "index_users_on_instructeur_id"
     t.index ["requested_merge_into_id"], name: "index_users_on_requested_merge_into_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
@@ -907,9 +901,6 @@ ActiveRecord::Schema.define(version: 2022_03_23_113327) do
   add_foreign_key "trusted_device_tokens", "instructeurs"
   add_foreign_key "types_de_champ", "procedure_revisions", column: "revision_id"
   add_foreign_key "types_de_champ", "types_de_champ", column: "parent_id"
-  add_foreign_key "users", "administrateurs"
-  add_foreign_key "users", "experts"
-  add_foreign_key "users", "instructeurs"
   add_foreign_key "users", "users", column: "requested_merge_into_id"
   add_foreign_key "without_continuation_mails", "procedures"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_22_110900) do
+ActiveRecord::Schema.define(version: 2022_03_23_113327) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,7 +60,8 @@ ActiveRecord::Schema.define(version: 2022_03_22_110900) do
     t.datetime "created_at"
     t.string "encrypted_token"
     t.datetime "updated_at"
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_administrateurs_on_user_id"
   end
 
   create_table "administrateurs_instructeurs", id: false, force: :cascade do |t|
@@ -410,7 +411,8 @@ ActiveRecord::Schema.define(version: 2022_03_22_110900) do
   create_table "experts", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_experts_on_user_id"
   end
 
   create_table "experts_procedures", force: :cascade do |t|
@@ -539,8 +541,9 @@ ActiveRecord::Schema.define(version: 2022_03_22_110900) do
     t.text "encrypted_login_token"
     t.datetime "login_token_created_at"
     t.datetime "updated_at"
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.index ["agent_connect_id"], name: "index_instructeurs_on_agent_connect_id", unique: true
+    t.index ["user_id"], name: "index_instructeurs_on_user_id"
   end
 
   create_table "invites", id: :serial, force: :cascade do |t|
@@ -852,6 +855,7 @@ ActiveRecord::Schema.define(version: 2022_03_22_110900) do
   end
 
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "administrateurs", "users"
   add_foreign_key "administrateurs_instructeurs", "administrateurs"
   add_foreign_key "administrateurs_instructeurs", "instructeurs"
   add_foreign_key "administrateurs_procedures", "administrateurs"
@@ -876,12 +880,14 @@ ActiveRecord::Schema.define(version: 2022_03_22_110900) do
   add_foreign_key "dossiers", "groupe_instructeurs"
   add_foreign_key "dossiers", "procedure_revisions", column: "revision_id"
   add_foreign_key "dossiers", "users"
+  add_foreign_key "experts", "users"
   add_foreign_key "experts_procedures", "experts"
   add_foreign_key "experts_procedures", "procedures"
   add_foreign_key "france_connect_informations", "users"
   add_foreign_key "geo_areas", "champs"
   add_foreign_key "groupe_instructeurs", "procedures"
   add_foreign_key "initiated_mails", "procedures"
+  add_foreign_key "instructeurs", "users"
   add_foreign_key "merge_logs", "users"
   add_foreign_key "procedure_presentations", "assign_tos"
   add_foreign_key "procedure_revision_types_de_champ", "procedure_revision_types_de_champ", column: "parent_id"


### PR DESCRIPTION
_Cette PR est la dernière concernant #6976 🙌_

Dans cette PR :

- On rajoute des contraintes 'foreign key' et 'NOT NULL' aux colonnes `<roles>.user_id`,
- On supprime les anciennes colonnes `users.<role>_id`.

## Implémentation

Les migrations d'ajout de contraintes sont implémentées en plusieurs passes (sur les conseils de `strong_migrations`), pour éviter de locker la base trop longtemps pendant la migration.

Fix #6976