### PR TITLE
fix(migrate): lien administrateurs_procedures - administrateurs

### DIFF
--- a/db/migrate/20220301160753_add_administrateur_foreign_key_to_administrateurs_procedure.rb
+++ b/db/migrate/20220301160753_add_administrateur_foreign_key_to_administrateurs_procedure.rb
@@ -2,8 +2,8 @@ class AddAdministrateurForeignKeyToAdministrateursProcedure < ActiveRecord::Migr
   include Database::MigrationHelpers
 
   def up
-    delete_orphans :administrateurs_procedures, :administrateurs_procedures
-    add_foreign_key :administrateurs_procedures, :administrateurs_procedures
+    delete_orphans :administrateurs_procedures, :administrateurs
+    add_foreign_key :administrateurs_procedures, :administrateurs
   end
 
   def down


### PR DESCRIPTION
Lié à l'issue #7189 

Avant :
```
demat-social@87dc25795bd1:/opt/ds$ bin/rails db:migrate
D, [2022-04-22T12:35:55.999316 #331] DEBUG -- :   Flipper::Adapters::ActiveRecord::Feature Load (0.4ms)  SELECT "flipper_features".* FROM "flipper_features"
[...]
D, [2022-04-22T12:35:56.461906 #331] DEBUG -- :    (0.8ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
I, [2022-04-22T12:35:56.462568 #331]  INFO -- : Migrating to AddAdministrateurForeignKeyToAdministrateursProcedure (20220301160753)
== 20220301160753 AddAdministrateurForeignKeyToAdministrateursProcedure: migrating
-- Deleting records from administrateurs_procedures where the associated administrateurs_procedure no longer exists
D, [2022-04-22T12:35:56.464754 #331] DEBUG -- :   TRANSACTION (0.3ms)  BEGIN
D, [2022-04-22T12:35:56.465214 #331] DEBUG -- :    (0.2ms)  SET statement_timeout TO 3600000
D, [2022-04-22T12:35:56.465684 #331] DEBUG -- :    (0.3ms)  SET lock_timeout TO 10000
D, [2022-04-22T12:35:56.466074 #331] DEBUG -- :    (0.2ms)  SHOW lock_timeout
-- foreign_key_column_for("administrateurs_procedures")
   -> 0.0002s
-- query_values("SELECT \"administrateurs_procedures\".\"administrateurs_procedure_id\" FROM \"administrateurs_procedures\" LEFT OUTER JOIN \"administrateurs_procedures\" ON \"administrateurs_procedures\".\"id\" = \"administrateurs_procedures\".\"administrateurs_procedure_id\" WHERE \"administrateurs_procedures\".\"id\" IS NULL")
D, [2022-04-22T12:35:56.467840 #331] DEBUG -- :    (0.8ms)  SELECT "administrateurs_procedures"."administrateurs_procedure_id" FROM "administrateurs_procedures" LEFT OUTER JOIN "administrateurs_procedures" ON "administrateurs_procedures"."id" = "administrateurs_procedures"."administrateurs_procedure_id" WHERE "administrateurs_procedures"."id" IS NULL
D, [2022-04-22T12:35:56.468465 #331] DEBUG -- :   TRANSACTION (0.3ms)  ROLLBACK
D, [2022-04-22T12:35:56.469046 #331] DEBUG -- :    (0.3ms)  SELECT pg_advisory_unlock(80405764889057790)
rails aborted!
StandardError: An error has occurred, this and all later migrations canceled:

PG::DuplicateAlias: ERROR:  table name "administrateurs_procedures" specified more than once
/opt/ds/app/lib/database/migration_helpers.rb:124:in `block in delete_orphans'
/opt/ds/app/lib/database/migration_helpers.rb:114:in `delete_orphans'
/opt/ds/db/migrate/20220301160753_add_administrateur_foreign_key_to_administrateurs_procedure.rb:5:in `up'

Caused by:
ActiveRecord::StatementInvalid: PG::DuplicateAlias: ERROR:  table name "administrateurs_procedures" specified more than once
/opt/ds/app/lib/database/migration_helpers.rb:124:in `block in delete_orphans'
/opt/ds/app/lib/database/migration_helpers.rb:114:in `delete_orphans'
/opt/ds/db/migrate/20220301160753_add_administrateur_foreign_key_to_administrateurs_procedure.rb:5:in `up'
[...]
```

