### PR TITLE
Correction d'une exception lors de la création d'une démarche avec les estimations de durée activées

### DIFF
--- a/app/views/shared/_procedure_description.html.haml
+++ b/app/views/shared/_procedure_description.html.haml
@@ -8,7 +8,7 @@
 %h1.procedure-title
   = procedure.libelle
 
-- if procedure.feature_enabled?(:procedure_estimated_fill_duration)
+- if procedure.persisted? && procedure.feature_enabled?(:procedure_estimated_fill_duration)
   %p.procedure-configuration.procedure-configuration--fill-duration
     %span.icon.clock
     = t('shared.procedure_description.estimated_fill_duration', estimated_minutes: estimated_fill_duration_minutes(procedure))


### PR DESCRIPTION
Oups.

Du coup, en attendant que ce correctif soit déployé, j'ai désactivé les estimations de démarche en prod.