### PR TITLE
fix(autosave): morph instead of replace to preserve controller instances

### DIFF
--- a/app/javascript/controllers/autosave_status_controller.ts
+++ b/app/javascript/controllers/autosave_status_controller.ts
@@ -85,7 +85,6 @@ export class AutosaveStatusController extends ApplicationController {
 
   private logError(error: ResponseError) {
     if (error && error.message) {
-      error.message = `[Autosave] ${error.message}`;
       console.error(error);
       this.globalDispatch('sentry:capture-exception', error);
     }

--- a/app/views/champs/piece_justificative/show.turbo_stream.haml
+++ b/app/views/champs/piece_justificative/show.turbo_stream.haml
@@ -1,5 +1,5 @@
 = fields_for @champ.input_name, @champ do |form|
-  = turbo_stream.replace @champ.input_group_id, partial: "shared/dossiers/editable_champs/editable_champ", locals: { champ: @champ, form: form }
+  = turbo_stream.morph @champ.input_group_id, partial: "shared/dossiers/editable_champs/editable_champ", locals: { champ: @champ, form: form }
 
 - if @champ.piece_justificative_file.attached?
   - attachment = @champ.piece_justificative_file.attachment

--- a/spec/controllers/champs/piece_justificative_controller_spec.rb
+++ b/spec/controllers/champs/piece_justificative_controller_spec.rb
@@ -29,7 +29,7 @@ describe Champs::PieceJustificativeController, type: :controller do
       it 'renders the attachment template as Javascript' do
         subject
         expect(response.status).to eq(200)
-        expect(response.body).to include("action=\"replace\" target=\"#{champ.input_group_id}\"")
+        expect(response.body).to include("&quot;action&quot;:&quot;morph&quot;,&quot;target&quot;:&quot;#{champ.input_group_id}&quot;")
       end
 
       it 'updates dossier.last_champ_updated_at' do


### PR DESCRIPTION
Nous avons une “race condition” entre la fin de la requête http et le remplacement du DOM par turbo. Si le remplacement est effectué avant l’enregistrement de la fin de la requête, alors le code dans `detache` va abort la requête et une erreur sera émise. En utilisant `morph` on évite l’appel à `detache` (ce qui est mieux dans ce cas là de toute façon).

Le bug est très difficile à reproduire. Je n’ai jamais réussi à reproduire en local. En prod j’ai réussi à reproduire dans Safari relativement facilement. Dans Chrome j’ai eu l’erreur qu’une fois lors de mes tests. Sentry confirme que le bug est récurrent.

Enfin, ce bug à mis en évidence le fait que les sourcemaps dans Safari sont cassés :facepalm:

https://sentry.io/organizations/demarches-simplifiees/issues/3377463883/?project=1429547&query=is:unresolved&statsPeriod=14d