Après : 
```
demat-social@87dc25795bd1:/opt/ds$ bin/rails db:migrate
D, [2022-04-22T13:14:50.899615 #1004] DEBUG -- :   Flipper::Adapters::ActiveRecord::Feature Load (0.4ms)  SELECT "flipper_features".* FROM "flipper_features"
D, [2022-04-22T13:14:51.844480 #1004] DEBUG -- sentry: initialized a background worker with 8 threads
E, [2022-04-22T13:14:51.858935 #1004] ERROR -- : [SKYLIGHT] [5.0.1] could not load config file; msg=wrong number of arguments (given 4, expected 1); disabling Skylight agent
D, [2022-04-22T13:14:52.217716 #1004] DEBUG -- :    (0.3ms)  SELECT pg_try_advisory_lock(80405764889057790)
D, [2022-04-22T13:14:52.221977 #1004] DEBUG -- :    (1.1ms)  SELECT "schema_migrations"."version" FROM "schema_migrations" ORDER BY "schema_migrations"."version" ASC
I, [2022-04-22T13:14:52.222795 #1004]  INFO -- : Migrating to AddAdministrateurForeignKeyToAdministrateursProcedure (20220301160753)
== 20220301160753 AddAdministrateurForeignKeyToAdministrateursProcedure: migrating
-- Deleting records from administrateurs_procedures where the associated administrateur no longer exists
D, [2022-04-22T13:14:52.226292 #1004] DEBUG -- :   TRANSACTION (0.3ms)  BEGIN
D, [2022-04-22T13:14:52.226850 #1004] DEBUG -- :    (0.3ms)  SET statement_timeout TO 3600000
D, [2022-04-22T13:14:52.227516 #1004] DEBUG -- :    (0.4ms)  SET lock_timeout TO 10000
D, [2022-04-22T13:14:52.228179 #1004] DEBUG -- :    (0.3ms)  SHOW lock_timeout
-- foreign_key_column_for("administrateurs")
   -> 0.0001s
-- query_values("SELECT \"administrateurs_procedures\".\"administrateur_id\" FROM \"administrateurs_procedures\" LEFT OUTER JOIN \"administrateurs\" ON \"administrateurs\".\"id\" = \"administrateurs_procedures\".\"administrateur_id\" WHERE \"administrateurs\".\"id\" IS NULL")
D, [2022-04-22T13:14:52.230450 #1004] DEBUG -- :    (1.1ms)  SELECT "administrateurs_procedures"."administrateur_id" FROM "administrateurs_procedures" LEFT OUTER JOIN "administrateurs" ON "administrateurs"."id" = "administrateurs_procedures"."administrateur_id" WHERE "administrateurs"."id" IS NULL
   -> 0.0014s
-- exec_delete("DELETE FROM \"administrateurs_procedures\" WHERE 1=0")
D, [2022-04-22T13:14:52.231707 #1004] DEBUG -- :    (0.6ms)  DELETE FROM "administrateurs_procedures" WHERE 1=0
   -> 0.0010s
   -> 0 rows
   -> 0.0065s
   -> 0 rows
-- add_foreign_key(:administrateurs_procedures, :administrateurs)
D, [2022-04-22T13:14:52.253267 #1004] DEBUG -- :    (20.7ms)  ALTER TABLE "administrateurs_procedures" ADD CONSTRAINT "fk_rails_631cce46b5"
FOREIGN KEY ("administrateur_id")
  REFERENCES "administrateurs" ("id")

   -> 0.0213s
== 20220301160753 AddAdministrateurForeignKeyToAdministrateursProcedure: migrated (0.0281s)

D, [2022-04-22T13:14:52.258252 #1004] DEBUG -- :   ActiveRecord::SchemaMigration Create (0.6ms)  INSERT INTO "schema_migrations" ("version") VALUES ($1) RETURNING "version"  [["version", "20220301160753"]]
[...]
```