### PR TITLE
remove the confusing help ('nom@site.com')

### DIFF
--- a/app/views/super_admins/sessions/new.html.haml
+++ b/app/views/super_admins/sessions/new.html.haml
@@ -6,7 +6,7 @@
       = form_for SuperAdmin.new, url: super_admin_session_path, html: { class: "form" } do |f|
         %h1.fr-h2 Connectez-vous
 
-        = f.label :email, "Email (nom@site.com)"
+        = f.label :email, "Email"
         = f.text_field :email, type: :email, autocomplete: 'username', autofocus: true
 
         = f.label :password, "Mot de passe (#{PASSWORD_MIN_LENGTH} caractères minimum)"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -92,7 +92,7 @@ fr:
     registrations:
       new:
         title: "Créez-vous un compte %{name}"
-        email_label: 'Email (nom@site.com)'
+        email_label: 'Email'
         email_placeholder: 'Votre adresse email'
         wanna_say: 'Voulez-vous dire'
         password_label: "Mot de passe (%{min_length} caractères minimum)"
@@ -258,7 +258,7 @@ fr:
       sessions:
         new:
           sign_in: Connectez-vous
-          email: Email (nom@site.com)
+          email: Email
           password: Mot de passe (%{min_length} caractères minimum)
           remember_me: Se souvenir de moi
           reset_password: Mot de passe oublié ?

--- a/config/locales/views/agent_connect/agent/en.yml
+++ b/config/locales/views/agent_connect/agent/en.yml
@@ -19,4 +19,4 @@ en:
           <h1 class="mt-2 mb-2">Connect</h1>
           <p><b class="bold">With AgentConnect</b></p>
         whats_agentconnect: 'What is AgentConnect?'
-        pro_email: Professional email (nom@site.com)
+        pro_email: Professional email

--- a/config/locales/views/agent_connect/agent/fr.yml
+++ b/config/locales/views/agent_connect/agent/fr.yml
@@ -19,4 +19,4 @@ fr:
           <h1 class="mt-2 mb-2">Connectez-vous</h1>
           <p><b class="bold">Avec AgentConnect</b></p>
         whats_agentconnect: 'Quʼest ce quʼAgentConnect ?'
-        pro_email: Email professionnel (nom@site.com)
+        pro_email: Email professionnel


### PR DESCRIPTION
closes #7727

Dans les formulaires de login, le label pour le champ email est "Email (nom@site.com)" ou "Email professionnel (nom@site.com)", ce qui prête à confusion d'après #7727.

Ici, on enlève simplement "(nom@site.com)" pour clarifier l'usage du champ pour l'utilisateur·rice.

# Avant

![Screenshot 2022-09-06 at 15-26-59 S’identifier avec AgentConnect · demarches-simplifiees fr](https://user-images.githubusercontent.com/1193334/188647258-e78b766d-a904-4569-b7ea-cfe12c4611c8.png)

![Screenshot 2022-09-06 at 15-26-48 Se connecter · demarches-simplifiees fr](https://user-images.githubusercontent.com/1193334/188647270-02090b4e-0ca2-48c6-87e1-69ca94c4ed58.png)

# Après

![Screenshot 2022-09-06 at 15-28-30 S’identifier avec AgentConnect · demarches-simplifiees fr](https://user-images.githubusercontent.com/1193334/188649602-0961daa1-7c51-4a05-93cb-00b336691863.png)

![Screenshot 2022-09-06 at 15-28-16 Se connecter · demarches-simplifiees fr](https://user-images.githubusercontent.com/1193334/188649645-4d7d38c7-aeea-4ff1-8d69-3d72fe79800e.png)

