### PR TITLE
Usager : correction du PDF de dossier vide quand un champ "Autre" est présent.

### DIFF
--- a/app/views/dossiers/dossier_vide.pdf.prawn
+++ b/app/views/dossiers/dossier_vide.pdf.prawn
@@ -26,7 +26,10 @@ def format_in_2_columns(pdf, label)
   pdf.text "\n"
 end
 
-def format_with_checkbox(pdf, label, offset = 0)
+def format_with_checkbox(pdf, option, offset = 0)
+  # Option is a [text, value] pair, or a string used for both.
+  label = option.is_a?(String) ? option : option.first
+
   pdf.font 'marianne', size: 9 do
     pdf.stroke_rectangle [0 + offset, pdf.cursor], 10, 10
     pdf.text_box label, at: [15 + offset, pdf.cursor]

--- a/app/views/dossiers/dossier_vide.pdf.prawn
+++ b/app/views/dossiers/dossier_vide.pdf.prawn
@@ -199,7 +199,7 @@ prawn_document(page_size: "A4") do |pdf|
   pdf.text "\n"
 
   add_title(pdf, 'Formulaire')
-  add_single_line(pdf, @procedure.description + "\n", 9, :italic) if @procedure.description.present?
+  add_single_line(pdf, @dossier.procedure.description + "\n", 9, :italic) if @dossier.procedure.description.present?
   add_champs(pdf, @dossier.champs)
   add_page_numbering(pdf)
   add_procedure(pdf, @dossier)

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -202,6 +202,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_drop_down_list do
+      after(:build) do |procedure, _evaluator|
+        build(:type_de_champ_drop_down_list, :with_other, procedure: procedure)
+      end
+    end
+
     trait :with_address do
       after(:build) do |procedure, _evaluator|
         build(:type_de_champ_address, procedure: procedure)

--- a/spec/factories/type_de_champ.rb
+++ b/spec/factories/type_de_champ.rb
@@ -92,6 +92,9 @@ FactoryBot.define do
       trait :without_selectable_values do
         drop_down_list_value { "\r\n--separateur--\r\n--separateur 2--\r\n \r\n" }
       end
+      trait :with_other do
+        drop_down_other { true }
+      end
     end
     factory :type_de_champ_multiple_drop_down_list do
       type_champ { TypeDeChamp.type_champs.fetch(:multiple_drop_down_list) }

--- a/spec/views/dossiers/dossier_vide.pdf.prawn_spec.rb
+++ b/spec/views/dossiers/dossier_vide.pdf.prawn_spec.rb
@@ -1,5 +1,5 @@
 describe 'dossiers/dossier_vide.pdf.prawn', type: :view do
-  let(:procedure) { create(:procedure, :with_all_champs) }
+  let(:procedure) { create(:procedure, :with_all_champs, :with_drop_down_list) }
   let(:dossier) { create(:dossier, procedure: procedure) }
 
   before do

--- a/spec/views/dossiers/dossier_vide.pdf.prawn_spec.rb
+++ b/spec/views/dossiers/dossier_vide.pdf.prawn_spec.rb
@@ -1,0 +1,16 @@
+describe 'dossiers/dossier_vide.pdf.prawn', type: :view do
+  let(:procedure) { create(:procedure, :with_all_champs) }
+  let(:dossier) { create(:dossier, procedure: procedure) }
+
+  before do
+    assign(:procedure, procedure)
+    assign(:dossier, dossier)
+  end
+
+  subject { render }
+
+  it 'renders a PDF document with empty fields' do
+    subject
+    expect(rendered).to be_present
+  end
+end


### PR DESCRIPTION
Previously a drop-down list with an `["Autre", "__other__"]` value crashed the PDF generation.

Fix https://sentry.io/organizations/demarches-simplifiees/issues/3229937046/