### PR TITLE
API entreprise : specific error

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -114,8 +114,15 @@ module Users
       sanitized_siret = siret_model.siret
       begin
         etablissement = APIEntrepriseService.create_etablissement(@dossier, sanitized_siret, current_user.id)
-      rescue APIEntreprise::API::Error::RequestFailed, APIEntreprise::API::Error::BadGateway, APIEntreprise::API::Error::TimedOut, APIEntreprise::API::Error::ServiceUnavailable, APIEntrepriseToken::TokenError
-        return render_siret_error(t('errors.messages.siret_network_error'))
+      rescue APIEntreprise::API::Error::RequestFailed, APIEntreprise::API::Error::BadGateway, APIEntreprise::API::Error::TimedOut, APIEntreprise::API::Error::ServiceUnavailable, APIEntrepriseToken::TokenError => e
+        if e.is_a?(APIEntrepriseToken::TokenError) || APIEntrepriseService.api_up?
+          # probably random error, invite user to retry
+          Sentry.capture_exception(e, extra: { dossier_id: @dossier.id, siret: sanitized_siret })
+          return render_siret_error(t('errors.messages.siret_network_error'))
+        else
+          # global API Entreprise error. TODO: degraded mode + notify ops
+          return render_siret_error(t('errors.messages.siret_api_down'))
+        end
       end
       if etablissement.nil?
         return render_siret_error(t('errors.messages.siret_unknown'))

--- a/app/lib/api_entreprise/api.rb
+++ b/app/lib/api_entreprise/api.rb
@@ -72,6 +72,13 @@ class APIEntreprise::API
     call(url)
   end
 
+  def current_status
+    status_url = "https://entreprise.api.gouv.fr/watchdoge/dashboard/current_status"
+    response = Typhoeus.get(status_url, timeout: 1)
+
+    handle_response(response)
+  end
+
   private
 
   def call_with_siret(resource_name, siret_or_siren, user_id: nil)

--- a/app/services/api_entreprise_service.rb
+++ b/app/services/api_entreprise_service.rb
@@ -25,4 +25,17 @@ class APIEntrepriseService
 
     etablissement
   end
+
+  def self.api_up?(uname = "apie_2_etablissements")
+    statuses = APIEntreprise::API.new.current_status.fetch(:results)
+
+    # find results having uname = apie_2_etablissements
+    status = statuses.find { |result| result[:uname] == uname }
+
+    status.fetch(:code) == 200
+  rescue => e
+    Sentry.capture_exception(e, extra: { uname: uname })
+
+    nil
+  end
 end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -370,6 +370,7 @@ fr:
       procedure_not_found: "La démarche n’existe pas"
       siret_unknown: 'Désolé, nous n’avons pas trouvé d’établissement enregistré correspondant à ce numéro SIRET.'
       siret_network_error: 'Désolé, la récupération des informations SIRET est temporairement indisponible. Veuillez réessayer dans quelques instants.'
+      siret_api_down: "L'INSEE rencontre actuellement un problème majeur qui empêche le traitement des informations SIRET. Il n'y a pas encore de date de résolution annoncée."
       siret_not_found: 'Nous n’avons pas trouvé d’établissement correspondant à ce numéro de SIRET.'
       # etablissement_fail: 'Désolé, nous n’avons pas réussi à enregistrer l’établissement correspondant à ce numéro SIRET'
       france_connect:

