### PR TITLE
Usager : correction de l'affichage du sélecteur de date et heure

### DIFF
--- a/config/initializers/date_select.rb
+++ b/config/initializers/date_select.rb
@@ -25,7 +25,7 @@ module ActionView
         end
         field_for = "#{prefix.join('_')}_#{@options[:field_name]}"
 
-        "<label class='screen-reader-text' for='#{field_for}_#{n}i'>#{label}</label>"
+        "<label class='sr-only' for='#{field_for}_#{n}i'>#{label}</label>"
       end
 
       # Returns the separator for a given datetime component.


### PR DESCRIPTION
The accessibility labels where not properly hidden, which resulted in the labels being visible and stacked vertically.

Fix #7410

## Before

<img width="493" alt="Capture d’écran 2022-05-31 à 15 16 04" src="https://user-images.githubusercontent.com/179923/171182266-0fd8c532-3fb6-4d0d-9f88-d4ca80cae9d2.png">


## After
<img width="506" alt="Capture d’écran 2022-05-31 à 15 09 24" src="https://user-images.githubusercontent.com/179923/171181076-b159a632-06e0-465a-81b4-bda0fa26b767.png">

