### PR TITLE
feat(procedure.duree_conservation_dossiers_dans_ds): decrease max duree_conservation_dossiers_dans_ds from 36 to 12

### DIFF
--- a/app/dashboards/procedure_dashboard.rb
+++ b/app/dashboards/procedure_dashboard.rb
@@ -36,7 +36,9 @@ class ProcedureDashboard < Administrate::BaseDashboard
     refused_mail_template: MailTemplateField,
     without_continuation_mail_template: MailTemplateField,
     attestation_template: AttestationTemplateField,
-    procedure_expires_when_termine_enabled: Field::Boolean
+    procedure_expires_when_termine_enabled: Field::Boolean,
+    duree_conservation_dossiers_dans_ds: Field::Number,
+    duree_conservation_etendue_par_ds: Field::Boolean
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -84,14 +86,18 @@ class ProcedureDashboard < Administrate::BaseDashboard
     :refused_mail_template,
     :without_continuation_mail_template,
     :attestation_template,
-    :procedure_expires_when_termine_enabled
+    :procedure_expires_when_termine_enabled,
+    :duree_conservation_dossiers_dans_ds,
+    :duree_conservation_etendue_par_ds
   ].freeze
 
   # FORM_ATTRIBUTES
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
-    :procedure_expires_when_termine_enabled
+    :procedure_expires_when_termine_enabled,
+    :duree_conservation_dossiers_dans_ds,
+    :duree_conservation_etendue_par_ds
   ].freeze
 
   # Overwrite this method to customize how procedures are displayed

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -65,7 +65,7 @@ class Procedure < ApplicationRecord
   default_scope -> { kept }
 
   OLD_MAX_DUREE_CONSERVATION = 36
-  NEW_MAX_DUREE_CONSERVATION = 12
+  NEW_MAX_DUREE_CONSERVATION = ENV.fetch('NEW_MAX_DUREE_CONSERVATION') { 12 }.to_i
 
   MIN_WEIGHT = 350000
 

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -18,6 +18,7 @@
 #  description                               :string
 #  direction                                 :string
 #  duree_conservation_dossiers_dans_ds       :integer
+#  duree_conservation_etendue_par_ds         :boolean          default(FALSE)
 #  durees_conservation_required              :boolean          default(TRUE)
 #  encrypted_api_particulier_token           :string
 #  euro_flag                                 :boolean          default(FALSE)
@@ -63,8 +64,8 @@ class Procedure < ApplicationRecord
   self.discard_column = :hidden_at
   default_scope -> { kept }
 
-  MAX_DUREE_CONSERVATION = 36
-  MAX_DUREE_CONSERVATION_EXPORT = 3.hours
+  OLD_MAX_DUREE_CONSERVATION = 36
+  NEW_MAX_DUREE_CONSERVATION = 12
 
   MIN_WEIGHT = 350000
 
@@ -270,7 +271,22 @@ class Procedure < ApplicationRecord
     if: :validate_for_publication?
   validate :check_juridique
   validates :path, presence: true, format: { with: /\A[a-z0-9_\-]{3,200}\z/ }, uniqueness: { scope: [:path, :closed_at, :hidden_at, :unpublished_at], case_sensitive: false }
-  validates :duree_conservation_dossiers_dans_ds, allow_nil: false, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: MAX_DUREE_CONSERVATION }
+  validates :duree_conservation_dossiers_dans_ds, allow_nil: false,
+                                                  numericality: {
+                                                    only_integer: true,
+                                                                  greater_than_or_equal_to: 1,
+                                                                  less_than_or_equal_to: OLD_MAX_DUREE_CONSERVATION
+                                                  },
+                                                  if: :duree_conservation_etendue_par_ds
+
+  validates :duree_conservation_dossiers_dans_ds, allow_nil: false,
+                                                    numericality: {
+                                                      only_integer: true,
+                                                                    greater_than_or_equal_to: 1,
+                                                                    less_than_or_equal_to: NEW_MAX_DUREE_CONSERVATION
+                                                    },
+                                                    unless: :duree_conservation_etendue_par_ds
+
   validates :lien_dpo, email_or_link: true, allow_nil: true
   validates_with MonAvisEmbedValidator
 

--- a/app/views/administrateurs/procedures/_informations.html.haml
+++ b/app/views/administrateurs/procedures/_informations.html.haml
@@ -27,8 +27,8 @@
   Sur #{APPLICATION_NAME}
   %span.mandatory *
 
-%p.notice (durée en mois après le début de l’instruction)
-= f.number_field :duree_conservation_dossiers_dans_ds, class: 'form-control', placeholder: '6', required: true
+%p.notice Durée en mois après le début de l’instruction. Pour les démarches classiques, cette durée ne peut exceder 12 mois. Si vous avez besoin d'une durée supérieur à 12 mois, merci d'en faire la demande à notre support
+= f.number_field :duree_conservation_dossiers_dans_ds, {class: 'form-control', placeholder: '6', required: true}.merge(f.object.duree_conservation_etendue_par_ds ? {} : {max: 12})
 
 - if @procedure.created_at.present?
   = f.label :lien_site_web do

