### PR TITLE
fix(dossier/attestation_pdf): don't overlap DS name over logo

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,10 +6,16 @@ require:
   - ./lib/cops/application_name.rb
   - ./lib/cops/unscoped.rb
 
+inherit_mode:
+  merge:
+    - Include
+
 AllCops:
   TargetRubyVersion: 3.0
   DisabledByDefault: true
   SuggestExtensions: false
+  Include:
+    - "app/**/*.prawn"
   Exclude:
     - "db/schema.rb"
     - "db/migrate/20190730153555_recreate_structure.rb"

--- a/app/views/administrateurs/attestation_templates/show.pdf.prawn
+++ b/app/views/administrateurs/attestation_templates/show.pdf.prawn
@@ -2,7 +2,7 @@ require 'prawn/measurement_extensions'
 
 #----- A4 page size
 page_size = 'A4'
-page_height = 842
+# page_height = 842
 page_width = 595
 
 #----- margins
@@ -11,7 +11,7 @@ top_margin = 50
 bottom_margin = 20
 footer_height = top_margin - bottom_margin
 
-right_margin = (page_width - body_width)/2
+right_margin = (page_width - body_width) / 2
 left_margin = right_margin
 
 #----- size of images
@@ -32,7 +32,7 @@ logo = @attestation[:logo]
 signature = @attestation[:signature]
 
 prawn_document(margin: [top_margin, right_margin, bottom_margin, left_margin], page_size: page_size) do |pdf|
-  pdf.font_families.update( 'marianne' => { normal: Rails.root.join('lib/prawn/fonts/marianne/marianne-regular.ttf' )})
+  pdf.font_families.update('marianne' => { normal: Rails.root.join('lib/prawn/fonts/marianne/marianne-regular.ttf') })
   pdf.font 'marianne'
 
   grey = '555555'
