### PR TITLE
feat(champ siret): permet la soumission du formulaire lorsque l'api est down

### DIFF
--- a/app/views/shared/champs/siret/_etablissement.html.haml
+++ b/app/views/shared/champs/siret/_etablissement.html.haml
@@ -9,8 +9,11 @@
 - when :network_error
   = t('errors.messages.siret_network_error')
 
+- when :api_entreprise_down
+  = t('errors.messages.api_entreprise_down')
+
 - else
-  - if siret.present? 
+  - if siret.present?
     - if siret == etablissement&.siret && raison_sociale_or_name(etablissement).present?
       = render EditableChamp::EtablissementTitreComponent.new(etablissement: etablissement)
     - else

--- a/app/views/shared/champs/siret/_etablissement.html.haml
+++ b/app/views/shared/champs/siret/_etablissement.html.haml
@@ -10,5 +10,8 @@
   = t('errors.messages.siret_network_error')
 
 - else
-  - if siret.present? && siret == etablissement&.siret
-    = render EditableChamp::EtablissementTitreComponent.new(etablissement: etablissement)
+  - if siret.present? 
+    - if siret == etablissement&.siret && raison_sociale_or_name(etablissement).present?
+      = render EditableChamp::EtablissementTitreComponent.new(etablissement: etablissement)
+    - else
+      Ce SIRET existe, nous en récupérons les informations.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -371,6 +371,7 @@ fr:
       siret_unknown: 'Désolé, nous n’avons pas trouvé d’établissement enregistré correspondant à ce numéro SIRET.'
       siret_network_error: 'Désolé, la récupération des informations SIRET est temporairement indisponible. Veuillez réessayer dans quelques instants.'
       siret_not_found: 'Nous n’avons pas trouvé d’établissement correspondant à ce numéro de SIRET.'
+      api_entreprise_down: 'Notre fournisseur de données semble en panne, nous récupérerons les données plus tard.'
       # etablissement_fail: 'Désolé, nous n’avons pas réussi à enregistrer l’établissement correspondant à ce numéro SIRET'
       france_connect:
         connexion: "Erreur lors de la connexion à France Connect."


### PR DESCRIPTION
premier commit : on affiche un message minimal (ridicule) qui permet à l'utilisateur de savoir dans le cas nominal que le siret est enregistré (voir #7775 )

![Screenshot 2022-09-19 at 11-04-35 Modification du brouillon nº 4745781 (avec siret) · demarches-simplifiees fr](https://user-images.githubusercontent.com/907405/190992753-d1d57205-354c-477e-8e37-1009f090f9ff.png)

second commit : on réutilise le travail de @colinux pour enregistrer un établissement en mode dégradé lorsque l'api est down et on affiche un message expliquant la situation :

![Screenshot 2022-09-19 at 11-55-44 Modifier · Dossier nº 4745781 (avec siret) · demarches-simplifiees fr](https://user-images.githubusercontent.com/907405/190993257-4a902b0e-bb10-46c9-83bf-edc4dae39a6d.png)
