### PR TITLE
fix: contact captcha invisibility, view_component update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -741,7 +741,7 @@ GEM
       activemodel (>= 3.0.0)
       public_suffix
     vcr (6.1.0)
-    view_component (2.53.0)
+    view_component (2.62.0)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
     virtus (2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -727,7 +727,7 @@ GEM
       rails (>= 6.0.0)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
       unf_ext
@@ -741,7 +741,7 @@ GEM
       activemodel (>= 3.0.0)
       public_suffix
     vcr (6.1.0)
-    view_component (2.62.0)
+    view_component (2.63.0)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
     virtus (2.0.0)

--- a/app/components/types_de_champ_editor/conditions_component/conditions_component.html.haml
+++ b/app/components/types_de_champ_editor/conditions_component/conditions_component.html.haml
@@ -1,5 +1,5 @@
 .flex.justify-start.section{ id: dom_id(@tdc.stable_self, :conditions) }
-  = form_with url: admin_procedure_condition_path(@procedure_id, @tdc.stable_id), method: :patch, class: 'form width-100' do |f|
+  = form_tag admin_procedure_condition_path(@procedure_id, @tdc.stable_id), method: :patch, class: 'form width-100' do
     .conditionnel.mt-2.width-100
       .flex
         %p.mr-2 Logique conditionnelle

--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -96,6 +96,6 @@ class SupportController < ApplicationController
   end
 
   def redirect_to_root
-    redirect_to root_path, alert: t('invisible_captcha.custom_message')
+    redirect_to root_path, alert: t('invisible_captcha.sentence_for_humans')
   end
 end

--- a/app/views/support/index.html.haml
+++ b/app/views/support/index.html.haml
@@ -26,8 +26,6 @@
           = t('.your_question')
         = hidden_field_tag :type, params[:type]
 
-      = invisible_captcha
-
       %dl
         - @options.each do |(question, question_type, link)|
           %dt
@@ -70,6 +68,8 @@
         = file_field_tag :piece_jointe
 
       = hidden_field_tag :tags, @tags&.join(',')
+
+      = invisible_captcha
 
       .send-wrapper
         = button_tag t('send_mail', scope: [:utils]), type: :submit, class: 'button send primary'

--- a/config/application.rb
+++ b/config/application.rb
@@ -88,8 +88,5 @@ module TPS
     config.view_component.show_previews_source = true
     config.view_component.default_preview_layout = 'component_preview'
     config.view_component.preview_paths << "#{Rails.root}/spec/components/previews"
-
-    # see: https://viewcomponent.org/known_issues.html
-    config.view_component.use_global_output_buffer = true
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,7 +31,7 @@
 
 en:
   invisible_captcha:
-    custom_message: 'If you are a human, ignore this field'
+    sentence_for_humans: 'If you are a human, ignore this field'
 
   help: 'Help'
   help_dropdown:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -21,7 +21,7 @@
 
 fr:
   invisible_captcha:
-    custom_message: 'Si vous êtes un humain, veuillez ignorer ce champs'
+    sentence_for_humans: 'Si vous êtes un humain, laissez ce champ vide'
   help: 'Aide'
   help_dropdown:
     problem_title: Un problème avec le site ?

--- a/spec/controllers/support_controller_spec.rb
+++ b/spec/controllers/support_controller_spec.rb
@@ -122,7 +122,7 @@ describe SupportController, type: :controller do
         let(:params) { { subject: 'bonjour', text: 'un message', InvisibleCaptcha.honeypots.sample => 'boom' } }
         it 'does not create a conversation on HelpScout' do
           expect { subject }.not_to change(Commentaire, :count)
-          expect(flash[:alert]).to eq(I18n.t('invisible_captcha.custom_message'))
+          expect(flash[:alert]).to eq(I18n.t('invisible_captcha.sentence_for_humans'))
         end
       end
     end


### PR DESCRIPTION
Le bug venait de l'option expérimentale du `use_global_output_buffer` de `view_component` qui met le bazard dans les buffers

Cette option vient d'être retirée (elle causait trop de problèmes, et a priori yen a plus besoin maintenant)
https://github.com/github/view_component/pull/1432

J'ai donc fait la mise à jour de la gem.

J'ai vérifié le fonctionnement des components de PJ qui étaient introduits [dans la PR qui avait introduit l'option](https://github.com/betagouv/demarches-simplifiees.fr/pull/7266), et j'ai pas contacté de différence (mais je veux bien un second avis ou un feedback + précis sur les motivations de l'option pour être certain de regarder au bon endroit.)

Je corrige aussi le libellé du champ affiché sur les navigateurs non visuels.

Closes #7627 


EDIT: remplacement dans `ConditionalComponent` de `form_with` par `form_tag` qui n'est pas affecté par le pb de buffer de view_component avec turbo. Cf 2 screenshots :

form_with/main :
![Capture d’écran 2022-08-02 à 18 15 19](https://user-images.githubusercontent.com/150279/182425908-e31deaad-ed3f-4720-bd06-c4b53da408b6.png)


form_tag/cette branche :
![Capture d’écran 2022-08-02 à 18 14 22](https://user-images.githubusercontent.com/150279/182425886-5d4e2557-cf8f-4d6d-8963-e31eeb0a6919.png)

