### PR TITLE
'Choix parmi une liste' becomes 'Choix unique'

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -2126,7 +2126,7 @@ enum TypeDeChamp {
   dossier_link
 
   """
-  Choix parmi une liste
+  Choix unique
   """
   drop_down_list
 

--- a/config/locales/models/type_de_champ/fr.yml
+++ b/config/locales/models/type_de_champ/fr.yml
@@ -18,7 +18,7 @@ fr:
           phone: 'Téléphone'
           address: 'Adresse'
           yes_no: 'Oui/Non'
-          drop_down_list: 'Choix parmi une liste'
+          drop_down_list: 'Choix unique'
           multiple_drop_down_list: 'Choix multiples'
           linked_drop_down_list: 'Deux menus déroulants liés'
           pays: 'Pays'

--- a/spec/factories/type_de_champ.rb
+++ b/spec/factories/type_de_champ.rb
@@ -75,7 +75,7 @@ FactoryBot.define do
       type_champ { TypeDeChamp.type_champs.fetch(:datetime) }
     end
     factory :type_de_champ_drop_down_list do
-      libelle { 'Choix parmi une liste' }
+      libelle { 'Choix unique' }
       type_champ { TypeDeChamp.type_champs.fetch(:drop_down_list) }
       drop_down_list_value { "val1\r\nval2\r\n--separateur--\r\nval3" }
       trait :long do

--- a/spec/system/administrateurs/types_de_champ_spec.rb
+++ b/spec/system/administrateurs/types_de_champ_spec.rb
@@ -142,7 +142,7 @@ describe 'As an administrateur I can edit types de champ', js: true do
   scenario "adding a dropdown champ" do
     add_champ(remove_flash_message: true)
 
-    select('Choix parmi une liste', from: 'Type de champ')
+    select('Choix unique', from: 'Type de champ')
     fill_in 'Libellé du champ', with: 'Libellé de champ menu déroulant', fill_options: { clear: :backspace }
     fill_in 'Options de la liste', with: 'Un menu', fill_options: { clear: :backspace }
     check "Proposer une option « autre » avec un texte libre"


### PR DESCRIPTION
closes #7374

On renomme "Choix parmi une liste" en "Choix unique".

# Avant

![image](https://user-images.githubusercontent.com/1193334/188600364-6ca3d42d-c8e5-4361-9340-6500522ac29a.png)

# Après

![image](https://user-images.githubusercontent.com/1193334/188600485-29daa4ed-02fa-4d86-a639-d33e698f2fad.png)
