### PR TITLE
feat: conditionnel, ajout du controller

### DIFF
--- a/app/controllers/administrateurs/conditions_controller.rb
+++ b/app/controllers/administrateurs/conditions_controller.rb
@@ -1,0 +1,74 @@
+module Administrateurs
+  class ConditionsController < AdministrateurController
+    include Logic
+
+    before_action :retrieve_procedure, :retrieve_coordinate_and_uppers
+
+    def update
+      condition = condition_form.to_condition
+      tdc.update!(condition: condition)
+
+      render 'administrateurs/types_de_champ/update.turbo_stream.haml'
+    end
+
+    def add_row
+      condition = Logic.add_empty_condition_to(tdc.condition)
+      tdc.update!(condition: condition)
+
+      render 'administrateurs/types_de_champ/update.turbo_stream.haml'
+    end
+
+    def delete_row
+      condition = condition_form.delete_row(row_index).to_condition
+      tdc.update!(condition: condition)
+
+      render 'administrateurs/types_de_champ/update.turbo_stream.haml'
+    end
+
+    def destroy
+      tdc.update!(condition: nil)
+
+      render 'administrateurs/types_de_champ/update.turbo_stream.haml'
+    end
+
+    def change_targeted_champ
+      condition = condition_form.change_champ(row_index).to_condition
+      tdc.update!(condition: condition)
+
+      render 'administrateurs/types_de_champ/update.turbo_stream.haml'
+    end
+
+    private
+
+    def condition_form
+      ConditionForm.new(condition_params)
+    end
+
+    def retrieve_coordinate_and_uppers
+      @coordinate = draft_revision.coordinate_for(tdc)
+      @upper_coordinates = draft_revision
+        .revision_types_de_champ_public
+        .includes(:type_de_champ)
+        .take_while { |c| c != @coordinate }
+    end
+
+    def tdc
+      @tdc ||= draft_revision.find_and_ensure_exclusive_use(params[:stable_id])
+    end
+
+    def draft_revision
+      @procedure.draft_revision
+    end
+
+    def condition_params
+      params
+        .require(:type_de_champ)
+        .require(:condition_form)
+        .permit(:top_operator_name, rows: [:targeted_champ, :operator_name, :value])
+    end
+
+    def row_index
+      params[:row_index].to_i
+    end
+  end
+end

--- a/app/models/condition_form.rb
+++ b/app/models/condition_form.rb
@@ -1,0 +1,58 @@
+class ConditionForm
+  include ActiveModel::Model
+  include Logic
+
+  attr_accessor :top_operator_name, :rows
+
+  def to_condition
+    case sub_conditions.count
+    when 0
+      nil
+    when 1
+      sub_conditions.first
+    else
+      top_operator_class.new(sub_conditions)
+    end
+  end
+
+  def delete_row(i)
+    rows.slice!(i)
+
+    self
+  end
+
+  def change_champ(i)
+    sub_conditions[i] = Logic.ensure_compatibility_from_left(sub_conditions[i])
+
+    self
+  end
+
+  private
+
+  def top_operator_class
+    Logic.class_from_name(top_operator_name)
+  end
+
+  def sub_conditions
+    @sub_conditions ||= rows.map { |row| row_to_condition(row) }
+  end
+
+  def row_to_condition(row)
+    left = Logic.from_json(row[:targeted_champ])
+    right = parse_value(row[:value])
+
+    Logic.class_from_name(row[:operator_name]).new(left, right)
+  end
+
+  def parse_value(value)
+    return empty if value.blank?
+
+    number = Integer(value) rescue nil
+    return constant(number) if number.present?
+
+    json = JSON.parse(value) rescue nil
+    return Logic.from_json(value) if json.present?
+
+    constant(value)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -434,6 +434,12 @@ Rails.application.routes.draw do
         resource 'sources', only: [:show, :update], controller: 'sources_particulier'
       end
 
+      resources :conditions, only: [:update, :destroy], param: :stable_id do
+        patch :add_row, on: :member
+        patch :change_targeted_champ, on: :member
+        delete :delete_row, on: :member
+      end
+
       put 'clone'
       put 'archive'
       get 'publication' => 'procedures#publication', as: :publication

