### PR TITLE
perf(dossier): limite la verification des lignes aux seuls champs enfants

### DIFF
--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -78,8 +78,6 @@ class Champ < ApplicationRecord
   before_save :normalize
   after_update_commit :fetch_external_data_later
 
-  validates :type_de_champ_id, uniqueness: { scope: [:dossier_id, :row] }
-
   def public?
     !private?
   end

--- a/spec/models/champ_spec.rb
+++ b/spec/models/champ_spec.rb
@@ -16,16 +16,6 @@ describe Champ do
     end
   end
 
-  describe "validations" do
-    let(:row) { 1 }
-    let(:champ) { create(:champ, type_de_champ: create(:type_de_champ), row: row) }
-    let(:champ2) { build(:champ, type_de_champ: champ.type_de_champ, row: champ.row, dossier: champ.dossier) }
-
-    it "returns false when champ with same type_de_champ and row already exist" do
-      expect(champ2).not_to be_valid
-    end
-  end
-
   describe "normalization" do
     it "should remove null bytes before save" do
       champ = create(:champ, value: "foo\u0000bar")


### PR DESCRIPTION
Gain, one request per champ not child