### PR TITLE
types_de_champ -> types_de_champs_public

### DIFF
--- a/app/graphql/types/revision_type.rb
+++ b/app/graphql/types/revision_type.rb
@@ -8,7 +8,7 @@ module Types
     field :annotation_descriptors, [Types::ChampDescriptorType], null: false
 
     def champ_descriptors
-      Loaders::Association.for(object.class, :types_de_champ).load(object)
+      Loaders::Association.for(object.class, :types_de_champ_public).load(object)
     end
 
     def annotation_descriptors

--- a/app/helpers/procedure_helper.rb
+++ b/app/helpers/procedure_helper.rb
@@ -34,7 +34,7 @@ module ProcedureHelper
     {
       isAnnotation: false,
       typeDeChampsTypes: TypeDeChamp.type_de_champ_types_for(procedure, current_user),
-      typeDeChamps: (procedure.draft_revision ? procedure.draft_revision : procedure).types_de_champ.as_json_for_editor,
+      typeDeChamps: (procedure.draft_revision ? procedure.draft_revision : procedure).types_de_champ_public.as_json_for_editor,
       baseUrl: admin_procedure_types_de_champ_path(procedure),
       directUploadUrl: rails_direct_uploads_url,
       continuerUrl: admin_procedure_path(procedure)

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -56,7 +56,7 @@ class Champ < ApplicationRecord
   scope :public_only, -> { where(private: false) }
   scope :private_only, -> { where(private: true) }
   scope :ordered, -> { includes(:type_de_champ).order(:row, 'types_de_champ.order_place') }
-  scope :public_ordered, -> { public_only.joins(dossier: { revision: :revision_types_de_champ }).where('procedure_revision_types_de_champ.type_de_champ_id = champs.type_de_champ_id').order(:position) }
+  scope :public_ordered, -> { public_only.joins(dossier: { revision: :revision_types_de_champ_public }).where('procedure_revision_types_de_champ.type_de_champ_id = champs.type_de_champ_id').order(:position) }
   # we need to do private champs order as manual join to avoid conflicting join names
   scope :private_ordered, -> do
     private_only.joins('

--- a/app/models/concerns/dossier_rebase_concern.rb
+++ b/app/models/concerns/dossier_rebase_concern.rb
@@ -141,7 +141,7 @@ module DossierRebaseConcern
 
   def flattened_all_types_de_champ(published: false)
     revision = published ? procedure.published_revision : self.revision
-    types_de_champ = revision.types_de_champ + revision.types_de_champ_private
+    types_de_champ = revision.types_de_champ_public + revision.types_de_champ_private
     (types_de_champ + types_de_champ.filter(&:repetition?).flat_map(&:types_de_champ))
       .index_by(&:stable_id)
   end

--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -197,7 +197,7 @@ module TagsSubstitutionConcern
   end
 
   def champ_public_tags(dossier: nil)
-    types_de_champ = (dossier || procedure.active_revision).types_de_champ
+    types_de_champ = dossier&.types_de_champ || procedure.active_revision.types_de_champ_public
     types_de_champ_tags(types_de_champ, Dossier::SOUMIS)
   end
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -134,7 +134,7 @@ class Dossier < ApplicationRecord
 
   has_one :attestation_template, through: :revision
   has_one :procedure, through: :revision
-  has_many :types_de_champ, through: :revision
+  has_many :types_de_champ, through: :revision, source: :types_de_champ_public
   has_many :types_de_champ_private, through: :revision
 
   belongs_to :transfer, class_name: 'DossierTransfer', foreign_key: 'dossier_transfer_id', optional: true, inverse_of: :dossiers

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -73,9 +73,9 @@ class Procedure < ApplicationRecord
   belongs_to :published_revision, class_name: 'ProcedureRevision', optional: true
   has_many :deleted_dossiers, dependent: :destroy
 
-  has_many :published_types_de_champ, through: :published_revision, source: :types_de_champ
+  has_many :published_types_de_champ, through: :published_revision, source: :types_de_champ_public
   has_many :published_types_de_champ_private, through: :published_revision, source: :types_de_champ_private
-  has_many :draft_types_de_champ, through: :draft_revision, source: :types_de_champ
+  has_many :draft_types_de_champ, through: :draft_revision, source: :types_de_champ_public
   has_many :draft_types_de_champ_private, through: :draft_revision, source: :types_de_champ_private
   has_one :draft_attestation_template, through: :draft_revision, source: :attestation_template
   has_one :published_attestation_template, through: :published_revision, source: :attestation_template
@@ -220,11 +220,11 @@ class Procedure < ApplicationRecord
       :module_api_carto,
       published_revision: [
         :types_de_champ_private,
-        :types_de_champ
+        :types_de_champ_public
       ],
       draft_revision: [
         :types_de_champ_private,
-        :types_de_champ
+        :types_de_champ_public
       ]
     )
   }
