### PR TITLE
display alert message when no email is given for an invite

### DIFF
--- a/app/controllers/invites_controller.rb
+++ b/app/controllers/invites_controller.rb
@@ -3,7 +3,7 @@ class InvitesController < ApplicationController
   before_action :store_user_location!, only: [:show]
 
   def create
-    email = params[:invite_email].downcase
+    email = params[:invite_email]&.downcase
     @dossier = current_user.dossiers.visible_by_user.find(params[:dossier_id])
     invite = Invite.create(
       dossier: @dossier,

--- a/spec/controllers/invites_controller_spec.rb
+++ b/spec/controllers/invites_controller_spec.rb
@@ -121,6 +121,15 @@ describe InvitesController, type: :controller do
             it { expect(flash[:alert]).to be_present }
           end
 
+          context "when user does'nt give any email" do
+            subject { post :create, params: { dossier_id: dossier.id } }
+            before do
+              subject
+            end
+            it { expect { subject }.not_to change(Invite, :count) }
+            it { expect(flash[:alert]).to be_present }
+          end
+
           context 'when email is already used' do
             let!(:invite) { create(:invite, dossier: dossier) }
 


### PR DESCRIPTION
no exception is raised anymore in this case

[fix exception](https://sentry.io/organizations/demarches-simplifiees/issues/3300886343/?project=1429550&query=is%3Aunresolved+assigned%3Ame&statsPeriod=14d)

close #7631 