### PR TITLE
fix(User.merge): when user have an instructeur having dossier_opertions_logs containing instructeur_id

### DIFF
--- a/app/models/dossier_operation_log.rb
+++ b/app/models/dossier_operation_log.rb
@@ -12,7 +12,6 @@
 #  updated_at          :datetime         not null
 #  bill_signature_id   :bigint
 #  dossier_id          :bigint
-#  instructeur_id      :bigint
 #
 class DossierOperationLog < ApplicationRecord
   enum operation: {

--- a/db/migrate/20220406144202_remove_column_instructeur_id_from_dossier_operation_log.rb
+++ b/db/migrate/20220406144202_remove_column_instructeur_id_from_dossier_operation_log.rb
@@ -1,0 +1,5 @@
+class RemoveColumnInstructeurIdFromDossierOperationLog < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured { remove_column :dossier_operation_logs, :instructeur_id }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -267,13 +267,11 @@ ActiveRecord::Schema.define(version: 2022_04_07_081538) do
     t.text "digest"
     t.bigint "dossier_id"
     t.datetime "executed_at"
-    t.bigint "instructeur_id"
     t.datetime "keep_until"
     t.string "operation", null: false
     t.datetime "updated_at", null: false
     t.index ["bill_signature_id"], name: "index_dossier_operation_logs_on_bill_signature_id"
     t.index ["dossier_id"], name: "index_dossier_operation_logs_on_dossier_id"
-    t.index ["instructeur_id"], name: "index_dossier_operation_logs_on_instructeur_id"
     t.index ["keep_until"], name: "index_dossier_operation_logs_on_keep_until"
   end
 
@@ -872,7 +870,6 @@ ActiveRecord::Schema.define(version: 2022_04_07_081538) do
   add_foreign_key "commentaires", "dossiers"
   add_foreign_key "commentaires", "experts"
   add_foreign_key "dossier_operation_logs", "bill_signatures"
-  add_foreign_key "dossier_operation_logs", "instructeurs"
   add_foreign_key "dossier_transfer_logs", "dossiers"
   add_foreign_key "dossiers", "dossier_transfers"
   add_foreign_key "dossiers", "groupe_instructeurs"


### PR DESCRIPTION
`instructeur_id` n'est pas utilisé sur opération loi et devrai être supprimé. C'est un audit logique, on ne peux pas les récrire.