--- a/spec/controllers/administrateurs/conditions_controller_spec.rb
+++ b/spec/controllers/administrateurs/conditions_controller_spec.rb
@@ -1,0 +1,124 @@
+describe Administrateurs::ConditionsController, type: :controller do
+  include Logic
+
+  let(:procedure) { create(:procedure, :with_type_de_champ, types_de_champ_count: 2) }
+  let(:first_coordinate) { procedure.draft_revision.revision_types_de_champ.first }
+  let(:second_tdc) { procedure.draft_revision.types_de_champ.second }
+
+  before do
+    sign_in(procedure.administrateurs.first.user)
+  end
+
+  let(:default_params) do
+    {
+      procedure_id: procedure.id,
+      stable_id: second_tdc.stable_id
+    }
+  end
+
+  describe '#update' do
+    before do
+      post :update, params: params
+    end
+
+    let(:params) { default_params.merge(type_de_champ: { condition_form: condition_form }) }
+
+    let(:condition_form) do
+      {
+        rows: [
+          {
+            targeted_champ: champ_value(1).to_json,
+            operator_name: Logic::Eq.name,
+            value: '2'
+          }
+        ]
+      }
+    end
+
+    it do
+      expect(second_tdc.reload.condition).to eq(ds_eq(champ_value(1), constant(2)))
+      expect(assigns(:coordinate)).to eq(procedure.draft_revision.coordinate_for(second_tdc))
+      expect(assigns(:upper_coordinates)).to eq([first_coordinate])
+    end
+  end
+
+  describe '#add_row' do
+    before do
+      post :add_row, params: default_params
+    end
+
+    it do
+      expect(second_tdc.reload.condition).to eq(empty_operator(empty, empty))
+      expect(assigns(:coordinate)).to eq(procedure.draft_revision.coordinate_for(second_tdc))
+      expect(assigns(:upper_coordinates)).to eq([first_coordinate])
+    end
+  end
+
+  describe '#delete_row' do
+    before do
+      delete :delete_row, params: params.merge(row_index: 0)
+    end
+
+    let(:params) { default_params.merge(type_de_champ: { condition_form: condition_form }) }
+
+    let(:condition_form) do
+      {
+        rows: [
+          {
+            targeted_champ: champ_value(1).to_json,
+            operator_name: Logic::Eq.name,
+            value: '2'
+          }
+        ]
+      }
+    end
+
+    it do
+      expect(second_tdc.reload.condition).to eq(nil)
+      expect(assigns(:coordinate)).to eq(procedure.draft_revision.coordinate_for(second_tdc))
+      expect(assigns(:upper_coordinates)).to eq([first_coordinate])
+    end
+  end
+
+  describe '#destroy' do
+    before do
+      second_tdc.update(condition: empty_operator(empty, empty))
+      delete :destroy, params: default_params
+    end
+
+    it do
+      expect(second_tdc.reload.condition).to eq(nil)
+      expect(assigns(:coordinate)).to eq(procedure.draft_revision.coordinate_for(second_tdc))
+      expect(assigns(:upper_coordinates)).to eq([first_coordinate])
+    end
+  end
+
+  describe '#change_targeted_champ' do
+    let!(:number_tdc) { create(:type_de_champ_integer_number) }
+
+    before do
+      second_tdc.update(condition: empty_operator(empty, empty))
+      patch :change_targeted_champ, params: params
+    end
+
+    let(:params) { default_params.merge(type_de_champ: { condition_form: condition_form }) }
+
+    let(:condition_form) do
+      {
+        rows: [
+          {
+            targeted_champ: champ_value(number_tdc.stable_id).to_json,
+            operator_name: Logic::EmptyOperator.name,
+            value: empty.to_json
+          }
+        ]
+      }
+    end
+
+    it do
+      expect(second_tdc.reload.condition).to eq(ds_eq(champ_value(number_tdc.stable_id), constant(0)))
+      expect(assigns(:coordinate)).to eq(procedure.draft_revision.coordinate_for(second_tdc))
+      expect(assigns(:upper_coordinates)).to eq([first_coordinate])
+    end
+  end
+end

--- a/spec/models/condition_form_spec.rb
+++ b/spec/models/condition_form_spec.rb
@@ -1,0 +1,52 @@
+describe ConditionForm, type: :model do
+  include Logic
+
+  describe 'to_condition' do
+    let(:top_operator_name) { '' }
+
+    subject { ConditionForm.new(rows: rows, top_operator_name: top_operator_name).to_condition }
+
+    context 'when a row is added' do
+      let(:rows) { [{ targeted_champ: champ_value(1).to_json, operator_name: Logic::Eq.name, value: '1' }] }
+      it { is_expected.to eq(ds_eq(champ_value(1), constant(1))) }
+    end
+
+    context 'when two rows are added' do
+      let(:top_operator_name) { Logic::And.name }
+      let(:rows) do
+        [
+          { targeted_champ: champ_value(1).to_json, operator_name: Logic::Eq.name, value: '2' },
+          { targeted_champ: champ_value(3).to_json, operator_name: Logic::GreaterThan.name, value: '4' }
+        ]
+      end
+
+      let(:expected) do
+        ds_and([
+          ds_eq(champ_value(1), constant(2)),
+          greater_than(champ_value(3), constant(4))
+        ])
+      end
+      it { is_expected.to eq(expected) }
+    end
+
+    context 'when 3 rows are added' do
+      let(:top_operator_name) { Logic::Or.name }
+      let(:rows) do
+        [
+          { targeted_champ: champ_value(1).to_json, operator_name: Logic::Eq.name, value: '2' },
+          { targeted_champ: champ_value(3).to_json, operator_name: Logic::GreaterThan.name, value: '4' },
+          { targeted_champ: champ_value(5).to_json, operator_name: Logic::LessThan.name, value: '6' }
+        ]
+      end
+
+      let(:expected) do
+        ds_or([
+          ds_eq(champ_value(1), constant(2)),
+          greater_than(champ_value(3), constant(4)),
+          less_than(champ_value(5), constant(6))
+        ])
+      end
+      it { is_expected.to eq(expected) }
+    end
+  end
+end


### PR DESCRIPTION
Ce controller permet d'éditer les conditions d'un type de champ, en particulier il permet

- d'enregistrer une condition
- ajouter une nouvelle ligne
- de supprimer une ligne
- de supprimer toute la condition
- de modifier le champ visé d'obtenir la liste des opérateurs compatibles ainsi qu'une valeur par défaut 