### PR TITLE
fix(dsfr): input checkbox/radio visibility on old firefox

### DIFF
--- a/app/assets/stylesheets/dsfr.scss
+++ b/app/assets/stylesheets/dsfr.scss
@@ -15,3 +15,16 @@ select {
 .button.primary {
   font-weight: bold;
 }
+
+// fix firefox < 80 not supporting "appearance: auto" on inputs
+// scss-lint:disable DuplicateProperty
+input[type="checkbox"] {
+  -moz-appearance: checkbox;
+  -moz-appearance: auto;
+}
+
+input[type="radio"] {
+  -moz-appearance: radio;
+  -moz-appearance: auto;
+}
+// scss-lint:enable DuplicateProperty

--- a/app/views/root/landing.html.haml
+++ b/app/views/root/landing.html.haml
@@ -27,7 +27,7 @@
           %p.role-panel-explanation Réalisez vos demandes en toute simplicité et retrouvez vos dossiers en ligne
 
           = link_to "Comment trouver ma démarche ?", COMMENT_TROUVER_MA_DEMARCHE_URL, class: "fr-btn fr-btn--lg fr-mr-1w fr-mb-2w", **external_link_attributes
-          = link_to "Se connecter", new_user_session_path, class: "fr-btn fr-btn--secondary fr-btn--lg", **external_link_attributes
+          = link_to "Se connecter", new_user_session_path, class: "fr-btn fr-btn--secondary fr-btn--lg"
 
   - cache "numbers-panel", :expires_in => 3.hours do
     .landing-panel


### PR DESCRIPTION
Firefox < 80 ne supporte pas `-moz-appearance: auto` injecté par le DSFR, ce qui rend les checkbox & radio transparentes (invisibles) car il ya un `-moz-appearance: none` injecté auparavant.

https://secure.helpscout.net/conversation/1997732059/1988062?folderId=1653799

ff 78 :
![Capture d’écran 2022-09-08 à 11 09 49](https://user-images.githubusercontent.com/150279/189083382-0a304d44-4b19-42af-a772-dbd414ebb4aa.png)

Je profite de cette PR pour fixer aussi rapidos un lien de la home qui s'ouvrait par erreur dans une nouvelle fenêtre (introduit dans #7731) 