### PR TITLE
Technique : correction du nom du feature-flag `procedure_estimated_fill_duration`

### DIFF
--- a/app/helpers/procedure_helper.rb
+++ b/app/helpers/procedure_helper.rb
@@ -38,7 +38,7 @@ module ProcedureHelper
       baseUrl: admin_procedure_types_de_champ_path(procedure),
       directUploadUrl: rails_direct_uploads_url,
       continuerUrl: admin_procedure_path(procedure),
-      estimatedFillDuration: procedure.feature_enabled?(:procedure_estimate_fill_duration) ? procedure.draft_revision.estimated_fill_duration : 0
+      estimatedFillDuration: procedure.feature_enabled?(:procedure_estimated_fill_duration) ? procedure.draft_revision.estimated_fill_duration : 0
     }
   end
 


### PR DESCRIPTION
Ce correctif corrige l'affichage initial de la durée de remplissage dans l'éditeur de champs.