### PR TITLE
feat(administrateurs) : supprime les droits admins non utilisés depuis 6 mois

### DIFF
--- a/app/jobs/cron/purge_unused_admin_job.rb
+++ b/app/jobs/cron/purge_unused_admin_job.rb
@@ -1,0 +1,7 @@
+class Cron::PurgeUnusedAdminJob < Cron::CronJob
+  self.schedule_expression = "every monday at 5 am"
+
+  def perform(*args)
+    Administrateur.unused.destroy_all
+  end
+end

--- a/spec/models/administrateur_spec.rb
+++ b/spec/models/administrateur_spec.rb
@@ -163,4 +163,34 @@ describe Administrateur, type: :model do
       end
     end
   end
+
+  describe 'unused' do
+    subject { Administrateur.unused }
+
+    let(:new_admin) { create(:administrateur) }
+    let(:unused_admin) { create(:administrateur) }
+
+    before do
+      new_admin.user.update(last_sign_in_at: (6.months - 1.day).ago)
+      unused_admin.user.update(last_sign_in_at: (6.months + 1.day).ago)
+    end
+
+    it { is_expected.to match([unused_admin]) }
+
+    context 'with a hidden procedure' do
+      let(:procedure) { create(:procedure, hidden_at: 1.month.ago) }
+
+      before { unused_admin.procedures << procedure }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'with a service' do
+      let(:service) { create(:service) }
+
+      before { unused_admin.services << service }
+
+      it { is_expected.to be_empty }
+    end
+  end
 end


### PR DESCRIPTION
Premier jet:

Cette pr supprime les droits administrateurs pour les comptes remplissant les conditions suivantes :
- pas de connexion depuis 6 mois
- pas de procédure, ni de procédure cachée
- pas de service

Je ne prend pas la peine d envoyer un mail, je me dis que les litiges doivent être rare et la recréation de droit facile.

close #7199 
