### PR TITLE
Usager : affichage du temps estimé pour remplir la démarche (derrière un feature flag)

### DIFF
--- a/app/assets/stylesheets/procedure_context.scss
+++ b/app/assets/stylesheets/procedure_context.scss
@@ -44,15 +44,13 @@ $procedure-description-line-height: 22px;
     }
   }
 
-  .procedure-auto-archive {
-    cursor: pointer;
-
+  .procedure-configuration {
+    font-size: 20px;
     margin-bottom: 32px;
+  }
 
-    p {
-      padding-top: 8px;
-      font-size: 16px;
-    }
+  .procedure-configuration--auto-archive {
+    cursor: pointer;
 
     summary {
       font-size: 20px;
@@ -63,6 +61,11 @@ $procedure-description-line-height: 22px;
       &::-webkit-details-marker {
         display: none;
       }
+    }
+
+    p {
+      padding-top: 8px;
+      font-size: 16px;
     }
   }
 

--- a/app/helpers/procedure_helper.rb
+++ b/app/helpers/procedure_helper.rb
@@ -84,7 +84,8 @@ module ProcedureHelper
   end
 
   def estimated_fill_duration_minutes(procedure)
-    minutes = (procedure.active_revision.estimated_fill_duration / 60.0).round
+    seconds = procedure.active_revision.estimated_fill_duration
+    minutes = (seconds / 60.0).round
     [1, minutes].max
   end
 end

--- a/app/helpers/procedure_helper.rb
+++ b/app/helpers/procedure_helper.rb
@@ -82,4 +82,9 @@ module ProcedureHelper
     return "//#{uri}" if uri.scheme.nil?
     uri.to_s
   end
+
+  def estimated_fill_duration_minutes(procedure)
+    minutes = (procedure.active_revision.estimated_fill_duration / 60.0).round
+    [1, minutes].max
+  end
 end

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -180,6 +180,15 @@ class ProcedureRevision < ApplicationRecord
     tdcs_as_json
   end
 
+  # Estimated duration to fill the form, in seconds
+  def estimated_fill_duration
+    tdc_durations = types_de_champ_public.fillable.map do |tdc|
+      duration = tdc.estimated_fill_duration(self)
+      tdc.mandatory ? duration : duration / 2
+    end
+    tdc_durations.sum
+  end
+
   private
 
   def children_types_de_champ_as_json(tdcs_as_json, parent_tdcs)

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -180,16 +180,24 @@ class ProcedureRevision < ApplicationRecord
     tdcs_as_json
   end
 
-  # Estimated duration to fill the form, in seconds
+  # Estimated duration to fill the form, in seconds.
+  #
+  # If the revision is locked (i.e. published), the result is cached (because type de champs can no longer be mutated).
   def estimated_fill_duration
+    Rails.cache.fetch("#{cache_key_with_version}/estimated_fill_duration", expires_in: 12.hours, force: !locked?) do
+      compute_estimated_fill_duration
+    end
+  end
+
+  private
+
+  def compute_estimated_fill_duration
     tdc_durations = types_de_champ_public.fillable.map do |tdc|
       duration = tdc.estimated_fill_duration(self)
       tdc.mandatory ? duration : duration / 2
     end
     tdc_durations.sum
   end
-
-  private
 
   def children_types_de_champ_as_json(tdcs_as_json, parent_tdcs)
     parent_tdcs.each do |parent_tdc|

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -66,7 +66,7 @@ class TypeDeChamp < ApplicationRecord
   has_one :revision, through: :revision_type_de_champ
   has_one :procedure, through: :revision
 
-  delegate :tags_for_template, :libelle_for_export, to: :dynamic_type
+  delegate :estimated_fill_duration, :tags_for_template, :libelle_for_export, to: :dynamic_type
 
   class WithIndifferentAccess
     def self.load(options)

--- a/app/models/types_de_champ/annuaire_education_type_de_champ.rb
+++ b/app/models/types_de_champ/annuaire_education_type_de_champ.rb
@@ -1,2 +1,5 @@
 class TypesDeChamp::AnnuaireEducationTypeDeChamp < TypesDeChamp::TextTypeDeChamp
+  def estimated_fill_duration(revision)
+    FILL_DURATION_MEDIUM
+  end
 end

--- a/app/models/types_de_champ/carte_type_de_champ.rb
+++ b/app/models/types_de_champ/carte_type_de_champ.rb
@@ -11,4 +11,8 @@ class TypesDeChamp::CarteTypeDeChamp < TypesDeChamp::TypeDeChampBase
     :znieff,
     :cadastres
   ]
