### PR TITLE
Rewording for expiration messages in instruction panel

### DIFF
--- a/config/locales/shared.en.yml
+++ b/config/locales/shared.en.yml
@@ -20,12 +20,12 @@ en:
           ine_notice: Student National Number. It is usually composed of alphanumeric characters.
       header:
         expires_at:
-          brouillon: "Expires at %{date} (%{duree_conservation_totale} months after the creation of this file)"
-          en_construction: "Expires at %{date} (%{duree_conservation_totale} months after the last la edition of this file)"
+          brouillon: "Expires on %{date} (%{duree_conservation_totale} months after this file was created)"
+          en_construction: "Expires on %{date} (%{duree_conservation_totale} months after this file was last modified)"
           en_instruction: "This file is being instructed, the administration will answer as soon as possible"
-          accepte: "Expires at %{date} (%{duree_conservation_totale} months after the acceptation of this file)"
-          refuse: "Expires at %{date} (%{duree_conservation_totale} months after the rejection of this file)"
-          sans_suite: "Expires at %{date} (%{duree_conservation_totale} months after this file had been closed)"
+          accepte: "Expires on %{date} (%{duree_conservation_totale} months after this file was accepted)"
+          refuse: "Expires on %{date} (%{duree_conservation_totale} months after this file was rejected)"
+          sans_suite: "Expires on %{date} (%{duree_conservation_totale} months after this file was closed)"
     champs:
       cnaf:
         show:

--- a/config/locales/shared.fr.yml
+++ b/config/locales/shared.fr.yml
@@ -21,11 +21,11 @@ fr:
       header:
         expires_at:
           brouillon: "Expirera le %{date} (%{duree_conservation_totale} mois après la création du dossier)"
-          en_construction: "Expirera le %{date} (%{duree_conservation_totale} mois après la dernière date d'édition)"
+          en_construction: "Expirera le %{date} (%{duree_conservation_totale} mois après la dernière modification du dossier)"
           en_instruction: "Ce dossier est en instruction, il n'expirera pas"
           accepte: "Expirera le %{date}  (%{duree_conservation_totale} mois après l'acceptation du dossier)"
           refuse: "Expirera le %{date}  (%{duree_conservation_totale} mois après le refus du dossier)"
-          sans_suite: "Expirera le %{date} (%{duree_conservation_totale} mois après que le dossier aie été classé sans suite)"
+          sans_suite: "Expirera le %{date} (%{duree_conservation_totale} mois après le classement sans suite du dossier)"
 
 
     champs:


### PR DESCRIPTION
L'anglais penche naturellement vers une structure verbale plutôt que nominale (quitte à substantiver ensuite derrière avec un -ING ! Lol)
Je verrais donc plutôt :
•	month(s) after this file was created
•	month(s) after this file was last edited
•	month(s) after this file was accepted
•	month(s) after this file was rejected
•	month(s) after this file was closed

Et pour expires, c'est plutôt suivi de "by" ou "on" avec une date derrière, et je verrais plutôt "on" ici.

plus une petite homogénéisation pour le français.
qu'en pensez vous ? 
