### PR TITLE
feat(GroupeInstructeurs.closed): add closed option to GroupeInstructeur in order to prevent usagers to submit dossier

### DIFF
--- a/app/models/groupe_instructeur.rb
+++ b/app/models/groupe_instructeur.rb
@@ -3,6 +3,7 @@
 # Table name: groupe_instructeurs
 #
 #  id           :bigint           not null, primary key
+#  closed       :boolean          default(FALSE)
 #  label        :text             not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null

--- a/app/views/administrateurs/_groups_header.haml
+++ b/app/views/administrateurs/_groups_header.haml
@@ -6,4 +6,11 @@
 
     = f.label :label, 'Nom du groupe'
     = f.text_field :label, placeholder: 'Ville de Bordeaux', required: true
-    = f.submit 'Renommer', class: 'button primary send'
+    .editable-champ.editable-champ-checkbox
+      = f.label :closed, 'Groupe inactif'
+      .notice
+        %p Si cette option est activé les usagers ne pourront plus séléctionné ce groupe d'instructeur
+      = f.check_box :closed
+
+    %br
+    = f.submit 'Valider', class: 'button primary send'

--- a/app/views/shared/dossiers/_edit.html.haml
+++ b/app/views/shared/dossiers/_edit.html.haml
@@ -28,7 +28,7 @@
           = dossier.procedure.routing_criteria_name
           %span.mandatory *
         = f.select :groupe_instructeur_id,
-          dossier.procedure.groupe_instructeurs.order(:label).map { |gi| [gi.label, gi.id] },
+          dossier.procedure.groupe_instructeurs.where(closed: false).order(:label).map { |gi| [gi.label, gi.id] },
           { include_blank: dossier.brouillon? }
 
     - dossier.champs.each do |champ|

--- a/db/migrate/20220620132646_add_column_closed_to_groupe_instructeurs.rb
+++ b/db/migrate/20220620132646_add_column_closed_to_groupe_instructeurs.rb
@@ -1,0 +1,5 @@
+class AddColumnClosedToGroupeInstructeurs < ActiveRecord::Migration[6.1]
+  def change
+    add_column :groupe_instructeurs, :closed, :boolean, default: false
+  end
+end

--- a/db/migrate/20220620141238_add_index_on_procedure_id_and_closed_to_groupe_instructeurs.rb
+++ b/db/migrate/20220620141238_add_index_on_procedure_id_and_closed_to_groupe_instructeurs.rb
@@ -1,0 +1,7 @@
+class AddIndexOnProcedureIdAndClosedToGroupeInstructeurs < ActiveRecord::Migration[6.1]
+  include Database::MigrationHelpers
+  disable_ddl_transaction!
+  def up
+    add_concurrent_index :groupe_instructeurs, [:closed, :procedure_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_17_142759) do
+ActiveRecord::Schema.define(version: 2022_06_20_141238) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -510,10 +510,12 @@ ActiveRecord::Schema.define(version: 2022_06_17_142759) do
   end
 
   create_table "groupe_instructeurs", force: :cascade do |t|
+    t.boolean "closed", default: false
     t.datetime "created_at", null: false
     t.text "label", null: false
     t.bigint "procedure_id", null: false
     t.datetime "updated_at", null: false
+    t.index ["closed", "procedure_id"], name: "index_groupe_instructeurs_on_closed_and_procedure_id"
     t.index ["procedure_id", "label"], name: "index_groupe_instructeurs_on_procedure_id_and_label", unique: true
     t.index ["procedure_id"], name: "index_groupe_instructeurs_on_procedure_id"
   end

--- a/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
+++ b/spec/controllers/administrateurs/groupe_instructeurs_controller_spec.rb
@@ -188,19 +188,21 @@ describe Administrateurs::GroupeInstructeursController, type: :controller do
         params: {
           procedure_id: procedure.id,
           id: gi_1_1.id,
-          groupe_instructeur: { label: new_name }
+          groupe_instructeur: { label: new_name, closed: true }
         }
+      gi_1_1.reload
     end
 
-    it { expect(gi_1_1.reload.label).to eq(new_name) }
     it { expect(response).to redirect_to(admin_procedure_groupe_instructeur_path(procedure, gi_1_1)) }
+    it { expect(gi_1_1.label).to eq(new_name) }
+    it { expect(gi_1_1.closed).to eq(true) }
     it { expect(flash.notice).to be_present }
 
     context 'when the name is already taken' do
       let!(:gi_1_2) { procedure.groupe_instructeurs.create(label: 'groupe instructeur 2') }
       let(:new_name) { gi_1_2.label }
 
-      it { expect(gi_1_1.reload.label).not_to eq(new_name) }
+      it { expect(gi_1_1.label).not_to eq(new_name) }
       it { expect(flash.alert).to be_present }
     end
   end

--- a/spec/system/routing/full_scenario_spec.rb
+++ b/spec/system/routing/full_scenario_spec.rb
@@ -25,7 +25,7 @@ describe 'The routing', js: true do
     # rename defaut groupe to littéraire
     click_on 'voir'
     fill_in 'Nom du groupe', with: 'littéraire'
-    click_on 'Renommer'
+    click_on 'Valider'
     expect(page).to have_text('Le nom est à présent « littéraire ».')
     expect(page).to have_field('Nom du groupe', with: 'littéraire')
 
@@ -42,6 +42,13 @@ describe 'The routing', js: true do
     expect(page).to have_text("L’instructeur superwoman@inst.com a été affecté au groupe « littéraire »")
 
     superwoman = User.find_by(email: 'superwoman@inst.com').instructeur
+
+    # add inactive groupe
+    click_on 'Groupes d’instructeurs'
+    fill_in 'Ajouter un groupe', with: 'non visible car inactif'
+    click_on 'Ajouter le groupe'
+    check "Groupe inactif"
+    click_on 'Valider'
 
     # add scientifique groupe
     click_on 'Groupes d’instructeurs'
@@ -203,6 +210,8 @@ describe 'The routing', js: true do
     visit dossiers_path
     click_on user.dossiers.first.id.to_s
     click_on "Modifier mon dossier"
+    expect(page).to have_selector("option", text: "scientifique")
+    expect(page).not_to have_selector("option", text: "Groupe inactif")
 
     select(new_group, from: 'dossier_groupe_instructeur_id')
     click_on "Enregistrer les modifications du dossier"


### PR DESCRIPTION
# contexte 
ETQ administrateur je souhaite pouvoir desactiver un groupe d'instructeur

# solution 
1. 1 flag (closed) sur les `GroupeInstructeur` 
2. ETQ admin, je peux cocher/decocher ce flag sur la vue `/admin/procedures/:procedure_id/groupe_instructeurs/:id`
> <img width="1063" alt="Screen Shot 2022-06-20 at 4 28 34 PM" src="https://user-images.githubusercontent.com/125964/174624281-e6c4ed98-4bbf-4808-be95-028b6f270a73.png">
 3. ETQ usager, le groupe ne s'affiche aps dans la liste
 4. 🎉 

