### PR TITLE
ajoute un résumé des erreurs présentes dans l'éditeur de champ

### DIFF
--- a/app/components/types_de_champ_editor/editor_component/editor_component.html.haml
+++ b/app/components/types_de_champ_editor/editor_component/editor_component.html.haml
@@ -1,4 +1,5 @@
 .types-de-champ-editor.editor-root{ 'data-turbo': 'true', id: dom_id(@revision, :types_de_champ_editor) }
+  = render TypesDeChampEditor::ErrorsSummary.new(revision: @revision)
   = render TypesDeChampEditor::BlockComponent.new(block: @revision, coordinates: coordinates)
   .buttons
     = render TypesDeChampEditor::AddChampButtonComponent.new(revision: @revision, is_annotation: annotations?)

--- a/app/components/types_de_champ_editor/errors_summary.rb
+++ b/app/components/types_de_champ_editor/errors_summary.rb
@@ -1,0 +1,18 @@
+class TypesDeChampEditor::ErrorsSummary < ApplicationComponent
+  def initialize(revision:)
+    @revision = revision
+  end
+
+  private
+
+  def error_message
+    @revision.errors
+      .map { |error| error.options[:type_de_champ] }
+      .map { |tdc| tag.li(tdc_anchor(tdc)) }
+      .then { |lis| tag.ul(lis.reduce(&:+)) }
+  end
+
+  def tdc_anchor(tdc)
+    tag.a(tdc.libelle, href: champs_admin_procedure_path(@revision.procedure_id, anchor: dom_id(tdc.stable_self, :conditions)), data: { turbo: false })
+  end
+end

--- a/app/components/types_de_champ_editor/errors_summary/errors_summary.fr.yml
+++ b/app/components/types_de_champ_editor/errors_summary/errors_summary.fr.yml
@@ -1,0 +1,5 @@
+fr:
+  fix:
+    one: 'Corrigez le champ suivant :'
+    other: 'Corrigez les champs suivants :'
+

--- a/app/components/types_de_champ_editor/errors_summary/errors_summary.html.haml
+++ b/app/components/types_de_champ_editor/errors_summary/errors_summary.html.haml
@@ -1,0 +1,7 @@
+#errors-summary
+  - if @revision.invalid?
+    .card.warning
+      .card-title La logique conditionnelle est devenue invalide 
+
+      %p.mb-2= t('.fix', count: @revision.errors.count)
+      = error_message

--- a/app/views/administrateurs/procedures/show.html.haml
+++ b/app/views/administrateurs/procedures/show.html.haml
@@ -38,6 +38,9 @@
       %span.icon.archive
       Clore
 
+.container
+  = render TypesDeChampEditor::ErrorsSummary.new(revision: @procedure.draft_revision)
+
 - if @procedure.draft_changed?
   .container
     .card.featured

