### PR TITLE
feat(ArchiveUploader.upload_with_chunking_wrapper): expect to retry call to wrapper once

### DIFF
--- a/spec/services/archive_uploader_spec.rb
+++ b/spec/services/archive_uploader_spec.rb
@@ -82,7 +82,7 @@ describe ProcedureArchiveService do
       it 'does not retry more than once' do
         expect(uploader).to receive(:syscall_to_custom_uploader).with(anything).twice.and_raise(StandardError, "BOOM")
         expect { uploader.send(:upload_with_chunking_wrapper) }
-          .to raise_error(StandardError, "BOOM")
+          .to raise_error(RuntimeError, "custom archive attachment failed twice, retry later")
       end
     end
   end


### PR DESCRIPTION
constat : avec de grosses archive. le call au script du ds proxy peut nous retourner un status 136 (kinda OOM). retry pour essayer d'eviter a re-DL toutes les PJs