--- a/spec/fixtures/files/api_entreprise/current_status.json
+++ b/spec/fixtures/files/api_entreprise/current_status.json
@@ -1,0 +1,265 @@
+{
+  "results": [
+    {
+      "uname": "apie_2_etablissements",
+      "name": "Etablissements",
+      "provider": "insee",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:31:40.442Z",
+      "endpoint": "api_entreprise/v2/etablissements_restored"
+    },
+    {
+      "uname": "apie_2_certificats_qualibat",
+      "name": "Certificats Qualibat",
+      "provider": "qualibat",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:30:28.848Z",
+      "endpoint": "api_entreprise/v2/certificats_qualibat"
+    },
+    {
+      "uname": "apie_2_effectifs_annuels_acoss",
+      "name": "Effectifs annuels",
+      "provider": "acoss",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:30:41.415Z",
+      "endpoint": "api_entreprise/v2/effectifs_annuels_entreprise_acoss_covid"
+    },
+    {
+      "uname": "apie_2_effectifs_mensuels_entreprise_acoss",
+      "name": "Effectifs mensuels (entreprise)",
+      "provider": "acoss",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:31:17.437Z",
+      "endpoint": "api_entreprise/v2/effectifs_mensuels_entreprise_acoss_covid"
+    },
+    {
+      "uname": "apie_2_effectifs_mensuels_etablissement_acoss",
+      "name": "Effectifs mensuels (établissement)",
+      "provider": "acoss",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:31:52.412Z",
+      "endpoint": "api_entreprise/v2/effectifs_mensuels_etablissement_acoss_covid"
+    },
+    {
+      "uname": "apie_2_conventions_collectives",
+      "name": "Conventions Collectives",
+      "provider": "fabsocial",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:30:03.003Z",
+      "endpoint": "api_entreprise/v2/conventions_collectives"
+    },
+    {
+      "uname": "apie_2_agence_bio",
+      "name": "Certifications BIO",
+      "provider": "agencebio",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:30:03.042Z",
+      "endpoint": "api_entreprise/v2/certificats_agence_bio"
+    },
+    {
+      "uname": "apie_2_entreprises",
+      "name": "Entreprise",
+      "provider": "insee",
+      "api_version": 2,
+      "code": 206,
+      "timestamp": "2022-09-15T14:33:27.934Z",
+      "endpoint": "api_entreprise/v2/entreprises_restored"
+    },
+    {
+      "uname": "apie_2_eori",
+      "name": "Immatriculation EORI Douanes",
+      "provider": "douanes",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:33:46.047Z",
+      "endpoint": "api_entreprise/v2/eori_douanes"
+    },
+    {
+      "uname": "apie_2_attestations_fiscales_dgfip",
+      "name": "Attestations fiscales",
+      "provider": "dgfip",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:31:32.503Z",
+      "endpoint": "api_entreprise/v2/attestations_fiscales_dgfip"
+    },
+    {
+      "uname": "apie_2_cma_france",
+      "name": "Entreprises Artisanales CMA France",
+      "provider": "cmafrance",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:30:55.431Z",
+      "endpoint": "api_entreprise/v2/entreprises_artisanales"
+    },
+    {
+      "uname": "apie_2_liasses_fiscales_dgfip_complete",
+      "name": "Liasses fiscales (complete)",
+      "provider": "dgfip",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:32:55.595Z",
+      "endpoint": "api_entreprise/v2/liasses_fiscales_dgfip"
+    },
+    {
+      "uname": "apie_2_exercices_dgfip",
+      "name": "Exercices",
+      "provider": "dgfip",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:19:15.501Z",
+      "endpoint": "api_entreprise/v2/exercices"
+    },
+    {
+      "uname": "apie_2_cotisations_msa",
+      "name": "Cotisations MSA",
+      "provider": "msa",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:31:57.747Z",
+      "endpoint": "api_entreprise/v2/cotisations_msa"
+    },
+    {
+      "uname": "apie_2_eligibilites_cotisation_retraite_probtp",
+      "name": "Eligibilité cotisation retraite ProBTP",
+      "provider": "probtp",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:30:36.979Z",
+      "endpoint": "api_entreprise/v2/eligibilites_cotisation_retraite_probtp"
+    },
+    {
+      "uname": "apie_2_documents_associations_rna",
+      "name": "Documents associations",
+      "provider": "rna",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:31:57.924Z",
+      "endpoint": "api_entreprise/v2/documents_associations"
+    },
+    {
+      "uname": "apie_2_cartes_professionnelles_fntp",
+      "name": "Cartes professionnelles FNTP",
+      "provider": "fntp",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:00:06.107Z",
+      "endpoint": "api_entreprise/v2/cartes_professionnelles_fntp"
+    },
+    {
+      "uname": "apie_2_associations_rna",
+      "name": "Associations",
+      "provider": "rna",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:33:12.993Z",
+      "endpoint": "api_entreprise/v2/associations"
+    },
+    {
+      "uname": "apie_2_attestations_agefiph",
+      "name": "Attestations agefiph",
+      "provider": "agefiph",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:32:15.345Z",
+      "endpoint": "api_entreprise/v2/attestations_agefiph"
+    },
+    {
+      "uname": "apie_2_extraits_rcs_infogreffe",
+      "name": "Extraits RCS (Infogreffe)",
+      "provider": "infogreffe",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:33:48.762Z",
+      "endpoint": "api_entreprise/v2/extraits_rcs_infogreffe"
+    },
+    {
+      "uname": "apie_2_liasses_fiscales_dgfip_dictionnaire",
+      "name": "Liasses fiscales (dictionnaire)",
+      "provider": "dgfip",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:31:36.557Z",
+      "endpoint": "api_entreprise/v2/liasses_fiscales_dgfip"
+    },
+    {
+      "uname": "apie_2_certificats_cnetp",
+      "name": "Certificats CNETP",
+      "provider": "cnetp",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:32:23.801Z",
+      "endpoint": "api_entreprise/v2/certificats_cnetp"
+    },
+    {
+      "uname": "apie_2_certificats_opqibi",
+      "name": "Certificats OPQIBI",
+      "provider": "opqibi",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:00:03.725Z",
+      "endpoint": "api_entreprise/v2/certificats_opqibi"
+    },
+    {
+      "uname": "apie_2_certificats_rge_ademe",
+      "name": "Certificats RGE ADEME",
+      "provider": "ademe",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:00:04.174Z",
+      "endpoint": "api_entreprise/v2/certificats_rge_ademe"
+    },
+    {
+      "uname": "apie_2_liasses_fiscales_dgfip_declaration",
+      "name": "Liasses fiscales (déclaration)",
+      "provider": "dgfip",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:00:03.654Z",
+      "endpoint": "api_entreprise/v2/liasses_fiscales_dgfip"
+    },
+    {
+      "uname": "apie_2_extraits_courts_inpi",
+      "name": "Extraits courts INPI",
+      "provider": "inpi",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:00:04.660Z",
+      "endpoint": "api_entreprise/v2/extraits_courts_inpi"
+    },
+    {
+      "uname": "apie_2_actes_inpi",
+      "name": "Actes INPI",
+      "provider": "inpi",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:00:04.263Z",
+      "endpoint": "api_entreprise/v2/documents_inpi"
+    },
+    {
+      "uname": "apie_2_bilans_inpi",
+      "name": "Bilans INPI",
+      "provider": "inpi",
+      "api_version": 2,
+      "code": 200,
+      "timestamp": "2022-09-15T14:00:04.446Z",
+      "endpoint": "api_entreprise/v2/documents_inpi"
+    },
+    {
+      "uname": "apie_2_bilans_entreprises_bdf",
+      "name": "Bilans Entreprises Banque de France",
+      "provider": "bdf",
+      "api_version": 2,
+      "code": 404,
+      "timestamp": "2022-09-15T14:00:07.312Z",
+      "endpoint": "api_entreprise/v2/bilans_entreprises_bdf"
+    }
+  ]
+}

