### PR TITLE
fix(migration): following e764aade13985190b336bd4cbf14ac10893956e3 …we still need to remove those columns otherwise destroying a procedure fails due to index on types_de_champ.revision_id

### DIFF
--- a/lib/tasks/deployment/20220822135410_remove_unused_column_on_type_de_champs.rake
+++ b/lib/tasks/deployment/20220822135410_remove_unused_column_on_type_de_champs.rake
@@ -1,0 +1,16 @@
+namespace :after_party do
+  desc 'Deployment task: remove_unused_column_on_type_de_champs'
+  task remove_unused_column_on_type_de_champs: :environment do
+    puts "Running deploy task 'remove_unused_column_on_type_de_champs'"
+
+    StrongMigrations.disable_check :remove_column
+
+    ActiveRecord::Migration.remove_column :types_de_champ, :migrated_parent
+    ActiveRecord::Migration.remove_column :types_de_champ, :revision_id
+    ActiveRecord::Migration.remove_column :types_de_champ, :parent_id
+    ActiveRecord::Migration.remove_column :types_de_champ, :order_place
+
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
remonté par bouchra et le support, "mes procedures ne se suppriment pas". restait un index sur une colonne en attente de suppression