### PR TITLE
fix: dossier_transfer requires a valid email

### DIFF
--- a/app/controllers/users/profil_controller.rb
+++ b/app/controllers/users/profil_controller.rb
@@ -30,8 +30,14 @@ module Users
     end
 
     def transfer_all_dossiers
-      DossierTransfer.initiate(next_owner_email, current_user.dossiers)
-      flash.notice = t('.new_transfer', count: current_user.dossiers.count, email: next_owner_email)
+      transfer = DossierTransfer.initiate(next_owner_email, current_user.dossiers)
+
+      if transfer.valid?
+        flash.notice = t('.new_transfer', count: current_user.dossiers.count, email: next_owner_email)
+      else
+        flash.alert = transfer.errors.full_messages
+      end
+
       redirect_to profil_path
     end
 

--- a/app/models/dossier_transfer.rb
+++ b/app/models/dossier_transfer.rb
@@ -12,6 +12,8 @@ class DossierTransfer < ApplicationRecord
 
   EXPIRATION_LIMIT = 2.weeks
 
+  validates :email, format: { with: Devise.email_regexp }
+
   scope :pending, -> { where('created_at > ?', (Time.zone.now - EXPIRATION_LIMIT)) }
   scope :stale, -> { where('created_at < ?', (Time.zone.now - EXPIRATION_LIMIT)) }
   scope :with_dossiers, -> { joins(:dossiers).merge(Dossier.visible_by_user) }

--- a/app/views/users/dossiers/transferer.html.haml
+++ b/app/views/users/dossiers/transferer.html.haml
@@ -5,5 +5,5 @@
   = form_for @transfer, url: transfers_path, html: { class: 'form mt-2' } do |f|
     = f.label :email, 'Email du compte destinataire'
     = f.email_field :email
-    = f.hidden_field :dossiers, value: dossier.id
+    = f.hidden_field :dossier, value: dossier.id
     = f.submit "Envoyer la demande de transfert", class: 'button primary'

--- a/app/views/users/dossiers/transferer.html.haml
+++ b/app/views/users/dossiers/transferer.html.haml
@@ -4,6 +4,6 @@
 
   = form_for @transfer, url: transfers_path, html: { class: 'form mt-2' } do |f|
     = f.label :email, 'Email du compte destinataire'
-    = f.email_field :email
+    = f.email_field :email, required: true
     = f.hidden_field :dossier, value: dossier.id
     = f.submit "Envoyer la demande de transfert", class: 'button primary'

--- a/app/views/users/dossiers/transferer_all.html.haml
+++ b/app/views/users/dossiers/transferer_all.html.haml
@@ -3,5 +3,5 @@
 
   = form_for @transfer, url: transfers_path, html: { class: 'form mt-2' } do |f|
     = f.label :email, 'Email du compte destinataire'
-    = f.email_field :email
+    = f.email_field :email, required: true
     = f.submit "Envoyer la demande de transfert", class: 'button primary'

--- a/config/locales/models/dossier_transfer/en.yml
+++ b/config/locales/models/dossier_transfer/en.yml
@@ -1,0 +1,9 @@
+en:
+  activerecord:
+    errors:
+      models:
+        dossier_transfer:
+          attributes:
+            email:
+              format: "Email address %{message}"
+              invalid: "is invalid"

--- a/config/locales/models/dossier_transfer/fr.yml
+++ b/config/locales/models/dossier_transfer/fr.yml
@@ -1,0 +1,9 @@
+fr:
+  activerecord:
+    errors:
+      models:
+        dossier_transfer:
+          attributes:
+            email:
+              format: "L'adresse email %{message}"
+              invalid: "est invalide"

