### PR TITLE
perf(graphql): improuve dossier loading

### DIFF
--- a/app/graphql/connections/dossiers_connection.rb
+++ b/app/graphql/connections/dossiers_connection.rb
@@ -1,0 +1,23 @@
+module Connections
+  class DossiersConnection < GraphQL::Pagination::ActiveRecordRelationConnection
+    def initialize(items, lookahead: nil, **kwargs)
+      super(items, **kwargs)
+      @lookahead = lookahead
+    end
+
+    def nodes
+      if @nodes.nil? && preload?
+        DossierPreloader.new(super).all
+      else
+        super
+      end
+    end
+
+    private
+
+    # We check if the query selects champs form dossier. If it's the case we preload the dossier.
+    def preload?
+      @lookahead.selection(:nodes).selects?(:champs) || @lookahead.selection(:nodes).selects?(:annotations)
+    end
+  end
+end

--- a/app/graphql/types/champs/repetition_champ_type.rb
+++ b/app/graphql/types/champs/repetition_champ_type.rb
@@ -5,7 +5,11 @@ module Types::Champs
     field :champs, [Types::ChampType], null: false
 
     def champs
-      Loaders::Association.for(object.class, :champs).load(object)
+      if object.champs.loaded?
+        object.champs
+      else
+        Loaders::Association.for(object.class, :champs).load(object)
+      end
     end
   end
 end

--- a/app/graphql/types/dossier_type.rb
+++ b/app/graphql/types/dossier_type.rb
@@ -120,6 +120,8 @@ module Types
         Loaders::Champ
           .for(object, private: false)
           .load(ApplicationRecord.id_from_typed_id(id))
+      elsif object.champs.loaded?
+        object.champs
       else
         Loaders::Association.for(object.class, champs: :type_de_champ).load(object)
       end
@@ -130,6 +132,8 @@ module Types
         Loaders::Champ
           .for(object, private: true)
           .load(ApplicationRecord.id_from_typed_id(id))
+      elsif object.champs_private.loaded?
+        object.champs_private
       else
         Loaders::Association.for(object.class, champs_private: :type_de_champ).load(object)
       end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -251,13 +251,7 @@ class Dossier < ApplicationRecord
         :traitement,
         :groupe_instructeur,
         :etablissement,
-        procedure: [
-          :groupe_instructeurs,
-          :draft_types_de_champ,
-          :draft_types_de_champ_private,
-          :published_types_de_champ,
-          :published_types_de_champ_private
-        ],
+        procedure: [:groupe_instructeurs],
         avis: [:claimant, :expert]
       ).order(depose_at: 'asc')
   }
@@ -439,101 +433,8 @@ class Dossier < ApplicationRecord
     types_de_champ
   end
 
-  EXPORT_BATCH_SIZE = 2000
-
   def self.downloadable_sorted_batch
