### PR TITLE
Refactor(revision): retire l'usage de repetition.types_de_champ

### DIFF
--- a/app/controllers/champs/repetition_controller.rb
+++ b/app/controllers/champs/repetition_controller.rb
@@ -3,7 +3,7 @@ class Champs::RepetitionController < ApplicationController
 
   def add
     @champ = policy_scope(Champ).includes(:champs).find(params[:champ_id])
-    @champs = @champ.add_row
+    @champs = @champ.add_row(@champ.dossier.revision)
   end
 
   def remove

--- a/app/models/champs/repetition_champ.rb
+++ b/app/models/champs/repetition_champ.rb
@@ -27,11 +27,11 @@ class Champs::RepetitionChamp < Champ
     champs.group_by(&:row).values
   end
 
-  def add_row
+  def add_row(revision)
     added_champs = []
     transaction do
       row = (blank? ? -1 : champs.last.row) + 1
-      type_de_champ.types_de_champ.each do |type_de_champ|
+      revision.children_of(type_de_champ).each do |type_de_champ|
         added_champs << type_de_champ.champ.build(row: row)
       end
       self.champs << added_champs

--- a/app/models/concerns/dossier_rebase_concern.rb
+++ b/app/models/concerns/dossier_rebase_concern.rb
@@ -112,7 +112,7 @@ module DossierRebaseConcern
         end
       end
     else
-      champ = published_type_de_champ.build_champ
+      champ = published_type_de_champ.build_champ(revision: procedure.published_revision)
       self.champs << champ
     end
   end

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -31,11 +31,11 @@ class ProcedureRevision < ApplicationRecord
   scope :ordered, -> { order(:created_at) }
 
   def build_champs
-    types_de_champ_public.map(&:build_champ)
+    types_de_champ_public.map { |tdc| tdc.build_champ(revision: self) }
   end
 
   def build_champs_private
-    types_de_champ_private.map(&:build_champ)
+    types_de_champ_private.map { |tdc| tdc.build_champ(revision: self) }
   end
 
   def add_type_de_champ(params)

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -102,10 +102,12 @@ class TypeDeChamp < ApplicationRecord
 
   has_many :champ, inverse_of: :type_de_champ, dependent: :destroy do
     def build(params = {})
+      params.delete(:revision)
       super(params.merge(proxy_association.owner.params_for_champ))
     end
 
     def create(params = {})
+      params.delete(:revision)
       super(params.merge(proxy_association.owner.params_for_champ))
     end
   end
@@ -153,8 +155,8 @@ class TypeDeChamp < ApplicationRecord
     }
   end
 
-  def build_champ
-    dynamic_type.build_champ
+  def build_champ(params)
+    dynamic_type.build_champ(params)
   end
 
   def check_mandatory

--- a/app/models/types_de_champ/repetition_type_de_champ.rb
+++ b/app/models/types_de_champ/repetition_type_de_champ.rb
@@ -1,7 +1,8 @@
 class TypesDeChamp::RepetitionTypeDeChamp < TypesDeChamp::TypeDeChampBase
-  def build_champ
+  def build_champ(params)
+    revision = params[:revision]
     champ = super
-    champ.add_row
+    champ.add_row(revision)
     champ
   end
 

--- a/app/models/types_de_champ/type_de_champ_base.rb
+++ b/app/models/types_de_champ/type_de_champ_base.rb
@@ -25,8 +25,8 @@ class TypesDeChamp::TypeDeChampBase
     libelle
   end
 
-  def build_champ
-    @type_de_champ.champ.build
+  def build_champ(params)
+    @type_de_champ.champ.build(params)
   end
 
   def filter_to_human(filter_value)

--- a/spec/models/champs/header_section_champ_spec.rb
+++ b/spec/models/champs/header_section_champ_spec.rb
@@ -23,11 +23,25 @@ describe Champs::HeaderSectionChamp do
     end
 
     context 'for repetition champs' do
