### PR TITLE
fix: drop down other input width

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -48,6 +48,7 @@ class RootController < ApplicationController
 -- avant l'option C --
             option C"
           champ.value = '["option B", "option C"]'
+          champ.type_de_champ.drop_down_other = "1"
         end
       end
 

--- a/app/views/shared/dossiers/editable_champs/_drop_down_other_input.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_drop_down_other_input.html.haml
@@ -1,4 +1,4 @@
 .drop_down_other{ class: champ.other_value_present? ? '' : 'hidden' }
   .notice
     %p Veuillez saisir votre autre choix
-  = form.text_field :value_other, maxlength: 200, size: nil, placeholder: "Saisissez ici", disabled: !champ.other_value_present?
+  = form.text_field :value_other, maxlength: 200, size: nil, disabled: !champ.other_value_present?

--- a/app/views/shared/dossiers/editable_champs/_drop_down_other_input.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_drop_down_other_input.html.haml
@@ -1,4 +1,4 @@
 .drop_down_other{ class: champ.other_value_present? ? '' : 'hidden' }
   .notice
     %p Veuillez saisir votre autre choix
-  = form.text_field :value_other, maxlength: "200", placeholder: "Saisissez ici", disabled: !champ.other_value_present?
+  = form.text_field :value_other, maxlength: 200, size: nil, placeholder: "Saisissez ici", disabled: !champ.other_value_present?


### PR DESCRIPTION
contexte :
> problème de mise en forme du champ choix parmi une liste avec l'option "autre" en texte libre lorsqu'on choisis un bloc répétable, la zone de texte sort du bloc répétable

Supprime aussi le placeholder comme c'est devenu la recommendation pour les champs libres / sans format prédéfini

closes #7601