### PR TITLE
fix(types_de_champ): editor inputs should have unique ids

### DIFF
--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -42,9 +42,9 @@
               = form.text_area :drop_down_list_value, class: 'small-margin small width-100', rows: 7, id: dom_id(type_de_champ, :drop_down_list_value)
             - if type_de_champ.drop_down_list_with_other?
               .cell
-                = form.label :drop_down_other do
+                = form.label :drop_down_other, for: dom_id(type_de_champ, :drop_down_other) do
                   Proposer une option &apos;autre&apos; avec un texte libre
-                = form.check_box :drop_down_other, class: "small-margin small"
+                = form.check_box :drop_down_other, class: "small-margin small", id: dom_id(type_de_champ, :drop_down_other)
 
         - if type_de_champ.linked_drop_down_list?
           .flex.column.justify-start.flex-grow


### PR DESCRIPTION
Petit correctif sur la #7501

Avec l'introduction de [morphdom](https://github.com/patrick-steele-idem/morphdom) en cas de `id` non uniques sur la page ça va éventuellement faire 💥 . ~Je n'ai pas encore de très bonne idée de comment faire en sorte de s'en assurer. Dans mon navigateur j'ai l'extension [axe](https://www.deque.com/axe/) dans les dev tools qui me hurle dessus quand ce n’est pas le cas, mais ce n’est pas très automatique.~

Bon finalement j'ai une solution : #7504