### PR TITLE
fix(sentry/3139111475): clean up some "corrupted" data, some dossier still have depose_at nil while en_construction_at is set

### DIFF
--- a/lib/tasks/deployment/20220513135112_fix_depose_at_nil_on_dossier_state_not_brouillon.rake
+++ b/lib/tasks/deployment/20220513135112_fix_depose_at_nil_on_dossier_state_not_brouillon.rake
@@ -1,0 +1,17 @@
+namespace :after_party do
+  desc 'Deployment task: fix_depose_at_nil_on_dossier_state_not_brouillon'
+  task fix_depose_at_nil_on_dossier_state_not_brouillon: :environment do
+    puts "Running deploy task 'fix_depose_at_nil_on_dossier_state_not_brouillon'"
+
+    # Put your task implementation HERE.
+    dossiers_with_depose_at_nil = Dossier.state_not_brouillon.where(depose_at: nil)
+
+    rake_puts "Number of dossiers not in brouillon without depose_at : #{dossiers_with_depose_at_nil.count}"
+
+    dossiers_with_depose_at_nil.update_all("depose_at = en_construction_at")
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
https://sentry.io/organizations/demarches-simplifiees/issues/3139111475/activity/?project=1429550&query=is%3Aunresolved

contexte ETQ mfo je jardine dans sentry, et je tombe sur un depose_at.nil sur un dossier pas brouillon

apres un check des données de prod : `Dossier.state_not_brouillon.where(depose_at: nil).count` ; on a 1754 dossier dans ce cas.

pour fixer la donnée, voir si on peut reprendre le `en_construction_at` : `Dossier.state_not_brouillon.where(depose_at: nil).where.not(en_construction_at: nil).count` ; on en a aussi 1754

donc on met en_construction_at dans depose_at.

préféré mettre ca ds une after partie ; l'impression que les migration sont plus liées au schema, les after partie a la data.

