### PR TITLE
ETQ Admin, lorsque je publie une démarche, je souhaite indiquer si elle en remplace une autre

### DIFF
--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -216,9 +216,15 @@ module Administrateurs
       @procedure_lien_test = commencer_test_url(path: @procedure.path)
       @procedure.path = @procedure.suggested_path(current_administrateur)
       @current_administrateur = current_administrateur
+      @closed_procedures = current_administrateur.procedures.with_discarded.closes.map { |p| ["#{p.libelle} (#{p.id})", p.id] }.to_h
     end
 
     def publish
+      if params[:old_procedure].present?
+        old_procedure = current_administrateur.procedures.with_discarded.closes.find(params[:old_procedure])
+        old_procedure.update!(replaced_by_procedure_id: @procedure.id)
+      end
+
       @procedure.assign_attributes(publish_params)
 
       if @procedure.draft_changed?

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -48,6 +48,7 @@
 #  draft_revision_id                         :bigint
 #  parent_procedure_id                       :bigint
 #  published_revision_id                     :bigint
+#  replaced_by_procedure_id                  :bigint
 #  service_id                                :bigint
 #  zone_id                                   :bigint
 #
@@ -86,6 +87,8 @@ class Procedure < ApplicationRecord
 
   has_many :experts_procedures, dependent: :destroy
   has_many :experts, through: :experts_procedures
+  has_many :replaced_procedures, -> { with_discarded }, inverse_of: :replaced_by_procedure, class_name: "Procedure",
+  foreign_key: "replaced_by_procedure_id", dependent: :nullify
 
   has_one :module_api_carto, dependent: :destroy
   has_one :legacy_attestation_template, class_name: 'AttestationTemplate', dependent: :destroy
@@ -93,6 +96,7 @@ class Procedure < ApplicationRecord
 
   belongs_to :parent_procedure, class_name: 'Procedure', optional: true
   belongs_to :canonical_procedure, class_name: 'Procedure', optional: true
+  belongs_to :replaced_by_procedure, -> { with_discarded }, inverse_of: :replaced_procedures, class_name: "Procedure", optional: true
   belongs_to :service, optional: true
   belongs_to :zone, optional: true
 
@@ -502,6 +506,7 @@ class Procedure < ApplicationRecord
     procedure.cloned_from_library = from_library
     procedure.parent_procedure = self
     procedure.canonical_procedure = nil
+    procedure.replaced_by_procedure = nil
 
     if from_library
       procedure.service = nil

--- a/app/views/administrateurs/procedures/_publication_form.html.haml
+++ b/app/views/administrateurs/procedures/_publication_form.html.haml
@@ -28,6 +28,9 @@
                         style: 'width: 300px; display: inline;')
         .text-info.mb-4
           Attention, diffusez toujours le <strong>lien complet</strong> affiché ci-dessus, et non pas un lien générique vers #{APPLICATION_NAME}. Ne dites pas non plus aux usagers de se rendre sur le site générique #{APPLICATION_NAME}, donnez-leur toujours le lien complet.
+      - if @closed_procedures.present?
+        %h2.card-title Cette démarche remplace une close ? Si oui, veuillez indiquer le n° de la démarche remplacée
+        = select_tag :old_procedure, options_for_select(@closed_procedures), include_blank: true
       %h2.card-title Diffusion de la démarche
       %p Où les utilisateurs trouveront-ils le lien de la démarche ? Typiquement, il s’agit d’une page de votre site web.
       %p.center

--- a/app/views/users/dossiers/_procedure_removed_banner.html.haml
+++ b/app/views/users/dossiers/_procedure_removed_banner.html.haml
@@ -12,6 +12,8 @@
     - else
       %p
         = t('users.dossiers.header.banner.procedure_deleted_dossier_en_cours_content')
+
+    = render partial: "users/dossiers/replacement_procedure", locals: { replacement_procedure: dossier.procedure.replaced_by_procedure }
     %p
       = t('users.dossiers.header.banner.contact_service', service_name: dossier.procedure.service.nom, service_phone_number: dossier.procedure.service.telephone, service_email: dossier.procedure.service.email)
 
