### PR TITLE
Graphql: Fix champs order in repetitions

### DIFF
--- a/app/models/dossier_preloader.rb
+++ b/app/models/dossier_preloader.rb
@@ -83,7 +83,7 @@ class DossierPreloader
     end
 
     parent.association(name).target = champs.sort_by do |champ|
-      positions[dossier.revision_id][champ.type_de_champ_id]
+      [champ.row, positions[dossier.revision_id][champ.type_de_champ_id]]
     end
 
     # Load children champs


### PR DESCRIPTION
Dans l'API GraphQL, on parle ici de la requete demarche qui retourne plusieurs dossiers.
Depuis le 21 Juillet, cette requete ne trie pas correctement les champs dans les repetitions.
Ainsi deux blocs de type 
```
   Nom: XXX
   Prénom: xxxxx
   Nom: YYYY
   Prénom: yyyy
```
Sortent 
```
   Nom: XXX
   Nom: YYYY
   Prénom: xxxxx
   Prénom: yyyy
```
Cette PR corrige le pb en réordonnant chaque champ suivant [le numero de ligne, l'ordre du champ dans la revision en cours]
