### PR TITLE
publiccode.yml : ajout du lien vers la dernière release

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -7,7 +7,7 @@ name: Démarches Simplifiéees
 url: 'https://github.com/betagouv/demarches-simplifiees.fr'
 landingURL: 'https://www.demarches-simplifiees.fr/'
 roadmap: 'https://github.com/betagouv/demarches-simplifiees.fr/wiki/Feuille-de-route'
-releaseDate: '2022-01-26'
+releaseDate: 'https://github.com/betagouv/demarches-simplifiees.fr/releases/latest'
 developmentStatus: beta
 softwareType: standalone/backend
 categories:


### PR DESCRIPTION
Le format publiccode.yml demande de renseigner la clé `releaseDate`.
Les mises en production de Démarches Simplifiés étant fréquentes, il semble plus judicieux de donner comme valeur à la clé `releaseDate` un lien permettant de connaitre quelle est la dernière version.

Ce choix semble compatible avec l'aide contextuelle embarquée dans [l'éditeur d'etalab](https://publiccode-editor.etalab.studio/) , il est indiqué que cette clé contient le dernier numéro de version stable du logiciel. Le numéro de version est une chaîne de caractères qui n'est pas censée être interprétée ou analysée, mais simplement affichée. Les analyseurs syntaxiques ne doivent pas supposer l'existence d'une version sémantique ou d'un autre format de version spécifique.