### PR TITLE
chore(sentry): tag dossier & procedure ids on dossier endpoints

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -389,7 +389,13 @@ module Users
     end
 
     def dossier
-      @dossier ||= dossier_scope.find(params[:id] || params[:dossier_id])
+      @dossier ||= dossier_scope.find(params[:id] || params[:dossier_id]).tap do |dossier|
+                       # Ease search & groupments by tags
+                       Sentry.configure_scope do |scope|
+                         scope.set_tags(procedure: dossier.procedure.id)
+                         scope.set_tags(dossier: dossier.id)
+                       end
+                     end
     end
 
     def dossier_with_champs


### PR DESCRIPTION
On créé un tag dans Sentry avec l'id du dossier, et surtout de la procédure. Grâce aux regroupements qu'on peut faire avec sentry, ça peut aider à identifier plus simplement des procédures ou dossiers qui posent problème plutôt qu'aller les voir 1 à un 1 dans les payloads.