-      let(:procedure) { create(:procedure, types_de_champ: [build(:type_de_champ_repetition, types_de_champ: types_de_champ)]) }
+      let(:procedure) { create(:procedure, :with_repetition) }
       let(:dossier) { create(:dossier, procedure: procedure) }
 
       let(:first_header)  { dossier.champs.first.champs[0] }
       let(:second_header) { dossier.champs.first.champs[3] }
+
+      before do
+        revision = procedure.active_revision
+        tdc_repetition = revision.types_de_champ_public.first
+        revision.remove_type_de_champ(revision.children_of(tdc_repetition))
+
+        types_de_champ.each do |tdc|
+          revision.add_type_de_champ(
+            libelle: tdc.libelle,
+            type_champ: tdc.type_champ,
+            parent_id: tdc_repetition.stable_id
+          )
+        end
+      end
 
       it 'returns the index of the section in the repetition (starting from 1)' do
         expect(first_header.section_index).to eq 1

--- a/spec/models/concern/tags_substitution_concern_spec.rb
+++ b/spec/models/concern/tags_substitution_concern_spec.rb
@@ -161,19 +161,23 @@ describe TagsSubstitutionConcern, type: :model do
 
     context 'when the procedure has a type de champ repetition' do
       let(:template) { '--Répétition--' }
-      let(:types_de_champ) do
-        [
-          build(:type_de_champ_repetition, libelle: 'Répétition', types_de_champ: [
-            build(:type_de_champ_text, libelle: 'Nom', order_place: 1),
-            build(:type_de_champ_text, libelle: 'Prénom', order_place: 2)
-          ])
-        ]
+      let(:repetition) do
+        repetition_tdc = procedure.active_revision.add_type_de_champ(type_champ: 'repetition', libelle: 'Répétition')
+        procedure.active_revision.add_type_de_champ(type_champ: 'text', libelle: 'Nom', parent_id: repetition_tdc.stable_id)
+        procedure.active_revision.add_type_de_champ(type_champ: 'text', libelle: 'Prénom', parent_id: repetition_tdc.stable_id)
+
+        repetition_tdc
+      end
+
+      let(:dossier) do
+        repetition
+        create(:dossier, procedure: procedure)
       end
 
       before do
         repetition = dossier.champs
           .find { |champ| champ.libelle == 'Répétition' }
-        repetition.add_row
+        repetition.add_row(dossier.revision)
         paul_champs, pierre_champs = repetition.rows
 
         paul_champs.first.update(value: 'Paul')

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1190,11 +1190,13 @@ describe Dossier do
     end
 
     context "with champ repetition" do
-      let(:procedure) { create(:procedure, types_de_champ: [type_de_champ_repetition]) }
-      let(:type_de_champ_repetition) { build(:type_de_champ_repetition, mandatory: true) }
+      let(:procedure) { create(:procedure, :with_repetition) }
+      let(:revision) { procedure.active_revision }
+      let(:type_de_champ_repetition) { revision.types_de_champ.first }
 
       before do
-        create(:type_de_champ_text, mandatory: true, parent: type_de_champ_repetition)
+        type_de_champ_repetition.update(mandatory: true)
+        revision.children_of(type_de_champ_repetition).first.update(mandatory: true)
       end
 
       context "when no champs" do
@@ -1215,7 +1217,7 @@ describe Dossier do
         let(:champ_with_error) { dossier.champs.first.champs.first }
 
         before do
-          dossier.champs.first.add_row
+          dossier.champs.first.add_row(dossier.revision)
         end
 
         it 'should have errors' do
@@ -1763,8 +1765,8 @@ describe Dossier do
       datetime_champ.update(value: Date.today.to_s)
       text_champ.update(value: 'bonjour')
       # Add two rows then remove previous to last row in order to create a "hole" in the sequence
-      repetition_champ.add_row
-      repetition_champ.add_row
+      repetition_champ.add_row(repetition_champ.dossier.revision)
+      repetition_champ.add_row(repetition_champ.dossier.revision)
       repetition_champ.champs.where(row: repetition_champ.champs.last.row - 1).destroy_all
       repetition_champ.reload
     end


### PR DESCRIPTION
Modifie la construction des champ, en leur passant la révision courante pour permettre aux répétitions de construire les sous champs correspondants 

- [x] depend de #7302 