### PR TITLE
[administrateur] indiquer que la démarche est interne

### DIFF
--- a/app/assets/stylesheets/toggle-switch.scss
+++ b/app/assets/stylesheets/toggle-switch.scss
@@ -9,6 +9,7 @@
   height: 24px;
   margin: 0;
   margin-right: 15px;
+  margin-bottom: 40px;
 }
 
 // Hide default HTML checkbox
@@ -20,7 +21,7 @@
 }
 
 // The control
-.toggle-switch-control {
+%toggle-switch-control-placeholder {
   position: absolute;
   width: 47px;
   cursor: pointer;
@@ -31,31 +32,46 @@
   background-color: $border-grey;
   transition: 0.4s;
   border: 1px solid transparent;
+
+  &::before {
+    position: absolute;
+    content: "";
+    height: 20px;
+    width: 20px;
+    left: 1px;
+    bottom: 1px;
+    background-color: $white;
+    transition: 0.4s;
+  }
+
+  input:focus + & {
+    border-color: $blue-france-500;
+    box-shadow: 0px 0px 2px 1px $blue-france-500;
+  }
+
+  input:checked + &::before {
+    transform: translateX(23px);
+  }
 }
 
-.toggle-switch-control::before {
-  position: absolute;
-  content: "";
-  height: 20px;
-  width: 20px;
-  left: 1px;
-  bottom: 1px;
-  background-color: $white;
-  transition: 0.4s;
+.toggle-switch-control {
+  @extend %toggle-switch-control-placeholder;
+  background-color: $border-grey;
+
+  input:checked + & {
+    background-color: $green;
+  }
 }
 
-input:checked + .toggle-switch-control {
+.toggle-switch-control-2 {
+  @extend %toggle-switch-control-placeholder;
   background-color: $green;
+
+  input:checked + & {
+    background-color: $dark-red;
+  }
 }
 
-input:focus + .toggle-switch-control {
-  border-color: $blue-france-500;
-  box-shadow: 0px 0px 2px 1px $blue-france-500;
-}
-
-input:checked + .toggle-switch-control::before {
-  transform: translateX(23px);
-}
 
 .toggle-switch-label {
   margin-left: 47px;
@@ -67,23 +83,38 @@ input:checked + .toggle-switch-control::before {
   color: $green;
 }
 
+.toggle-switch-label.on-2 {
+  color: $dark-red;
+}
+
 .toggle-switch-label.off {
   color: $grey;
 }
 
-.toggle-switch-checkbox:checked ~ .toggle-switch-label.off {
-  display: none;
+.toggle-switch-label.off-2 {
+  color: $green;
 }
 
-.toggle-switch-checkbox:not(:checked) ~ .toggle-switch-label.on {
+.toggle-switch-checkbox:checked ~ .toggle-switch-label.off,
+.toggle-switch-checkbox:checked ~ .toggle-switch-label.off-2,
+.toggle-switch-checkbox:not(:checked) ~ .toggle-switch-label.on,
+.toggle-switch-checkbox:not(:checked) ~ .toggle-switch-label.on-2 {
   display: none;
 }
 
 // Rounded control
-.toggle-switch-control.round {
+%toggle-switch-control-round-placeholder {
   border-radius: 24px;
+
+  &::before {
+    border-radius: 50%;
+  }
 }
 
-.toggle-switch-control.round::before {
-  border-radius: 50%;
+.toggle-switch-control.round {
+  @extend %toggle-switch-control-round-placeholder;
+}
+
+.toggle-switch-control-2.round {
+  @extend %toggle-switch-control-round-placeholder;
 }

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -297,6 +297,7 @@ module Administrateurs
         :duree_conservation_dossiers_dans_ds,
         :zone_id,
         :lien_dpo,
+        :internal,
         :procedure_expires_when_termine_enabled
       ]
       permited_params = if @procedure&.locked?

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -25,6 +25,7 @@
 #  for_individual                            :boolean          default(FALSE)
 #  hidden_at                                 :datetime
 #  instructeurs_self_management_enabled      :boolean
+#  internal                                  :boolean          default(FALSE)
 #  juridique_required                        :boolean          default(TRUE)
 #  libelle                                   :string
 #  lien_demarche                             :string

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -492,6 +492,7 @@ class Procedure < ApplicationRecord
       procedure.administrateurs = [admin]
       procedure.api_entreprise_token = nil
       procedure.encrypted_api_particulier_token = nil
+      procedure.internal = false
       procedure.api_particulier_scopes = []
     else
       procedure.administrateurs = administrateurs

--- a/app/views/administrateurs/procedures/_informations.html.haml
+++ b/app/views/administrateurs/procedures/_informations.html.haml
@@ -64,6 +64,17 @@
 
 = f.label :lien_dpo, 'Lien ou email pour contacter le Délégué à la Protection des Données (DPO)'
 = f.text_field :lien_dpo, class: 'form-control'
+
+%h3.header-subsection= t(:scope_procedure, scope: [:administrateurs, :informations])
+%p.notice= t(:notice_public_scope_html, scope: [:administrateurs, :informations])
+%p.notice= t(:notice_internal_scope, scope: [:administrateurs, :informations])
+
+%label.toggle-switch
+  = f.check_box :internal, class: 'toggle-switch-checkbox'
+  %span.toggle-switch-control-2.round
+  %span.toggle-switch-label.on-2 Démarche réservée aux agents
+  %span.toggle-switch-label.off-2 Démarche publique
+
 %h3.header-subsection Notice explicative de la démarche
 
 %p.notice

--- a/config/locales/views/administrateurs/informations/fr.yml
+++ b/config/locales/views/administrateurs/informations/fr.yml
@@ -1,0 +1,7 @@
+fr:
+  administrateurs:
+    informations:
+      scope_procedure: Portée de la démarche
+      notice_public_scope_html: "Les démarches hébergées par Démarches Simplifiées sont par défaut à destination des usagers ou des personnes morales. En ce sens, le descriptif et les champs du formulaire qui constituent votre démarche sont <a href=\"https://guides.etalab.gouv.fr/juridique/opendata/#qu-est-ce-que-l-open-data\" target=\"_blank\">communicables à tous, et peuvent être mis à disposition en accès libre et gratuit</a>, sous un format numérique facilement réutilisable. Les valeurs saisies par les usagers restent evidemment confidentielles."
+      notice_internal_scope: Si votre démarche est réservée aux agents de votre administration, vous pouvez réduire sa portée ici.
+

--- a/db/migrate/20220520181047_add_internal_to_procedures.rb
+++ b/db/migrate/20220520181047_add_internal_to_procedures.rb
@@ -1,0 +1,10 @@
+class AddInternalToProcedures < ActiveRecord::Migration[6.1]
+  def up
+    add_column :procedures, :internal, :boolean
+    change_column_default :procedures, :internal, false
+  end
+
+  def down
+    remove_column :procedures, :internal
+  end
+end

--- a/db/migrate/20220520183305_backfill_add_internal_to_procedures.rb
+++ b/db/migrate/20220520183305_backfill_add_internal_to_procedures.rb
@@ -1,0 +1,10 @@
+class BackfillAddInternalToProcedures < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    Procedure.in_batches do |relation|
+      relation.update_all internal: false
+      sleep(0.01)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_20_173939) do
+ActiveRecord::Schema.define(version: 2022_05_20_183305) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -641,6 +641,7 @@ ActiveRecord::Schema.define(version: 2022_05_20_173939) do
     t.boolean "for_individual", default: false
     t.datetime "hidden_at"
     t.boolean "instructeurs_self_management_enabled"
+    t.boolean "internal", default: false
     t.boolean "juridique_required", default: true
     t.string "libelle"
     t.string "lien_demarche"

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -439,6 +439,7 @@ describe Procedure do
       create(:procedure,
         received_mail: received_mail,
         service: service,
+        internal: internal,
         attestation_template: build(:attestation_template, logo: logo, signature: signature),
         types_de_champ: [type_de_champ_0, type_de_champ_1, type_de_champ_2, type_de_champ_pj, type_de_champ_repetition],
         types_de_champ_private: [type_de_champ_private_0, type_de_champ_private_1, type_de_champ_private_2, type_de_champ_private_repetition],
@@ -456,6 +457,7 @@ describe Procedure do
     let(:type_de_champ_private_repetition) { build(:type_de_champ_repetition, :private, position: 3, types_de_champ: [build(:type_de_champ, :private)]) }
     let(:received_mail) { build(:received_mail) }
     let(:from_library) { false }
+    let(:internal) { false }
     let(:administrateur) { procedure.administrateurs.first }
     let(:logo) { Rack::Test::UploadedFile.new('spec/fixtures/files/white.png', 'image/png') }
     let(:signature) { Rack::Test::UploadedFile.new('spec/fixtures/files/black.png', 'image/png') }
@@ -522,6 +524,13 @@ describe Procedure do
       expect(cloned_procedure).to have_same_attributes_as(procedure, except: ["path", "draft_revision_id"])
     end
 
+    context 'which is internal' do
+      let(:internal) { true }
+      it 'should keep internal for same admin' do
+        expect(subject.internal).to be_truthy
+      end
+    end
+
     context 'when the procedure is cloned from the library' do
       let(:from_library) { true }
 
@@ -562,6 +571,7 @@ describe Procedure do
 
     context 'when the procedure is cloned to another administrateur' do
       let(:administrateur) { create(:administrateur) }
+      let(:internal) { true }
 
       it 'should clone service' do
         expect(subject.service.id).not_to eq(service.id)
@@ -577,6 +587,10 @@ describe Procedure do
 
       it 'should discard specific api_entreprise_token' do
         expect(subject.read_attribute(:api_entreprise_token)).to be_nil
+      end
+
+      it 'should reset internal to false' do
+        expect(subject.internal).to be_falsey
       end
 
       it 'should have one administrateur' do

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -381,6 +381,14 @@ describe Procedure do
     end
   end
 
+  describe 'internal' do
+    let(:procedure) { create(:procedure) }
+
+    it 'is false by default' do
+      expect(procedure.internal).to be_falsy
+    end
+  end
+
   describe 'active' do
     let(:procedure) { create(:procedure) }
     subject { Procedure.active(procedure.id) }


### PR DESCRIPTION
Nous avons l'intention de rendre public les champs des démarches closes.
Il arrive que DS soit parfois utilisé pour des démarches à usage interne. Les champs de ces démarches n'ont pas lieu d'être publiés.

En tant qu'administrateur, je peux indiquer que ma démarche est à usage interne.

## Démarche publique

![portee-demarche-publique](https://user-images.githubusercontent.com/1111966/170056321-f10e139a-f506-43f8-9382-93955204bcf1.png)

## Démarche interne

![portee-demarche-interne](https://user-images.githubusercontent.com/1111966/170056348-3bb62b52-722b-42aa-a4e5-e64b7aa88629.png)

close #7357 