@@ -21,6 +23,8 @@
       = render(partial: 'users/dossiers/show/print_dossier', locals: { dossier: dossier }) if !dossier.brouillon?
     %p
       = t('users.dossiers.header.banner.procedure_close_content')
+
+    = render partial: "users/dossiers/replacement_procedure", locals: { replacement_procedure: dossier.procedure.replaced_by_procedure }
     %p
       = t('users.dossiers.header.banner.contact_service', service_name: dossier.procedure.service.nom, service_phone_number: dossier.procedure.service.telephone, service_email: dossier.procedure.service.email)
 

--- a/app/views/users/dossiers/_replacement_procedure.html.haml
+++ b/app/views/users/dossiers/_replacement_procedure.html.haml
@@ -1,0 +1,3 @@
+- if replacement_procedure.present?
+  %p
+    #{t('users.dossiers.header.banner.new_procedure_content')} #{link_to t('users.dossiers.header.banner.new_procedure_link'), commencer_path(replacement_procedure.path)}

--- a/config/locales/views/users/header/en.yml
+++ b/config/locales/views/users/header/en.yml
@@ -9,6 +9,8 @@ en:
           procedure_deleted_dossier_en_cours_content: You can still consult your file, but it is no longer possible to modify it
           procedure_deleted_dossier_termine_content: Your file has been processed by the administration, no action is possible
           procedure_close_content: You can still consult your file, but it will not be processed by the administration
+          new_procedure_link: see the procedure
+          new_procedure_content: "A new procedure is available, consult it here:"
           contact_service: For more information, please contact the service %{service_name}, available at  %{service_phone_number} or by email %{service_email}
           states:
             brouillon: Your file is still in draft and will soon expire. So it will be deleted soon without being instructed. If you want to pursue your procedure you can submit it now. Otherwise you are able to delay its expiration by clicking on the underneath button.

--- a/config/locales/views/users/header/fr.yml
+++ b/config/locales/views/users/header/fr.yml
@@ -8,6 +8,8 @@ fr:
           procedure_deleted_dossier_en_cours_content: "Vous pouvez toujours consulter votre dossier, mais il n’est plus possible de le modifier."
           procedure_deleted_dossier_termine_content: "Votre dossier a été traité par l'administration, aucune action n'est possible"
           procedure_close_content: "Vous pouvez toujours consulter votre dossier, mais il ne sera pas traité par l'administration"
+          new_procedure_link: voir la démarche
+          new_procedure_content: "Une nouvelle démarche est disponible, consultez-la ici :"
           contact_service: Pour plus d'informations, veuillez vous rapprocher du service %{service_name}, disponible au %{service_phone_number} ou par email %{service_email}
           title: Votre dossier va expirer
           states:

--- a/db/migrate/20220520173939_add_replacement_procedure_id_to_procedures.rb
+++ b/db/migrate/20220520173939_add_replacement_procedure_id_to_procedures.rb
@@ -1,0 +1,5 @@
+class AddReplacementProcedureIdToProcedures < ActiveRecord::Migration[6.1]
+  def change
+    add_column :procedures, :replaced_by_procedure_id, :bigint, foreign_key: { to_table: :procedures }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_26_140107) do
+ActiveRecord::Schema.define(version: 2022_05_20_173939) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "unaccent"
@@ -653,6 +654,7 @@ ActiveRecord::Schema.define(version: 2022_04_26_140107) do
     t.boolean "procedure_expires_when_termine_enabled", default: true
     t.datetime "published_at"
     t.bigint "published_revision_id"
+    t.bigint "replaced_by_procedure_id"
     t.text "routing_criteria_name", default: "Votre ville"
     t.boolean "routing_enabled"
     t.bigint "service_id"


### PR DESCRIPTION
#7335 

**Lorsque l'admin veut publier une nouvelle démarche, s’il a des démarches supprimées ou closes, nous lui demandons si la nouvelle démarche en remplace une :**

<img width="1026" alt="image" src="https://user-images.githubusercontent.com/21340608/170118358-4702f001-f8b0-4614-9903-5051a17f9c98.png">


**Si oui, l'usager est informé lorsqu'il consulte un dossier dont la démarche est supprimée mais remplacée par une nouvelle :**
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/21340608/169871558-a012ffeb-f627-4777-a119-0f37683ba8dd.png">



