### PR TITLE
FIX: remove an unwanted character in footer

### DIFF
--- a/app/views/root/_footer.html.haml
+++ b/app/views/root/_footer.html.haml
@@ -48,4 +48,3 @@
               = link_to t("links.footer.status_page.label"), t("links.footer.status_page.url"), title: t("links.footer.status_page.title"), class: "footer-link", target: "_blank", rel: "noopener noreferrer"
             %li.footer-link
               = link_to t("links.footer.security.label"), t("links.footer.security.url"), title: t("links.footer.security.title"), class: "footer-link", target: "_blank", rel: "noopener noreferrer"
-    }


### PR DESCRIPTION
Close #7463 "ETQ usager, je ne devrait pas voir le caractère **}** en pied de page"

**Décrivez le bug**
Un caractère **}** s'affiche en pied de page de la page d’accueil.

**Reproduction**
Comment reproduire le problème :
1. Aller sur la page 'page d’accueil'
2. Un caractère **}** est présent en pied de page

**Comportement attendu**
Un caractère **}** n'est pas présent en pied de page de la page d’accueil.

**Capture d'écran**
![Sélection_064](https://user-images.githubusercontent.com/6709977/173387281-a5987aba-d084-456a-9c29-20e0d501f551.png)

--------------------
> `trackingAdullactContrib `