### PR TITLE
fix(archives): don't fail when there are no weight estimation

### DIFF
--- a/app/helpers/archive_helper.rb
+++ b/app/helpers/archive_helper.rb
@@ -6,7 +6,7 @@ module ArchiveHelper
   def estimate_weight(archive, nb_dossiers_termines, average_dossier_weight)
     if archive.present? && archive.available?
       archive.file.byte_size
-    else
+    elsif !average_dossier_weight.nil?
       nb_dossiers_termines * average_dossier_weight
     end
   end

--- a/app/views/shared/archives/_table.html.haml
+++ b/app/views/shared/archives/_table.html.haml
@@ -29,7 +29,7 @@
           - else
             %span.icon.retry
             = t(:archive_pending_html, scope: [:instructeurs, :procedure], created_period: time_ago_in_words(matching_archive.created_at))
-        - elsif weight < Archive::MAX_SIZE
+        - elsif weight.nil? || weight < Archive::MAX_SIZE
           = link_to create_archive_url(procedure, month), method: :post, class: "button" do
             %span.icon.new-folder
             Demander la création

--- a/app/views/shared/archives/_table.html.haml_spec.rb
+++ b/app/views/shared/archives/_table.html.haml_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe 'shared/archives/_table.html.haml', type: :view do
+  include Rails.application.routes.url_helpers
+
+  let(:procedure) { create(:procedure) }
+  let(:all_archives) { create_list(:archive, 2) }
+  let(:month_date) { "2022-01-01T00:00:00+00:00" }
+  let(:average_dossier_weight) { 1024 }
+
+  before do
+      allow(view).to receive(:create_archive_url).and_return("/archive/created/stubed")
+    end
+
+  subject { render 'shared/archives/table.html.haml', count_dossiers_termines_by_month: [{ "month" => month_date, "count" => 5 }], archives: all_archives + [monthly_archive].compact, average_dossier_weight: average_dossier_weight, procedure: procedure }
+
+  context "when archive is available" do
+    let(:monthly_archive) { create(:archive, time_span_type: "monthly", month: month_date, job_status: :generated, file: Rack::Test::UploadedFile.new('spec/fixtures/files/RIB.pdf', 'application/pdf')) }
+    it 'renders archive by month with estimate_weight' do
+      expect(subject).to have_text("Janvier 2022")
+      expect(subject).to have_text("Télécharger")
+      expect(subject).to have_text("338 ko")
+    end
+  end
+
+  context "when archive is not available" do
+    let(:monthly_archive) { nil }
+    it 'renders archive a estimated weight' do
+      expect(subject).to have_text("Janvier 2022")
+      expect(subject).to have_text("Demander")
+      expect(subject).to have_text("5 ko")
+    end
+
+    context "when there are no weight estimation" do
+      let(:average_dossier_weight) { nil }
+      it 'supports an empty estimation weight' do
+        expect(subject).to have_text("Demander")
+      end
+    end
+
+    context "when estimation is too heavy" do
+      let(:average_dossier_weight) { Archive::MAX_SIZE + 1 }
+      it 'supports an empty estimation weight' do
+        expect(subject).to have_text("trop volumineuse")
+      end
+    end
+  end
+end


### PR DESCRIPTION
A priori ça peut arriver lorsqu'il n'y a pas de dossier "terminé" sur une procédure

Closes #7615