### PR TITLE
Supprime la restriction par taille d'export de pjs par dossier

### DIFF
--- a/app/controllers/experts/avis_controller.rb
+++ b/app/controllers/experts/avis_controller.rb
@@ -139,8 +139,6 @@ module Experts
     end
 
     def telecharger_pjs
-      return head(:forbidden) if !avis.dossier.export_and_attachments_downloadable?
-
       files = ActiveStorage::DownloadableFile.create_list_from_dossier(@dossier, true)
 
       zipline(files, "dossier-#{@dossier.id}.zip")

--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -218,8 +218,6 @@ module Instructeurs
     end
 
     def telecharger_pjs
-      return head(:forbidden) if !dossier.export_and_attachments_downloadable?
-
       files = ActiveStorage::DownloadableFile.create_list_from_dossier(dossier)
 
       zipline(files, "dossier-#{dossier.id}.zip")

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -56,8 +56,6 @@ class Dossier < ApplicationRecord
   INSTRUCTION_COMMENCEE = TERMINE + [states.fetch(:en_instruction)]
   SOUMIS = EN_CONSTRUCTION_OU_INSTRUCTION + TERMINE
 
-  TAILLE_MAX_ZIP = 100.megabytes
-
   REMAINING_DAYS_BEFORE_CLOSING = 2
   INTERVAL_BEFORE_CLOSING = "#{REMAINING_DAYS_BEFORE_CLOSING} days"
   REMAINING_WEEKS_BEFORE_EXPIRATION = 2
@@ -1082,10 +1080,6 @@ class Dossier < ApplicationRecord
         [type_de_champ.libelle_for_export(index), champ_value]
       end
     end
-  end
-
-  def export_and_attachments_downloadable?
-    PiecesJustificativesService.pieces_justificatives_total_size(self) < Dossier::TAILLE_MAX_ZIP
   end
 
   def linked_dossiers_for(instructeur_or_expert)

--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -14,11 +14,6 @@ class PiecesJustificativesService
     pjs_champs + pjs_commentaires
   end
 
-  def self.pieces_justificatives_total_size(dossier)
-    liste_pieces_justificatives(dossier)
-      .sum(&:byte_size)
-  end
-
   def self.serialize_types_de_champ_as_type_pj(revision)
     tdcs = revision.types_de_champ.filter { |type_champ| type_champ.old_pj.present? }
     tdcs.map.with_index do |type_champ, order_place|

--- a/app/views/experts/avis/_header.html.haml
+++ b/app/views/experts/avis/_header.html.haml
@@ -9,11 +9,7 @@
         %button.button.dropdown-button.icon-only{ 'aria-expanded' => 'false', 'aria-controls' => 'print-pj-menu' }
           %span.icon.attached
         %ul#print-pj-menu.print-menu.dropdown-content
-          %li
-            - if dossier.export_and_attachments_downloadable?
-              = link_to "Télécharger le dossier et toutes ses pièces jointes", telecharger_pjs_expert_avis_path(avis), target: "_blank", rel: "noopener", class: "menu-item menu-link"
-            - else
-              %p.menu-item Le téléchargement des pièces jointes est désactivé pour les dossiers de plus de #{number_to_human_size Dossier::TAILLE_MAX_ZIP}.
+          %li= link_to "Télécharger le dossier et toutes ses pièces jointes", telecharger_pjs_expert_avis_path(avis), target: "_blank", rel: "noopener", class: "menu-item menu-link"
 
     %nav.tabs
       %ul

--- a/app/views/instructeurs/dossiers/_header_actions.html.haml
+++ b/app/views/instructeurs/dossiers/_header_actions.html.haml
@@ -16,11 +16,7 @@
   %button.button.dropdown-button.icon-only{ 'aria-expanded' => 'false', 'aria-controls' => 'print-pj-menu' }
     %span.icon.attached
   %ul#print-pj-menu.print-menu.dropdown-content
-    %li
-      - if dossier.export_and_attachments_downloadable?
-        = link_to "Télécharger le dossier et toutes ses pièces jointes", telecharger_pjs_instructeur_dossier_path(dossier.procedure, dossier), target: "_blank", rel: "noopener", class: "menu-item menu-link"
-      - else
-        %p.menu-item Le téléchargement des pièces jointes est désactivé pour les dossiers de plus de #{number_to_human_size Dossier::TAILLE_MAX_ZIP}.
+    %li= link_to "Télécharger le dossier et toutes ses pièces jointes", telecharger_pjs_instructeur_dossier_path(dossier.procedure, dossier), target: "_blank", rel: "noopener", class: "menu-item menu-link"
 
 = render partial: "instructeurs/procedures/dossier_actions",
   locals: { procedure_id: dossier.procedure.id,

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1190,30 +1190,6 @@ describe Dossier do
     after { Timecop.return }
   end
 
-  describe '#export_and_attachments_downloadable?' do
-    let(:dossier) { create(:dossier, user: user) }
-
-    context "no attachments" do
-      it {
-        expect(dossier.export_and_attachments_downloadable?).to be true
-      }
-    end
-
-    context "with a small attachment" do
-      it {
-        expect(PiecesJustificativesService).to receive(:pieces_justificatives_total_size).and_return(4.megabytes)
-        expect(dossier.export_and_attachments_downloadable?).to be true
-      }
-    end
-
-    context "with a too large attachment" do
-      it {
-        expect(PiecesJustificativesService).to receive(:pieces_justificatives_total_size).and_return(100.megabytes)
-        expect(dossier.export_and_attachments_downloadable?).to be false
-      }
-    end
-  end
-
   describe '#notify_draft_not_submitted' do
     let!(:user1) { create(:user) }
     let!(:user2) { create(:user) }


### PR DESCRIPTION
En voulant optimiser des requêtes AR, je me suis rendu compte qu'on calculait **à chaque affichage dossier instructeur** le poids de l'archive d'un dossier soit 9 requêtes (20% du sql) au minimum.

Or on fait maintenant des méga exports de plusieurs gig, je me dis que cette contrainte n'a plus lieu d'être.

Par contre je constate également qu'on utilise zipline pour faire du synchrone.

Afin d'être ceinture et bretelles, il serait préférable qu'on passe également par un job pour éviter le pire des cas ou un instructeur cliquerait frénétiquement sur un export de gros dossier.

@tchak @mfo si ca vous va, je me brancherais dans un second temps sur votre mécanisme de création de zip par vue filtrée pour ... 1 dossier.

Dites moi si vous préférez qu'on ne merge pas tant que la création du zip n'est pas asynchrone.