--- a/app/views/administrateurs/procedures/show.html.haml
+++ b/app/views/administrateurs/procedures/show.html.haml
@@ -4,44 +4,45 @@
             metadatas: ["Créée le #{@procedure.created_at.strftime('%d/%m/%Y')} - n° #{@procedure.id}", "#{@procedure.close? ? "Close le #{@procedure.closed_at.strftime('%d/%m/%Y')}" : @procedure.locked? ? "Publiée - #{procedure_lien(@procedure)}" : "Brouillon"}"] }
 
 .container.procedure-admin-container
-  - if !@procedure.brouillon?
-    = link_to admin_procedure_archives_path(@procedure), class: 'button', id: "archive-procedure" do
-      %span.icon.download
-      Télécharger
+  - if @procedure.draft_revision.valid?
+    - if !@procedure.brouillon?
+      = link_to admin_procedure_archives_path(@procedure), class: 'button', id: "archive-procedure" do
+        %span.icon.download
+        Télécharger
 
-  = link_to @procedure.active_revision.draft? ? commencer_dossier_vide_test_path(path: @procedure.path) : commencer_dossier_vide_path(path: @procedure.path), target: "_blank", rel: "noopener", class: 'button', id: "pdf-procedure" do
-    %span.icon.printer
-    PDF
+      = link_to @procedure.active_revision.draft? ? commencer_dossier_vide_test_path(path: @procedure.path) : commencer_dossier_vide_path(path: @procedure.path), target: "_blank", rel: "noopener", class: 'button', id: "pdf-procedure" do
+        %span.icon.printer
+        PDF
 
-  = link_to apercu_admin_procedure_path(@procedure), target: "_blank", rel: "noopener", class: 'button', id: "preview-procedure" do
-    %span.icon.preview
-    Prévisualiser
+    = link_to apercu_admin_procedure_path(@procedure), target: "_blank", rel: "noopener", class: 'button', id: "preview-procedure" do
+      %span.icon.preview
+      Prévisualiser
 
-  - if @procedure.brouillon? || @procedure.draft_changed?
-    = link_to sanitize_url(@procedure_lien_test), target: :blank, rel: :noopener, class: 'button' do
-      %span.icon.in-progress
-      Tester
+    - if @procedure.brouillon? || @procedure.draft_changed?
+      = link_to sanitize_url(@procedure_lien_test), target: :blank, rel: :noopener, class: 'button' do
+        %span.icon.in-progress
+        Tester
 
-  - if @procedure.publiee? || @procedure.brouillon?
-    = link_to admin_procedure_transfert_path(@procedure), class: 'button' do
-      %span.icon.reply
-      Envoyer une copie
+    - if @procedure.publiee? || @procedure.brouillon?
+      = link_to admin_procedure_transfert_path(@procedure), class: 'button' do
+        %span.icon.reply
+        Envoyer une copie
 
-  - if !@procedure.publiee? && !@procedure.close? && !@procedure.depubliee?
-    = link_to 'Publier', admin_procedure_publication_path(@procedure), class: 'button primary', id: 'publish-procedure-link', data: { disable_with: "Publication..." }
+    - if !@procedure.publiee? && !@procedure.close? && !@procedure.depubliee?
+      = link_to 'Publier', admin_procedure_publication_path(@procedure), class: 'button primary', id: 'publish-procedure-link', data: { disable_with: "Publication..." }
 
-  - if (@procedure.close? || @procedure.depubliee?) && !@procedure.draft_changed?
-    = link_to 'Réactiver', admin_procedure_publication_path(@procedure), class: 'button primary', id: 'publish-procedure-link', data: { disable_with: "Publication..." }
+    - if (@procedure.close? || @procedure.depubliee?) && !@procedure.draft_changed?
+      = link_to 'Réactiver', admin_procedure_publication_path(@procedure), class: 'button primary', id: 'publish-procedure-link', data: { disable_with: "Publication..." }
 
-  - if @procedure.locked? && !@procedure.close?
-    = link_to admin_procedure_archive_path(procedure_id: @procedure.id), method: :put, class: 'button', id: "close-procedure-link", data: { confirm:  "Voulez-vous vraiment clore la démarche ? \nLes dossiers en cours pourront être instruits, mais aucun nouveau dossier ne pourra plus être déposé.", disable_with: "Archivage..."} do
-      %span.icon.archive
-      Clore
+    - if @procedure.locked? && !@procedure.close?
+      = link_to admin_procedure_archive_path(procedure_id: @procedure.id), method: :put, class: 'button', id: "close-procedure-link", data: { confirm:  "Voulez-vous vraiment clore la démarche ? \nLes dossiers en cours pourront être instruits, mais aucun nouveau dossier ne pourra plus être déposé.", disable_with: "Archivage..."} do
+        %span.icon.archive
+        Clore
 
 .container
   = render TypesDeChampEditor::ErrorsSummary.new(revision: @procedure.draft_revision)
 
-- if @procedure.draft_changed?
+- if @procedure.draft_changed? && @procedure.draft_revision.valid?
   .container
     .card.featured
       .card-title

--- a/app/views/administrateurs/types_de_champ/_insert.turbo_stream.haml
+++ b/app/views/administrateurs/types_de_champ/_insert.turbo_stream.haml
@@ -1,3 +1,5 @@
+= turbo_stream.replace 'errors-summary', render(TypesDeChampEditor::ErrorsSummary.new(revision: @procedure.draft_revision))
+
 - if @destroyed.present?
   = turbo_stream.remove dom_id(@destroyed, :type_de_champ_editor)
 


### PR DESCRIPTION
Je l'ai ajouté en haut de l'éditeur de champ et en haut de la page de configuration de la démarche

Je bloque aussi toutes les actions sur la publication, le test ... si la procédure est invalide

![Screenshot 2022-09-01 at 14-45-20 demarches-simplifiees fr](https://user-images.githubusercontent.com/907405/187917284-d9461296-e2eb-4e46-ad2c-87280649d7b2.png)
