### PR TITLE
feat(carte/export): list geo labels for carte champ

### DIFF
--- a/app/helpers/champ_helper.rb
+++ b/app/helpers/champ_helper.rb
@@ -59,27 +59,4 @@ module ChampHelper
       end
     end
   end
-
-  def geo_area_label(geo_area)
-    case geo_area.source
-    when GeoArea.sources.fetch(:cadastre)
-      safe_join ["Parcelle n° #{geo_area.numero} - Feuille #{geo_area.prefixe} #{geo_area.section} - #{geo_area.surface.round} m", tag.sup("2")]
-    when GeoArea.sources.fetch(:selection_utilisateur)
-      if geo_area.polygon?
-        if geo_area.area.present?
-          safe_join ["Une aire de surface #{geo_area.area} m", tag.sup("2")]
-        else
-          "Une aire de surface inconnue"
-        end
-      elsif geo_area.line?
-        if geo_area.length.present?
-          "Une ligne longue de #{geo_area.length} m"
-        else
-          "Une ligne de longueur inconnue"
-        end
-      elsif geo_area.point?
-        "Un point situé à #{geo_area.location}"
-      end
-    end
-  end
 end

--- a/app/models/champs/carte_champ.rb
+++ b/app/models/champs/carte_champ.rb
@@ -108,7 +108,7 @@ class Champs::CarteChamp < Champ
   end
 
   def for_export
-    nil
+    geo_areas.map(&:label).join("\n")
   end
 
   def blank?

--- a/app/models/geo_area.rb
+++ b/app/models/geo_area.rb
@@ -12,6 +12,7 @@
 #  geo_reference_id :string
 #
 class GeoArea < ApplicationRecord
+  include ActionView::Helpers::NumberHelper
   belongs_to :champ, optional: false
 
   # FIXME: once geo_areas are migrated to not use YAML serialization we can enable store_accessor
@@ -67,6 +68,29 @@ class GeoArea < ApplicationRecord
         dossier_id: champ.dossier_id
       ).compact
     }
+  end
+
+  def label
+    case source
+    when GeoArea.sources.fetch(:cadastre)
+      I18n.t("cadastre", scope: 'geo_area.label', numero: numero, prefixe: prefixe, section: section, surface: surface.round)
+    when GeoArea.sources.fetch(:selection_utilisateur)
+      if polygon?
+        if area > 0
+          I18n.t("area", scope: 'geo_area.label', area: number_with_delimiter(area))
+        else
+          I18n.t("area_unknown", scope: 'geo_area.label')
+        end
+      elsif line?
+        if length > 0
+          I18n.t("line", scope: 'geo_area.label', length: number_with_delimiter(length))
+        else
+          I18n.t("line_unknown", scope: 'geo_area.label')
+        end
+      elsif point?
+        I18n.t("point", scope: 'geo_area.label', location: location)
+      end
+    end
   end
 
   def safe_geometry

--- a/app/views/shared/champs/carte/_geo_area.html.haml
+++ b/app/views/shared/champs/carte/_geo_area.html.haml
@@ -1,11 +1,11 @@
 %li{ class: editing ? 'mb-1' : 'flex column mb-2', data: { controller: 'geo-area', geo_area_id_value: geo_area.id } }
   - if editing
     = link_to '#', data: { action: 'geo-area#onClick' } do
-      = geo_area_label(geo_area)
+      = geo_area.label
     = text_field_tag :description, geo_area.description, data: { action: 'focus->geo-area#onFocus input->geo-area#onInput', geo_area_target: 'description' }, placeholder: 'Description', class: 'no-margin'
   - else
     = link_to '#', data: { action: 'geo-area#onClick' } do
-      = geo_area_label(geo_area)
+      = geo_area.label
     - if geo_area.description.present?
       %span
         = geo_area.description

--- a/config/locales/models/geo_area/en.yml
+++ b/config/locales/models/geo_area/en.yml
@@ -1,0 +1,17 @@
+en:
+  activerecord:
+    attributes:
+      geo_area:
+        source:
+          cadastre: Cadastral parcel
+          quartier_prioritaire: Priority neighbourhood
+          selection_utilisateur: User selection
+  geo_area:
+    label:
+      cadastre: "Parcel n° %{numero} - Sheet %{prefixe} %{section} - %{surface} m²"
+      area: "An area of %{area} m²"
+      area_unknown: "An area of unknown surface"
+      line: "A %{length} m long line"
+      line_unknown: "A line of unknown length"
+      point: "A point located at %{location}"
+

