### PR TITLE
feat(adminstrateurs#dossier_vide): add button to /dossier_vide so administrateur can have a pdf version of their form to send it in regards to RGPD

### DIFF
--- a/app/views/administrateurs/procedures/show.html.haml
+++ b/app/views/administrateurs/procedures/show.html.haml
@@ -4,6 +4,10 @@
             metadatas: ["Créée le #{@procedure.created_at.strftime('%d/%m/%Y')} - n° #{@procedure.id}", "#{@procedure.close? ? "Close le #{@procedure.closed_at.strftime('%d/%m/%Y')}" : @procedure.locked? ? "Publiée - #{procedure_lien(@procedure)}" : "Brouillon"}"] }
 
 .container.procedure-admin-container
+  = link_to @procedure.active_revision.draft? ? commencer_dossier_vide_test_path(path: @procedure.path) : commencer_dossier_vide_path(path: @procedure.path), target: "_blank", rel: "noopener", class: 'button', id: "pdf-procedure" do
+    %span.icon.printer
+    PDF
+
   = link_to apercu_admin_procedure_path(@procedure), target: "_blank", rel: "noopener", class: 'button', id: "preview-procedure" do
     %span.icon.preview
     Prévisualiser

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -246,7 +246,7 @@ Rails.application.routes.draw do
     end
 
     namespace :commencer do
-      get '/test/:path/dossier_vide', action: 'dossier_vide_pdf_test', as: :dossier_vide_test
+      get '/test/:path/dossier_vide', action: :dossier_vide_pdf_test, as: :dossier_vide_test
       get '/test/:path', action: 'commencer_test', as: :test
       get '/:path', action: 'commencer'
       get '/:path/dossier_vide', action: 'dossier_vide_pdf', as: :dossier_vide

--- a/spec/controllers/users/commencer_controller_spec.rb
+++ b/spec/controllers/users/commencer_controller_spec.rb
@@ -160,4 +160,41 @@ describe Users::CommencerController, type: :controller do
       end
     end
   end
+
+  describe '#dossier_vide_pdf' do
+    before { get :dossier_vide_pdf, params: { path: procedure.path } }
+
+    context 'published procedure' do
+      let(:procedure) { create(:procedure, :published, :with_service, :with_path) }
+
+      it 'works' do
+        expect(response).to have_http_status(:success)
+      end
+    end
+    context 'not published procedure' do
+      let(:procedure) { create(:procedure, :with_service, :with_path) }
+
+      it 'redirects to procedure not found' do
+        expect(response).to have_http_status(302)
+      end
+    end
+  end
+
+  describe '#dossier_vide_test_pdf' do
+    before { get :dossier_vide_pdf_test, params: { path: procedure.path } }
+
+    context 'not published procedure' do
+      let(:procedure) { create(:procedure, :with_service, :with_path) }
+
+      it 'works' do
+        expect(response).to have_http_status(:success)
+      end
+    end
+    context 'published procedure' do
+      let(:procedure) { create(:procedure, :published, :with_service, :with_path) }
+      it 'redirect to procedure not found' do
+        expect(response).to have_http_status(302)
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://github.com/betagouv/demarches-simplifiees.fr/issues/7131
j'ai ajouté le bouton dans le headers de l'`administrateurs/procedures/show`

<img width="1040" alt="Screen Shot 2022-04-22 at 3 50 04 PM" src="https://user-images.githubusercontent.com/125964/164727749-b2b0e1e0-05a5-45b9-9597-a17ac4eca1f9.png">

