### PR TITLE
fix(drop_down_list): ensure to skip disabled input when sending data via autosave

### DIFF
--- a/app/javascript/controllers/autosave_controller.ts
+++ b/app/javascript/controllers/autosave_controller.ts
@@ -176,6 +176,6 @@ export class AutosaveController extends ApplicationController {
         ...parent.querySelectorAll<HTMLInputElement>('input[data-id]')
       ];
     }
-    return inputs;
+    return inputs.filter((element) => !element.disabled);
   }
 }

--- a/spec/system/users/dropdown_spec.rb
+++ b/spec/system/users/dropdown_spec.rb
@@ -1,14 +1,6 @@
-describe 'dropdown list with other option activated' do
+describe 'dropdown list with other option activated', js: true do
   let(:password) { 'my-s3cure-p4ssword' }
   let!(:user) { create(:user, password: password) }
-
-  let(:list_items) do
-    <<~END_OF_LIST
-      --Primary 1--
-      Secondary 1.1
-      Secondary 1.2
-    END_OF_LIST
-  end
 
   let(:type_de_champ) { build(:type_de_champ_drop_down_list, libelle: 'simple dropdown other', drop_down_list_value: list_items, drop_down_other: true) }
 
@@ -20,15 +12,50 @@ describe 'dropdown list with other option activated' do
 
   before do
     login_as(user, scope: :user)
-    visit "/commencer/#{procedure.path}"
+    visit "/commencer/#{procedure.path}?locale=fr"
     click_on 'Commencer la démarche'
   end
+  context 'with radios' do
+    let(:list_items) do
+      <<~END_OF_LIST
+        --Primary 1--
+        Secondary 1.1
+        Secondary 1.2
+      END_OF_LIST
+    end
 
-  scenario 'Select other option and the other input hidden must appear', js: true do
-    fill_individual
+    scenario 'Select other option and the other input hidden must appear', js: true do
+      fill_individual
 
-    find('.radios').find('label:last-child').find('input').select_option
-    expect(page).to have_selector('.drop_down_other', visible: true)
+      find('.radios').find('label:last-child').find('input').select_option
+      expect(page).to have_selector('.drop_down_other', visible: true)
+    end
+  end
+
+  context 'with select' do
+    let(:list_items) do
+      <<~END_OF_LIST
+        --Primary 1--
+        Secondary 1.1
+        Secondary 1.2
+        Secondary 1.3
+        Secondary 1.4
+        Secondary 1.5
+        Secondary 1.6
+      END_OF_LIST
+    end
+
+    scenario 'with a select and other, selecting a value save it (avoid hidden other_value to be sent)' do
+      fill_individual
+
+      find(".drop_down_other input", visible: false)
+      select("Autre")
+      find(".drop_down_other input", visible: true)
+
+      select("Secondary 1.2")
+      expect(page).to have_selector(".autosave-status.succeeded", visible: true)
+      expect(user_dossier.champs.first.value).to eq("Secondary 1.2")
+    end
   end
 
   private


### PR DESCRIPTION
# contexte ; 

ETQ usagers, je souhaite selectionner un element dans une liste a choix unique, en mode dropdown (donc + de 6 elements).  aussi le champs de choix parmis une liste a l'option "autre" activé

# probleme ;

le chmps reste vide

# solution ; 
en effet, l'input est disabled (donc non envoyé) ; en revanche l'autosave ne skip pas les inputs disabled. donc on les skip