### PR TITLE
bug(expert/avis#instruction): raise when instructeur was merged

### DIFF
--- a/app/models/avis.rb
+++ b/app/models/avis.rb
@@ -60,14 +60,6 @@ class Avis < ApplicationRecord
     expert&.email
   end
 
-  def self.link_avis_to_instructeur(instructeur)
-    Avis.where(email: instructeur.email).update_all(email: nil, instructeur_id: instructeur.id)
-  end
-
-  def self.avis_exists_and_email_belongs_to_avis?(avis_id, email)
-    Avis.find_by(id: avis_id)&.email == email
-  end
-
   def spreadsheet_columns
     [
       ['Dossier ID', dossier_id.to_s],

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -302,9 +302,12 @@ class Instructeur < ApplicationRecord
     admin_with_new_instructeur.each do |admin|
       admin.instructeurs.delete(old_instructeur)
     end
-
     old_instructeur.commentaires.update_all(instructeur_id: id)
     old_instructeur.bulk_messages.update_all(instructeur_id: id)
+
+    Avis
+      .where(claimant_id: old_instructeur.id, claimant_type: Instructeur.name)
+      .update_all(claimant_id: id)
   end
 
   private

--- a/spec/controllers/experts/avis_controller_spec.rb
+++ b/spec/controllers/experts/avis_controller_spec.rb
@@ -104,17 +104,6 @@ describe Experts::AvisController, type: :controller do
           expect(flash.alert).to eq("Vous n’avez pas accès à cet avis.")
         end
       end
-      context 'with merged instructeur who was claimant' do
-        render_views
-        it 'does not raise' do
-          old_claimant = create(:instructeur)
-          avis_with_merged_instructeur = create(:avis, dossier: dossier, claimant: old_claimant, experts_procedure: experts_procedure)
-          instructeur.user.merge(old_claimant.user)
-          sign_in(avis_with_merged_instructeur.expert.user)
-          get :instruction, params: { id: avis_with_merged_instructeur.id, procedure_id: procedure.id }
-          expect(response).to have_http_status(200)
-        end
-      end
     end
 
     describe '#messagerie' do

--- a/spec/controllers/experts/avis_controller_spec.rb
+++ b/spec/controllers/experts/avis_controller_spec.rb
@@ -104,6 +104,17 @@ describe Experts::AvisController, type: :controller do
           expect(flash.alert).to eq("Vous n’avez pas accès à cet avis.")
         end
       end
+      context 'with merged instructeur who was claimant' do
+        render_views
+        it 'does not raise' do
+          old_claimant = create(:instructeur)
+          avis_with_merged_instructeur = create(:avis, dossier: dossier, claimant: old_claimant, experts_procedure: experts_procedure)
+          instructeur.user.merge(old_claimant.user)
+          sign_in(avis_with_merged_instructeur.expert.user)
+          get :instruction, params: { id: avis_with_merged_instructeur.id, procedure_id: procedure.id }
+          expect(response).to have_http_status(200)
+        end
+      end
     end
 
     describe '#messagerie' do

--- a/spec/models/avis_spec.rb
+++ b/spec/models/avis_spec.rb
@@ -45,35 +45,6 @@ RSpec.describe Avis, type: :model do
     end
   end
 
-  describe '.avis_exists_and_email_belongs_to_avis?' do
-    let(:dossier) { create(:dossier) }
-    let(:invited_email) { 'invited@avis.com' }
-    let!(:avis) { create(:avis, email: invited_email, dossier: dossier) }
-
-    subject { Avis.avis_exists_and_email_belongs_to_avis?(avis_id, email) }
-
-    context 'when the avis is unknown' do
-      let(:avis_id) { 666 }
-      let(:email) { 'unknown@mystery.com' }
-
-      it { is_expected.to be false }
-    end
-
-    context 'when the avis is known' do
-      let(:avis_id) { avis.id }
-
-      context 'when the email belongs to the invitation' do
-        let(:email) { invited_email }
-        it { is_expected.to be true }
-      end
-
-      context 'when the email is unknown' do
-        let(:email) { 'unknown@mystery.com' }
-        it { is_expected.to be false }
-      end
-    end
-  end
-
   describe "email sanitization" do
     let(:expert) { create(:expert) }
     let(:procedure) { create(:procedure) }

--- a/spec/models/instructeur_spec.rb
+++ b/spec/models/instructeur_spec.rb
@@ -828,6 +828,18 @@ describe Instructeur, type: :model do
         expect(administrateur.reload.instructeurs).to match_array(new_instructeur)
       end
     end
+
+    context 'when old instructeur has avis' do
+      let(:avis) { create(:avis, claimant: old_instructeur) }
+      before do
+        avis
+        subject
+      end
+      it 'reassign avis to new_instructeur' do
+        avis.reload
+        expect(avis.claimant).to eq(new_instructeur)
+      end
+    end
   end
 
   private


### PR DESCRIPTION
ETQ usager, avec un profil d'instructeur, ayant fait une demande d'avis sur un dossier. 
Je merge mon ancien compte dans un nouveau compte
Mes avis ne sont pas transposé sur le nouveau compte

https://sentry.io/organizations/demarches-simplifiees/issues/3173022390/?project=1429550&query=is%3Aunresolved
https://sentry.io/organizations/demarches-simplifiees/issues/3254070939/?project=1429550&query=is%3Aunresolved
https://sentry.io/organizations/demarches-simplifiees/issues/3280355218/?project=1429550&query=is%3Aunresolved

La PR se lit bien commit par commit (repliquer le bug, isoler le bug, fixer le bug, cleanup de deadcode)

Il va falloire rattraper de la donnée :D 