### PR TITLE
Refactor(revision) : retire l'utilisation de type_de_champ.types_de_champ dans le manager

### DIFF
--- a/app/views/fields/types_de_champ_collection_field/_show.html.haml
+++ b/app/views/fields/types_de_champ_collection_field/_show.html.haml
@@ -1,3 +1,5 @@
+- revision = page.resource.is_a?(Procedure) ? page.resource.active_revision : page.resource.revision
+
 - if field.data.any?
   %table.collection-data{ "aria-labelledby": "page-title" }
     %thead
@@ -11,7 +13,7 @@
           locals: { type_de_champ: type_de_champ }
 
         - if type_de_champ.type_champ == 'repetition'
-          - type_de_champ.types_de_champ.each do |sub_champ|
+          - revision.children_of(type_de_champ).each do |sub_champ|
             = render partial: 'fields/types_de_champ_collection_field/type_champ_line',
               locals: { type_de_champ: sub_champ }
 - else


### PR DESCRIPTION
- [x] dépend de #7302 