### PR TITLE
Fix contact admin form

### DIFF
--- a/app/views/support/admin.html.haml
+++ b/app/views/support/admin.html.haml
@@ -40,6 +40,8 @@
           %span.mandatory *
         = text_area_tag :text, params[:text], rows: 6, required: true
 
+      = invisible_captcha
+
       = hidden_field_tag :tags, @tags&.join(',')
       = hidden_field_tag :admin, true
 

--- a/spec/controllers/support_controller_spec.rb
+++ b/spec/controllers/support_controller_spec.rb
@@ -149,4 +149,29 @@ describe SupportController, type: :controller do
       end
     end
   end
+
+  context 'contact admin' do
+    subject do
+      post :create, params: params
+    end
+
+    let(:params) { { admin: "true", email: "email@pro.fr", subject: 'bonjour', text: 'un message' } }
+
+    describe "when form is filled" do
+      it "creates a conversation on HelpScout" do
+        expect_any_instance_of(Helpscout::FormAdapter).to receive(:send_form).and_return(true)
+        subject
+        expect(flash[:notice]).to match('Votre message a été envoyé.')
+      end
+    end
+
+    describe "when invisible captcha is filled" do
+      let(:params) { super().merge(InvisibleCaptcha.honeypots.sample => 'boom') }
+
+      it 'does not create a conversation on HelpScout' do
+        subject
+        expect(flash[:alert]).to eq(I18n.t('invisible_captcha.sentence_for_humans'))
+      end
+    end
+  end
 end


### PR DESCRIPTION
Depuis l'introduction du captcha il y a quelques mois, le form de support pour les admins ne marchait plus car il ne contenait pas ce captcha