-    ExportPreloader.new(self).in_batches
-  end
-
-  class ExportPreloader
-    def initialize(dossiers)
-      @dossiers = dossiers
-    end
-
-    def in_batches
-      dossiers = @dossiers.downloadable_sorted.to_a
-      dossiers.each_slice(EXPORT_BATCH_SIZE) { |slice| load_dossiers(slice) }
-      dossiers
-    end
-
-    private
-
-    # returns: { revision_id : { type_de_champ_id : position } }
-    def positions
-      @positions ||= ProcedureRevisionTypeDeChamp
-        .where(revision_id: @dossiers.distinct.pluck(:revision_id))
-        .select(:revision_id, :type_de_champ_id, :position)
-        .group_by(&:revision_id)
-        .transform_values do |coordinates|
-          coordinates.index_by(&:type_de_champ_id).transform_values(&:position)
-        end
-    end
-
-    def load_dossiers(dossiers)
-      all_champs = Champ
-        .includes(:type_de_champ, piece_justificative_file_attachment: :blob)
-        .where(dossier_id: dossiers)
-        .to_a
-
-      load_etablissements(all_champs)
-
-      children_champs, root_champs = all_champs.partition(&:child?)
-      champs_by_dossier = root_champs.group_by(&:dossier_id)
-      champs_by_dossier_by_parent = children_champs
-        .group_by(&:dossier_id)
-        .transform_values do |champs|
-          champs.group_by(&:parent_id)
-        end
-
-      dossiers.each do |dossier|
-        load_dossier(dossier, champs_by_dossier[dossier.id], champs_by_dossier_by_parent[dossier.id] || {})
-      end
-    end
-
-    def load_etablissements(champs)
-      champs_siret = champs.filter(&:siret?)
-      etablissements_by_id = Etablissement.where(id: champs_siret.map(&:etablissement_id).compact).index_by(&:id)
-      champs_siret.each do |champ|
-        etablissement = etablissements_by_id[champ.etablissement_id]
-        champ.association(:etablissement).target = etablissement
-        if etablissement
-          etablissement.association(:champ).target = champ
-        end
-      end
-    end
-
-    def load_dossier(dossier, champs, children_by_parent = {})
-      champs_public, champs_private = champs.partition(&:public?)
-
-      load_champs(dossier, :champs, champs_public, dossier)
-      load_champs(dossier, :champs_private, champs_private, dossier)
-
-      # Load repetition children champs
-      champs.filter(&:repetition?).each do |parent_champ|
-        champs = children_by_parent[parent_champ.id] || []
-        parent_champ.association(:dossier).target = dossier
-
-        load_champs(parent_champ, :champs, champs, dossier)
-        parent_champ.association(:champs).set_inverse_instance(parent_champ)
-      end
-
-      # We need to do this because of the check on `Etablissement#champ` in
-      # `Etablissement#libelle_for_export`. By assigning `nil` to `target` we mark association
-      # as loaded and so the check on `Etablissement#champ` will not trigger n+1 query.
-      if dossier.etablissement
-        dossier.etablissement.association(:champ).target = nil
-      end
-    end
-
-    def load_champs(parent, name, champs, dossier)
-      champs.each do |champ|
-        champ.association(:dossier).target = dossier
-      end
-
-      parent.association(name).target = champs.sort_by do |champ|
-        positions[dossier.revision_id][champ.type_de_champ_id]
-      end
-    end
+    DossierPreloader.new(downloadable_sorted).in_batches
   end
 
   def user_deleted?

--- a/app/models/dossier_preloader.rb
+++ b/app/models/dossier_preloader.rb
@@ -11,6 +11,12 @@ class DossierPreloader
     dossiers
   end
 
+  def all
+    dossiers = @dossiers.to_a
+    load_dossiers(dossiers)
+    dossiers
+  end
+
   private
 
   # returns: { revision_id : { type_de_champ_id : position } }

--- a/app/models/dossier_preloader.rb
+++ b/app/models/dossier_preloader.rb
@@ -1,0 +1,92 @@
+class DossierPreloader
+  DEFAULT_BATCH_SIZE = 2000
+
+  def initialize(dossiers)
+    @dossiers = dossiers
+  end
+
+  def in_batches(size = DEFAULT_BATCH_SIZE)
+    dossiers = @dossiers.to_a
+    dossiers.each_slice(size) { |slice| load_dossiers(slice) }
+    dossiers
+  end
+
+  private
+
+  # returns: { revision_id : { type_de_champ_id : position } }
+  def positions
+    @positions ||= ProcedureRevisionTypeDeChamp
+      .where(revision_id: @dossiers.pluck(:revision_id).uniq)
+      .select(:revision_id, :type_de_champ_id, :position)
+      .group_by(&:revision_id)
+      .transform_values do |coordinates|
+        coordinates.index_by(&:type_de_champ_id).transform_values(&:position)
+      end
+  end
+
+  def load_dossiers(dossiers)
+    all_champs = Champ
+      .includes(:type_de_champ, piece_justificative_file_attachment: :blob)
+      .where(dossier_id: dossiers)
+      .to_a
+
+    load_etablissements(all_champs)
+
+    children_champs, root_champs = all_champs.partition(&:child?)
+    champs_by_dossier = root_champs.group_by(&:dossier_id)
+    champs_by_dossier_by_parent = children_champs
+      .group_by(&:dossier_id)
+      .transform_values do |champs|
+        champs.group_by(&:parent_id)
+      end
+
+    dossiers.each do |dossier|
+      load_dossier(dossier, champs_by_dossier[dossier.id] || [], champs_by_dossier_by_parent[dossier.id] || {})
+    end
+  end
+
+  def load_etablissements(champs)
+    champs_siret = champs.filter(&:siret?)
+    etablissements_by_id = Etablissement.where(id: champs_siret.map(&:etablissement_id).compact).index_by(&:id)
+    champs_siret.each do |champ|
+      etablissement = etablissements_by_id[champ.etablissement_id]
+      champ.association(:etablissement).target = etablissement
+      if etablissement
+        etablissement.association(:champ).target = champ
+      end
+    end
+  end
+
+  def load_dossier(dossier, champs, children_by_parent = {})
+    champs_public, champs_private = champs.partition(&:public?)
+
+    load_champs(dossier, :champs, champs_public, dossier, children_by_parent)
+    load_champs(dossier, :champs_private, champs_private, dossier, children_by_parent)
+
+    # We need to do this because of the check on `Etablissement#champ` in
+    # `Etablissement#libelle_for_export`. By assigning `nil` to `target` we mark association
+    # as loaded and so the check on `Etablissement#champ` will not trigger n+1 query.
+    if dossier.etablissement
+      dossier.etablissement.association(:champ).target = nil
+    end
+  end
+
+  def load_champs(parent, name, champs, dossier, children_by_parent)
+    champs.each do |champ|
+      champ.association(:dossier).target = dossier
+    end
+
+    parent.association(name).target = champs.sort_by do |champ|
+      positions[dossier.revision_id][champ.type_de_champ_id]
+    end
+
+    # Load children champs
+    champs.filter(&:repetition?).each do |parent_champ|
+      champs = children_by_parent[parent_champ.id] || []
+      parent_champ.association(:dossier).target = dossier
+
+      load_champs(parent_champ, :champs, champs, dossier, children_by_parent)
+      parent_champ.association(:champs).set_inverse_instance(parent_champ)
+    end
+  end
+end

