### PR TITLE
sentry(3002560608): some Dossier ready to be purged are missing the hidden_by_reason

### DIFF
--- a/lib/tasks/deployment/20220516160033_fix_hidden_by_reason_nil.rake
+++ b/lib/tasks/deployment/20220516160033_fix_hidden_by_reason_nil.rake
@@ -1,0 +1,14 @@
+namespace :after_party do
+  desc 'Deployment task: fix_hidden_by_reason_nil'
+  task fix_hidden_by_reason_nil: :environment do
+    puts "Running deploy task 'fix_hidden_by_reason_nil'"
+
+    # Put your task implementation HERE.
+    Dossier.en_construction_expired_to_delete.where(hidden_by_reason: nil).update_all(hidden_by_reason: :user_request)
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
https://sentry.io/organizations/demarches-simplifiees/issues/3002560608/?project=1429550&query=is%3Aunresolved ; 

le prob est qu'on essaie de detruire un dossier, mais il manque un `hidden_by_reason`. 

Apres une petite enquète, 
* 0 dossier en brouillon dans cet etat. 
* un peu plus de 1500 dossiers en construction sans le `hidden_by_reason`. 
* 11 dossiers termine et expirés par user/instructeur sans le `hidden_by_reason`
* sur les dates, 1ere occurence le 13 janvier, derniere occurence le 9 fevrier. (quelque soit le status : brouillon, en_construction, termine)

Sans avoir mis le doigt dessus, je pense que la root cause a été fixée (car pas de nouveaux dossiers dans ce cas depuis + 1mois et demi). 

@paul/@kara, je crois que vous avez le plus de visibilité la dessus, votre avis :plz: