### PR TITLE
fix(graphql): avoid n+1 on champ_descriptors

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -433,8 +433,9 @@ interface Demandeur {
 Une démarche
 """
 type Demarche {
-  annotationDescriptors: [ChampDescriptor!]!
-  champDescriptors: [ChampDescriptor!]!
+  activeRevision: Revision!
+  annotationDescriptors: [ChampDescriptor!]! @deprecated(reason: "Utilisez le champ `active_revision.annotation_descriptors` à la place.")
+  champDescriptors: [ChampDescriptor!]! @deprecated(reason: "Utilisez le champ `active_revision.champ_descriptors` à la place.")
 
   """
   Date de la création.
@@ -639,6 +640,8 @@ type DemarcheDescriptor {
   Numero de la démarche.
   """
   number: Int!
+  revision: Revision!
+  service: Service!
 
   """
   État de la démarche.
@@ -779,7 +782,7 @@ type Dossier {
   L’URL du dossier au format PDF.
   """
   pdf: File
-  revision: Revision!
+  revision: Revision! @deprecated(reason: "Utilisez le champ `demarche.revision` à la place.")
 
   """
   L’état du dossier.

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -118,7 +118,7 @@ type Avis {
   dateReponse: ISO8601DateTime
   expert: Profile
   id: ID!
-  instructeur: Profile! @deprecated(reason: "Utilisez le champ claimant à la place.")
+  instructeur: Profile! @deprecated(reason: "Utilisez le champ `claimant` à la place.")
   question: String!
   reponse: String
 }
@@ -328,7 +328,7 @@ type DateChamp implements Champ {
   """
   La valeur du champ formaté en ISO8601 (DateTime).
   """
-  value: ISO8601DateTime @deprecated(reason: "Utilisez le champ 'date' ou le fragment 'DatetimeChamp' à la place.")
+  value: ISO8601DateTime @deprecated(reason: "Utilisez le champ `date` ou le fragment `DatetimeChamp` à la place.")
 }
 
 type DatetimeChamp implements Champ {
@@ -434,8 +434,8 @@ Une démarche
 """
 type Demarche {
   activeRevision: Revision!
-  annotationDescriptors: [ChampDescriptor!]! @deprecated(reason: "Utilisez le champ `active_revision.annotation_descriptors` à la place.")
-  champDescriptors: [ChampDescriptor!]! @deprecated(reason: "Utilisez le champ `active_revision.champ_descriptors` à la place.")
+  annotationDescriptors: [ChampDescriptor!]! @deprecated(reason: "Utilisez le champ `activeRevision.annotationDescriptors` à la place.")
+  champDescriptors: [ChampDescriptor!]! @deprecated(reason: "Utilisez le champ `activeRevision.champDescriptors` à la place.")
 
   """
   Date de la création.

--- a/app/graphql/types/avis_type.rb
+++ b/app/graphql/types/avis_type.rb
@@ -11,7 +11,7 @@ module Types
       { Extensions::Attachment => { attachment: :piece_justificative_file } }
     ]
 
-    field :instructeur, Types::ProfileType, null: false, method: :claimant, deprecation_reason: "Utilisez le champ claimant à la place."
+    field :instructeur, Types::ProfileType, null: false, method: :claimant, deprecation_reason: "Utilisez le champ `claimant` à la place."
     field :claimant, Types::ProfileType, null: true
     field :expert, Types::ProfileType, null: true
   end

--- a/app/graphql/types/champs/date_champ_type.rb
+++ b/app/graphql/types/champs/date_champ_type.rb
@@ -2,7 +2,7 @@ module Types::Champs
   class DateChampType < Types::BaseObject
     implements Types::ChampType
 
-    field :value, GraphQL::Types::ISO8601DateTime, "La valeur du champ formaté en ISO8601 (DateTime).", null: true, deprecation_reason: "Utilisez le champ 'date' ou le fragment 'DatetimeChamp' à la place."
+    field :value, GraphQL::Types::ISO8601DateTime, "La valeur du champ formaté en ISO8601 (DateTime).", null: true, deprecation_reason: "Utilisez le champ `date` ou le fragment `DatetimeChamp` à la place."
     field :date, GraphQL::Types::ISO8601Date, "La valeur du champ formaté en ISO8601 (Date).", null: true
 
     def value

--- a/app/graphql/types/demarche_descriptor_type.rb
+++ b/app/graphql/types/demarche_descriptor_type.rb
@@ -5,20 +5,71 @@ Ceci est une version abrégée du type `Demarche`, qui n’expose que les métad
 Cela évite l’accès récursif aux dossiers."
 
     global_id_field :id
-    field :number, Int, "Numero de la démarche.", null: false, method: :id
-    field :title, String, "Titre de la démarche.", null: false, method: :libelle
+    field :number, Int, "Numero de la démarche.", null: false
+    field :title, String, "Titre de la démarche.", null: false
     field :description, String, "Description de la démarche.", null: false
     field :state, Types::DemarcheType::DemarcheState, "État de la démarche.", null: false
-    field :declarative, Types::DemarcheType::DossierDeclarativeState, "Pour une démarche déclarative, état cible des dossiers à valider automatiquement", null: true, method: :declarative_with_state
+    field :declarative, Types::DemarcheType::DossierDeclarativeState, "Pour une démarche déclarative, état cible des dossiers à valider automatiquement", null: true
 
-    field :date_creation, GraphQL::Types::ISO8601DateTime, "Date de la création.", null: false, method: :created_at
-    field :date_publication, GraphQL::Types::ISO8601DateTime, "Date de la publication.", null: true, method: :published_at
-    field :date_derniere_modification, GraphQL::Types::ISO8601DateTime, "Date de la dernière modification.", null: false, method: :updated_at
-    field :date_depublication, GraphQL::Types::ISO8601DateTime, "Date de la dépublication.", null: true, method: :unpublished_at
-    field :date_fermeture, GraphQL::Types::ISO8601DateTime, "Date de la fermeture.", null: true, method: :closed_at
+    field :date_creation, GraphQL::Types::ISO8601DateTime, "Date de la création.", null: false
+    field :date_publication, GraphQL::Types::ISO8601DateTime, "Date de la publication.", null: true
+    field :date_derniere_modification, GraphQL::Types::ISO8601DateTime, "Date de la dernière modification.", null: false
+    field :date_depublication, GraphQL::Types::ISO8601DateTime, "Date de la dépublication.", null: true
+    field :date_fermeture, GraphQL::Types::ISO8601DateTime, "Date de la fermeture.", null: true
+
+    field :revision, Types::RevisionType, null: false
+    field :service, Types::ServiceType, null: false
+
+    def service
+      Loaders::Record.for(Service).load(object.procedure.service_id)
+    end
+
+    def revision
+      object
+    end
 
     def state
-      object.aasm.current_state
+      object.procedure.aasm.current_state
+    end
+
+    def number
+      object.procedure.id
+    end
+
+    def title
+      object.procedure.libelle
+    end
+
+    def description
+      object.procedure.description
+    end
+
+    def declarative
+      object.procedure.declarative_with_state
+    end
+
+    def date_creation
+      object.procedure.created_at
+    end
+
+    def date_publication
+      object.procedure.published_at
+    end
+
+    def date_derniere_modification
+      object.procedure.updated_at
+    end
+
+    def date_depublication
+      object.procedure.unpublished_at
+    end
+
+    def date_fermeture
+      object.procedure.closed_at
+    end
+
+    def self.authorized?(object, context)
+      context.authorized_demarche?(object.procedure)
     end
   end
 end

--- a/app/graphql/types/demarche_type.rb
+++ b/app/graphql/types/demarche_type.rb
@@ -48,9 +48,10 @@ module Types
       argument :deleted_since, GraphQL::Types::ISO8601DateTime, required: false, description: "Dossiers supprimés depuis la date."
     end
 
-    field :champ_descriptors, [Types::ChampDescriptorType], null: false
-    field :annotation_descriptors, [Types::ChampDescriptorType], null: false
+    field :champ_descriptors, [Types::ChampDescriptorType], null: false, deprecation_reason: 'Utilisez le champ `activeRevision.champDescriptors` à la place.'
+    field :annotation_descriptors, [Types::ChampDescriptorType], null: false, deprecation_reason: 'Utilisez le champ `activeRevision.annotationDescriptors` à la place.'
 
+    field :active_revision, Types::RevisionType, null: false
     field :draft_revision, Types::RevisionType, null: false
     field :published_revision, Types::RevisionType, null: true
     field :revisions, [Types::RevisionType], null: false

--- a/app/graphql/types/dossier_type.rb
+++ b/app/graphql/types/dossier_type.rb
@@ -12,7 +12,7 @@ module Types
     field :number, Int, "Le numero du dossier.", null: false, method: :id
     field :state, DossierState, "L’état du dossier.", null: false
 
-    field :demarche, Types::DemarcheDescriptorType, null: false, method: :procedure
+    field :demarche, Types::DemarcheDescriptorType, null: false, method: :revision
 
     field :date_depot, GraphQL::Types::ISO8601DateTime, "Date de dépôt.", null: false, method: :depose_at
     field :date_passage_en_construction, GraphQL::Types::ISO8601DateTime, "Date du dernier passage en construction.", null: false, method: :en_construction_at
@@ -37,7 +37,7 @@ module Types
 
     field :usager, Types::ProfileType, null: false
     field :groupe_instructeur, Types::GroupeInstructeurType, null: false
-    field :revision, Types::RevisionType, null: false
+    field :revision, Types::RevisionType, null: false, deprecation_reason: 'Utilisez le champ `demarche.revision` à la place.'
 
     field :demandeur, Types::DemandeurType, null: false
 
@@ -79,12 +79,8 @@ module Types
       Loaders::Record.for(GroupeInstructeur).load(object.groupe_instructeur_id)
     end
 
-    def revision
-      Loaders::Record.for(ProcedureRevision).load(object.revision_id)
-    end
-
     def demandeur
-      if object.procedure.for_individual
+      if object.revision.procedure.for_individual
         Loaders::Association.for(object.class, :individual).load(object)
       else
         Loaders::Association.for(object.class, :etablissement).load(object)
@@ -166,7 +162,7 @@ module Types
     end
 
     def self.authorized?(object, context)
-      context.authorized_demarche?(object.procedure)
+      context.authorized_demarche?(object.revision.procedure)
     end
   end
 end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -383,7 +383,7 @@ class Dossier < ApplicationRecord
       .where.not(user: users_who_submitted)
   end
 
-  scope :for_api_v2, -> { includes(procedure: [:administrateurs], revision: [:attestation_template], etablissement: [], individual: [], traitement: []) }
+  scope :for_api_v2, -> { includes(revision: [:attestation_template, procedure: [:administrateurs]], etablissement: [], individual: [], traitement: []) }
 
   scope :with_notifications, -> do
     joins(:follows)

--- a/app/services/serializer_service.rb
+++ b/app/services/serializer_service.rb
@@ -74,6 +74,7 @@ class SerializerService
       datePassageEnConstruction
       datePassageEnInstruction
       dateTraitement
+      dateDepot
       dateSuppressionParUsager
       dateSuppressionParAdministration
       instructeurs {
@@ -103,8 +104,11 @@ class SerializerService
       motivationAttachment {
         ...FileFragment
       }
-      revision {
-        id
+      demarche {
+        number
+        revision {
+          id
+        }
       }
     }
 

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -1101,7 +1101,7 @@ describe Users::DossiersController, type: :controller do
     subject { patch :restore, params: { id: dossier.id } }
 
     context 'when the user want to restore his dossier' do
-      let!(:dossier) { create(:dossier, :with_individual, state: :accepte, en_construction_at: Time.zone.yesterday.beginning_of_day.utc, hidden_by_user_at: Time.zone.yesterday.beginning_of_day.utc, user: user, autorisation_donnees: true) }
+      let!(:dossier) { create(:dossier, :accepte, :with_individual, en_construction_at: Time.zone.yesterday.beginning_of_day.utc, hidden_by_user_at: Time.zone.yesterday.beginning_of_day.utc, user: user, autorisation_donnees: true) }
 
       before { subject }
 


### PR DESCRIPTION
Après réflexion – exposé une méthode qui liste les démarches n'est pas une bonne idée même pour l'usage interne, car ça ouvre la possibilité d'écrire une query qui liste les dossiers sur n démarches ce qui serait un désastre en termes de perf. Nous avons déjà un objet qui expose uniquement les metadata des démarches – `DemarcheDescriptorType`. Mais cet objet n'avais pas accès aux champs descriptors. Dans cette PR je lui ajoute les champs descriptors. Maintenant, il sera possible d'exposer une query qui liste les démarche descriptors.