--- a/lib/tasks/deployment/20220802133502_destroy_dossier_transfer_without_email.rake
+++ b/lib/tasks/deployment/20220802133502_destroy_dossier_transfer_without_email.rake
@@ -1,0 +1,25 @@
+namespace :after_party do
+  desc 'Deployment task: destroy_dossier_transfer_without_email'
+  task destroy_dossier_transfer_without_email: :environment do
+    puts "Running deploy task 'destroy_dossier_transfer_without_email'"
+
+    invalid_dossiers = DossierTransfer.where(email: "")
+
+    progress = ProgressReport.new(invalid_dossiers.count)
+
+    invalid_dossiers.find_each do |dossier_transfer|
+      puts "Destroy dossier transfer #{dossier_transfer.id}"
+      dossier_transfer.destroy_and_nullify
+
+      job = Delayed::Job.where("handler LIKE ALL(ARRAY[?, ?])", "%ActionMailer::MailDeliveryJob%", "%aj_globalid: gid://tps/DossierTransfer/#{dossier_transfer.id}\n%").first
+      job.destroy if job
+
+      progress.inc
+    end
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end

--- a/spec/controllers/users/profil_controller_spec.rb
+++ b/spec/controllers/users/profil_controller_spec.rb
@@ -133,14 +133,25 @@ describe Users::ProfilController, type: :controller do
     let(:next_owner) { 'loulou@lou.com' }
     let(:created_transfer) { DossierTransfer.first }
 
-    before do
+    subject {
       post :transfer_all_dossiers, params: { next_owner: next_owner }
-    end
+    }
+
+    before { subject }
 
     it "transfer all dossiers" do
       expect(created_transfer.email).to eq(next_owner)
       expect(created_transfer.dossiers).to match_array(dossiers)
       expect(flash.notice).to eq("Le transfert de 3 dossiers à #{next_owner} est en cours")
+    end
+
+    context "next owner has an empty email" do
+      let(:next_owner) { '' }
+
+      it "should not transfer to an empty email" do
+        expect { subject }.not_to change { DossierTransfer.count }
+        expect(flash.alert).to eq(["L'adresse email est invalide"])
+      end
     end
   end
 

--- a/spec/controllers/users/transfers_controller_spec.rb
+++ b/spec/controllers/users/transfers_controller_spec.rb
@@ -13,4 +13,33 @@ describe Users::TransfersController, type: :controller do
 
     it { expect { dossier_transfert.reload }.to raise_error(ActiveRecord::RecordNotFound) }
   end
+
+  describe "POST create" do
+    subject { post :create, params: { dossier_transfer: { email: email, dossier: dossier.id } } }
+
+    before { subject }
+
+    context "with valid email" do
+      let(:email) { "test@rspec.net" }
+
+      it { expect(DossierTransfer.last.email).to eq(email) }
+      it { expect(DossierTransfer.last.dossiers).to eq([dossier]) }
+    end
+
+    shared_examples 'email error' do
+      it { expect { subject }.not_to change { DossierTransfer.count } }
+      it { expect(flash.alert).to match([/invalide/]) }
+      it { is_expected.to redirect_to transferer_dossier_path(dossier.id) }
+    end
+
+    context "when email is empty" do
+      let(:email) { "" }
+      it_behaves_like 'email error'
+    end
+
+    context "when email is invalid" do
+      let(:email) { "not-an-email" }
+      it_behaves_like 'email error'
+    end
+  end
 end

--- a/spec/models/dossier_transfer_spec.rb
+++ b/spec/models/dossier_transfer_spec.rb
@@ -78,4 +78,30 @@ RSpec.describe DossierTransfer, type: :model do
       expect(DossierTransfer.count).to eq(0)
     end
   end
+
+  describe "validation" do
+    let(:email) { build(:dossier_transfer).email }
+
+    subject { build(:dossier_transfer, email: email) }
+
+    it "factory is valid" do
+      expect(subject).to be_valid
+    end
+
+    context "when email is blank" do
+      let(:email) { "" }
+
+      it "requires a valid email" do
+        expect(subject).to be_invalid
+      end
+    end
+
+    context "when email is not an email" do
+      let(:email) { "test" }
+
+      it "requires a valid email" do
+        expect(subject).to be_invalid
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Ajout d'un validateur sur le modèle
- gestion de l'erreur dans les 2 forms où on peut créer un transfert
- validation côté navigateur
- supprime les DossierTransfer sans email + les delayed jobs concernés

Closes #7621