### PR TITLE
add saml sp only if vars present

### DIFF
--- a/config/initializers/saml_idp.rb
+++ b/config/initializers/saml_idp.rb
@@ -17,12 +17,14 @@ if ENV['SAML_IDP_ENABLED'] == 'enabled'
       }
     }
 
-    service_providers = {
-      "https://#{ENV.fetch('SAML_DOLIST_HOST')}" => {
-        response_hosts: [ENV.fetch('SAML_DOLIST_HOST')],
-        cert: ENV.fetch("SAML_DOLIST_CERTIFICATE")
-      }
-    }
+    service_providers = {}
+    if ENV['SAML_DOLIST_HOST'].present?
+      service_providers["https://#{ENV.fetch('SAML_DOLIST_HOST')}"] =
+        {
+          response_hosts: [ENV.fetch('SAML_DOLIST_HOST')],
+          cert: ENV.fetch("SAML_DOLIST_CERTIFICATE")
+        }
+    end
 
     config.service_provider.finder = -> (entity_id) do
       service_providers[entity_id]


### PR DESCRIPTION
Cette PR permet que puma arrive à démarrer lorsque SAML est activé mais que la variable SAML_DOLIST_HOST n'est pas présente.

Cela permet 
- de pouvoir exposer la route /saml/metadata et permettre à un service provider d'ajouter les metadata de demarches-simplifiees.

- Et que dans l'attente que le service provider soit configuré, aucun service provider ne soit autorisé à envoyer une requête saml à demarches-simplifiees