### PR TITLE
feat(administrateur/procedures#publication): show dubious champs to administrateur

### DIFF
--- a/app/jobs/cron/find_dubious_procedures_job.rb
+++ b/app/jobs/cron/find_dubious_procedures_job.rb
@@ -9,17 +9,18 @@ class Cron::FindDubiousProceduresJob < Cron::CronJob
     'médical', 'handicap', 'maladie', 'allergie', 'hospitalisé', 'RQTH', 'vaccin'
   ]
 
-  def perform(*args)
-    # \\y is a word boundary
-    forbidden_regexp = FORBIDDEN_KEYWORDS
-      .map { |keyword| "\\y#{keyword}\\y" }
+  # \\y is a word boundary
+  def self.forbidden_regexp
+    FORBIDDEN_KEYWORDS.map { |keyword| "\\y#{keyword}\\y" }
       .join('|')
+  end
 
+  def perform(*args)
     # ~* -> case insensitive regexp match
     # https://www.postgresql.org/docs/current/static/functions-matching.html#FUNCTIONS-POSIX-REGEXP
     forbidden_tdcs = TypeDeChamp
       .joins(:procedure)
-      .where("unaccent(types_de_champ.libelle) ~* unaccent(?)", forbidden_regexp)
+      .where("unaccent(types_de_champ.libelle) ~* unaccent(?)", Cron::FindDubiousProceduresJob.forbidden_regexp)
       .where(type_champ: [TypeDeChamp.type_champs.fetch(:text), TypeDeChamp.type_champs.fetch(:textarea)])
       .where(procedures: { closed_at: nil, whitelisted_at: nil })
 

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -94,6 +94,11 @@ class TypeDeChamp < ApplicationRecord
   scope :not_repetition, -> { where.not(type_champ: type_champs.fetch(:repetition)) }
   scope :fillable, -> { where.not(type_champ: [type_champs.fetch(:header_section), type_champs.fetch(:explication)]) }
 
+  scope :dubious, -> {
+    where("unaccent(types_de_champ.libelle) ~* unaccent(?)", Cron::FindDubiousProceduresJob.forbidden_regexp)
+      .where(type_champ: [TypeDeChamp.type_champs.fetch(:text), TypeDeChamp.type_champs.fetch(:textarea)])
+  }
+
   has_many :champ, inverse_of: :type_de_champ, dependent: :destroy do
     def build(params = {})
       super(params.merge(proxy_association.owner.params_for_champ))

--- a/app/views/administrateurs/procedures/publication.html.haml
+++ b/app/views/administrateurs/procedures/publication.html.haml
@@ -4,6 +4,12 @@
                     link_to(@procedure.libelle, admin_procedure_path(@procedure)),
                     'Publication'] }
 .container
+  - if @procedure.draft_types_de_champ.dubious.present?
+    .card.warning.mb-3
+      .card-title Attention, certains champs ne peuvent être demandé par l'administration. Voici les champs qui nous semblent suspect :
+      %ul
+        - @procedure.draft_types_de_champ.dubious.each do |dubious_champs|
+          %li.dubious-champs= "#{dubious_champs.libelle} (#{dubious_champs.description})"
   .lien-demarche
     %h1
       - if @procedure.brouillon?

--- a/spec/system/administrateurs/procedure_publish_spec.rb
+++ b/spec/system/administrateurs/procedure_publish_spec.rb
@@ -122,4 +122,32 @@ describe 'Publishing a procedure', js: true do
       expect(page).to have_selector('#preview-procedure')
     end
   end
+
+  context 'when a procedure has dubious champs' do
+    let(:dubious_champs) do
+      [
+        build(:type_de_champ_text, libelle: 'NIR'),
+        build(:type_de_champ_text, libelle: 'carte bancaire')
+      ]
+    end
+    let(:not_dubious_champs) do
+      [build(:type_de_champ_text, libelle: 'Prénom')]
+    end
+    let!(:procedure) do
+      create(:procedure,
+               :with_service,
+               instructeurs: instructeurs,
+               administrateur: administrateur,
+               types_de_champ: not_dubious_champs + dubious_champs)
+    end
+
+    scenario 'an admin can publish it, but a warning appears' do
+      visit admin_procedures_path(statut: "brouillons")
+      click_on procedure.libelle
+      find('#publish-procedure-link').click
+
+      expect(page).to have_content("Attention, certains champs ne peuvent être demandé par l'administration.")
+      expect(page).to have_selector(".dubious-champs", count: dubious_champs.size)
+    end
+  end
 end


### PR DESCRIPTION
issue: https://github.com/betagouv/demarches-simplifiees.fr/issues/7128

ETQ administrateur, j'aimerais qu'on me rappelle que certains champs ne peuvent être demandé par l'administration avant de publier une procedure 

<img width="971" alt="Screen Shot 2022-04-25 at 2 28 18 PM" src="https://user-images.githubusercontent.com/125964/165089242-fa2b5988-6ed1-47bc-bdee-cd52ef64f845.png">
