### PR TITLE
Rollback customized generic placeholder

### DIFF
--- a/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
+++ b/app/components/types_de_champ_editor/champ_component/champ_component.html.haml
@@ -34,13 +34,6 @@
               = form.label :description, "Description du champ (optionnel)", for: dom_id(type_de_champ, :description)
               = form.text_area :description, class: 'small-margin small width-100', rows: 3, id: dom_id(type_de_champ, :description)
 
-          - if type_de_champ.generic?
-            .cell.mt-1
-              = form.label :placeholder, t(".generic.custom_placeholder_title"), class: 'flex-grow', for: dom_id(type_de_champ, :placeholder)
-              = form.text_field :placeholder, class: 'small-margin small width-100', placeholder: t("#{type_de_champ.type_champ}.placeholder", scope: "shared.dossiers.editable_champs"), id: dom_id(type_de_champ, :placeholder)
-              %p
-                = t(".generic.custom_placeholder_hint")
-
       .flex.justify-start.mt-1
         - if type_de_champ.drop_down_list?
           .flex.column.justify-start.width-33

--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -96,7 +96,6 @@ module Administrateurs
         :drop_down_secondary_libelle,
         :drop_down_secondary_description,
         :piece_justificative_template,
-        :placeholder,
         editable_options: [
           :cadastres,
           :unesco,

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -385,18 +385,6 @@ class ProcedureRevision < ApplicationRecord
         stable_id: from_type_de_champ.stable_id
       }
     end
-    if from_type_de_champ.placeholder != to_type_de_champ.placeholder
-      changes << {
-        model: :type_de_champ,
-        op: :update,
-        attribute: :placeholder,
-        label: from_type_de_champ.libelle,
-        private: from_type_de_champ.private?,
-        from: from_type_de_champ.placeholder,
-        to: to_type_de_champ.placeholder,
-        stable_id: from_type_de_champ.stable_id
-      }
-    end
     if to_type_de_champ.drop_down_list?
       if from_type_de_champ.drop_down_list_options != to_type_de_champ.drop_down_list_options
         changes << {

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -58,16 +58,7 @@ class TypeDeChamp < ApplicationRecord
     mesri: 'mesri'
   }
 
-  store_accessor :options, :cadastres,
-                           :drop_down_options,
-                           :drop_down_other,
-                           :drop_down_secondary_description,
-                           :drop_down_secondary_libelle,
-                           :old_pj,
-                           :placeholder,
-                           :skip_content_type_pj_validation,
-                           :skip_pj_validation
-
+  store_accessor :options, :cadastres, :old_pj, :drop_down_options, :skip_pj_validation, :skip_content_type_pj_validation, :drop_down_secondary_libelle, :drop_down_secondary_description, :drop_down_other
   has_many :revision_types_de_champ, -> { revision_ordered }, class_name: 'ProcedureRevisionTypeDeChamp', dependent: :destroy, inverse_of: :type_de_champ
   has_one :revision_type_de_champ, -> { revision_ordered }, class_name: 'ProcedureRevisionTypeDeChamp', inverse_of: false
   has_many :revisions, -> { ordered }, through: :revision_types_de_champ
@@ -224,10 +215,6 @@ class TypeDeChamp < ApplicationRecord
 
   def linked_drop_down_list?
     type_champ == TypeDeChamp.type_champs.fetch(:linked_drop_down_list)
-  end
-
-  def generic?
-    type_champ == TypeDeChamp.type_champs.fetch(:text) || type_champ == TypeDeChamp.type_champs.fetch(:textarea)
   end
 
   def exclude_from_view?

--- a/app/views/administrateurs/procedures/_revision_change_type_de_champ.html.haml
+++ b/app/views/administrateurs/procedures/_revision_change_type_de_champ.html.haml
@@ -44,8 +44,6 @@
       %li.mb-1= t("administrateurs.revision_changes.update_drop_down_other#{postfix}.enabled", label: change[:label])
     - else
       %li.mb-1= t("administrateurs.revision_changes.update_drop_down_other#{postfix}.disabled", label: change[:label])
-  - when :placeholder
-    %li.mb-1= t("update_placeholder#{postfix}", label: change[:label], to: change[:to], scope: [:administrateurs, :revision_changes])
   - when :carte_layers
     - added = change[:to].sort - change[:from].sort
     - removed = change[:from].sort - change[:to].sort

--- a/app/views/shared/dossiers/editable_champs/_text.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_text.html.haml
@@ -1,5 +1,5 @@
 = form.text_field :value,
   id: champ.input_id,
-  placeholder: champ.type_de_champ.placeholder.presence || t(".placeholder"),
+  placeholder: t(".placeholder"),
   required: champ.mandatory?,
   aria: { describedby: champ.describedby_id }

--- a/app/views/shared/dossiers/editable_champs/_textarea.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_textarea.html.haml
@@ -4,4 +4,4 @@
   rows: 6,
   required: champ.mandatory?,
   value: html_to_string(champ.value),
-  placeholder: champ.type_de_champ.placeholder.presence || t(".placeholder")
+  placeholder: t(".placeholder")

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -575,9 +575,3 @@ fr:
         weekly_distribution_details: "au cours des 6 derniers mois"
     procedure_description:
       estimated_fill_duration: "Temps de remplissage estimé : %{estimated_minutes} mn"
