### PR TITLE
[administrateur] rendre possible la publication en opendata du descriptif d'une démarche

### DIFF
--- a/app/assets/stylesheets/toggle-switch.scss
+++ b/app/assets/stylesheets/toggle-switch.scss
@@ -9,6 +9,7 @@
   height: 24px;
   margin: 0;
   margin-right: 15px;
+  margin-bottom: 40px;
 }
 
 // Hide default HTML checkbox

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -308,6 +308,7 @@ module Administrateurs
         :duree_conservation_dossiers_dans_ds,
         :zone_id,
         :lien_dpo,
+        :opendata,
         :procedure_expires_when_termine_enabled
       ]
       permited_params = if @procedure&.locked?

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -32,6 +32,7 @@
 #  lien_notice                               :string
 #  lien_site_web                             :string
 #  monavis_embed                             :text
+#  opendata                                  :boolean          default(TRUE)
 #  organisation                              :string
 #  path                                      :string           not null
 #  procedure_expires_when_termine_enabled    :boolean          default(TRUE)

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -487,6 +487,7 @@ class Procedure < ApplicationRecord
       procedure.administrateurs = [admin]
       procedure.api_entreprise_token = nil
       procedure.encrypted_api_particulier_token = nil
+      procedure.opendata = true
       procedure.api_particulier_scopes = []
     else
       procedure.administrateurs = administrateurs

--- a/app/views/administrateurs/procedures/_informations.html.haml
+++ b/app/views/administrateurs/procedures/_informations.html.haml
@@ -64,6 +64,17 @@
 
 = f.label :lien_dpo, 'Lien ou email pour contacter le Délégué à la Protection des Données (DPO)'
 = f.text_field :lien_dpo, class: 'form-control'
+
+%h3.header-subsection= t(:opendata_header, scope: [:administrateurs, :informations])
+%p.notice= t(:opendata_notice_html, scope: [:administrateurs, :informations])
+%p.notice= t(:opendata, scope: [:administrateurs, :informations])
+
+%label.toggle-switch
+  = f.check_box :opendata, class: 'toggle-switch-checkbox'
+  %span.toggle-switch-control.round
+  %span.toggle-switch-label.on Oui
+  %span.toggle-switch-label.off Non
+
 %h3.header-subsection Notice explicative de la démarche
 
 %p.notice

--- a/app/views/administrateurs/procedures/_informations.html.haml
+++ b/app/views/administrateurs/procedures/_informations.html.haml
@@ -65,15 +65,16 @@
 = f.label :lien_dpo, 'Lien ou email pour contacter le Délégué à la Protection des Données (DPO)'
 = f.text_field :lien_dpo, class: 'form-control'
 
-%h3.header-subsection= t(:opendata_header, scope: [:administrateurs, :informations])
-%p.notice= t(:opendata_notice_html, scope: [:administrateurs, :informations])
-%p.notice= t(:opendata, scope: [:administrateurs, :informations])
+- if Flipper.enabled? :opendata, @procedure
+  %h3.header-subsection= t(:opendata_header, scope: [:administrateurs, :informations])
+  %p.notice= t(:opendata_notice_html, scope: [:administrateurs, :informations])
+  %p.notice= t(:opendata, scope: [:administrateurs, :informations])
 
-%label.toggle-switch
-  = f.check_box :opendata, class: 'toggle-switch-checkbox'
-  %span.toggle-switch-control.round
-  %span.toggle-switch-label.on Oui
-  %span.toggle-switch-label.off Non
+  %label.toggle-switch
+    = f.check_box :opendata, class: 'toggle-switch-checkbox'
+    %span.toggle-switch-control.round
+    %span.toggle-switch-label.on Oui
+    %span.toggle-switch-label.off Non
 
 %h3.header-subsection Notice explicative de la démarche
 

--- a/config/locales/views/administrateurs/informations/fr.yml
+++ b/config/locales/views/administrateurs/informations/fr.yml
@@ -1,0 +1,8 @@
+fr:
+  administrateurs:
+    informations:
+      opendata_header: Open data
+      opendata_notice_html: "Les démarches à destination du public hébergées par Démarches Simplifiées sont dans leur majorité à destination des usagers ou des personnes morales, mais aussi aux agents ou contribuent au fonctionnement des services.<br>
+      Dans leur majorité, les descriptions des formulaires, le titre des champs, sont des informations qui peuvent être communiquées au public en Open data, sous un format numérique facilement exploitables. Les valeurs saisies par les usagers restent évidemment confidentielles.<br>
+      Ces informations seront publiées sur data.gouv.fr et seront mises à jours régulièrement."
+      opendata: "Autorisez-vous la publication du descriptif de la démarche ?"