--- a/app/views/administrateurs/procedures/_informations.html.haml
+++ b/app/views/administrateurs/procedures/_informations.html.haml
@@ -27,7 +27,10 @@
   Sur #{APPLICATION_NAME}
   %span.mandatory *
 
-%p.notice Durée en mois après le début de l’instruction. Pour les démarches classiques, cette durée ne peut exceder 12 mois. Si vous avez besoin d'une durée supérieur à 12 mois, merci d'en faire la demande à notre support
+%p.notice
+  = t(:notice, scope: [:administrateurs, :duree_conservation_dossiers_dans_ds])
+  - if f.object.duree_conservation_dossiers_dans_ds.to_i < Procedure::NEW_MAX_DUREE_CONSERVATION
+    = t(:new_duration_constraint, scope: [:administrateurs, :duree_conservation_dossiers_dans_ds], new_duration_in_month: Procedure::NEW_MAX_DUREE_CONSERVATION)
 = f.number_field :duree_conservation_dossiers_dans_ds, {class: 'form-control', placeholder: '6', required: true}.merge(f.object.duree_conservation_etendue_par_ds ? {} : {max: 12})
 
 - if @procedure.created_at.present?

--- a/app/views/administrateurs/procedures/_informations.html.haml
+++ b/app/views/administrateurs/procedures/_informations.html.haml
@@ -31,7 +31,7 @@
   = t(:notice, scope: [:administrateurs, :duree_conservation_dossiers_dans_ds])
   - if f.object.duree_conservation_dossiers_dans_ds.to_i < Procedure::NEW_MAX_DUREE_CONSERVATION
     = t(:new_duration_constraint, scope: [:administrateurs, :duree_conservation_dossiers_dans_ds], new_duration_in_month: Procedure::NEW_MAX_DUREE_CONSERVATION)
-= f.number_field :duree_conservation_dossiers_dans_ds, {class: 'form-control', placeholder: '6', required: true}.merge(f.object.duree_conservation_etendue_par_ds ? {} : {max: 12})
+= f.number_field :duree_conservation_dossiers_dans_ds, { class: 'form-control', placeholder: '6', required: true }.merge(f.object.duree_conservation_etendue_par_ds ? {} : { max: 12 })
 
 - if @procedure.created_at.present?
   = f.label :lien_site_web do

--- a/config/env.example.optional
+++ b/config/env.example.optional
@@ -137,3 +137,6 @@ DOLIST_BALANCING_VALUE="50"
 # Enable vite legacy build (IE11). Legacy build is used in production (except if set to "disabled").
 # You might want to enable it in other environements for testing. Build time will be greatly impacted.
 VITE_LEGACY=""
+
+# around july 2022, we changed the duree_conservation_dossiers_dans_ds, allow instances to choose their own duration
+NEW_MAX_DUREE_CONSERVATION=12

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -9,7 +9,6 @@ fr:
         path: Lien public
         organisation: Organisme
         duree_conservation_dossiers_dans_ds: Durée de conservation des dossiers sur demarches-simplifiees.fr
-        duree_conservation_dossiers_hors_ds: Durée de conservation des dossiers hors demarches-simplifiees.fr
         aasm_state/brouillon: Brouillon
         aasm_state/publiee: Publiée
         aasm_state/close: Close

--- a/config/locales/views/administrateurs/informations/en.yml
+++ b/config/locales/views/administrateurs/informations/en.yml
@@ -1,0 +1,11 @@
+en:
+  administrateurs:
+    informations:
+      opendata_header: Open data
+      opendata_notice_html: "Procedures on Démarches Simplifiées target individuals and companies, as well as public servant and the administration.<br>
+      Mostly forms and fields can be shared publicly as OpenData using a usable digital format. Of courses, user data are not shared<br>
+      Those information will be published and maintained on data.gouv.fr on a regular basis."
+      opendata: "Do you allow the publicaton of this procedure"
+    duree_conservation_dossiers_dans_ds:
+      notice: Duration in month after the beginning of the investigating.
+      new_duration_constraint: For classic procedure, this duration can not be higher than %{new_duration_in_month} months. If you need an higher duration than %{new_duration_in_month} months, please get in touch with our support.

--- a/config/locales/views/administrateurs/informations/fr.yml
+++ b/config/locales/views/administrateurs/informations/fr.yml
@@ -6,3 +6,6 @@ fr:
       Dans leur majorité, les descriptions des formulaires, le titre des champs, sont des informations qui peuvent être communiquées au public en Open data, sous un format numérique facilement exploitables. Les valeurs saisies par les usagers restent évidemment confidentielles.<br>
       Ces informations seront publiées sur data.gouv.fr et seront mises à jours régulièrement."
       opendata: "Autorisez-vous la publication du descriptif de la démarche ?"
+    duree_conservation_dossiers_dans_ds:
+      notice: Durée en mois après le début de l’instruction.
+      new_duration_constraint: Pour les démarches classiques, cette durée ne peut exceder %{new_duration_in_month} mois. Si vous avez besoin d'une durée supérieure à %{new_duration_in_month} mois, merci d'en faire la demande à notre support.

