### PR TITLE
fix(ChampEditor): add missing drop_down_other for  type_de_champ.drop_down_list_with_other?

### DIFF
--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -40,6 +40,12 @@
             .cell
               = form.label :drop_down_list_value, "Options de la liste", for: dom_id(type_de_champ, :drop_down_list_value)
               = form.text_area :drop_down_list_value, class: 'small-margin small width-100', rows: 7, id: dom_id(type_de_champ, :drop_down_list_value)
+            - if type_de_champ.drop_down_list_with_other?
+              .cell
+                = form.label :drop_down_other do
+                  Proposer une option &apos;autre&apos; avec un texte libre
+                = form.check_box :drop_down_other, class: "small-margin small"
+
         - if type_de_champ.linked_drop_down_list?
           .flex.column.justify-start.flex-grow
             .cell

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -202,6 +202,10 @@ class TypeDeChamp < ApplicationRecord
     ])
   end
 
+  def drop_down_list_with_other?
+    type_champ == TypeDeChamp.type_champs.fetch(:drop_down_list)
+  end
+
   def header_section?
     type_champ == TypeDeChamp.type_champs.fetch(:header_section)
   end

--- a/spec/system/administrateurs/types_de_champ_spec.rb
+++ b/spec/system/administrateurs/types_de_champ_spec.rb
@@ -135,8 +135,10 @@ describe 'As an administrateur I can edit types de champ', js: true do
     select('Choix parmi une liste', from: 'Type de champ')
     fill_in 'Libellé du champ', with: 'Libellé de champ menu déroulant', fill_options: { clear: :backspace }
     fill_in 'Options de la liste', with: 'Un menu', fill_options: { clear: :backspace }
+    check "Proposer une option 'autre' avec un texte libre"
 
     wait_until { procedure.draft_types_de_champ.first.drop_down_list_options == ['', 'Un menu'] }
+    wait_until { procedure.draft_types_de_champ.first.drop_down_other == "1" }
     expect(page).to have_content('Formulaire enregistré')
 
     page.refresh


### PR DESCRIPTION
# contexte: ETQ admin editant un type de champs Choix parmis une liste, je ne peux plus proposer l'option autre