### PR TITLE
Fix random tests errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,8 +138,9 @@ GEM
     browser (5.3.1)
     builder (3.2.4)
     byebug (11.1.3)
-    capybara (3.35.3)
+    capybara (3.37.1)
       addressable
+      matrix
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
       rack (>= 1.6.0)
@@ -149,7 +150,7 @@ GEM
     capybara-email (3.0.2)
       capybara (>= 2.4, < 4.0)
       mail
-    capybara-screenshot (1.0.25)
+    capybara-screenshot (1.0.26)
       capybara (>= 1.0, < 4)
       launchy
     case_transform (0.2)
@@ -450,7 +451,7 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.5.8)
-    nokogiri (1.13.7)
+    nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     open4 (1.3.4)
@@ -496,7 +497,7 @@ GEM
       pry (~> 0.13.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    public_suffix (4.0.6)
+    public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
     pundit (2.1.0)

--- a/app/models/procedure_revision_type_de_champ.rb
+++ b/app/models/procedure_revision_type_de_champ.rb
@@ -18,7 +18,7 @@ class ProcedureRevisionTypeDeChamp < ApplicationRecord
   has_many :revision_types_de_champ, -> { ordered }, foreign_key: :parent_id, class_name: 'ProcedureRevisionTypeDeChamp', inverse_of: :parent, dependent: :destroy
   has_one :procedure, through: :revision
   scope :root, -> { where(parent: nil) }
-  scope :ordered, -> { order(:position) }
+  scope :ordered, -> { order(:position, :id) }
   scope :revision_ordered, -> { order(:revision_id) }
   scope :public_only, -> { joins(:type_de_champ).where(types_de_champ: { private: false }) }
   scope :private_only, -> { joins(:type_de_champ).where(types_de_champ: { private: true }) }

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -105,7 +105,7 @@ module SystemHelpers
 
   def select_combobox(libelle, fill_with, value, check: true)
     fill_in libelle, with: fill_with
-    find('li[role="option"]', text: value).click
+    find('li[role="option"]', text: value, wait: 5).click
     if check
       check_selected_value(libelle, with: value)
     end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,3 +1,3 @@
 require 'webmock/rspec'
 
-WebMock.disable_net_connect!(allow_localhost: true)
+WebMock.disable_net_connect!(allow_localhost: true, net_http_connect_on_start: true)

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -4,6 +4,7 @@ describe 'The user' do
 
   let!(:procedure) { create(:procedure, :published, :for_individual, :with_all_champs_mandatory) }
   let(:user_dossier) { user.dossiers.first }
+  let!(:dossier_to_link) { create(:dossier) }
 
   scenario 'fill a dossier', js: true do
     log_in(user, procedure)
@@ -39,7 +40,7 @@ describe 'The user' do
     select_combobox('communes', 'Ambl', 'Ambléon (01300)')
 
     check('engagement')
-    fill_in('dossier_link', with: '123')
+    fill_in('dossier_link', with: dossier_to_link.id)
     find('.editable-champ-piece_justificative input[type=file]').attach_file(Rails.root + 'spec/fixtures/files/file.pdf')
 
     blur
@@ -69,8 +70,8 @@ describe 'The user' do
     expect(champ_value_for('departements')).to eq('02 - Aisne')
     expect(champ_value_for('communes')).to eq('Ambléon (01300)')
     expect(champ_value_for('engagement')).to eq('on')
-    expect(champ_value_for('dossier_link')).to eq('123')
     expect(champ_value_for('piece_justificative')).to be_nil # antivirus hasn't approved the file yet
+    expect(champ_value_for('dossier_link')).to eq(dossier_to_link.id.to_s)
 
     ## check data on the gui
 
@@ -94,7 +95,7 @@ describe 'The user' do
     check_selected_value('departements', with: '02 - Aisne')
     check_selected_value('communes', with: 'Ambléon (01300)')
     expect(page).to have_checked_field('engagement')
-    expect(page).to have_field('dossier_link', with: '123')
+    expect(page).to have_field('dossier_link', with: dossier_to_link.id.to_s)
     expect(page).to have_text('file.pdf')
     expect(page).to have_text('analyse antivirus en cours')
   end

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -179,13 +179,13 @@ describe 'The user' do
 
     expect(page).to have_css('.card-title', text: 'Votre dossier va expirer', visible: true)
     find('#test-user-repousser-expiration').click
-    expect(page).not_to have_selector('#test-user-repousser-expiration')
+    expect(page).to have_no_selector('#test-user-repousser-expiration')
 
     Timecop.freeze(simple_procedure.duree_conservation_dossiers_dans_ds.month.from_now) do
       visit brouillon_dossier_path(user_old_dossier)
       expect(page).to have_css('.card-title', text: 'Votre dossier va expirer', visible: true)
       find('#test-user-repousser-expiration').click
-      expect(page).not_to have_selector('#test-user-repousser-expiration')
+      expect(page).to have_no_selector('#test-user-repousser-expiration')
     end
   end
 
@@ -342,7 +342,7 @@ describe 'The user' do
       log_in(user, simple_procedure)
       fill_individual
 
-      expect(page).not_to have_button('Enregistrer le brouillon')
+      expect(page).to have_no_button('Enregistrer le brouillon')
       expect(page).to have_content('Votre brouillon est automatiquement enregistré')
 
       fill_in('texte obligatoire', with: 'a valid user input')

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -43,8 +43,8 @@ describe 'The user' do
     fill_in('dossier_link', with: dossier_to_link.id)
     find('.editable-champ-piece_justificative input[type=file]').attach_file(Rails.root + 'spec/fixtures/files/file.pdf')
 
+    expect(page).to have_css('span', text: 'Votre brouillon est automatiquement enregistré', visible: true)
     blur
-    sleep(0.7)
     expect(page).to have_css('span', text: 'Brouillon enregistré', visible: true)
 
     # check data on the dossier


### PR DESCRIPTION
- update capybara pour les derniers fix
- fix too many open files sur M1 à cause de webmock+capybara
- combobox: wait 5 secondes à cause du render avec React
- `brouillon_spec`:
   -  stratégrie de retry lorsque la db ne nous renvoie pas encore la valeur mise à jour. (Il ne s'agit pas d'erreur liée à un wait capybara, car on teste la valeur contre celle de la db)
   - matchers wait compatible (`.to have_no_*` plutôt que `.not_to have_*`)


- `procedure_revision_spec.rb:73` :  ce n'est pas lié au test mais au manque de stabilité de l'order sur les `revision_type_de_champ` : après avoir créé un nouveau `revision_type_de_champ`,
on se retrouve très momentanément avec 2 RTDC ayant le même position en attendant le renumérotation peu près.

  https://github.com/betagouv/demarches-simplifiees.fr/blob/main/app/models/procedure_revision.rb#L55

  Ceci conduisait à une renumérotation erronnée quand le reload des siblings par la db renvoyait aléatoirement
le nouveau RTDC *avant* les précédents.