--- a/db/migrate/20220622181047_add_opendata_to_procedures.rb
+++ b/db/migrate/20220622181047_add_opendata_to_procedures.rb
@@ -1,0 +1,10 @@
+class AddOpendataToProcedures < ActiveRecord::Migration[6.1]
+  def up
+    add_column :procedures, :opendata, :boolean
+    change_column_default :procedures, :opendata, true
+  end
+
+  def down
+    remove_column :procedures, :opendata
+  end
+end

--- a/db/migrate/20220622183305_backfill_add_opendata_to_procedures.rb
+++ b/db/migrate/20220622183305_backfill_add_opendata_to_procedures.rb
@@ -1,0 +1,10 @@
+class BackfillAddOpendataToProcedures < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    Procedure.in_batches do |relation|
+      relation.update_all opendata: true
+      sleep(0.01)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_21_160241) do
+ActiveRecord::Schema.define(version: 2022_06_22_183305) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -651,6 +651,7 @@ ActiveRecord::Schema.define(version: 2022_06_21_160241) do
     t.string "lien_notice"
     t.string "lien_site_web"
     t.text "monavis_embed"
+    t.boolean "opendata", default: true
     t.string "organisation"
     t.bigint "parent_procedure_id"
     t.string "path", null: false

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -381,6 +381,14 @@ describe Procedure do
     end
   end
 
+  describe 'opendata' do
+    let(:procedure) { create(:procedure) }
+
+    it 'is true by default' do
+      expect(procedure.opendata).to be_truthy
+    end
+  end
+
   describe 'active' do
     let(:procedure) { create(:procedure) }
     subject { Procedure.active(procedure.id) }

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -439,6 +439,7 @@ describe Procedure do
       create(:procedure,
         received_mail: received_mail,
         service: service,
+        opendata: opendata,
         attestation_template: build(:attestation_template, logo: logo, signature: signature),
         types_de_champ: [type_de_champ_0, type_de_champ_1, type_de_champ_2, type_de_champ_pj],
         types_de_champ_private: [type_de_champ_private_0, type_de_champ_private_1, type_de_champ_private_2],
@@ -456,6 +457,7 @@ describe Procedure do
     let(:type_de_champ_private_repetition) { build(:type_de_champ_repetition, :private, position: 3, procedure: procedure, types_de_champ: [build(:type_de_champ, :private)]) }
     let(:received_mail) { build(:received_mail) }
     let(:from_library) { false }
+    let(:opendata) { true }
     let(:administrateur) { procedure.administrateurs.first }
     let(:logo) { Rack::Test::UploadedFile.new('spec/fixtures/files/white.png', 'image/png') }
     let(:signature) { Rack::Test::UploadedFile.new('spec/fixtures/files/black.png', 'image/png') }
@@ -529,6 +531,13 @@ describe Procedure do
       expect(cloned_procedure).to have_same_attributes_as(procedure, except: ["path", "draft_revision_id"])
     end
 
+    context 'which is opendata' do
+      let(:opendata) { false }
+      it 'should keep opendata for same admin' do
+        expect(subject.opendata).to be_falsy
+      end
+    end
+
     context 'when the procedure is cloned from the library' do
       let(:from_library) { true }
 
@@ -569,6 +578,7 @@ describe Procedure do
 
     context 'when the procedure is cloned to another administrateur' do
       let(:administrateur) { create(:administrateur) }
+      let(:opendata) { false }
 
       it 'should clone service' do
         expect(subject.service.id).not_to eq(service.id)
@@ -584,6 +594,10 @@ describe Procedure do
 
       it 'should discard specific api_entreprise_token' do
         expect(subject.read_attribute(:api_entreprise_token)).to be_nil
+      end
+
+      it 'should reset opendata to true' do
+        expect(subject.opendata).to be_truthy
       end
 
       it 'should have one administrateur' do


### PR DESCRIPTION
close #7357 

Nous avons l'intention de rendre public les champs des démarches closes.
Il arrive que DS soit parfois utilisé pour des démarches à usage interne. Les champs de ces démarches n'ont pas lieu d'être publiés.

En tant qu'administrateur, je peux autoriser la publication en opendata  du descriptif d'une démarche.

Cette fonctionnalité n'est pas activée par défaut. Le feature flag `opendata` doit être activé
(nous l'activerons une fois que le wording sera validé)

![opendata-screenshot](https://user-images.githubusercontent.com/1111966/175255198-662c4007-4c98-49da-8fd3-de1b06e6ac79.png)

NB : cette PR fait suite à [celle-ci](https://github.com/betagouv/demarches-simplifiees.fr/pull/7405)