--- a/app/services/serializer_service.rb
+++ b/app/services/serializer_service.rb
@@ -4,6 +4,11 @@ class SerializerService
     data && data['dossier']
   end
 
+  def self.dossiers(procedure)
+    data = execute_query('serializeDossiers', { number: procedure.id })
+    data && data['demarche']['dossiers']
+  end
+
   def self.avis(avis)
     data = execute_query('serializeAvis', { number: avis.dossier_id, id: avis.to_typed_id })
     data && data['dossier']['avis'].first
@@ -31,6 +36,20 @@ class SerializerService
   end
 
   QUERY = <<-'GRAPHQL'
+    query serializeDossiers($number: Int!, $after: String) {
+      demarche(number: $number) {
+        dossiers(after: $after) {
+          nodes {
+            ...DossierFragment
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+
     query serializeDossier($number: Int!) {
       dossier(number: $number) {
         ...DossierFragment

--- a/lib/tasks/benchmarks.rake
+++ b/lib/tasks/benchmarks.rake
@@ -8,4 +8,14 @@ namespace :benchmarks do
       x.report("Démarche 55824") { ProcedureExportService.new(p_55824, p_55824.dossiers).to_xlsx }
     end
   end
+
+  desc 'Benchmark graphql'
+  task graphql: :environment do
+    p_45964 = Procedure.find(45964)
+    p_55824 = Procedure.find(55824)
+    Benchmark.bm do |x|
+      x.report("Démarche 45964") { SerializerService.dossiers(p_45964) }
+      x.report("Démarche 55824") { SerializerService.dossiers(p_55824) }
+    end
+  end
 end


### PR DESCRIPTION
avant

```bash
       user     system      total        real
Démarche 45964  5.046600   0.199924   5.246524 (  7.886772)
Démarche 55824  0.572324   0.027641   0.599965 (  3.326910)
       user     system      total        real
Démarche 45964  5.178551   0.199319   5.377870 (  8.055270)
Démarche 55824  0.575060   0.029134   0.604194 (  3.574730)
       user     system      total        real
Démarche 45964  5.067265   0.215094   5.282359 (  8.124228)
Démarche 55824  0.584960   0.022247   0.607207 (  3.735716)
```

apres

```bash
       user     system      total        real
Démarche 45964  5.266419   0.257377   5.523796 (  5.923106)
Démarche 55824  0.618082   0.008499   0.626581 (  0.875670)
       user     system      total        real
Démarche 45964  5.174630   0.246068   5.420698 (  5.788296)
Démarche 55824  0.703273   0.010570   0.713843 (  0.969464)
       user     system      total        real
Démarche 45964  5.321180   0.247275   5.568455 (  5.951879)
Démarche 55824  0.525899   0.078229   0.604128 (  0.807589)
```


La démarche 45964 est un cas "pathologique" avec plus de 200 champs