### PR TITLE
feat(graphql): new tokens should carry administrateur_id

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -1,20 +1,44 @@
 class API::V2::BaseController < ApplicationController
-  protect_from_forgery with: :null_session
+  # Disable forgery protection for API controllers when the request is authenticated
+  # with a bearer token. Otherwise the session will be nullified and we'll lose curent_user
+  protect_from_forgery with: :null_session, unless: :token?
+  skip_before_action :setup_tracking
+  prepend_before_action :authenticate_administrateur_from_token
 
   private
 
   def context
-    {
-      administrateur_id: current_administrateur&.id,
-      token: authorization_bearer_token
-    }
+    if api_token.administrateur?
+      { administrateur_id: api_token.administrateur_id }
+    else
+      { token: api_token.token }
+    end
+  end
+
+  def token?
+    authorization_bearer_token.present?
   end
 
   def authorization_bearer_token
-    received_token = nil
-    authenticate_with_http_token do |token, _options|
-      received_token = token
+    @authorization_bearer_token ||= begin
+      received_token = nil
+      authenticate_with_http_token do |token, _options|
+        received_token = token
+      end
+      received_token
     end
-    received_token
+  end
+
+  def authenticate_administrateur_from_token
+    if api_token.administrateur?
+      administrateur = Administrateur.includes(:user).find_by(id: api_token.administrateur_id)
+      if administrateur.valid_api_token?(api_token.token)
+        @current_user = administrateur.user
+      end
+    end
+  end
+
+  def api_token
+    @api_token ||= APIToken.new(authorization_bearer_token)
   end
 end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -5,7 +5,7 @@ class APIController < ApplicationController
 
   def find_administrateur_for_token(procedure)
     procedure.administrateurs.find do |administrateur|
-      administrateur.valid_api_token?(token)
+      administrateur.valid_api_token?(api_token.token)
     end
   end
 
@@ -15,7 +15,11 @@ class APIController < ApplicationController
     request.format = "json" if !request.params[:format]
   end
 
-  def token
+  def api_token
+    @api_token ||= APIToken.new(authorization_bearer_token)
+  end
+
+  def authorization_bearer_token
     params_token.presence || header_token
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -263,7 +263,13 @@ class ApplicationController < ActionController::Base
   end
 
   def sentry_user
-    { id: user_signed_in? ? "User##{current_user.id}" : 'Guest' }
+    if user_signed_in?
+      { id: "User##{current_user.id}" }
+    elsif administrateur_signed_in?
+      { id: "Administrateur##{current_administrateur.id}" }
+    else
+      { id: 'Guest' }
+    end
   end
 
   def sentry_config

--- a/app/models/administrateur.rb
+++ b/app/models/administrateur.rb
@@ -54,7 +54,7 @@ class Administrateur < ApplicationRecord
     api_token = Administrateur.generate_unique_secure_token
     encrypted_token = BCrypt::Password.create(api_token)
     update(encrypted_token: encrypted_token)
-    api_token
+    APIToken.signe(id, api_token)
   end
 
   def valid_api_token?(api_token)

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -1,0 +1,27 @@
+class APIToken
+  attr_reader :administrateur_id, :token
+
+  def initialize(token)
+    @token = token
+    verify!
+  end
+
+  def administrateur?
+    administrateur_id.present?
+  end
+
+  def self.message_verifier
+    Rails.application.message_verifier('api_v2_token')
+  end
+
+  def self.signe(administrateur_id, token)
+    message_verifier.generate([administrateur_id, token])
+  end
+
+  private
+
+  def verify!
+    @administrateur_id, @token = self.class.message_verifier.verified(@token) || [nil, @token]
+  rescue
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -22,7 +22,7 @@ describe ApplicationController, type: :controller do
       allow(@controller).to receive(:media_type).and_return('text/plain')
       allow(@controller).to receive(:current_user).and_return(current_user)
       expect(@controller).to receive(:current_instructeur).and_return(current_instructeur)
-      expect(@controller).to receive(:current_administrateur).and_return(current_administrateur)
+      expect(@controller).to receive(:current_administrateur).at_least(:once).and_return(current_administrateur)
       expect(@controller).to receive(:current_super_admin).and_return(current_super_admin)
       allow(Sentry).to receive(:set_user)
 

--- a/spec/models/administrateur_spec.rb
+++ b/spec/models/administrateur_spec.rb
@@ -6,10 +6,12 @@ describe Administrateur, type: :model do
   end
 
   describe "#renew_api_token" do
-    let!(:administrateur) { create(:administrateur) }
+    let(:administrateur) { create(:administrateur) }
     let!(:token) { administrateur.renew_api_token }
+    let(:encrypted_token) { BCrypt::Password.new(administrateur.encrypted_token) }
+    let(:base_token) { APIToken.new(token).token }
 
-    it { expect(BCrypt::Password.new(administrateur.encrypted_token)).to eq(token) }
+    it { expect(encrypted_token).to eq(base_token) }
 
     context 'when it s called twice' do
       let!(:new_token) { administrateur.renew_api_token }


### PR DESCRIPTION
Aujourd'hui, du fait de comment est architecture les token d'API, les logs et les exceptions dans Sentry ne sont pas annotés avec l'ID de l'user/admin. C’est très embêtant pour le debug et l'analyse de l'activité d'API. Je n’ai pas de solution pour corriger ça sur les token déjà en circulation, mais cette PR propose une évolution du format de token pour les nouveaux token qui résout le problème.