### PR TITLE
Permet la génération json du descriptif des démarches publiques

### DIFF
--- a/app/graphql/api/v2/schema.rb
+++ b/app/graphql/api/v2/schema.rb
@@ -72,7 +72,7 @@ class API::V2::Schema < GraphQL::Schema
 
   use GraphQL::Execution::Interpreter
   use GraphQL::Analysis::AST
-  use GraphQL::Schema::Timeout, max_seconds: 10
+  use GraphQL::Schema::Timeout, max_seconds: 30
   use GraphQL::Batch
   use GraphQL::Backtrace
 

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -581,7 +581,7 @@ type Demarche {
   number: Int!
   publishedRevision: Revision
   revisions: [Revision!]!
-  service: Service!
+  service: Service
 
   """
   État de la démarche.
@@ -600,6 +600,8 @@ Ceci est une version abrégée du type `Demarche`, qui n’expose que les métad
 Cela évite l’accès récursif aux dossiers.
 """
 type DemarcheDescriptor {
+  cadreJuridique: String
+
   """
   Date de la création.
   """
@@ -629,6 +631,7 @@ type DemarcheDescriptor {
   Pour une démarche déclarative, état cible des dossiers à valider automatiquement
   """
   declarative: DossierDeclarativeState
+  deliberation: String
 
   """
   Description de la démarche.
@@ -641,7 +644,7 @@ type DemarcheDescriptor {
   """
   number: Int!
   revision: Revision!
-  service: Service!
+  service: Service
 
   """
   État de la démarche.

--- a/app/graphql/types/base_field.rb
+++ b/app/graphql/types/base_field.rb
@@ -1,12 +1,12 @@
 module Types
   class BaseField < GraphQL::Schema::Field
-    def initialize(*args, require_admin: false, **kwargs, &block)
-      @require_admin = require_admin
+    def initialize(*args, internal: false, **kwargs, &block)
+      @internal = internal
       super(*args, **kwargs, &block)
     end
 
     def visible?(ctx)
-      super && (@require_admin ? ctx[:admin] : true)
+      super && (@internal ? ctx[:internal_use] : true)
     end
   end
 end

--- a/app/graphql/types/base_field.rb
+++ b/app/graphql/types/base_field.rb
@@ -1,0 +1,12 @@
+module Types
+  class BaseField < GraphQL::Schema::Field
+    def initialize(*args, require_admin: false, **kwargs, &block)
+      @require_admin = require_admin
+      super(*args, **kwargs, &block)
+    end
+
+    def visible?(ctx)
+      super && (@require_admin ? ctx[:admin] : true)
+    end
+  end
+end

--- a/app/graphql/types/demarche_descriptor_type.rb
+++ b/app/graphql/types/demarche_descriptor_type.rb
@@ -20,6 +20,9 @@ Cela évite l’accès récursif aux dossiers."
     field :revision, Types::RevisionType, null: false
     field :service, Types::ServiceType, null: true
 
+    field :cadre_juridique, String, null: true
+    field :deliberation, String, null: true
+
     def service
       Loaders::Record.for(Service).load(procedure.service_id)
     end
@@ -28,8 +31,16 @@ Cela évite l’accès récursif aux dossiers."
       object.is_a?(ProcedureRevision) ? object : object.active_revision
     end
 
+    def deliberation
+      Rails.application.routes.url_helpers.url_for(procedure.deliberation) if procedure.deliberation.attached?
+    end
+
     def state
       procedure.aasm.current_state
+    end
+
+    def cadre_juridique
+      procedure.cadre_juridique
     end
 
     def number

--- a/app/graphql/types/demarche_descriptor_type.rb
+++ b/app/graphql/types/demarche_descriptor_type.rb
@@ -18,7 +18,7 @@ Cela évite l’accès récursif aux dossiers."
     field :date_fermeture, GraphQL::Types::ISO8601DateTime, "Date de la fermeture.", null: true
 
     field :revision, Types::RevisionType, null: false
-    field :service, Types::ServiceType, null: false
+    field :service, Types::ServiceType, null: true
 
     def service
       Loaders::Record.for(Service).load(procedure.service_id)

--- a/app/graphql/types/demarche_descriptor_type.rb
+++ b/app/graphql/types/demarche_descriptor_type.rb
@@ -1,5 +1,6 @@
 module Types
   class DemarcheDescriptorType < Types::BaseObject
+    field_class BaseField
     description "Une démarche (métadonnées)
 Ceci est une version abrégée du type `Demarche`, qui n’expose que les métadonnées.
 Cela évite l’accès récursif aux dossiers."
@@ -23,12 +24,18 @@ Cela évite l’accès récursif aux dossiers."
     field :cadre_juridique, String, null: true
     field :deliberation, String, null: true
 
+    field :dossiers_count, Int, null: false, require_admin: true
+
     def service
       Loaders::Record.for(Service).load(procedure.service_id)
     end
 
     def revision
       object.is_a?(ProcedureRevision) ? object : object.active_revision
+    end
+
+    def dossiers_count
+      object.dossiers.count
     end
 
     def deliberation

--- a/app/graphql/types/demarche_descriptor_type.rb
+++ b/app/graphql/types/demarche_descriptor_type.rb
@@ -24,7 +24,7 @@ Cela évite l’accès récursif aux dossiers."
     field :cadre_juridique, String, null: true
     field :deliberation, String, null: true
 
-    field :dossiers_count, Int, null: false, require_admin: true
+    field :dossiers_count, Int, null: false, internal: true
 
     def service
       Loaders::Record.for(Service).load(procedure.service_id)

--- a/app/graphql/types/demarche_type.rb
+++ b/app/graphql/types/demarche_type.rb
@@ -30,7 +30,7 @@ module Types
     field :date_fermeture, GraphQL::Types::ISO8601DateTime, "Date de la fermeture.", null: true, method: :closed_at
 
     field :groupe_instructeurs, [Types::GroupeInstructeurType], null: false
-    field :service, Types::ServiceType, null: false
+    field :service, Types::ServiceType, null: true
 
     field :dossiers, Types::DossierType.connection_type, "Liste de tous les dossiers d’une démarche.", null: false do
       argument :order, Types::Order, default_value: :asc, required: false, description: "L’ordre des dossiers."

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -1,5 +1,7 @@
 module Types
   class QueryType < Types::BaseObject
+    field_class BaseField
+
     field :demarche, DemarcheType, null: false, description: "Informations concernant une démarche." do
       argument :number, Int, "Numéro de la démarche.", required: true
     end
@@ -12,7 +14,7 @@ module Types
       argument :number, Int, "Numéro du groupe instructeur.", required: true
     end
 
-    field :demarches_publiques, DemarcheDescriptorType.connection_type, null: false
+    field :demarches_publiques, DemarcheDescriptorType.connection_type, null: false, require_admin: true
 
     def demarches_publiques
       Procedure.publiques

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -17,7 +17,7 @@ module Types
     field :demarches_publiques, DemarcheDescriptorType.connection_type, null: false, require_admin: true, max_page_size: 30
 
     def demarches_publiques
-      Procedure.publiques
+      Procedure.opendata
     end
 
     def demarche(number:)

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -14,7 +14,7 @@ module Types
       argument :number, Int, "Numéro du groupe instructeur.", required: true
     end
 
-    field :demarches_publiques, DemarcheDescriptorType.connection_type, null: false, require_admin: true
+    field :demarches_publiques, DemarcheDescriptorType.connection_type, null: false, require_admin: true, max_page_size: 30
 
     def demarches_publiques
       Procedure.publiques

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -14,7 +14,7 @@ module Types
       argument :number, Int, "Numéro du groupe instructeur.", required: true
     end
 
-    field :demarches_publiques, DemarcheDescriptorType.connection_type, null: false, require_admin: true, max_page_size: 30
+    field :demarches_publiques, DemarcheDescriptorType.connection_type, null: false, internal: true, max_page_size: 30
 
     def demarches_publiques
       Procedure.opendata

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -12,6 +12,12 @@ module Types
       argument :number, Int, "Numéro du groupe instructeur.", required: true
     end
 
+    field :demarches_publiques, DemarcheDescriptorType.connection_type, null: false
+
+    def demarches_publiques
+      Procedure.publiques
+    end
+
     def demarche(number:)
       Procedure.for_api_v2.find(number)
     rescue => e

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -219,7 +219,7 @@ class Procedure < ApplicationRecord
   scope :brouillons,            -> { where(aasm_state: :brouillon) }
   scope :publiees,              -> { where(aasm_state: :publiee) }
   scope :closes,                -> { where(aasm_state: [:close, :depubliee]) }
-  scope :publiques,             -> { where(opendata: true) }
+  scope :opendata,              -> { where(opendata: true) }
   scope :publiees_ou_closes,    -> { where(aasm_state: [:publiee, :close, :depubliee]) }
   scope :by_libelle,            -> { order(libelle: :asc) }
   scope :created_during,        -> (range) { where(created_at: range) }

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -219,6 +219,7 @@ class Procedure < ApplicationRecord
   scope :brouillons,            -> { where(aasm_state: :brouillon) }
   scope :publiees,              -> { where(aasm_state: :publiee) }
   scope :closes,                -> { where(aasm_state: [:close, :depubliee]) }
+  scope :publiques,             -> { where(opendata: true) }
   scope :publiees_ou_closes,    -> { where(aasm_state: [:publiee, :close, :depubliee]) }
   scope :by_libelle,            -> { order(libelle: :asc) }
   scope :created_during,        -> (range) { where(created_at: range) }

--- a/app/services/demarches_publiques_export_service.rb
+++ b/app/services/demarches_publiques_export_service.rb
@@ -23,7 +23,7 @@ class DemarchesPubliquesExportService
   private
 
   def execute_query(cursor: nil)
-    result = API::V2::Schema.execute(query, variables: { cursor: cursor }, context: { internal_use: true, admin: true })
+    result = API::V2::Schema.execute(query, variables: { cursor: cursor }, context: { internal_use: true })
     raise DemarchesPubliquesExportService::Error.new(result["errors"]) if result["errors"]
     @graphql_data = result["data"]
   end

--- a/app/services/demarches_publiques_export_service.rb
+++ b/app/services/demarches_publiques_export_service.rb
@@ -44,6 +44,7 @@ class DemarchesPubliquesExportService
             service { nom organisme typeOrganisme }
             cadreJuridique
             deliberation
+            dossiersCount
             revision {
               champDescriptors {
                 type

--- a/app/services/demarches_publiques_export_service.rb
+++ b/app/services/demarches_publiques_export_service.rb
@@ -1,0 +1,99 @@
+class DemarchesPubliquesExportService
+  attr_reader :io
+  def initialize(io)
+    @io = io
+  end
+
+  def call
+    end_cursor = nil
+    first = true
+    write_array_opening
+    loop do
+      write_demarches_separator if !first
+      execute_query(cursor: end_cursor)
+      end_cursor = last_cursor
+      io.write(jsonify(demarches))
+      first = false
+      break if !has_next_page?
+    end
+    write_array_closing
+    io.close
+  end
+
+  private
+
+  def execute_query(cursor: nil)
+    result = API::V2::Schema.execute(query, variables: { cursor: cursor }, context: { internal_use: true, admin: true })
+    raise DemarchesPubliquesExportService::Error.new(result["errors"]) if result["errors"]
+    @graphql_data = result["data"]
+  end
+
+  def query
+    "query($cursor: String) {
+      demarchesPubliques(after: $cursor) {
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+        edges {
+          node {
+            number
+            title
+            description
+            datePublication
+            service { nom organisme typeOrganisme }
+            cadreJuridique
+            deliberation
+            revision {
+              champDescriptors {
+                type
+                label
+                description
+                required
+                options
+                champDescriptors {
+                  type
+                  label
+                  description
+                  required
+                  options
+                }
+              }
+            }
+          }
+        }
+      }
+    }"
+  end
+
+  def last_cursor
+    @graphql_data["demarchesPubliques"]["pageInfo"]["endCursor"]
+  end
+
+  def has_next_page?
+    @graphql_data["demarchesPubliques"]["pageInfo"]["hasNextPage"]
+  end
+
+  def demarches
+    @graphql_data["demarchesPubliques"]["edges"].map { |edge| edge["node"] }
+  end
+
+  def jsonify(demarches)
+    demarches.map(&:to_json).join(',')
+  end
+
+  def write_array_opening
+    io.write('[')
+  end
+
+  def write_array_closing
+    io.write(']')
+  end
+
+  def write_demarches_separator
+    io.write(',')
+  end
+end
+
+class DemarchesPubliquesExportService::Error < StandardError
+end

--- a/spec/services/demarches_publiques_export_service_spec.rb
+++ b/spec/services/demarches_publiques_export_service_spec.rb
@@ -1,5 +1,6 @@
 describe DemarchesPubliquesExportService do
   let(:procedure) { create(:procedure, :published, :with_service, :with_type_de_champ) }
+  let!(:dossier) { create(:dossier, procedure: procedure) }
   let(:io) { StringIO.new }
 
   describe 'call' do
@@ -16,6 +17,7 @@ describe DemarchesPubliquesExportService do
         cadreJuridique: "un cadre juridique important",
         deliberation: nil,
         datePublication: procedure.published_at.iso8601,
+        dossiersCount: 1,
         revision: {
           champDescriptors: [
             {

--- a/spec/services/demarches_publiques_export_service_spec.rb
+++ b/spec/services/demarches_publiques_export_service_spec.rb
@@ -1,0 +1,45 @@
+describe DemarchesPubliquesExportService do
+  let(:procedure) { create(:procedure, :published, :with_service, :with_type_de_champ) }
+  let(:io) { StringIO.new }
+
+  describe 'call' do
+    it 'generate json for all closed procedures' do
+      expected_result = {
+        number: procedure.id,
+        title: procedure.libelle,
+        description: "Demande de subvention à l'intention des associations",
+        service: {
+          nom: procedure.service.nom,
+          organisme: "organisme",
+          typeOrganisme: "association"
+        },
+        cadreJuridique: "un cadre juridique important",
+        deliberation: nil,
+        datePublication: procedure.published_at.iso8601,
+        revision: {
+          champDescriptors: [
+            {
+              description: procedure.types_de_champ.first.description,
+              label: procedure.types_de_champ.first.libelle,
+              options: nil,
+              required: false,
+              type: "text",
+              champDescriptors: nil
+            }
+          ]
+        }
+      }
+
+      DemarchesPubliquesExportService.new(io).call
+      expect(JSON.parse(io.string)[0]
+        .deep_symbolize_keys)
+        .to eq(expected_result)
+    end
+    it 'raises exception when procedure with bad data' do
+      procedure.libelle = nil
+      procedure.save(validate: false)
+
+      expect { DemarchesPubliquesExportService.new(io).call }.to raise_error(DemarchesPubliquesExportService::Error)
+    end
+  end
+end


### PR DESCRIPTION
La classe `DemarchesPubliquesExportService` permet la génération d'un fichier json qui décrit l'ensemble des démarches publiques en s'appuyant sur l'api graphql.

Une prochaine PR permettra la publication de ce fichier json dans data.gouv.fr