--- a/spec/lib/api_entreprise/api_spec.rb
+++ b/spec/lib/api_entreprise/api_spec.rb
@@ -289,4 +289,18 @@ describe APIEntreprise::API do
       expect(WebMock).not_to have_requested(:get, /https:\/\/entreprise.api.gouv.fr\/v2\/entreprises\/#{siren}/)
     end
   end
+
+  describe 'current_status' do
+    subject { described_class.new.current_status }
+    let(:body) { File.read('spec/fixtures/files/api_entreprise/current_status.json') }
+
+    before do
+      stub_request(:get, "https://entreprise.api.gouv.fr/watchdoge/dashboard/current_status")
+        .to_return(body: body)
+    end
+
+    it "returns the current status response" do
+      expect(subject).to eq(JSON.parse(body, symbolize_names: true))
+    end
+  end
 end

--- a/spec/services/api_entreprise_service_spec.rb
+++ b/spec/services/api_entreprise_service_spec.rb
@@ -52,4 +52,44 @@ describe APIEntrepriseService do
       end
     end
   end
+
+  describe "#api_up?" do
+    subject { described_class.api_up? }
+    let(:body) { File.read('spec/fixtures/files/api_entreprise/current_status.json') }
+    let(:status) { 200 }
+
+    before do
+      stub_request(:get, "https://entreprise.api.gouv.fr/watchdoge/dashboard/current_status")
+        .to_return(body: body, status: status)
+    end
+
+    it "returns true when api etablissement is up" do
+      expect(subject).to be_truthy
+    end
+
+    context "when api entreprise is down" do
+      let(:body) do
+        original_body = super()
+
+        json = JSON.parse(original_body)
+        # API etablissements is the first listed
+        json["results"][0]["code"] = 502
+
+        JSON.generate(json)
+      end
+
+      it "returns false" do
+        expect(subject).to be_falsy
+      end
+    end
+
+    context "when api entreprise status is unknown" do
+      let(:body) { "" }
+      let(:status) { 0 }
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Version minimale un peu crade pour mieux informer les usagers et soulager le support : en cas d'erreur de récupération d'infos SIRET lors de l'ouverture d'un dossier, on teste le status de l'API entreprise sur https://entreprise.api.gouv.fr/watchdoge/dashboard/current_status

S'ils indiquent qu'elle est down pour l'API v2 etablissements, on affiche un message spécifique (qui pour le moment concerne spécifiquement à la situation du moment).

C'est aussi un premier point d'entrée pour le futur mode dégradé (cf #7766)