### PR TITLE
fix(graphql): change doc location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,4 @@ public/vite-test
 
 
 app/graphql/schema.json
-public/graphql/schema
+public/doc/graphql

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "lint:js": "eslint --ext .js,.jsx,.ts,.tsx ./app/javascript",
     "webpack:build": "NODE_ENV=production bin/webpack",
     "lint:types": "tsc",
-    "graphql:doc:build": "bin/rake graphql:schema:json && graphdoc --force",
+    "graphql:doc:build": "RAILS_ENV=production bin/rake graphql:schema:json && graphdoc --force",
     "postinstall": "patch-package",
     "test": "vitest",
     "coverage": "vitest run --coverage"
@@ -90,6 +90,6 @@
   },
   "graphdoc": {
     "schemaFile": "./app/graphql/schema.json",
-    "output": "./public/graphql/schema"
+    "output": "./public/doc/graphql"
   }
 }


### PR DESCRIPTION
/graphql is the root of GraphQL Engine and rails makes it harder to look for static assets under it