### PR TITLE
fix(spec): including Logic module broke spreadsheet architect

### DIFF
--- a/spec/models/logic/binary_operator_spec.rb
+++ b/spec/models/logic/binary_operator_spec.rb
@@ -1,6 +1,5 @@
-include Logic
-
 describe Logic::BinaryOperator do
+  include Logic
   let(:two_greater_than_one) { greater_than(constant(2), constant(1)) }
 
   describe '#type' do
@@ -22,6 +21,7 @@ describe Logic::BinaryOperator do
 end
 
 describe Logic::GreaterThan do
+  include Logic
   it 'computes' do
     expect(greater_than(constant(1), constant(1)).compute).to be(false)
     expect(greater_than(constant(2), constant(1)).compute).to be(true)
@@ -29,6 +29,7 @@ describe Logic::GreaterThan do
 end
 
 describe Logic::GreaterThanEq do
+  include Logic
   it 'computes' do
     expect(greater_than_eq(constant(0), constant(1)).compute).to be(false)
     expect(greater_than_eq(constant(1), constant(1)).compute).to be(true)
@@ -37,6 +38,7 @@ describe Logic::GreaterThanEq do
 end
 
 describe Logic::LessThan do
+  include Logic
   it 'computes' do
     expect(less_than(constant(1), constant(1)).compute).to be(false)
     expect(less_than(constant(1), constant(2)).compute).to be(true)
@@ -44,6 +46,7 @@ describe Logic::LessThan do
 end
 
 describe Logic::LessThanEq do
+  include Logic
   it 'computes' do
     expect(less_than_eq(constant(0), constant(1)).compute).to be(true)
     expect(less_than_eq(constant(1), constant(1)).compute).to be(true)


### PR DESCRIPTION
sur mon autre [PR](https://github.com/betagouv/demarches-simplifiees.fr/pull/7471) des tests cassaient : 
```

rspec ./spec/services/procedure_export_service_spec.rb:322# ProcedureExportService to_xlsx Avis sheet should have headers
rspec ./spec/services/procedure_export_service_spec.rb:334# ProcedureExportService to_xlsx Avis sheet should have data
rspec ./spec/services/procedure_export_service_spec.rb:92# ProcedureExportService to_xlsx Dossiers sheet should have data
rspec ./spec/services/procedure_export_service_spec.rb:88# ProcedureExportService to_xlsx Dossiers sheet should have headers
rspec ./spec/services/procedure_export_service_spec.rb:118# ProcedureExportService to_xlsx Dossiers sheet with a procedure routee 
rspec ./spec/services/procedure_export_service_spec.rb:119# ProcedureExportService to_xlsx Dossiers sheet with a procedure routee 
rspec ./spec/services/procedure_export_service_spec.rb:109# ProcedureExportService to_xlsx Dossiers sheet with a birthdate 
rspec ./spec/services/procedure_export_service_spec.rb:110# ProcedureExportService to_xlsx Dossiers sheet with a birthdate 
rspec ./spec/services/procedure_export_service_spec.rb:271# ProcedureExportService to_xlsx Etablissement sheet should have headers
rspec ./spec/services/procedure_export_service_spec.rb:311# ProcedureExportService to_xlsx Etablissement sheet should have data
rspec ./spec/services/procedure_export_service_spec.rb:348# ProcedureExportService to_xlsx Repetitions sheet should have sheets
rspec ./spec/services/procedure_export_service_spec.rb:369# ProcedureExportService to_xlsx Repetitions sheet should have data
rspec ./spec/services/procedure_export_service_spec.rb:393# ProcedureExportService to_xlsx Repetitions sheet with long libelle composed of utf8 characteres should have valid sheet name
rspec ./spec/services/procedure_export_service_spec.rb:378# ProcedureExportService to_xlsx Repetitions sheet with invalid characters should have valid sheet name
rspec ./spec/services/procedure_export_service_spec.rb:404# ProcedureExportService to_xlsx Repetitions sheet with non unique labels should have sheets
rspec ./spec/services/procedure_export_service_spec.rb:359# ProcedureExportService to_xlsx Repetitions sheet with cloned procedure should have headers
rspec ./spec/services/procedure_export_service_spec.rb:416# ProcedureExportService to_xlsx Repetitions sheet with empty repetition should not have data
Randomized with seed 4558
```
J'ai pas la fin de l'histoire, mais le faire de rescoper l'inclusion de logic fait que le to_xlsx ne plante plus 