### PR TITLE
fix: css, couleur au focus des inputs box

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -214,7 +214,9 @@
       background-color: $border-grey;
     }
 
-    &:focus {
+    &:focus,
+    &:focus-visible {
+      outline: 0;
       border: 1px solid $blue-france-500;
       box-shadow: 0px 0px 2px 1px $blue-france-500;
     }


### PR DESCRIPTION
avant

firefox :
![Screenshot 2022-07-04 at 10-04-10 Modification du brouillon nº 4745700 (Une bien belle démarche) · demarches-simplifiees fr](https://user-images.githubusercontent.com/907405/177111393-d78770e7-e1de-4693-b6ff-55492c418d75.png)

chromium :
![chromium_avant](https://user-images.githubusercontent.com/907405/177111493-90bd2025-e41a-4440-887c-42a30bcd756c.png)

apres 

firefox
![Screenshot 2022-07-04 at 10-02-21 Modification du brouillon nº 4745700 (Une bien belle démarche) · demarches-simplifiees fr](https://user-images.githubusercontent.com/907405/177111426-20f05dba-edab-40b0-a03b-06a377248562.png)

chromium
![chromium_apres](https://user-images.githubusercontent.com/907405/177111560-79bf7985-1822-4ea5-b56c-62c1d2c1e9f0.png)