### PR TITLE
fix(conditional,ux): retire l'attribut `required` sur les `input` du formulaire

### DIFF
--- a/app/javascript/controllers/champ_dropdown_controller.ts
+++ b/app/javascript/controllers/champ_dropdown_controller.ts
@@ -68,9 +68,6 @@ export class ChampDropdownController extends ApplicationController {
     if (options.length) {
       disable(hidden);
 
-      if (secondarySelectElement.required) {
-        secondarySelectElement.appendChild(makeOption(''));
-      }
       for (const option of options) {
         secondarySelectElement.appendChild(makeOption(option));
       }

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -34,6 +34,7 @@ class Champ < ApplicationRecord
   delegate :libelle,
     :type_champ,
     :procedure,
+    :mandatory?,
     :description,
     :drop_down_list_options,
     :drop_down_other?,
@@ -91,12 +92,8 @@ class Champ < ApplicationRecord
     @sections ||= dossier.sections_for(self)
   end
 
-  def mandatory?
-    type_de_champ.mandatory? && visible?
-  end
-
   def mandatory_blank_and_visible?
-    mandatory? && blank?
+    mandatory? && blank? && visible?
   end
 
   def blank?

--- a/app/models/champs/drop_down_list_champ.rb
+++ b/app/models/champs/drop_down_list_champ.rb
@@ -22,7 +22,6 @@
 class Champs::DropDownListChamp < Champ
   THRESHOLD_NB_OPTIONS_AS_RADIO = 5
   OTHER = '__other__'
-  delegate :options_without_empty_value_when_mandatory, to: :type_de_champ
 
   def render_as_radios?
     enabled_non_empty_options.size <= THRESHOLD_NB_OPTIONS_AS_RADIO

--- a/app/models/champs/piece_justificative_champ.rb
+++ b/app/models/champs/piece_justificative_champ.rb
@@ -39,7 +39,7 @@ class Champs::PieceJustificativeChamp < Champ
   end
 
   def mandatory_blank_and_visible?
-    mandatory? && !piece_justificative_file.attached?
+    mandatory? && !piece_justificative_file.attached? && visible?
   end
 
   def for_export

--- a/app/models/champs/siret_champ.rb
+++ b/app/models/champs/siret_champ.rb
@@ -25,6 +25,6 @@ class Champs::SiretChamp < Champ
   end
 
   def mandatory_blank_and_visible?
-    mandatory? && Siret.new(siret: value).invalid?
+    mandatory? && Siret.new(siret: value).invalid? && visible?
   end
 end

--- a/app/models/champs/titre_identite_champ.rb
+++ b/app/models/champs/titre_identite_champ.rb
@@ -33,7 +33,7 @@ class Champs::TitreIdentiteChamp < Champ
   end
 
   def mandatory_blank_and_visible?
-    mandatory? && !piece_justificative_file.attached?
+    mandatory? && !piece_justificative_file.attached? && visible?
   end
 
   def for_export

--- a/app/models/type_de_champ.rb
+++ b/app/models/type_de_champ.rb
@@ -301,14 +301,6 @@ class TypeDeChamp < ApplicationRecord
     self.drop_down_options = parse_drop_down_list_value(value)
   end
 
-  # historicaly we added a blank ("") option by default to avoid wrong selection
-  #   see self.parse_drop_down_list_value
-  #   then rails decided to add this blank ("") option when the select is required
-  #   so we revert this change
-  def options_without_empty_value_when_mandatory(options)
-    mandatory? ? options.reject(&:blank?) : options
-  end
-
   def drop_down_list_options?
     drop_down_list_options.any?
   end

--- a/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
+++ b/app/models/types_de_champ/linked_drop_down_list_type_de_champ.rb
@@ -30,15 +30,14 @@ class TypesDeChamp::LinkedDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBas
     tags
   end
 
-  def add_blank_option_when_not_mandatory(options)
-    return options if mandatory
+  def add_blank_option(options)
     options.unshift('')
   end
 
   def primary_options
     primary_options = unpack_options.map(&:first)
     if primary_options.present?
-      primary_options = add_blank_option_when_not_mandatory(primary_options)
+      primary_options = add_blank_option(primary_options)
     end
     primary_options
   end
@@ -58,7 +57,7 @@ class TypesDeChamp::LinkedDropDownListTypeDeChamp < TypesDeChamp::TypeDeChampBas
     chunked = options.slice_before(PRIMARY_PATTERN)
     chunked.map do |chunk|
       primary, *secondary = chunk
-      secondary = add_blank_option_when_not_mandatory(secondary)
+      secondary = add_blank_option(secondary)
       [PRIMARY_PATTERN.match(primary)&.[](1), secondary]
     end
   end

--- a/app/views/shared/dossiers/editable_champs/_address.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_address.html.haml
@@ -1,6 +1,5 @@
 = form.hidden_field :value
 = form.hidden_field :external_id
 = react_component("ComboAdresseSearch",
-  required: champ.mandatory?,
   id: champ.input_id,
   describedby: champ.describedby_id)

--- a/app/views/shared/dossiers/editable_champs/_annuaire_education.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_annuaire_education.html.haml
@@ -1,6 +1,5 @@
 = form.hidden_field :value
 = form.hidden_field :external_id
 = react_component("ComboAnnuaireEducationSearch",
-  required: champ.mandatory?,
   id: champ.input_id,
   describedby: champ.describedby_id)

--- a/app/views/shared/dossiers/editable_champs/_champ_label_content.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_champ_label_content.html.haml
@@ -1,5 +1,5 @@
 #{champ.libelle}
-- if champ.type_de_champ.mandatory?
+- if champ.mandatory?
   %span.mandatory *
 
 - if champ.updated_at.present? && seen_at.present?

--- a/app/views/shared/dossiers/editable_champs/_checkbox.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_checkbox.html.haml
@@ -1,4 +1,4 @@
 = form.check_box :value,
-  { required: champ.mandatory?, id: champ.input_id, aria: { describedby: champ.describedby_id } },
+  { id: champ.input_id, aria: { describedby: champ.describedby_id } },
   'on',
   'off'

--- a/app/views/shared/dossiers/editable_champs/_cnaf.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_cnaf.html.haml
@@ -3,7 +3,6 @@
     = form.label :numero_allocataire, t('.numero_allocataire_label')
     %p.notice= t('.numero_allocataire_notice')
     = form.text_field :numero_allocataire,
-      required: champ.mandatory?,
       aria: { describedby: champ.describedby_id },
       class: "width-33-desktop"
 
@@ -11,6 +10,5 @@
     = form.label :code_postal, t('.code_postal_label')
     %p.notice= t('.code_postal_notice')
     = form.text_field :code_postal,
-      required: champ.mandatory?,
       aria: { describedby: champ.describedby_id },
       class: "width-33-desktop"

--- a/app/views/shared/dossiers/editable_champs/_communes.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_communes.html.haml
@@ -3,7 +3,6 @@
 = form.hidden_field :departement
 = form.hidden_field :code_departement
 = react_component("ComboCommunesSearch",
-  required: champ.mandatory?,
   id: champ.input_id,
   classNameDepartement: "width-33-desktop width-100-mobile",
   className: "width-66-desktop width-100-mobile",

--- a/app/views/shared/dossiers/editable_champs/_date.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_date.html.haml
@@ -2,6 +2,5 @@
   id: champ.input_id,
   aria: { describedby: champ.describedby_id },
   value: champ.value,
-  required: champ.mandatory?,
   placeholder: 'aaaa-mm-jj',
   class: "width-33-desktop"

--- a/app/views/shared/dossiers/editable_champs/_decimal_number.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_decimal_number.html.haml
@@ -2,5 +2,4 @@
   id: champ.input_id,
   aria: { describedby: champ.describedby_id },
   step: :any,
-  placeholder: "3.14",
-  required: champ.mandatory?
+  placeholder: "3.14"

--- a/app/views/shared/dossiers/editable_champs/_departements.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_departements.html.haml
@@ -1,7 +1,6 @@
 = form.hidden_field :value
 = form.hidden_field :external_id
 = react_component("ComboDepartementsSearch",
-  required: champ.mandatory?,
   id: champ.input_id,
   className: "width-33-desktop width-100-mobile",
   describedby: champ.describedby_id)

--- a/app/views/shared/dossiers/editable_champs/_dgfip.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_dgfip.html.haml
@@ -3,7 +3,6 @@
     = form.label :numero_fiscal, t('.numero_fiscal_label')
     %p.notice= t('.numero_fiscal_notice')
     = form.text_field :numero_fiscal,
-      required: champ.mandatory?,
       aria: { describedby: champ.describedby_id },
       class: "width-33-desktop"
 
@@ -11,6 +10,5 @@
     = form.label :reference_avis, t('.reference_avis_label')
     %p.notice= t('.reference_avis_notice')
     = form.text_field :reference_avis,
-      required: champ.mandatory?,
       aria: { describedby: champ.describedby_id },
       class: "width-33-desktop"

--- a/app/views/shared/dossiers/editable_champs/_dossier_link.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_dossier_link.html.haml
@@ -4,7 +4,6 @@
     aria: { describedby: champ.describedby_id },
     placeholder: "Numéro de dossier",
     autocomplete: 'off',
-    required: champ.mandatory?,
     data: { controller: 'turbo-input', turbo_input_url_value: champs_dossier_link_path(champ.id) },
     class: "width-33-desktop"
 

--- a/app/views/shared/dossiers/editable_champs/_drop_down_list.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_drop_down_list.html.haml
@@ -16,7 +16,7 @@
           = form.radio_button :value, Champs::DropDownListChamp::OTHER, checked: champ.other_value_present?
           Autre
   - else
-    = form.select :value, champ.options_without_empty_value_when_mandatory(champ.options), { selected: champ.selected }, required: champ.mandatory?, id: champ.input_id, aria: { describedby: champ.describedby_id }
+    = form.select :value, champ.options_without_empty_value_when_mandatory(champ.options), { selected: champ.selected }, id: champ.input_id, aria: { describedby: champ.describedby_id }
 
   - if champ.drop_down_other?
     = render partial: "shared/dossiers/editable_champs/drop_down_other_input", locals: { form: form, champ: champ }

--- a/app/views/shared/dossiers/editable_champs/_drop_down_list.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_drop_down_list.html.haml
@@ -16,7 +16,7 @@
           = form.radio_button :value, Champs::DropDownListChamp::OTHER, checked: champ.other_value_present?
           Autre
   - else
-    = form.select :value, champ.options_without_empty_value_when_mandatory(champ.options), { selected: champ.selected }, id: champ.input_id, aria: { describedby: champ.describedby_id }
+    = form.select :value, champ.options, { selected: champ.selected }, id: champ.input_id, aria: { describedby: champ.describedby_id }
 
   - if champ.drop_down_other?
     = render partial: "shared/dossiers/editable_champs/drop_down_other_input", locals: { form: form, champ: champ }

--- a/app/views/shared/dossiers/editable_champs/_email.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_email.html.haml
@@ -1,5 +1,4 @@
 = form.email_field :value,
   id: champ.input_id,
   aria: { describedby: champ.describedby_id },
-  placeholder: t(".placeholder"),
-  required: champ.mandatory?
+  placeholder: t(".placeholder")

--- a/app/views/shared/dossiers/editable_champs/_engagement.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_engagement.html.haml
@@ -1,4 +1,4 @@
 = form.check_box :value,
-  { required: champ.mandatory?, id: champ.input_id, aria: { describedby: champ.describedby_id } },
+  { id: champ.input_id, aria: { describedby: champ.describedby_id } },
   'on',
   'off'

--- a/app/views/shared/dossiers/editable_champs/_iban.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_iban.html.haml
@@ -1,7 +1,6 @@
 = form.text_field :value,
   id: champ.input_id,
   placeholder: t(".placeholder"),
-  required: champ.mandatory?,
   aria: { describedby: champ.describedby_id },
   data: { controller: 'iban-input'},
   class: "width-66-desktop",

--- a/app/views/shared/dossiers/editable_champs/_integer_number.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_integer_number.html.haml
@@ -1,5 +1,4 @@
 = form.number_field :value,
   id: champ.input_id,
   aria: { describedby: champ.describedby_id },
-  placeholder: 5,
-  required: champ.mandatory?
+  placeholder: 5

--- a/app/views/shared/dossiers/editable_champs/_linked_drop_down_list.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_linked_drop_down_list.html.haml
@@ -2,7 +2,7 @@
   = form.select :primary_value,
     champ.primary_options,
     {},
-    { data: { secondary_options: champ.secondary_options }, required: champ.mandatory?, id: champ.input_id, aria: { describedby: champ.describedby_id } }
+    { data: { secondary_options: champ.secondary_options }, id: champ.input_id, aria: { describedby: champ.describedby_id } }
 
   .secondary{ class: champ.has_secondary_options_for_primary? ? '' : 'hidden' }
     = form.label :secondary_value, for: "#{champ.input_id}-secondary" do
@@ -14,5 +14,5 @@
     = form.select :secondary_value,
       champ.secondary_options[champ.primary_value],
       {},
-      { data: { secondary: true }, disabled: !champ.has_secondary_options_for_primary?, required: champ.mandatory?, id: "#{champ.input_id}-secondary", aria: { describedby: "#{champ.describedby_id}-secondary" } }
+      { data: { secondary: true }, disabled: !champ.has_secondary_options_for_primary?, id: "#{champ.input_id}-secondary", aria: { describedby: "#{champ.describedby_id}-secondary" } }
   = form.hidden_field :secondary_value, value: '', disabled: champ.has_secondary_options_for_primary?

--- a/app/views/shared/dossiers/editable_champs/_linked_drop_down_list.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_linked_drop_down_list.html.haml
@@ -7,7 +7,7 @@
   .secondary{ class: champ.has_secondary_options_for_primary? ? '' : 'hidden' }
     = form.label :secondary_value, for: "#{champ.input_id}-secondary" do
       = champ.drop_down_secondary_libelle.presence || "Valeur secondaire dépendant de la première"
-      - if champ.type_de_champ.mandatory?
+      - if champ.mandatory?
         %span.mandatory *
     - if champ.drop_down_secondary_description.present?
       .notice{ id: "#{champ.describedby_id}-secondary" }= string_to_html(champ.drop_down_secondary_description)

--- a/app/views/shared/dossiers/editable_champs/_mesri.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_mesri.html.haml
@@ -3,7 +3,6 @@
     = form.label :ine, t('.ine_label')
     %p.notice= t('.ine_notice')
     = form.text_field :ine,
-      required: champ.mandatory?,
       aria: { describedby: champ.describedby_id },
       class: "width-33-desktop"
 

--- a/app/views/shared/dossiers/editable_champs/_number.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_number.html.haml
@@ -1,5 +1,4 @@
 = form.number_field :value,
   id: champ.input_id,
   aria: { describedby: champ.describedby_id },
-  placeholder: champ.libelle,
-  required: champ.mandatory?
+  placeholder: champ.libelle

--- a/app/views/shared/dossiers/editable_champs/_pays.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_pays.html.haml
@@ -1,7 +1,6 @@
 = form.hidden_field :value
 = form.hidden_field :external_id
 = react_component("ComboPaysSearch",
-  required: champ.mandatory?,
   id: champ.input_id,
   className: "width-33-desktop width-100-mobile",
   describedby: champ.describedby_id)

--- a/app/views/shared/dossiers/editable_champs/_phone.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_phone.html.haml
@@ -5,5 +5,4 @@
   id: champ.input_id,
   aria: { describedby: champ.describedby_id },
   placeholder: t(".placeholder"),
-  required: champ.mandatory?,
   pattern: "[^a-z^A-Z]+"

--- a/app/views/shared/dossiers/editable_champs/_pole_emploi.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_pole_emploi.html.haml
@@ -3,6 +3,5 @@
     = form.label :identifiant, t('.identifiant_label')
     %p.notice= t('.identifiant_notice')
     = form.text_field :identifiant,
-      required: champ.mandatory?,
       aria: { describedby: champ.describedby_id },
       class: "width-33-desktop"

--- a/app/views/shared/dossiers/editable_champs/_regions.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_regions.html.haml
@@ -1,7 +1,6 @@
 = form.hidden_field :value
 = form.hidden_field :external_id
 = react_component("ComboRegionsSearch",
-  required: champ.mandatory?,
   id: champ.input_id,
   className: "width-33-desktop width-100-mobile",
   describedby: champ.describedby_id)

--- a/app/views/shared/dossiers/editable_champs/_siret.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_siret.html.haml
@@ -3,7 +3,6 @@
   aria: { describedby: champ.describedby_id },
   placeholder: t(".placeholder"),
   data: { controller: 'turbo-input', turbo_input_url_value: champs_siret_path(champ.id) },
-  required: champ.mandatory?,
   pattern: "[0-9]{14}",
   title: t(".title"),
   class: "width-33-desktop",

--- a/app/views/shared/dossiers/editable_champs/_text.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_text.html.haml
@@ -1,4 +1,3 @@
 = form.text_field :value,
   id: champ.input_id,
-  required: champ.mandatory?,
   aria: { describedby: champ.describedby_id }

--- a/app/views/shared/dossiers/editable_champs/_textarea.html.haml
+++ b/app/views/shared/dossiers/editable_champs/_textarea.html.haml
@@ -2,5 +2,4 @@
   id: champ.input_id,
   aria: { describedby: champ.describedby_id },
   rows: 6,
-  required: champ.mandatory?,
   value: html_to_string(champ.value)


### PR DESCRIPTION
Alors, j'ai conscience que c'est un changement conséquent pour les vacances d’août

Aujourd'hui, on utilise l'attribut `required` sur les champs obligatoires pour forcer un contrôle de surface par le navigateur.

pbs UX :
- Les messages d'erreurs (au moins sur ff) sont mal positionnés
![mauvais_positionnement](https://user-images.githubusercontent.com/907405/183869859-a6e3f57e-b446-4ecb-ba21-a72b1d423ef3.png)
- Le mécanisme ne marche pas sur le choix parmi une liste
- Nous n'avons pas de maîtrise sur le texte, ni ne pouvons faire une barre de résumé des erreurs

pbs spécifique au conditionnel :
- aujourd'hui le mécanisme pour le conditionnel ne fait que afficher ou cacher des éléments du dom. Il ne fait pas de modification des elements, ni de suppression / insertion.
  - du coup, dans le cas d'un enfant obligatoire d'un bloc répétable conditionné, si le bloc répétable devient caché, on ne peut pas retirer l'attribut `required` de l'enfant, ce qui bloque de manière invisible la soumission du formulaire

solution proposée :
- on retire les attributs `requried` pour résoudre le pb du condtionnel
- dans un second temps on ajoute une gestion plus fine des messages d'erreurs

voir aussi les blogs sur la validation de forms : https://github.com/betagouv/demarches-simplifiees.fr/wiki/Accessibilit%C3%A9#blog