-
-  types_de_champ_editor:
-    champ_component:
-      generic:
-        custom_placeholder_title: "Spécimen de saisie (optionnel)"
-        custom_placeholder_hint: Modèle de réponse visible dans le champ avant la saisie par l'usager

--- a/config/locales/views/administrateurs/revision_changes/fr.yml
+++ b/config/locales/views/administrateurs/revision_changes/fr.yml
@@ -28,7 +28,6 @@ fr:
         enabled: Le champ « %{label} » comporte maintenant un choix « Autre »
         disabled: Le champ « %{label} » ne comporte plus de choix « Autre »
       update_carte_layers: Les référentiels cartographiques du champ « %{label} » ont été modifiés
-      update_placeholder: Le spécimen de saisie du champ « %{label} » a été modifié. Le nouveau spécimen est « %{to} ».
       add_private: L’annotation privée « %{label} » a été ajoutée
       remove_private: L’annotation privée « %{label} » a été supprimée
       move_private:

--- a/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
+++ b/spec/controllers/administrateurs/types_de_champ_controller_spec.rb
@@ -30,7 +30,6 @@ describe Administrateurs::TypesDeChampController, type: :controller do
         type_de_champ: {
           type_champ: type_champ,
           libelle: 'l1.5',
-          placeholder: "custom placeholder",
           after_stable_id: first_coordinate.stable_id
         }
       }

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -357,7 +357,7 @@ describe ProcedureRevision do
       before do
         updated_tdc = new_draft.find_and_ensure_exclusive_use(first_tdc.stable_id)
 
-        updated_tdc.update(libelle: 'modifier le libelle', description: 'une description', mandatory: !updated_tdc.mandatory, placeholder: "new placeholder")
+        updated_tdc.update(libelle: 'modifier le libelle', description: 'une description', mandatory: !updated_tdc.mandatory)
       end
 
       it do
@@ -390,16 +390,6 @@ describe ProcedureRevision do
             private: false,
             from: false,
             to: true,
-            stable_id: first_tdc.stable_id
-          },
-          {
-            model: :type_de_champ,
-            op: :update,
-            attribute: :placeholder,
-            label: first_tdc.libelle,
-            private: false,
-            from: first_tdc.placeholder,
-            to: "new placeholder",
             stable_id: first_tdc.stable_id
           }
         ])

--- a/spec/system/administrateurs/types_de_champ_spec.rb
+++ b/spec/system/administrateurs/types_de_champ_spec.rb
@@ -165,35 +165,4 @@ describe 'As an administrateur I can edit types de champ', js: true do
     end
     expect(page).not_to have_content('Durée de remplissage estimée')
   end
-
-  describe "placeholders for generic types" do
-    let(:placeholder) { "my placeholder" }
-    before do
-      add_champ
-    end
-
-    it "text champ" do
-      select('Texte', from: 'Type de champ')
-      expect(page).to have_content('Spécimen de saisie')
-
-      fill_in 'Spécimen de saisie', with: placeholder
-
-      wait_until { procedure.draft_types_de_champ.first.placeholder == placeholder }
-
-      page.refresh
-      expect(page).to have_selector("input[value='#{placeholder}']")
-    end
-
-    it "textarea champ" do
-      select('Zone de texte', from: 'Type de champ')
-      expect(page).to have_content('Spécimen de saisie')
-
-      fill_in 'Spécimen de saisie', with: placeholder
-
-      wait_until { procedure.draft_types_de_champ.first.placeholder == placeholder }
-
-      page.refresh
-      expect(page).to have_selector("input[value='#{placeholder}']")
-    end
-  end
 end

--- a/spec/views/shared/dossiers/_edit.html.haml_spec.rb
+++ b/spec/views/shared/dossiers/_edit.html.haml_spec.rb
@@ -34,24 +34,6 @@ describe 'shared/dossiers/edit.html.haml', type: :view do
         expect(subject).to have_css('input[type="tel"][placeholder^="0612"]')
       end
     end
-
-    context "with generic champs" do
-      let(:champ_text) { create(:champ_text, dossier: dossier) }
-      let(:champs) { [champ_text, champ_textarea] }
-
-      it "renders default placeholders" do
-        expect(subject).to have_css('input[placeholder*="réponse"]')
-        expect(subject).to have_css('textarea[placeholder*="réponse"]')
-      end
-
-      it "renders customized placeholders" do
-        champ_text.type_de_champ.placeholder = "custom1 placeholder"
-        champ_textarea.type_de_champ.placeholder = "custom2 placeholder"
-
-        expect(subject).to have_css('input[placeholder*="custom1"]')
-        expect(subject).to have_css('textarea[placeholder*="custom2"]')
-      end
-    end
   end
 
   context 'with a single-value list' do


### PR DESCRIPTION
Rétropédalage suite à des discussions avec @Olivier-Marcellin : ce n'est pas le placeholder qui doit être personnalisé pour les types de champs génériques texte/zone de texte. Ça se fera probablement via la description uniquement, après concertation avec le DSFR.

Je revert donc les 2 commits qui introduisaient la personnalisation du placeholder pour ces 2 types de champs et qui ont été mergé (sans mise en prod) via https://github.com/betagouv/demarches-simplifiees.fr/pull/7532 