### PR TITLE
fix(revision): update children coordinate instead of duplicating

### DIFF
--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -81,7 +81,7 @@ class ProcedureRevision < ApplicationRecord
     if tdc.only_present_on_draft?
       tdc
     else
-      revise_type_de_champ(coordinate)
+      replace_tdc_and_children_by_clones(coordinate)
     end
   end
 
@@ -415,7 +415,7 @@ class ProcedureRevision < ApplicationRecord
     changes
   end
 
-  def revise_type_de_champ(coordinate)
+  def replace_tdc_and_children_by_clones(coordinate)
     cloned_type_de_champ = coordinate.type_de_champ.deep_clone(include: [:types_de_champ]) do |original, kopy|
       PiecesJustificativesService.clone_attachments(original, kopy)
     end
@@ -437,7 +437,7 @@ class ProcedureRevision < ApplicationRecord
     coordinate, tdc = coordinate_and_tdc(stable_id)
 
     if coordinate.child? && !tdc.only_present_on_draft?
-      revise_type_de_champ(coordinate.parent)
+      replace_tdc_and_children_by_clones(coordinate.parent)
     end
   end
 end

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -72,6 +72,7 @@ class ProcedureRevision < ApplicationRecord
     TypeDeChamp.new.tap { |tdc| tdc.errors.add(:base, e.message) }
   end
 
+  # Only called by by controller update
   def find_or_clone_type_de_champ(stable_id)
     coordinate, tdc = coordinate_and_tdc(stable_id)
 
@@ -84,6 +85,7 @@ class ProcedureRevision < ApplicationRecord
 
   def move_type_de_champ(stable_id, position)
     # Ensure that if this is a child, it's parent is cloned to the new revision
+    # Needed because the order could be based on the ancient system
     clone_parent_to_draft_revision(stable_id)
 
     coordinate, _ = coordinate_and_tdc(stable_id)
@@ -97,6 +99,7 @@ class ProcedureRevision < ApplicationRecord
 
   def remove_type_de_champ(stable_id)
     # Ensure that if this is a child, it's parent is cloned to the new revision
+    # Needed because the order could be based on the ancient system
     clone_parent_to_draft_revision(stable_id)
 
     coordinate, tdc = coordinate_and_tdc(stable_id)

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -423,9 +423,11 @@ class ProcedureRevision < ApplicationRecord
     coordinate.update!(type_de_champ: cloned_type_de_champ)
 
     # sync old and new system
-    revision_types_de_champ.where(parent: coordinate).find_each do |coordinate|
-      cloned_child_type_de_champ = cloned_child_types_de_champ.find { |tdc| tdc.stable_id == coordinate.type_de_champ.stable_id }
-      coordinate.update!(type_de_champ: cloned_child_type_de_champ)
+    children_coordinates = revision_types_de_champ.where(parent: coordinate)
+
+    children_coordinates.find_each do |child_coordinate|
+      cloned_child_type_de_champ = cloned_child_types_de_champ.find { |tdc| tdc.stable_id == child_coordinate.type_de_champ.stable_id }
+      child_coordinate.update!(type_de_champ: cloned_child_type_de_champ)
     end
 
     cloned_type_de_champ

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -73,9 +73,6 @@ class ProcedureRevision < ApplicationRecord
   end
 
   def find_or_clone_type_de_champ(stable_id)
-    # Ensure that if this is a child, it's parent is cloned to the new revision
-    clone_parent_to_draft_revision(stable_id)
-
     coordinate, tdc = coordinate_and_tdc(stable_id)
 
     if tdc.only_present_on_draft?

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -74,6 +74,9 @@ class ProcedureRevision < ApplicationRecord
 
   # Only called by by controller update
   def find_or_clone_type_de_champ(stable_id)
+    # Ensure that if this is a child, it's parent is cloned to the new revision
+    clone_parent_to_draft_revision(stable_id)
+
     coordinate, tdc = coordinate_and_tdc(stable_id)
 
     if tdc.only_present_on_draft?

--- a/app/models/procedure_revision_type_de_champ.rb
+++ b/app/models/procedure_revision_type_de_champ.rb
@@ -26,6 +26,10 @@ class ProcedureRevisionTypeDeChamp < ApplicationRecord
     type_de_champ.private?
   end
 
+  def child?
+    parent_id.present?
+  end
+
   def siblings
     if parent_id.present?
       revision.revision_types_de_champ.where(parent_id: parent_id).ordered

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -275,6 +275,27 @@ describe ProcedureRevision do
     end
   end
 
+  describe '#update_type_de_champ' do
+    let(:procedure) { create(:procedure, :with_repetition) }
+    let(:last_coordinate) { draft.revision_types_de_champ.last }
+    let(:last_type_de_champ) { last_coordinate.type_de_champ }
+
+    context 'bug with duplicated repetition child' do
+      before do
+        procedure.publish!
+        procedure.reload
+        draft.find_or_clone_type_de_champ(last_type_de_champ.stable_id).update(libelle: 'new libelle')
+        procedure.reload
+        draft.reload
+      end
+
+      it do
+        expect(procedure.revisions.size).to eq(2)
+        expect(draft.revision_types_de_champ.where.not(parent_id: nil).size).to eq(1)
+      end
+    end
+  end
+
   describe '#compare' do
     let(:first_tdc) { draft.types_de_champ_public.first }
     let(:new_draft) { procedure.create_new_revision }


### PR DESCRIPTION
on ne peut pas encore enlever `clone_parent_to_draft_revision(stable_id)` dans `find_or_clone_type_de_champ(stable_id)`

c'est l'enfant qui sera cloné, mais le parent a besoin d'être cloné avant