### PR TITLE
use vite_legacy_javascript to fix dynamic import for 60 <= ff < 66

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -15,9 +15,16 @@
 
     = vite_client_tag
     = vite_react_refresh_tag
-    = vite_javascript_tag 'application'
-    - if administrateur_signed_in?
-      = vite_javascript_tag 'track-admin'
+
+    - if vite_legacy?
+      = vite_legacy_javascript_tag 'application'
+      - if administrateur_signed_in?
+        = vite_legacy_javascript_tag 'track-admin'
+    - else
+      = vite_javascript_tag 'application'
+      - if administrateur_signed_in?
+        = vite_javascript_tag 'track-admin'
+
 
     = preload_link_tag(asset_url("Muli-Regular.woff2"))
     = preload_link_tag(asset_url("Muli-Bold.woff2"))
@@ -42,9 +49,6 @@
 
       - if content_for?(:footer)
         = content_for(:footer)
-
-      - if vite_legacy?
-        = vite_legacy_javascript_tag 'application'
 
       = yield :charts_js
 


### PR DESCRIPTION
firefox 60 prend script=module
firefox ~ 67 prend les dynamic import

du coup pour tous les ff entre 60 et ~67 , ils ne peuvent pas lire les script nomodule pour les anciens browser MAIS ils ne peuvent pas lire non plus les scripts module qui contienne des dynamic import

workaround temporaire on force vite a ne builder que la version des scripts compatibles anciens navigateurs pour la prod.