+
+  def estimated_fill_duration(revision)
+    FILL_DURATION_LONG
+  end
 end

--- a/app/models/types_de_champ/cnaf_type_de_champ.rb
+++ b/app/models/types_de_champ/cnaf_type_de_champ.rb
@@ -1,2 +1,5 @@
 class TypesDeChamp::CnafTypeDeChamp < TypesDeChamp::TextTypeDeChamp
+  def estimated_fill_duration(revision)
+    FILL_DURATION_MEDIUM
+  end
 end

--- a/app/models/types_de_champ/dgfip_type_de_champ.rb
+++ b/app/models/types_de_champ/dgfip_type_de_champ.rb
@@ -1,2 +1,5 @@
 class TypesDeChamp::DgfipTypeDeChamp < TypesDeChamp::TextTypeDeChamp
+  def estimated_fill_duration(revision)
+    FILL_DURATION_MEDIUM
+  end
 end

--- a/app/models/types_de_champ/iban_type_de_champ.rb
+++ b/app/models/types_de_champ/iban_type_de_champ.rb
@@ -1,2 +1,5 @@
 class TypesDeChamp::IbanTypeDeChamp < TypesDeChamp::TypeDeChampBase
+  def estimated_fill_duration(revision)
+    FILL_DURATION_MEDIUM
+  end
 end

--- a/app/models/types_de_champ/mesri_type_de_champ.rb
+++ b/app/models/types_de_champ/mesri_type_de_champ.rb
@@ -1,2 +1,5 @@
 class TypesDeChamp::MesriTypeDeChamp < TypesDeChamp::TextTypeDeChamp
+  def estimated_fill_duration(revision)
+    FILL_DURATION_MEDIUM
+  end
 end

--- a/app/models/types_de_champ/piece_justificative_type_de_champ.rb
+++ b/app/models/types_de_champ/piece_justificative_type_de_champ.rb
@@ -1,2 +1,5 @@
 class TypesDeChamp::PieceJustificativeTypeDeChamp < TypesDeChamp::TypeDeChampBase
+  def estimated_fill_duration(revision)
+    FILL_DURATION_LONG
+  end
 end

--- a/app/models/types_de_champ/pole_emploi_type_de_champ.rb
+++ b/app/models/types_de_champ/pole_emploi_type_de_champ.rb
@@ -1,2 +1,5 @@
 class TypesDeChamp::PoleEmploiTypeDeChamp < TypesDeChamp::TextTypeDeChamp
+  def estimated_fill_duration(revision)
+    FILL_DURATION_MEDIUM
+  end
 end

--- a/app/models/types_de_champ/repetition_type_de_champ.rb
+++ b/app/models/types_de_champ/repetition_type_de_champ.rb
@@ -6,6 +6,15 @@ class TypesDeChamp::RepetitionTypeDeChamp < TypesDeChamp::TypeDeChampBase
     champ
   end
 
+  def estimated_fill_duration(revision)
+    estimated_rows_in_repetition = 2.5
+    estimated_row_duration = @type_de_champ
+      .types_de_champ
+      .map { |child_tdc| child_tdc.estimated_fill_duration(revision) }
+      .sum
+    estimated_row_duration * estimated_rows_in_repetition
+  end
+
   # We have to truncate the label here as spreadsheets have a (30 char) limit on length.
   def libelle_for_export(index = 0)
     str = "(#{stable_id}) #{libelle}"

