### PR TITLE
feat(users/procedure/*): add link to texte_juridique or deliberation

### DIFF
--- a/app/views/users/_procedure_footer.html.haml
+++ b/app/views/users/_procedure_footer.html.haml
@@ -45,6 +45,15 @@
             %ul
               - politiques.each do |politique|
                 %li= politique
+            %p.mt-2.footer-header Cadre juridique :
+            %ul
+              - if procedure.deliberation.attached?
+                %li
+                  = link_to url_for(procedure.deliberation), target: '_blank', rel: 'noopener' do
+                    = "Texte cadrant la demande d'information"
+              - else
+                %li
+                  = link_to "Texte juridique la demande d'information", procedure.cadre_juridique, target: '_blank', rel: 'noopener'
 
     = render partial: 'users/general_footer_row', locals: { dossier: dossier }
 


### PR DESCRIPTION
issue: https://github.com/betagouv/demarches-simplifiees.fr/issues/7108

ETQ utilisateur, je dois retrouver soit le liens vers le `procedure.text_juridique`, soit le document uploadé `procedure.deliberation`
<img width="1043" alt="Screen Shot 2022-04-22 at 4 15 27 PM" src="https://user-images.githubusercontent.com/125964/164732637-b0b38831-b4b3-4585-93e0-4e4aacf067ee.png">

