### PR TITLE
fix(champ): remove null byte before save

### DIFF
--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -75,6 +75,7 @@ class Champ < ApplicationRecord
   before_create :set_dossier_id, if: :needs_dossier_id?
   before_validation :set_dossier_id, if: :needs_dossier_id?
   before_save :cleanup_if_empty
+  before_save :normalize
   after_update_commit :fetch_external_data_later
 
   validates :type_de_champ_id, uniqueness: { scope: [:dossier_id, :row] }
@@ -243,6 +244,12 @@ class Champ < ApplicationRecord
     if fetch_external_data? && external_id.present? && data.nil?
       ChampFetchExternalDataJob.perform_later(self, external_id)
     end
+  end
+
+  def normalize
+    return if value.nil?
+
+    self.value = value.delete("\u0000")
   end
 
   class NotImplemented < ::StandardError

--- a/spec/models/champ_spec.rb
+++ b/spec/models/champ_spec.rb
@@ -26,6 +26,13 @@ describe Champ do
     end
   end
 
+  describe "normalization" do
+    it "should remove null bytes before save" do
+      champ = create(:champ, value: "foo\u0000bar")
+      expect(champ.value).to eq "foobar"
+    end
+  end
+
   describe '#public?' do
     let(:type_de_champ) { build(:type_de_champ) }
     let(:champ) { type_de_champ.champ.build }


### PR DESCRIPTION
Les null bytes peuvent être injectés lors de c/c depuis certains documents,
et ne sont pas sauvegardables en base, rendant la sauvegarde d'un dossier impossible.

Closes #7656

https://sentry.io/organizations/demarches-simplifiees/issues/3194932607/activity/?project=1429550&query=is%3Aunresolved