### PR TITLE
fix(Dossier.processed_in_month): used by ProcedureArchiveService ; until now we skipped all dossiers from last day of month 🌈🍨

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -120,6 +120,8 @@ group :development do
 end
 
 group :development, :test do
+  gem 'sorbet'
+  gem 'sorbet-runtime'
   gem 'graphql-schema_comparator'
   gem 'mina', require: false # Deploy
   gem 'pry-byebug' # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -120,13 +120,13 @@ group :development do
 end
 
 group :development, :test do
-  gem 'sorbet'
-  gem 'sorbet-runtime'
   gem 'graphql-schema_comparator'
   gem 'mina', require: false # Deploy
   gem 'pry-byebug' # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'rspec-rails'
   gem 'simple_xlsx_reader'
+  gem 'sorbet'
+  gem 'sorbet-runtime'
   gem 'spring' # Spring speeds up development by keeping your application running in the background
   gem 'spring-commands-rspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -677,6 +677,18 @@ GEM
       tilt (~> 2.0)
     skylight (5.0.1)
       activesupport (>= 5.2.0)
+    sorbet (0.5.9827)
+      sorbet-static (= 0.5.9827)
+    sorbet-runtime (0.5.9827)
+    sorbet-static (0.5.9827-universal-darwin-14)
+    sorbet-static (0.5.9827-universal-darwin-15)
+    sorbet-static (0.5.9827-universal-darwin-16)
+    sorbet-static (0.5.9827-universal-darwin-17)
+    sorbet-static (0.5.9827-universal-darwin-18)
+    sorbet-static (0.5.9827-universal-darwin-19)
+    sorbet-static (0.5.9827-universal-darwin-20)
+    sorbet-static (0.5.9827-universal-darwin-21)
+    sorbet-static (0.5.9827-x86_64-linux)
     spreadsheet_architect (4.1.0)
       axlsx_styler (>= 1.0.0, < 2)
       caxlsx (>= 2.0.2, < 4)
@@ -874,6 +886,8 @@ DEPENDENCIES
   sib-api-v3-sdk
   simple_xlsx_reader
   skylight
+  sorbet
+  sorbet-runtime
   spreadsheet_architect
   spring
   spring-commands-rspec

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -1,3 +1,4 @@
+# typed: true
 # == Schema Information
 #
 # Table name: dossiers
@@ -38,6 +39,7 @@
 #  user_id                                            :integer
 #
 class Dossier < ApplicationRecord
+  extend T::Sig
   self.ignored_columns = [:en_construction_conservation_extension]
   include DossierFilteringConcern
   include DossierRebaseConcern
@@ -233,8 +235,8 @@ class Dossier < ApplicationRecord
   scope :en_instruction,              -> { not_archived.state_en_instruction }
   scope :termine,                     -> { not_archived.state_termine }
 
+  sig { params(args: DateTime).returns(T.untyped) }
   scope :processed_in_month, -> (date) do
-    date = date.to_datetime
     state_termine
       .joins(:traitements)
       .where(traitements: { processed_at: date.beginning_of_month..date.end_of_month })

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -234,6 +234,7 @@ class Dossier < ApplicationRecord
   scope :termine,                     -> { not_archived.state_termine }
 
   scope :processed_in_month, -> (date) do
+    date = date.to_datetime
     state_termine
       .joins(:traitements)
       .where(traitements: { processed_at: date.beginning_of_month..date.end_of_month })

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -233,10 +233,10 @@ class Dossier < ApplicationRecord
   scope :en_instruction,              -> { not_archived.state_en_instruction }
   scope :termine,                     -> { not_archived.state_termine }
 
-  scope :processed_in_month, -> (month) do
+  scope :processed_in_month, -> (date) do
     state_termine
       .joins(:traitements)
-      .where(traitements: { processed_at: month.beginning_of_month..month.end_of_month })
+      .where(traitements: { processed_at: date.beginning_of_month..date.end_of_month })
   end
   scope :downloadable_sorted, -> {
     state_not_brouillon

--- a/app/services/procedure_archive_service.rb
+++ b/app/services/procedure_archive_service.rb
@@ -22,7 +22,7 @@ class ProcedureArchiveService
     dossiers = if archive.time_span_type == 'everything'
       dossiers.state_termine
     else
-      dossiers.processed_in_month(archive.month)
+      dossiers.processed_in_month(archive.month.to_datetime)
     end
 
     attachments = ActiveStorage::DownloadableFile.create_list_from_dossiers(dossiers)

--- a/sorbet/config
+++ b/sorbet/config
@@ -1,0 +1,3 @@
+--dir
+.
+--ignore=/vendor/bundle

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1720,4 +1720,29 @@ describe Dossier do
       expect(rebased_datetime_champ.rebased_at).not_to be_nil
     end
   end
+
+  describe '#processed_in_month' do
+    include ActiveSupport::Testing::TimeHelpers
+
+    let(:dossier_accepte_at) { DateTime.new(2022, 3, 31, 12, 0) }
+    before do
+      travel_to(dossier_accepte_at) do
+        dossier = create(:dossier, :accepte)
+      end
+    end
+
+    context 'given a date' do
+      let(:archive_date) { Date.new(2022, 3, 1) }
+      it 'includes a dossier processed_at at last day of month' do
+        expect(Dossier.processed_in_month(archive_date).count).to eq(1)
+      end
+    end
+
+    context 'given a datetime' do
+      let(:archive_date) { DateTime.new(2022, 3, 1, 12, 0) }
+      it 'includes a dossier processed_at at last day of month' do
+        expect(Dossier.processed_in_month(archive_date).count).to eq(1)
+      end
+    end
+  end
 end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1731,13 +1731,6 @@ describe Dossier do
       end
     end
 
-    context 'given a date' do
-      let(:archive_date) { Date.new(2022, 3, 1) }
-      it 'includes a dossier processed_at at last day of month' do
-        expect(Dossier.processed_in_month(archive_date).count).to eq(1)
-      end
-    end
-
     context 'given a datetime' do
       let(:archive_date) { DateTime.new(2022, 3, 1, 12, 0) }
       it 'includes a dossier processed_at at last day of month' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,6 +13,7 @@ require 'rspec/rails'
 require 'axe-rspec'
 require 'devise'
 require 'shoulda-matchers'
+require 'sorbet-runtime'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are


### PR DESCRIPTION
### contexte 
En testant la fonction d'export, je me suis rendu compte que le 31/03 ; un dossier accepte le dernier jour du mois n'etait pas présent dans l'archive

### solution 
j'ai hésité, mais je pense que c'est un super cas d'usage pour introduire Sorbet. 🎆 

### info 
* Lire commit par commit
* j'ai tenté d'utiliser rails-sorbet ; il trouvait pas les déclarations en dehors des classes.
* a la vue de notre contexte, j'ai l'impression qu'il serait préférable d'utiliser rbs (les types natifs ruby) plutot que sorbet car les déclaration a l'exterieur du fichier de code m'ont l'air plus pratique pour les autres instance. Qu'en pensez-vous ?