### PR TITLE
Usager : l'attestation de dépôt est envoyée en pièce-jointe dans l'email de notification de dépôt

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -21,6 +21,7 @@ class NotificationMailer < ApplicationMailer
     @service = @dossier.procedure.service
     @logo_url = attach_logo(@dossier.procedure)
     @rendered_template = sanitize(@body)
+    attachments[@attachment[:filename]] = @attachment[:content] if @attachment.present?
 
     I18n.with_locale(@dossier.user_locale) do
       mail(subject: @subject, to: @email, template_name: 'send_notification')
@@ -62,6 +63,7 @@ class NotificationMailer < ApplicationMailer
         @subject = mail_template.subject_for_dossier(@dossier)
         @body = mail_template.body_for_dossier(@dossier)
         @actions = mail_template.actions_for_dossier(@dossier)
+        @attachment = mail_template.attachment_for_dossier(@dossier)
       end
     end
   end

--- a/app/models/concerns/mail_template_concern.rb
+++ b/app/models/concerns/mail_template_concern.rb
@@ -21,6 +21,10 @@ module MailTemplateConcern
     [MailTemplateConcern::Actions::SHOW, MailTemplateConcern::Actions::ASK_QUESTION]
   end
 
+  def attachment_for_dossier(dossier)
+    nil
+  end
+
   def update_rich_body
     self.rich_body = self.body
   end

--- a/app/models/mails/initiated_mail.rb
+++ b/app/models/mails/initiated_mail.rb
@@ -20,5 +20,24 @@ module Mails
     DISPLAYED_NAME = I18n.t('activerecord.models.mail.initiated_mail.proof_of_receipt')
     DEFAULT_SUBJECT = I18n.t('activerecord.models.mail.initiated_mail.default_subject', dossier_number: '--numéro du dossier--', procedure_libelle: '--libellé démarche--')
     DOSSIER_STATE = Dossier.states.fetch(:en_construction)
+
+    def attachment_for_dossier(dossier)
+      if procedure.feature_enabled?(:procedure_dossier_papertrail)
+        {
+          filename: I18n.t('users.dossiers.show.papertrail.filename'),
+          content: deposit_receipt_for_dossier(dossier)
+        }
+      end
+    end
+
+    private
+
+    def deposit_receipt_for_dossier(dossier)
+      ApplicationController.render(
+        template: 'users/dossiers/papertrail',
+        formats: [:pdf],
+        assigns: { dossier: dossier }
+      )
+    end
   end
 end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -469,7 +469,7 @@ fr:
       attestation:
         no_longer_available: "L’attestation n'est plus disponible sur ce dossier."
       papertrail:
-        receipt: "Accusé de dépôt"
+        receipt: "Attestation de dépôt"
         description: "Ce document atteste que %{user_name} a déposé le %{date} un dossier sur la démarche « %{procedure} »."
         file_submitted_at: "Dossier déposé le"
         dossier_state: "État du dossier"

--- a/spec/mailers/previews/notification_mailer_preview.rb
+++ b/spec/mailers/previews/notification_mailer_preview.rb
@@ -26,8 +26,7 @@ class NotificationMailerPreview < ActionMailer::Preview
   end
 
   def dossier_with_image
-    procedure = Procedure.where(id: Mails::InitiatedMail.where("body like ?", "%<img%").pluck(:procedure_id).uniq).order("RANDOM()").first
-    procedure.dossiers.last
+    Dossier.joins(procedure: [:initiated_mail]).where("initiated_mails.body like ?", "%<img%").order('RANDOM()').first
   end
 
   def dossier_with_motivation


### PR DESCRIPTION
Suite de #6146 : l'attestation de dépôt est maintenant envoyée en pièce jointe dans l'email de notification envoyé juste après le dépôt.

L'attestation reste téléchargeable à tout moment depuis le site.

<details>
<summary>

### Note sur la formulation "Accusé" / "Attestation"
</summary>

En ce moment on mélange un peu "Accusé de dépôt" et "Attestation de dépôt". Les autres emails de notification parlent d'"Accusé de passage en instruction", "Accusé de rejet" – mais quand ils 'agit d'un document PDF, je trouve que "Accusé de dépôt" fait assez violent (genre quoi, je suis accusé ?), alors que "Attestation" oriente plus vers le contexte de droits à exercer.

Du coup pour l'instant je considère que :
- Les emails sont des "Accusés" (de dépôt, de passage en instruction, etc)
- Le document PDF est une "Attestation"

Ça a le mérite d'être plus cohérent que la version actuelle. Après à voir si on veut affiner ça par la suite.
</details>
