### PR TITLE
fix(admin/attestation): page layout 

### DIFF
--- a/app/views/administrateurs/attestation_templates/_informations.html.haml
+++ b/app/views/administrateurs/attestation_templates/_informations.html.haml
@@ -42,4 +42,4 @@
 
 = f.label :footer do
   Pied de page
-= f.text_field :footer, class: 'form-control', maxlength: 190
+= f.text_field :footer, class: 'form-control', maxlength: 190, size: nil


### PR DESCRIPTION
Parce-qu'il n'y a plus de `max-width: 500px` sur chaque input du site depuis #7555, et-parce-que rails, par défaut, définit l'attribut html `input#size` à partir du `maxlength`, cet input cassait la page et occupait autant de place que nécessaire.

Ça rejoint #7609 

J'ai pas trouvé d'autres maxlength qui pourraient être concernés


![Capture d’écran 2022-07-27 à 14 24 28](https://user-images.githubusercontent.com/150279/181248662-229e3edd-7bf0-4660-b8f7-897fd22431a9.png)

