### PR TITLE
fix: remove instructeur when admin is removed

### DIFF
--- a/app/controllers/manager/procedures_controller.rb
+++ b/app/controllers/manager/procedures_controller.rb
@@ -73,6 +73,14 @@ module Manager
       if administrateur.present?
         procedure.administrateurs.delete(administrateur)
       end
+
+      instructeur = Instructeur.by_email(current_super_admin.email)
+      if instructeur.present?
+        procedure.groupe_instructeurs.map do |groupe_instructeur|
+          groupe_instructeur.assign_tos.where(instructeur: instructeur).destroy_all
+        end
+      end
+
       redirect_to manager_procedure_path(procedure)
     end
 


### PR DESCRIPTION
closes #7738
see #7699 pt 2

Quand on s'ajoute en tant qu'administrateur & instructeur pour la journée : 

![image](https://user-images.githubusercontent.com/1193334/189832038-03cc8259-ef0d-41aa-be63-3761acee38c9.png)

Puis qu'on s'en retire : 

![image](https://user-images.githubusercontent.com/1193334/189832099-0c4c2967-475b-43e4-938e-78780953eafe.png)

Il y avait une erreur 500 si on s'ajoutait de nouveau. On règle ça en retirant l'instructeur de la démarche en même temps qu'on retire l'instructeur.