### PR TITLE
fix: add administrateur with confirmation

### DIFF
--- a/app/controllers/manager/procedures_controller.rb
+++ b/app/controllers/manager/procedures_controller.rb
@@ -65,7 +65,7 @@ module Manager
     end
 
     def add_administrateur_with_confirmation
-      confirmation_url = confirm_add_administrateur_manager_procedure_url(id: procedure.id, email: current_super_admin.email)
+      confirmation_url = confirm_add_administrateur_manager_procedure_url(id: procedure.id, email: params[:email])
 
       flash[:notice] = "Veuillez partager ce lien : #{confirmation_url} avec un autre super admin pour que l'operation soit effectuée"
       redirect_to manager_procedure_path(procedure)

--- a/spec/controllers/manager/procedures_controller_spec.rb
+++ b/spec/controllers/manager/procedures_controller_spec.rb
@@ -79,4 +79,22 @@ describe Manager::ProceduresController, type: :controller do
 
     it { expect(procedure.administrateurs).to eq([autre_administrateur]) }
   end
+
+  describe "#add_administrateur_with_confirmation" do
+    let(:procedure) { create(:procedure, administrateurs: [administrateur]) }
+
+    before do
+      post :add_administrateur_with_confirmation, params: { id: procedure.id, email: autre_administrateur.email }
+    end
+
+    it { expect(response).to redirect_to(manager_procedure_path) }
+
+    it { expect(flash[:notice]).to match(/Veuillez partager ce lien :/) }
+
+    it "flashes the confirmation url with the right email address" do
+      expect(flash[:notice]).to include(
+        confirm_add_administrateur_manager_procedure_url(id: procedure.id, email: autre_administrateur.email)
+      )
+    end
+  end
 end


### PR DESCRIPTION
When adding an administrateur, use the given email address instead of the current admin's one.

See #7699

# Avant

![Screenshot 2022-09-07 at 10-09-21 Détails démarche de test #1 - Tps](https://user-images.githubusercontent.com/1193334/188825925-75a18881-e65d-4c27-91f5-ebd8f6337773.png)

![image](https://user-images.githubusercontent.com/1193334/188826093-35a0025c-a35f-4df8-ae2a-97ce2b200870.png)

# Après

![image](https://user-images.githubusercontent.com/1193334/188830182-2f31b2c9-cabe-41dc-8384-43f7d1e72844.png)

