### PR TITLE
Corrige les link_to avec turbo

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -42,8 +42,12 @@
 
       = yield :charts_js
 
-      // Container for custom turbo-stream actions
-      %turbo-events
-      // Container for turbo form that we can submit from inside other forms
-      %div{ 'data-turbo': 'true' }
-        = form_tag('', id: :turbo_form)
+    // Container for custom turbo-stream actions
+    %turbo-events
+
+    // We patch `@hotwired/turbo` to attach forms generated from links to this
+    // container instead of the body to avoid conflicts with `@rails/ujs`. We also
+    // patch `@hotwired/turbo` to add a timeout before removing the form because in
+    // order to be accepted as a valid `turbo form`` either global `turbo drive`` should
+    // be enabled or the form needs to have a parent with `data-turbo="true"` on it.
+    %div{ 'data-turbo': 'true' }

--- a/app/views/shared/dossiers/editable_champs/_repetition.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_repetition.html.haml
@@ -3,6 +3,6 @@
     = render partial: 'shared/dossiers/editable_champs/repetition_row', locals: { form: form, champ: champ, row: champs }
 
 .actions{ 'data-turbo': 'true' }
-  = button_tag type: :submit, form: :turbo_form, formaction: champs_repetition_path(champ.id), formmethod: :post, class: 'button add-row' do
+  = link_to champs_repetition_path(champ.id), data: { turbo_method: :post }, class: 'button add-row' do
     %span.icon.add
     Ajouter un élément pour « #{champ.libelle} »

--- a/app/views/shared/dossiers/editable_champs/_repetition_row.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_repetition_row.html.haml
@@ -5,5 +5,5 @@
       = render partial: 'shared/dossiers/editable_champs/editable_champ', locals: { form: form, champ: champ }
 
   .flex.row-reverse{ 'data-turbo': 'true' }
-    = button_tag type: :submit, form: :turbo_form, formaction: champs_repetition_path(champ.id, champ_ids: row.map(&:id), row_id: row_dom_id), formmethod: :delete, class: 'button danger remove-row' do
+    = link_to champs_repetition_path(champ.id, champ_ids: row.map(&:id), row_id: row_dom_id), data: { turbo_method: :delete }, class: 'button danger remove-row' do
       Supprimer l’élément

--- a/patches/@hotwired+turbo+7.1.0.patch
+++ b/patches/@hotwired+turbo+7.1.0.patch
@@ -1,0 +1,32 @@
+diff --git a/node_modules/@hotwired/turbo/dist/turbo.es2017-esm.js b/node_modules/@hotwired/turbo/dist/turbo.es2017-esm.js
+index 963422f..65364f1 100644
+--- a/node_modules/@hotwired/turbo/dist/turbo.es2017-esm.js
++++ b/node_modules/@hotwired/turbo/dist/turbo.es2017-esm.js
+@@ -2621,9 +2621,9 @@ class Session {
+                 form.addEventListener("turbo:submit-start", () => form.remove());
+             }
+             else {
+-                form.addEventListener("submit", () => form.remove());
++                form.addEventListener("submit", () => setTimeout(() => form.remove(), 500));
+             }
+-            document.body.appendChild(form);
++            (document.querySelector('body > [data-turbo="true"]') || document.body).appendChild(form);
+             return dispatch("submit", { cancelable: true, target: form });
+         }
+         else {
+diff --git a/node_modules/@hotwired/turbo/dist/turbo.es2017-umd.js b/node_modules/@hotwired/turbo/dist/turbo.es2017-umd.js
+index 101db1f..ce43031 100644
+--- a/node_modules/@hotwired/turbo/dist/turbo.es2017-umd.js
++++ b/node_modules/@hotwired/turbo/dist/turbo.es2017-umd.js
+@@ -2627,9 +2627,9 @@ Copyright © 2021 Basecamp, LLC
+                     form.addEventListener("turbo:submit-start", () => form.remove());
+                 }
+                 else {
+-                    form.addEventListener("submit", () => form.remove());
++                  form.addEventListener("submit", () => setTimeout(() => form.remove(), 500));
+                 }
+-                document.body.appendChild(form);
++                (document.querySelector('body > [data-turbo="true"]') || document.body).appendChild(form);
+                 return dispatch("submit", { cancelable: true, target: form });
+             }
+             else {


### PR DESCRIPTION
Finalement, je préfère corriger `turbo` et utiliser `link_to`. La solution de passer par des `button` vers un `form` externe pose trop de problèmes.
* il y a des endroits dans le code ou on veut vraiment que ça soit un `a` et pas un `button`. Stylé les `button` comme des `a` je pense que c'est une mauvaise idée.
* le `button` au milieu du `form` reste un `submit button` et il y a trop de risque qu'il soit enclenché par un "enter" au mauvais endroit.

Le patch de `turbo` est minimal et pourra être supprimé si on active `turbo` global un jour ou si `turbo` corrige leur bugs (oui, je prévois de faire des issues dans `turbo` mais j'ai peu d'espoir vis-à-vis de ce que je vois de comment le projet est géré)

L'avantage de `patch-package` c'est qu'on aura direct une erreur en cas de bump de version de `turbo` donc pas de surprises.