--- a/app/models/types_de_champ/siret_type_de_champ.rb
+++ b/app/models/types_de_champ/siret_type_de_champ.rb
@@ -1,2 +1,5 @@
 class TypesDeChamp::SiretTypeDeChamp < TypesDeChamp::TypeDeChampBase
+  def estimated_fill_duration(revision)
+    FILL_DURATION_MEDIUM
+  end
 end

--- a/app/models/types_de_champ/textarea_type_de_champ.rb
+++ b/app/models/types_de_champ/textarea_type_de_champ.rb
@@ -1,2 +1,5 @@
 class TypesDeChamp::TextareaTypeDeChamp < TypesDeChamp::TextTypeDeChamp
+  def estimated_fill_duration(revision)
+    FILL_DURATION_MEDIUM
+  end
 end

--- a/app/models/types_de_champ/titre_identite_type_de_champ.rb
+++ b/app/models/types_de_champ/titre_identite_type_de_champ.rb
@@ -1,4 +1,8 @@
 class TypesDeChamp::TitreIdentiteTypeDeChamp < TypesDeChamp::TypeDeChampBase
   FRANCE_CONNECT = 'france_connect'
   PIECE_JUSTIFICATIVE = 'piece_justificative'
+
+  def estimated_fill_duration(revision)
+    FILL_DURATION_LONG
+  end
 end

--- a/app/models/types_de_champ/type_de_champ_base.rb
+++ b/app/models/types_de_champ/type_de_champ_base.rb
@@ -3,6 +3,10 @@ class TypesDeChamp::TypeDeChampBase
 
   delegate :description, :libelle, :stable_id, to: :@type_de_champ
 
+  FILL_DURATION_SHORT  = 10.seconds.in_seconds
+  FILL_DURATION_MEDIUM = 1.minute.in_seconds
+  FILL_DURATION_LONG   = 3.minutes.in_seconds
+
   def initialize(type_de_champ)
     @type_de_champ = type_de_champ
   end
@@ -23,6 +27,12 @@ class TypesDeChamp::TypeDeChampBase
 
   def libelle_for_export(index = 0)
     libelle
+  end
+
+  # Default estimated duration to fill the champ in a form, in seconds.
+  # May be overridden by subclasses.
+  def estimated_fill_duration(revision)
+    FILL_DURATION_SHORT
   end
 
   def build_champ(params)

--- a/app/models/types_de_champ/type_de_champ_base.rb
+++ b/app/models/types_de_champ/type_de_champ_base.rb
@@ -1,7 +1,7 @@
 class TypesDeChamp::TypeDeChampBase
   include ActiveModel::Validations
 
-  delegate :description, :libelle, :stable_id, to: :@type_de_champ
+  delegate :description, :libelle, :mandatory, :stable_id, to: :@type_de_champ
 
   FILL_DURATION_SHORT  = 10.seconds.in_seconds
   FILL_DURATION_MEDIUM = 1.minute.in_seconds

--- a/app/views/administrateurs/procedures/champs.html.haml
+++ b/app/views/administrateurs/procedures/champs.html.haml
@@ -1,6 +1,6 @@
 = render partial: 'administrateurs/breadcrumbs',
   locals: { steps: [link_to('Démarches', admin_procedures_path),
-                    link_to(@procedure.libelle, admin_procedure_path(@procedure)),
+                    link_to(@procedure.libelle.truncate_words(10), admin_procedure_path(@procedure)),
                     'Configuration des champs'], preview: true }
 
 .container

--- a/app/views/shared/_procedure_description.html.haml
+++ b/app/views/shared/_procedure_description.html.haml
@@ -8,10 +8,15 @@
 %h1.procedure-title
   = procedure.libelle
 
+- if procedure.feature_enabled?(:procedure_estimated_fill_duration)
+  %p.procedure-configuration.procedure-configuration--fill-duration
+    %span.icon.clock
+    = t('shared.procedure_description.estimated_fill_duration', estimated_minutes: estimated_fill_duration_minutes(procedure))
+
 - if procedure.auto_archive_on
-  %details.procedure-auto-archive
+  %details.procedure-configuration.procedure-configuration--auto-archive
     %summary