@@ -444,7 +444,7 @@ class Procedure < ApplicationRecord
     populate_champ_stable_ids
     include_list = {
       draft_revision: {
-        revision_types_de_champ: {
+        revision_types_de_champ_public: {
           type_de_champ: :types_de_champ
         },
         revision_types_de_champ_private: {
@@ -714,7 +714,7 @@ class Procedure < ApplicationRecord
 
   def create_new_revision
     draft_revision
-      .deep_clone(include: [:revision_types_de_champ, :revision_types_de_champ_private])
+      .deep_clone(include: [:revision_types_de_champ_public, :revision_types_de_champ_private])
       .tap(&:save!)
   end
 

--- a/app/models/procedure_revision_type_de_champ.rb
+++ b/app/models/procedure_revision_type_de_champ.rb
@@ -32,7 +32,7 @@ class ProcedureRevisionTypeDeChamp < ApplicationRecord
 
   def set_position
     self.position ||= begin
-      types_de_champ = (private? ? revision.revision_types_de_champ_private : revision.revision_types_de_champ).filter(&:persisted?)
+      types_de_champ = (private? ? revision.revision_types_de_champ_private : revision.revision_types_de_champ_public).filter(&:persisted?)
 
       if types_de_champ.present?
         types_de_champ.last.position + 1

--- a/app/services/pieces_justificatives_service.rb
+++ b/app/services/pieces_justificatives_service.rb
@@ -28,7 +28,7 @@ class PiecesJustificativesService
   end
 
   def self.serialize_types_de_champ_as_type_pj(revision)
-    tdcs = revision.types_de_champ.filter { |type_champ| type_champ.old_pj.present? }
+    tdcs = revision.types_de_champ_public.filter { |type_champ| type_champ.old_pj.present? }
     tdcs.map.with_index do |type_champ, order_place|
       description = type_champ.description
       if /^(?<original_description>.*?)(?:[\r\n]+)Récupérer le formulaire vierge pour mon dossier : (?<lien_demarche>http.*)$/m =~ description

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -18,6 +18,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.irregular 'type_de_champ_private', 'types_de_champ_private'
   inflect.irregular 'procedure_revision_type_de_champ', 'procedure_revision_types_de_champ'
   inflect.irregular 'revision_type_de_champ', 'revision_types_de_champ'
+  inflect.irregular 'revision_type_de_champ_public', 'revision_types_de_champ_public'
   inflect.irregular 'revision_type_de_champ_private', 'revision_types_de_champ_private'
   inflect.irregular 'assign_to', 'assign_tos'
   inflect.uncountable(['avis', 'pays'])

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -333,7 +333,7 @@ end
 
 def add_types_de_champs(types_de_champ, to: nil, scope: :public)
   revision = to
-  association_name = scope == :private ? :revision_types_de_champ_private : :revision_types_de_champ
+  association_name = scope == :private ? :revision_types_de_champ_private : :revision_types_de_champ_public
 
   types_de_champ.each do |type_de_champ|
     type_de_champ.revision = revision

--- a/spec/factories/procedure_revision.rb
+++ b/spec/factories/procedure_revision.rb
@@ -10,8 +10,8 @@ FactoryBot.define do
 
         revision.procedure = original.procedure
         revision.attestation_template_id = original.attestation_template_id
-        original.revision_types_de_champ.each do |r_tdc|
-          revision.revision_types_de_champ << build(:procedure_revision_type_de_champ, from_original: r_tdc)
+        original.revision_types_de_champ_public.each do |r_tdc|
+          revision.revision_types_de_champ_public << build(:procedure_revision_type_de_champ, from_original: r_tdc)
         end
         original.revision_types_de_champ_private.each do |r_tdc|
           revision.revision_types_de_champ_private << build(:procedure_revision_type_de_champ, from_original: r_tdc)

--- a/spec/factories/type_de_champ.rb
+++ b/spec/factories/type_de_champ.rb
@@ -25,7 +25,7 @@ FactoryBot.define do
         if type_de_champ.private?
           type_de_champ.revision.types_de_champ_private << type_de_champ
         else
-          type_de_champ.revision.types_de_champ << type_de_champ
+          type_de_champ.revision.types_de_champ_public << type_de_champ
         end
       elsif evaluator.parent
         type_de_champ.revision = evaluator.parent.revision

--- a/spec/models/procedure_presentation_and_revisions_spec.rb
+++ b/spec/models/procedure_presentation_and_revisions_spec.rb
@@ -48,7 +48,7 @@ describe ProcedurePresentation do
         it { is_expected.to match(['libelle 2', 'libelle 1']) }
 
         context 'and finally, when this tdc is removed' do
-          let!(:previous_tdc2) { procedure.published_revision.types_de_champ.find_by(libelle: 'libelle 2') }
+          let!(:previous_tdc2) { procedure.published_revision.types_de_champ_public.find_by(libelle: 'libelle 2') }
 
           before do
             procedure.draft_revision.remove_type_de_champ(previous_tdc2.stable_id)
@@ -61,7 +61,7 @@ describe ProcedurePresentation do
       end
 
       context 'when there is another published revision with a renamed tdc' do
-        let!(:previous_tdc) { procedure.published_revision.types_de_champ.first }
+        let!(:previous_tdc) { procedure.published_revision.types_de_champ_public.first }
         let!(:changed_tdc) { { type_champ: :number, libelle: 'changed libelle 1' } }
 
         before do
@@ -75,7 +75,7 @@ describe ProcedurePresentation do
       end
 
       context 'when there is another published which removes a previous tdc' do
-        let!(:previous_tdc) { procedure.published_revision.types_de_champ.first }
+        let!(:previous_tdc) { procedure.published_revision.types_de_champ_public.first }
 
         before do
           type_de_champ = procedure.draft_revision.remove_type_de_champ(previous_tdc.id)

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -1,26 +1,26 @@
 describe ProcedureRevision do
   let(:procedure) { create(:procedure, :with_type_de_champ, :with_type_de_champ_private, :with_repetition) }
   let(:revision) { procedure.active_revision }
-  let(:type_de_champ) { revision.types_de_champ.first }
+  let(:type_de_champ) { revision.types_de_champ_public.first }
   let(:type_de_champ_private) { revision.types_de_champ_private.first }
   let(:type_de_champ_repetition) do
-    type_de_champ = revision.types_de_champ.repetition.first
+    type_de_champ = revision.types_de_champ_public.repetition.first
     type_de_champ.update(stable_id: 3333)
     type_de_champ
   end
 
   describe '#add_type_de_champ' do
     it 'type_de_champ' do
-      expect(revision.types_de_champ.size).to eq(2)
+      expect(revision.types_de_champ_public.size).to eq(2)
       new_type_de_champ = revision.add_type_de_champ({
         type_champ: TypeDeChamp.type_champs.fetch(:text),
         libelle: "Un champ text"
       })
       revision.reload
-      expect(revision.types_de_champ.size).to eq(3)
-      expect(revision.types_de_champ.last).to eq(new_type_de_champ)
-      expect(revision.revision_types_de_champ.last.position).to eq(2)
-      expect(revision.revision_types_de_champ.last.type_de_champ).to eq(new_type_de_champ)
+      expect(revision.types_de_champ_public.size).to eq(3)
+      expect(revision.types_de_champ_public.last).to eq(new_type_de_champ)
+      expect(revision.revision_types_de_champ_public.last.position).to eq(2)
+      expect(revision.revision_types_de_champ_public.last.type_de_champ).to eq(new_type_de_champ)
     end
 
     it 'type_de_champ_private' do
@@ -47,24 +47,24 @@ describe ProcedureRevision do
 
   describe '#move_type_de_champ' do
     let(:procedure) { create(:procedure, :with_type_de_champ, types_de_champ_count: 4) }
-    let(:last_type_de_champ) { revision.types_de_champ.last }
+    let(:last_type_de_champ) { revision.types_de_champ_public.last }
 
     it 'move down' do
-      expect(revision.types_de_champ.index(type_de_champ)).to eq(0)
+      expect(revision.types_de_champ_public.index(type_de_champ)).to eq(0)
       type_de_champ.update(order_place: nil)
       revision.move_type_de_champ(type_de_champ.stable_id, 2)
       revision.reload
-      expect(revision.types_de_champ.index(type_de_champ)).to eq(2)
+      expect(revision.types_de_champ_public.index(type_de_champ)).to eq(2)
       expect(revision.procedure.types_de_champ.index(type_de_champ)).to eq(2)
       expect(revision.procedure.types_de_champ_for_procedure_presentation.not_repetition.index(type_de_champ)).to eq(2)
     end
 
     it 'move up' do
-      expect(revision.types_de_champ.index(last_type_de_champ)).to eq(3)
+      expect(revision.types_de_champ_public.index(last_type_de_champ)).to eq(3)
       last_type_de_champ.update(order_place: nil)
       revision.move_type_de_champ(last_type_de_champ.stable_id, 0)
       revision.reload
-      expect(revision.types_de_champ.index(last_type_de_champ)).to eq(0)
+      expect(revision.types_de_champ_public.index(last_type_de_champ)).to eq(0)
       expect(revision.procedure.types_de_champ.index(last_type_de_champ)).to eq(0)
       expect(revision.procedure.types_de_champ_for_procedure_presentation.not_repetition.index(last_type_de_champ)).to eq(0)
     end
@@ -106,10 +106,10 @@ describe ProcedureRevision do
 
   describe '#remove_type_de_champ' do
     it 'type_de_champ' do
-      expect(revision.types_de_champ.size).to eq(2)
+      expect(revision.types_de_champ_public.size).to eq(2)
       revision.remove_type_de_champ(type_de_champ.stable_id)
       procedure.reload
-      expect(revision.types_de_champ.size).to eq(1)
+      expect(revision.types_de_champ_public.size).to eq(1)
     end
 
     it 'type_de_champ_private' do
@@ -120,11 +120,11 @@ describe ProcedureRevision do
 
     it 'type_de_champ_repetition' do
       expect(type_de_champ_repetition.types_de_champ.size).to eq(1)
-      expect(revision.types_de_champ.size).to eq(2)
+      expect(revision.types_de_champ_public.size).to eq(2)
       revision.remove_type_de_champ(type_de_champ_repetition.types_de_champ.first.stable_id)
       type_de_champ_repetition.reload
       expect(type_de_champ_repetition.types_de_champ.size).to eq(0)
-      expect(revision.types_de_champ.size).to eq(2)
+      expect(revision.types_de_champ_public.size).to eq(2)
     end
   end
 
@@ -140,35 +140,35 @@ describe ProcedureRevision do
     end
 
     it 'should have types_de_champ' do
-      expect(new_revision.types_de_champ.count).to eq(2)
+      expect(new_revision.types_de_champ_public.count).to eq(2)
       expect(new_revision.types_de_champ_private.count).to eq(1)
-      expect(new_revision.types_de_champ).to eq(revision.types_de_champ)
+      expect(new_revision.types_de_champ_public).to eq(revision.types_de_champ_public)
       expect(new_revision.types_de_champ_private).to eq(revision.types_de_champ_private)
 
-      expect(new_revision.revision_types_de_champ.count).to eq(2)
+      expect(new_revision.revision_types_de_champ_public.count).to eq(2)
       expect(new_revision.revision_types_de_champ_private.count).to eq(1)
-      expect(new_revision.revision_types_de_champ.count).to eq(revision.revision_types_de_champ.count)
+      expect(new_revision.revision_types_de_champ_public.count).to eq(revision.revision_types_de_champ_public.count)
       expect(new_revision.revision_types_de_champ_private.count).to eq(revision.revision_types_de_champ_private.count)
-      expect(new_revision.revision_types_de_champ).not_to eq(revision.revision_types_de_champ)
+      expect(new_revision.revision_types_de_champ_public).not_to eq(revision.revision_types_de_champ_public)
       expect(new_revision.revision_types_de_champ_private).not_to eq(revision.revision_types_de_champ_private)
     end
 
     describe '#compare' do
-      let(:type_de_champ_first) { revision.types_de_champ.first }
-      let(:type_de_champ_second) { revision.types_de_champ.second }
+      let(:type_de_champ_first) { revision.types_de_champ_public.first }
+      let(:type_de_champ_second) { revision.types_de_champ_public.second }
 
       it 'type_de_champ' do
-        expect(new_revision.types_de_champ.size).to eq(2)
+        expect(new_revision.types_de_champ_public.size).to eq(2)
         new_type_de_champ = new_revision.add_type_de_champ({
           type_champ: TypeDeChamp.type_champs.fetch(:text),
           libelle: "Un champ text"
         })
         revision.reload
-        expect(new_revision.types_de_champ.size).to eq(3)
-        expect(new_revision.types_de_champ.last).to eq(new_type_de_champ)
-        expect(new_revision.revision_types_de_champ.last.position).to eq(2)
-        expect(new_revision.revision_types_de_champ.last.type_de_champ).to eq(new_type_de_champ)
-        expect(new_revision.revision_types_de_champ.last.type_de_champ.revision).to eq(new_revision)
+        expect(new_revision.types_de_champ_public.size).to eq(3)
+        expect(new_revision.types_de_champ_public.last).to eq(new_type_de_champ)
+        expect(new_revision.revision_types_de_champ_public.last.position).to eq(2)
+        expect(new_revision.revision_types_de_champ_public.last.type_de_champ).to eq(new_type_de_champ)
+        expect(new_revision.revision_types_de_champ_public.last.type_de_champ.revision).to eq(new_revision)
         expect(procedure.active_revision.different_from?(new_revision)).to be_truthy
         expect(procedure.active_revision.compare(new_revision)).to eq([
           {
@@ -180,7 +180,7 @@ describe ProcedureRevision do
           }
         ])
 
-        new_revision.find_or_clone_type_de_champ(new_revision.types_de_champ.first.stable_id).update(libelle: 'modifier le libelle')
+        new_revision.find_or_clone_type_de_champ(new_revision.types_de_champ_public.first.stable_id).update(libelle: 'modifier le libelle')
         expect(procedure.active_revision.compare(new_revision.reload)).to eq([
           {
             model: :type_de_champ,
@@ -200,9 +200,9 @@ describe ProcedureRevision do
             stable_id: new_type_de_champ.stable_id
           }
         ])
-        expect(new_revision.types_de_champ.first.revision).to eq(new_revision)
+        expect(new_revision.types_de_champ_public.first.revision).to eq(new_revision)
 
-        new_revision.move_type_de_champ(new_revision.types_de_champ.second.stable_id, 2)
+        new_revision.move_type_de_champ(new_revision.types_de_champ_public.second.stable_id, 2)
         expect(procedure.active_revision.compare(new_revision.reload)).to eq([
           {
             model: :type_de_champ,
@@ -231,9 +231,9 @@ describe ProcedureRevision do
             stable_id: type_de_champ_second.stable_id
           }
         ])
-        expect(new_revision.types_de_champ.last.revision).to eq(revision)
+        expect(new_revision.types_de_champ_public.last.revision).to eq(revision)
 
-        new_revision.remove_type_de_champ(new_revision.types_de_champ.first.stable_id)
+        new_revision.remove_type_de_champ(new_revision.types_de_champ_public.first.stable_id)
         expect(procedure.active_revision.compare(new_revision.reload)).to eq([
           {
             model: :type_de_champ,
@@ -251,8 +251,8 @@ describe ProcedureRevision do
           }
         ])
 
-        new_revision.find_or_clone_type_de_champ(new_revision.types_de_champ.last.stable_id).update(description: 'une description')
-        new_revision.find_or_clone_type_de_champ(new_revision.types_de_champ.last.stable_id).update(mandatory: true)
+        new_revision.find_or_clone_type_de_champ(new_revision.types_de_champ_public.last.stable_id).update(description: 'une description')
+        new_revision.find_or_clone_type_de_champ(new_revision.types_de_champ_public.last.stable_id).update(mandatory: true)
         expect(procedure.active_revision.compare(new_revision.reload)).to eq([
           {
             model: :type_de_champ,
@@ -290,8 +290,8 @@ describe ProcedureRevision do
           }
         ])
 
-        new_revision.find_or_clone_type_de_champ(new_revision.types_de_champ.last.types_de_champ.first.stable_id).update(type_champ: :drop_down_list)
-        new_revision.find_or_clone_type_de_champ(new_revision.types_de_champ.last.types_de_champ.first.stable_id).update(drop_down_options: ['one', 'two'])
+        new_revision.find_or_clone_type_de_champ(new_revision.types_de_champ_public.last.types_de_champ.first.stable_id).update(type_champ: :drop_down_list)
+        new_revision.find_or_clone_type_de_champ(new_revision.types_de_champ_public.last.types_de_champ.first.stable_id).update(drop_down_options: ['one', 'two'])
         expect(procedure.active_revision.compare(new_revision.reload)).to eq([
           {
             model: :type_de_champ,
@@ -335,7 +335,7 @@ describe ProcedureRevision do
             private: false,
             from: "text",
             to: "drop_down_list",
-            stable_id: new_revision.types_de_champ.last.types_de_champ.first.stable_id
+            stable_id: new_revision.types_de_champ_public.last.types_de_champ.first.stable_id
           },
           {
             model: :type_de_champ,
@@ -345,12 +345,12 @@ describe ProcedureRevision do
             private: false,
             from: [],
             to: ["one", "two"],
-            stable_id: new_revision.types_de_champ.last.types_de_champ.first.stable_id
+            stable_id: new_revision.types_de_champ_public.last.types_de_champ.first.stable_id
           }
         ])
 
-        new_revision.find_or_clone_type_de_champ(new_revision.types_de_champ.last.types_de_champ.first.stable_id).update(type_champ: :carte)
-        new_revision.find_or_clone_type_de_champ(new_revision.types_de_champ.last.types_de_champ.first.stable_id).update(options: { cadastres: true, znieff: true })
+        new_revision.find_or_clone_type_de_champ(new_revision.types_de_champ_public.last.types_de_champ.first.stable_id).update(type_champ: :carte)
+        new_revision.find_or_clone_type_de_champ(new_revision.types_de_champ_public.last.types_de_champ.first.stable_id).update(options: { cadastres: true, znieff: true })
         expect(procedure.active_revision.compare(new_revision.reload)).to eq([
           {
             model: :type_de_champ,
@@ -394,7 +394,7 @@ describe ProcedureRevision do
             private: false,
             from: "text",
             to: "carte",
-            stable_id: new_revision.types_de_champ.last.types_de_champ.first.stable_id
+            stable_id: new_revision.types_de_champ_public.last.types_de_champ.first.stable_id
           },
           {
             model: :type_de_champ,
@@ -404,7 +404,7 @@ describe ProcedureRevision do
             private: false,
             from: [],
             to: [:cadastres, :znieff],
-            stable_id: new_revision.types_de_champ.last.types_de_champ.first.stable_id
+            stable_id: new_revision.types_de_champ_public.last.types_de_champ.first.stable_id
           }
         ])
       end

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -822,15 +822,15 @@ describe Procedure do
       subject
       expect(procedure.published_revision).to be_present
       expect(procedure.published_revision.published_at).to eq(publication_date)
-      expect(procedure.published_revision.types_de_champ.first.libelle).to eq('libelle 1')
+      expect(procedure.published_revision.types_de_champ_public.first.libelle).to eq('libelle 1')
     end
 
     it 'creates a new draft revision' do
       expect { subject }.to change(ProcedureRevision, :count).by(1)
       expect(procedure.draft_revision).to be_present
-      expect(procedure.draft_revision.revision_types_de_champ).to be_present
-      expect(procedure.draft_revision.types_de_champ).to be_present
-      expect(procedure.draft_revision.types_de_champ.first.libelle).to eq('libelle 1')
+      expect(procedure.draft_revision.revision_types_de_champ_public).to be_present
+      expect(procedure.draft_revision.types_de_champ_public).to be_present
+      expect(procedure.draft_revision.types_de_champ_public.first.libelle).to eq('libelle 1')
     end
 
     context 'when the procedure has dossiers' do

--- a/spec/services/procedure_export_service_spec.rb
+++ b/spec/services/procedure_export_service_spec.rb
@@ -18,8 +18,8 @@ describe ProcedureExportService do
 
     before do
       # change one tdc place to check if the header is ordered
-      tdc_first = procedure.active_revision.revision_types_de_champ.first
-      tdc_last = procedure.active_revision.revision_types_de_champ.last
+      tdc_first = procedure.active_revision.revision_types_de_champ_public.first
+      tdc_last = procedure.active_revision.revision_types_de_champ_public.last
 
       tdc_first.update(position: tdc_last.position + 1)
       procedure.reload


### PR DESCRIPTION
Pour #7156 , j ai besoin de lister les types de champ publiques et privées de toutes les révisions d'une démarches.

J'allais donc créer la méthode `type_de_champ` or elle existe déjà pour récupérer uniquement les type de champ publiques.

D'ou ce refactor qui renomme la méthode avant dans un introduire une nouvelle

PS: ca touche pas mal de truc, ca risque de coincer.