### PR TITLE
Usager : l'accusé de dépôt affiche la première date de dépôt du dossier

### DIFF
--- a/app/views/users/dossiers/papertrail.pdf.prawn
+++ b/app/views/users/dossiers/papertrail.pdf.prawn
@@ -70,7 +70,7 @@ prawn_document(margin: [top_margin, right_margin, bottom_margin, left_margin], p
     pdf.fill_color grey
     pdf.pad_top(7) do
       pdf.text "#{Dossier.human_attribute_name(:id)} : #{@dossier.id.to_s}", size: 10, character_spacing: -0.2, align: :justify
-      pdf.text t('.file_submitted_at') + ' : ' + l(@dossier.en_construction_at, format: '%e %B %Y'), size: 10, character_spacing: -0.2, align: :justify
+      pdf.text t('.file_submitted_at') + ' : ' + l(@dossier.depose_at, format: '%e %B %Y'), size: 10, character_spacing: -0.2, align: :justify
       pdf.text t('.dossier_state') + ' : ' + papertrail_dossier_state(@dossier), size: 10, character_spacing: -0.2, align: :justify
     end
 

--- a/app/views/users/dossiers/papertrail.pdf.prawn
+++ b/app/views/users/dossiers/papertrail.pdf.prawn
@@ -42,7 +42,7 @@ prawn_document(margin: [top_margin, right_margin, bottom_margin, left_margin], p
     pdf.pad_top(40) { pdf.text @dossier.procedure.libelle, size: 14, character_spacing: -0.2, align: :center }
 
     pdf.fill_color grey
-    description = t('.description', user_name: papertrail_requester_identity(@dossier), procedure: @dossier.procedure.libelle, date: l(@dossier.created_at, format: '%e %B %Y'))
+    description = t('.description', user_name: papertrail_requester_identity(@dossier), procedure: @dossier.procedure.libelle, date: l(@dossier.depose_at, format: '%e %B %Y'))
     pdf.pad_top(30) { pdf.text description, size: 10, character_spacing: -0.2, align: :left }
 
     pdf.fill_color black


### PR DESCRIPTION
A dossier has several submission dates:
- `depose_at` is the first date at which the dossier was submitted
- `en_construction_at` is the last date at which the dossier was
  submitted OR reverted from `en_instruction` to `en_construction`.

For now we prefer to display the earliest date:
- it gives more rights to the user,
- `en_construction_at` means the administration can reset at will the date printed on deposit receipts (by moving the dossier `en_instruction` and then back), which we don't want.