### PR TITLE
Fix: purge stuck exports & archives

### DIFF
--- a/app/dashboards/archive_dashboard.rb
+++ b/app/dashboards/archive_dashboard.rb
@@ -11,7 +11,7 @@ class ArchiveDashboard < Administrate::BaseDashboard
     id: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
-    status: Field::String,
+    job_status: Field::String,
     file: AttachmentField
   }.freeze
 
@@ -24,7 +24,7 @@ class ArchiveDashboard < Administrate::BaseDashboard
     :id,
     :created_at,
     :updated_at,
-    :status,
+    :job_status,
     :file
   ].freeze
 
@@ -34,6 +34,6 @@ class ArchiveDashboard < Administrate::BaseDashboard
     :id,
     :created_at,
     :updated_at,
-    :status
+    :job_status
   ].freeze
 end

--- a/app/jobs/cron/purge_stale_archives_job.rb
+++ b/app/jobs/cron/purge_stale_archives_job.rb
@@ -3,5 +3,6 @@ class Cron::PurgeStaleArchivesJob < Cron::CronJob
 
   def perform
     Archive.stale(Archive::RETENTION_DURATION).destroy_all
+    Archive.stuck(Archive::MAX_DUREE_GENERATION).destroy_all
   end
 end

--- a/app/jobs/cron/purge_stale_exports_job.rb
+++ b/app/jobs/cron/purge_stale_exports_job.rb
@@ -3,5 +3,6 @@ class Cron::PurgeStaleExportsJob < Cron::CronJob
 
   def perform
     Export.stale(Export::MAX_DUREE_CONSERVATION_EXPORT).destroy_all
+    Export.stuck(Export::MAX_DUREE_GENERATION).destroy_all
   end
 end

--- a/app/models/archive.rb
+++ b/app/models/archive.rb
@@ -14,6 +14,7 @@ class Archive < ApplicationRecord
   include TransientModelsWithPurgeableJobConcern
 
   RETENTION_DURATION = 4.days
+  MAX_DUREE_GENERATION = 24.hours
   MAX_SIZE = 100.gigabytes
 
   has_and_belongs_to_many :groupe_instructeurs

--- a/app/models/concerns/transient_models_with_purgeable_job_concern.rb
+++ b/app/models/concerns/transient_models_with_purgeable_job_concern.rb
@@ -35,6 +35,11 @@ module TransientModelsWithPurgeableJobConcern
         .where('updated_at < ?', (Time.zone.now - duration))
     }
 
+    scope :stuck, lambda { |duration|
+      where(job_status: [job_statuses.fetch(:pending)])
+        .where('updated_at < ?', (Time.zone.now - duration))
+    }
+
     def available?
       generated?
     end

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -17,6 +17,7 @@ class Export < ApplicationRecord
   include TransientModelsWithPurgeableJobConcern
 
   MAX_DUREE_CONSERVATION_EXPORT = 16.hours
+  MAX_DUREE_GENERATION = 12.hours
 
   enum format: {
     csv: 'csv',

--- a/spec/models/export_spec.rb
+++ b/spec/models/export_spec.rb
@@ -31,6 +31,16 @@ RSpec.describe Export, type: :model do
     it { expect(Export.stale(Export::MAX_DUREE_CONSERVATION_EXPORT)).to match_array([stale_export_generated, stale_export_failed]) }
   end
 
+  describe '.stuck' do
+    let!(:export) { create(:export) }
+    let(:stuck_date) { Time.zone.now() - (Export::MAX_DUREE_GENERATION + 1.minute) }
+    let!(:stale_export_generated) { create(:export, :generated, updated_at: stuck_date) }
+    let!(:stale_export_failed) { create(:export, :failed, updated_at: stuck_date) }
+    let!(:stale_export_pending) { create(:export, :pending, updated_at: stuck_date) }
+
+    it { expect(Export.stuck(Export::MAX_DUREE_GENERATION)).to match_array([stale_export_pending]) }
+  end
+
   describe '.destroy' do
     let!(:groupe_instructeur) { create(:groupe_instructeur) }
     let!(:export) { create(:export, groupe_instructeurs: [groupe_instructeur]) }


### PR DESCRIPTION
Fix 1 bug sur le manager (archives) :
Closes #7614 


Et surtout purge les exports et archives bloqués, en cours de génération.

Avec la PR #7547, ça reproduit le comportement d'avant, c'est à dire
que quoiqu'il arrive un export est purgé :
- soit 16h après sa génération (on a 16h pour le télécharger)
- soit 12h après sa création, et qu'il est bloqué (on lui laisse 12h pour se générer)

Auparavant, tous les exports étaient purgés au bout de 3h quelle que soit
le statut.

Même chose pour les archives mais avec 24h de génération (est-ce suffisant / trop ?)


Ça soulève aussi un autre point : si une démarche ou un dossier a été mis à jour dans l'intervalle, il est impossible de relancer un export avec les données mises à jour tant qu'on a pas passé ces délais. Peut-être prévoir un mécanisme pour forcer une re-génération ?

EDIT: il y a bien un mécanisme de regénération disponible 20 minutes après qu'un export a été généré avec succès.