--- a/config/locales/models/geo_area/fr.yml
+++ b/config/locales/models/geo_area/fr.yml
@@ -6,3 +6,12 @@ fr:
           cadastre: Parcelle cadastrale
           quartier_prioritaire: Quartier prioritaire
           selection_utilisateur: Sélection utilisateur
+  geo_area:
+    label:
+      cadastre: "Parcelle n° %{numero} - Feuille %{prefixe} %{section} - %{surface} m²"
+      area: "Une aire de surface %{area} m²"
+      area_unknown: "Une aire de surface inconnue"
+      line: "Une ligne longue de %{length} m"
+      line_unknown: "Une ligne de longueur inconnue"
+      point: "Un point situé à %{location}"
+

--- a/spec/factories/geo_area.rb
+++ b/spec/factories/geo_area.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
 
     trait :cadastre do
       source { GeoArea.sources.fetch(:cadastre) }
-      properties { { numero: '42', section: 'A11', prefixe: '000', commune: '75127', contenance: '1234', id: '75127000A1142' } }
+      properties { { numero: '42', section: 'A11', prefixe: '000', commune: '75127', contenance: 123, id: '75127000A1142' } }
     end
 
     trait :legacy_cadastre do

--- a/spec/models/champs/carte_champ_spec.rb
+++ b/spec/models/champs/carte_champ_spec.rb
@@ -41,4 +41,22 @@ describe Champs::CarteChamp do
       it { is_expected.to eq(feature_collection) }
     end
   end
+
+  describe "#for_export" do
+    context "when geo areas is a point" do
+      let(:geo_areas) { [build(:geo_area, :selection_utilisateur, :point)] }
+
+      it "returns point label" do
+        expect(champ.for_export).to eq("Un point situé à 46°32'19\"N 2°25'42\"E")
+      end
+    end
+
+    context "when geo area is a cadastre parcelle" do
+      let(:geo_areas) { [build(:geo_area, :selection_utilisateur, :cadastre)] }
+
+      it "returns cadastre parcelle label" do
+        expect(champ.for_export).to match(/Parcelle n° 42/)
+      end
+    end
+  end
 end

--- a/spec/models/geo_area_spec.rb
+++ b/spec/models/geo_area_spec.rb
@@ -111,4 +111,37 @@ RSpec.describe GeoArea, type: :model do
       it { expect(geo_area.description).to be_nil }
     end
   end
+
+  describe "#label" do
+    context "when geo is a line" do
+      let(:geo_area) { build(:geo_area, :selection_utilisateur, :line_string, champ: nil) }
+      it "should return the label" do
+        expect(geo_area.label).to eq("Une ligne longue de 21,2 m")
+      end
+
+      it "should return unknown length" do
+        geo_area.geometry["coordinates"] = []
+        expect(geo_area.label).to eq("Une ligne de longueur inconnue")
+      end
+    end
+
+    context "when geo is a polygon" do
+      let(:geo_area) { build(:geo_area, :selection_utilisateur, :polygon, champ: nil) }
+      it "should return the label" do
+        expect(geo_area.label).to eq("Une aire de surface 103,6 m²")
+      end
+
+      it "should return unknown surface" do
+        geo_area.geometry["coordinates"] = []
+        expect(geo_area.label).to eq("Une aire de surface inconnue")
+      end
+    end
+
+    context "when geo is a cadastre parcelle" do
+      let(:geo_area) { build(:geo_area, :selection_utilisateur, :cadastre, champ: nil) }
+      it "should return the label" do
+        expect(geo_area.label).to eq("Parcelle n° 42 - Feuille 000 A11 - 123 m²")
+      end
+    end
+  end
 end


### PR DESCRIPTION
C'est une proposition pour résoudre des demandes sur le support : les champs de type "carte" restent vides dans les exports.

Cette implémentation réutilise les libellés des _geo_area_ utilisés à différents endroits sur le site, par exemple _Parcelle n°, Feuille A01…_ ou _Une aire de surface 23m²_ etc…

Note: on remplace l'html `<sup>2</sup>` par le caractère `²`  pour l'affichage du texte `m²`, ce qui permet de ne plus avoir à manipuler de l'html dans ces labels


![Capture d’écran 2022-08-31 à 17 33 18](https://user-images.githubusercontent.com/150279/187718981-d9a6bf88-874d-41a1-9b34-521ad47ab7cb.png)