--- a/db/migrate/20220708151654_drop_duree_conservation_dossiers_hors_ds.rb
+++ b/db/migrate/20220708151654_drop_duree_conservation_dossiers_hors_ds.rb
@@ -1,0 +1,5 @@
+class DropDureeConservationDossiersHorsDs < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured { remove_column :procedures, :duree_conservation_dossiers_hors_ds }
+  end
+end

--- a/db/migrate/20220708151802_add_column_duree_conservation_entendue_par_ds.rb
+++ b/db/migrate/20220708151802_add_column_duree_conservation_entendue_par_ds.rb
@@ -1,0 +1,5 @@
+class AddColumnDureeConservationEntendueParDs < ActiveRecord::Migration[6.1]
+  def change
+    add_column :procedures, :duree_conservation_etendue_par_ds, :boolean
+  end
+end

--- a/db/migrate/20220708151917_backfill_duree_conservation_entendue_par_ds.rb
+++ b/db/migrate/20220708151917_backfill_duree_conservation_entendue_par_ds.rb
@@ -1,0 +1,8 @@
+class BackfillDureeConservationEntendueParDs < ActiveRecord::Migration[6.1]
+  def change
+    Procedure.in_batches do |relation|
+      relation.update_all duree_conservation_etendue_par_ds: true
+      sleep(0.01)
+    end
+  end
+end

--- a/db/migrate/20220708152039_new_default_duree_conservation_entendue_par_ds.rb
+++ b/db/migrate/20220708152039_new_default_duree_conservation_entendue_par_ds.rb
@@ -1,0 +1,5 @@
+class NewDefaultDureeConservationEntendueParDs < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :procedures, :duree_conservation_etendue_par_ds, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_22_183305) do
+ActiveRecord::Schema.define(version: 2022_07_08_152039) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -636,7 +636,7 @@ ActiveRecord::Schema.define(version: 2022_06_22_183305) do
     t.string "direction"
     t.bigint "draft_revision_id"
     t.integer "duree_conservation_dossiers_dans_ds"
-    t.integer "duree_conservation_dossiers_hors_ds"
+    t.boolean "duree_conservation_etendue_par_ds", default: false
     t.boolean "durees_conservation_required", default: true
     t.string "encrypted_api_particulier_token"
     t.boolean "euro_flag", default: false

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -281,19 +281,26 @@ describe Procedure do
       end
     end
 
-    shared_examples 'duree de conservation' do
-      context 'duree_conservation_required it true, the field gets validated' do
+    describe 'duree de conservation dans ds' do
+      let(:field_name) { :duree_conservation_dossiers_dans_ds }
+
+      context 'for old procedures, duree_conservation_required it true, the field gets validated' do
+        subject { create(:procedure, duree_conservation_etendue_par_ds: true) }
         it { is_expected.not_to allow_value(nil).for(field_name) }
         it { is_expected.not_to allow_value('').for(field_name) }
         it { is_expected.not_to allow_value('trois').for(field_name) }
         it { is_expected.to allow_value(3).for(field_name) }
+        it { is_expected.to allow_value(36).for(field_name) }
+        it { is_expected.to validate_numericality_of(field_name).is_less_than_or_equal_to(Procedure::OLD_MAX_DUREE_CONSERVATION) }
       end
-    end
 
-    describe 'duree de conservation dans ds' do
-      let(:field_name) { :duree_conservation_dossiers_dans_ds }
-
-      it_behaves_like 'duree de conservation'
+      context 'for new procedures, duree_conservation_required it true, the field gets validated' do
+        subject { create(:procedure, duree_conservation_etendue_par_ds: false) }
+        it { is_expected.not_to allow_value(nil).for(field_name) }
+        it { is_expected.not_to allow_value('').for(field_name) }
+        it { is_expected.not_to allow_value('trois').for(field_name) }
+        it { is_expected.to validate_numericality_of(field_name).is_less_than_or_equal_to(Procedure::NEW_MAX_DUREE_CONSERVATION) }
+      end
     end
 
     describe 'draft_types_de_champ validations' do


### PR DESCRIPTION
# contexte. ETQ DS ; on cherche a faire des efforts sur la secu

Pour cela, on va limiter la durée de conversation des dossiers de 36 à 12 mois.

# solution 
un nouveau flag (`duree_conservation_etendue_par_ds`) pour conditionner la duree max de 12/36. 
* Les anciennes procedure ont ce flag a true (par du backfill). 
* Les nouvelles procédure on ce flag a false (par une migration set le default apres le backfill)
* Au support on peut activer ou pas ce flag, ce qui permet d'etendre la duree de conservation

ETQ super admin :
> <img width="1426" alt="Screen Shot 2022-07-08 at 5 43 30 PM" src="https://user-images.githubusercontent.com/125964/178026611-adafea76-9f0f-4fc2-adc2-017f2a293224.png">

ETQ administrateur 
> <img width="802" alt="Screen Shot 2022-07-08 at 5 47 48 PM" src="https://user-images.githubusercontent.com/125964/178027079-40f3adb9-edb0-4d88-9ba7-17e186831cb7.png">

il y a donc une validation front (si le flag est pas activé) et back (quoi qu'il en soit)