@@ -47,7 +47,7 @@ prawn_document(margin: [top_margin, right_margin, bottom_margin, left_margin], p
       else
         logo.rewind && logo.read
       end
-      pdf.image StringIO.new(logo_content), fit: [max_logo_width , max_logo_height], position: :center
+      pdf.image StringIO.new(logo_content), fit: [max_logo_width, max_logo_height], position: :center
     end
 
     pdf.fill_color grey
@@ -66,7 +66,7 @@ prawn_document(margin: [top_margin, right_margin, bottom_margin, left_margin], p
         else
           signature.rewind && signature.read
         end
-        pdf.image StringIO.new(signature_content), fit: [max_signature_size , max_signature_size], position: :right
+        pdf.image StringIO.new(signature_content), fit: [max_signature_size, max_signature_size], position: :right
       end
     end
   end

--- a/app/views/dossiers/dossier_vide.pdf.prawn
+++ b/app/views/dossiers/dossier_vide.pdf.prawn
@@ -21,8 +21,8 @@ end
 def format_in_2_lines(pdf, champ, nb_lines = 1)
   add_single_line(pdf, champ.libelle, 9, :bold)
   add_optionnal_description(pdf, champ)
-  height = 10 * (nb_lines+1)
-  pdf.bounding_box([0, pdf.cursor],:width => 460,:height => height) do
+  height = 10 * (nb_lines + 1)
+  pdf.bounding_box([0, pdf.cursor], :width => 460, :height => height) do
     pdf.stroke_bounds
   end
   pdf.text "\n"
@@ -30,7 +30,7 @@ end
 
 def format_in_2_columns(pdf, label)
   pdf.text_box label, width: 200, height: 100, overflow: :expand, at: [0, pdf.cursor]
-  pdf.bounding_box([110, pdf.cursor+5],:width => 350,:height => 20) do
+  pdf.bounding_box([110, pdf.cursor + 5], :width => 350, :height => 20) do
     pdf.stroke_bounds
   end
 
@@ -51,7 +51,7 @@ def format_with_checkbox(pdf, option, offset = 0)
     render_expanding_text_box(pdf, label, at: [15, pdf.cursor])
 
     if value == Champs::DropDownListChamp::OTHER
-      pdf.bounding_box([110, pdf.cursor + 3],:width => 350,:height => 20) do
+      pdf.bounding_box([110, pdf.cursor + 3], :width => 350, :height => 20) do
         pdf.stroke_bounds
       end
     end
@@ -64,14 +64,14 @@ def add_page_numbering(pdf)
   # do not have page numbering
   string = '<page> / <total>'
   options = {
-      at: [0, -15],
-      align: :right
+    at: [0, -15],
+    align: :right
   }
   pdf.number_pages string, options
 end
 
 def add_procedure(pdf, dossier)
-  pdf.repeat(lambda {|page| page > 1 })  do
+  pdf.repeat(lambda { |page| page > 1 }) do
     pdf.draw_text dossier.procedure.libelle, :at => pdf.bounds.top_left
   end
 end
@@ -186,7 +186,7 @@ def add_champs(pdf, champs)
   champs.each do |champ|
     if champ.type == 'Champs::RepetitionChamp'
       add_libelle(pdf, champ)
-      (1..3).each do
+      3.times do
         champ.rows.each do |row|
           row.each do |inner_champ|
             render_single_champ(pdf, inner_champ)
@@ -200,10 +200,10 @@ def add_champs(pdf, champs)
 end
 
 prawn_document(page_size: "A4") do |pdf|
-  pdf.font_families.update( 'marianne' => {
-      normal: Rails.root.join('lib/prawn/fonts/marianne/marianne-regular.ttf' ),
-      bold: Rails.root.join('lib/prawn/fonts/marianne/marianne-bold.ttf' ),
-      italic: Rails.root.join('lib/prawn/fonts/marianne/marianne-thin.ttf' ),
+  pdf.font_families.update('marianne' => {
+    normal: Rails.root.join('lib/prawn/fonts/marianne/marianne-regular.ttf'),
+    bold: Rails.root.join('lib/prawn/fonts/marianne/marianne-bold.ttf'),
+    italic: Rails.root.join('lib/prawn/fonts/marianne/marianne-thin.ttf')
   })
   pdf.font 'marianne'
   pdf.image DOSSIER_PDF_EXPORT_LOGO_SRC, width: 300, position: :center

--- a/app/views/dossiers/show.pdf.prawn
+++ b/app/views/dossiers/show.pdf.prawn
@@ -29,7 +29,7 @@ def format_in_2_lines(pdf, label, text)
   maybe_start_new_page(pdf, min_height)
 
   pdf.pad_bottom(2) do
-    pdf.font 'marianne', style: :bold, size: 12  do
+    pdf.font 'marianne', style: :bold, size: 12 do
       pdf.text label
     end
   end
@@ -211,9 +211,9 @@ def add_etats_dossier(pdf, dossier)
 end
 
 prawn_document(page_size: "A4") do |pdf|
-  pdf.font_families.update( 'marianne' => {
-    normal: Rails.root.join('lib/prawn/fonts/marianne/marianne-regular.ttf' ),
-    bold: Rails.root.join('lib/prawn/fonts/marianne/marianne-bold.ttf' ),
+  pdf.font_families.update('marianne' => {
+    normal: Rails.root.join('lib/prawn/fonts/marianne/marianne-regular.ttf'),
+    bold: Rails.root.join('lib/prawn/fonts/marianne/marianne-bold.ttf')
   })
   pdf.font 'marianne'
 

--- a/app/views/users/dossiers/papertrail.pdf.prawn
+++ b/app/views/users/dossiers/papertrail.pdf.prawn
@@ -25,16 +25,13 @@ prawn_document(margin: [top_margin, right_margin, bottom_margin, left_margin], p
   grey = '555555'
   black = '333333'
 
-  pdf.float do
-    pdf.image DOSSIER_PDF_EXPORT_LOGO_SRC, height: 64
-  end
+  pdf.pad_bottom(30) do
+    pdf.image DOSSIER_PDF_EXPORT_LOGO_SRC, width: 300, position: :center
 
-  pdf.bounding_box([110, pdf.cursor - 18], width: header_width - 200) do
-    pdf.fill_color black
-    pdf.text APPLICATION_NAME, size: 20, style: :bold
-
-    pdf.fill_color grey
-    pdf.text t('.receipt'), size: 14
+    pdf.pad_top(15) do
+      pdf.fill_color grey
+      pdf.text t('.receipt'), size: 14, align: :center
+    end
   end
 
   pdf.bounding_box([body_left_margin, pdf.cursor - 20], width: body_width) do

--- a/app/views/users/dossiers/papertrail.pdf.prawn
+++ b/app/views/users/dossiers/papertrail.pdf.prawn
@@ -10,7 +10,6 @@ right_margin = 20
 bottom_margin = 20
 left_margin = 20
 
-header_width = page_width - left_margin - right_margin
 body_width = 400
 
 body_left_margin = (page_width - body_width - left_margin - right_margin) / 2
@@ -66,7 +65,7 @@ prawn_document(margin: [top_margin, right_margin, bottom_margin, left_margin], p
 
     pdf.fill_color grey
     pdf.pad_top(7) do
-      pdf.text "#{Dossier.human_attribute_name(:id)} : #{@dossier.id.to_s}", size: 10, character_spacing: -0.2, align: :justify
+      pdf.text "#{Dossier.human_attribute_name(:id)} : #{@dossier.id}", size: 10, character_spacing: -0.2, align: :justify
       pdf.text t('.file_submitted_at') + ' : ' + l(@dossier.depose_at, format: '%e %B %Y'), size: 10, character_spacing: -0.2, align: :justify
       pdf.text t('.dossier_state') + ' : ' + papertrail_dossier_state(@dossier), size: 10, character_spacing: -0.2, align: :justify
     end


### PR DESCRIPTION
Closes #7698 

Et on en profite pour activer rubocop sur les fichiers *.prawn

![Capture d’écran 2022-08-31 à 11 35 20](https://user-images.githubusercontent.com/150279/187648037-41196477-f888-41a0-a358-16b790be9ea8.png)
