### PR TITLE
fix(dossier_vide.pdf.prawn): avoid overlap on for multiline label on label

### DIFF
--- a/app/views/dossiers/dossier_vide.pdf.prawn
+++ b/app/views/dossiers/dossier_vide.pdf.prawn
@@ -48,7 +48,7 @@ def format_with_checkbox(pdf, option, offset = 0)
 
   pdf.font 'marianne', size: 9 do
     pdf.stroke_rectangle [0 + offset, pdf.cursor], 10, 10
-    pdf.text_box label, at: [15 + offset, pdf.cursor - 1]
+    render_expanding_text_box(pdf, label, at: [15, pdf.cursor])
 
     if value == Champs::DropDownListChamp::OTHER
       pdf.bounding_box([110, pdf.cursor + 3],:width => 350,:height => 20) do


### PR DESCRIPTION
cf: remonté par bouchra https://mattermost.incubateur.net/betagouv/pl/hqspcqtk7jdftmih7i5nhq4hfc
> Je souhaite utiliser la nouvelle fonctionnalité "PDF". Cependant, lors de la lecture du PDF, les blocs répétables sont indiqués plusieurs fois. Cela finit même par se superposer et être illisible.

avant :
<img width="875" alt="Screen Shot 2022-05-18 at 2 27 45 PM" src="https://user-images.githubusercontent.com/125964/169043517-86f0970e-85e3-498a-b89a-d6ec8a50d64b.png">

après :
<img width="887" alt="Screen Shot 2022-05-18 at 2 55 59 PM" src="https://user-images.githubusercontent.com/125964/169043661-2cf68a6f-93be-46fa-8ae8-507764d49f9c.png">