-      %span.icon.clock
+      %span.icon.edit
 
       %span.procedure-auto-archive-title Date limite : #{procedure_auto_archive_date(procedure)}
     %p Vous pouvez déposer vos dossiers jusqu’au #{procedure_auto_archive_datetime(procedure)}.

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -26,6 +26,7 @@ features = [
   :hide_instructeur_email,
   :procedure_revisions,
   :procedure_routage_api,
+  :procedure_estimated_fill_duration,
   :procedure_process_expired_dossiers_termine
 ]
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -524,3 +524,5 @@ en:
         dossiers_count: "Nb files"
         weekly_distribution: "Weekly distribution"
         weekly_distribution_details: "in the last 6 months"
+    procedure_description:
+      estimated_fill_duration: "Estimated fill time: %{estimated_minutes} mn"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -575,3 +575,5 @@ fr:
         dossiers_count: "Nb dossiers"
         weekly_distribution: "Répartition par semaine"
         weekly_distribution_details: "au cours des 6 derniers mois"
+    procedure_description:
+      estimated_fill_duration: "Temps de remplissage estimé : %{estimated_minutes} mn"

--- a/spec/helpers/procedure_helper_spec.rb
+++ b/spec/helpers/procedure_helper_spec.rb
@@ -1,10 +1,32 @@
 RSpec.describe ProcedureHelper, type: :helper do
-  let(:auto_archive_date) { Time.zone.local(2020, 8, 2, 12, 00) }
-  let(:procedure) { build(:procedure, auto_archive_on: auto_archive_date) }
+  describe '#procedure_auto_archive_datetime' do
+    let(:auto_archive_date) { Time.zone.local(2020, 8, 2, 12, 00) }
+    let(:procedure) { build(:procedure, auto_archive_on: auto_archive_date) }
 
-  subject { procedure_auto_archive_datetime(procedure) }
+    subject { procedure_auto_archive_datetime(procedure) }
 
-  it "displays the day before the auto archive date (to account for the '23h59' ending time)" do
-    expect(subject).to have_text("1 août 2020 à 23 h 59 (heure de Paris)")
+    it "displays the day before the auto archive date (to account for the '23h59' ending time)" do
+      expect(subject).to have_text("1 août 2020 à 23 h 59 (heure de Paris)")
+    end
+  end
+
+  describe '#estimated_fill_duration_minutes' do
+    subject { estimated_fill_duration_minutes(procedure) }
+
+    context 'with champs' do
+      let(:procedure) { build(:procedure, :with_yes_no, :with_piece_justificative) }
+
+      it 'rounds up the duration to the minute' do
+        expect(subject).to eq(2)
+      end
+    end
+
+    context 'without champs' do
+      let(:procedure) { build(:procedure) }
+
+      it 'never displays ‘zero minutes’' do
+        expect(subject).to eq(1)
+      end
+    end
   end
 end

--- a/spec/views/shared/_procedure_description.html.haml_spec.rb
+++ b/spec/views/shared/_procedure_description.html.haml_spec.rb
@@ -22,4 +22,11 @@ describe 'shared/_procedure_description.html.haml', type: :view do
       expect(rendered).to have_text('Date limite')
     end
   end
+
+  context 'when the procedure_estimated_fill_duration feature is enabled' do
+    before { Flipper.enable(:procedure_estimated_fill_duration) }
+    after { Flipper.disable(:procedure_estimated_fill_duration) }
+
+    it { is_expected.to have_text('Temps de remplissage estimé') }
+  end
 end


### PR DESCRIPTION
Cette PR affiche le temps de remplissage estimé de la démarche sur la page "/commencer" (#237). Pour l'instant c'est derrière un feature-flag.

Je veux bien votre avis sur l'implémentation.

## TODO

- [x] Mettre en cache la durée estimée
- [x] Ajouter des tests

## Capture d'écran
<img width="485" alt="Capture d’écran 2022-05-18 à 17 56 23" src="https://user-images.githubusercontent.com/179923/169088133-f243a7a9-2268-431e-b983-538b1ee94b49.png">

