### PR TITLE
fix-ux(issue#7774) : indicateur menu email navbar

### DIFF
--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -317,6 +317,7 @@
   color: $blue-france-500;
 }
 
-#account-btn:before, #account-btn_copy:before {
+#account-btn::before,
+#account-btn_copy::before {
   content: none;
 }

--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -316,3 +316,7 @@
 .link {
   color: $blue-france-500;
 }
+
+#account-btn:before, #account-btn_copy:before {
+  content: none;
+}

--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -317,7 +317,6 @@
   color: $blue-france-500;
 }
 
-#account-btn::before,
-#account-btn_copy::before {
-  content: none;
+.account-btn::before {
+  content: none !important;
 }

--- a/app/views/layouts/_account_dropdown.haml
+++ b/app/views/layouts/_account_dropdown.haml
@@ -1,6 +1,6 @@
-%nav.fr-nav{ role: "navigation", "aria-label"=> t('menu_aria_label', scope: [:layouts]) }
+%nav.fr-translate.fr-nav{ role: "navigation", "aria-label"=> t('menu_aria_label', scope: [:layouts]) }
   .fr-nav__item
-    %button.fr-translate__btn.fr-btn{ "aria-controls" => "account", "aria-expanded" => "false", :title => t('my_account', scope: [:layouts]) }
+    %button#account-btn.fr-translate__btn.fr-btn{ "aria-controls" => "account", "aria-expanded" => "false", :title => t('my_account', scope: [:layouts]) }
       = image_tag "icons/account-circle.svg", alt: t('my_account', scope: [:layouts]), width: 20, height: 20, loading: 'lazy'
       &nbsp;
       = " #{current_email}"

--- a/app/views/layouts/_account_dropdown.haml
+++ b/app/views/layouts/_account_dropdown.haml
@@ -1,6 +1,6 @@
 %nav.fr-translate.fr-nav{ role: "navigation", "aria-label"=> t('menu_aria_label', scope: [:layouts]) }
   .fr-nav__item
-    %button#account-btn.fr-translate__btn.fr-btn{ "aria-controls" => "account", "aria-expanded" => "false", :title => t('my_account', scope: [:layouts]) }
+    %button.account-btn.fr-translate__btn.fr-btn{ "aria-controls" => "account", "aria-expanded" => "false", :title => t('my_account', scope: [:layouts]) }
       = image_tag "icons/account-circle.svg", alt: t('my_account', scope: [:layouts]), width: 20, height: 20, loading: 'lazy'
       &nbsp;
       = " #{current_email}"

--- a/spec/views/layouts/_header_spec.rb
+++ b/spec/views/layouts/_header_spec.rb
@@ -20,7 +20,7 @@ describe 'layouts/_header.html.haml', type: :view do
     let(:profile) { nil }
 
     it { is_expected.to have_css(".fr-header__logo") }
-    it { is_expected.to_not have_css("button#account-btn") }
+    it { is_expected.to_not have_css(".account-btn") }
 
     it 'displays the Help link' do
       expect(subject).to have_link('Aide', href: FAQ_URL)
@@ -45,7 +45,7 @@ describe 'layouts/_header.html.haml', type: :view do
 
     it { is_expected.to have_css(".fr-header__logo") }
     it { is_expected.to have_link("Dossiers", href: dossiers_path) }
-    it { is_expected.to have_selector(:button, user.email, id: "account-btn") }
+    it { is_expected.to have_selector(:button, user.email, class: "account-btn") }
 
     it 'displays the Help button' do
       expect(subject).to have_link("Aide", href: FAQ_URL)
@@ -59,7 +59,7 @@ describe 'layouts/_header.html.haml', type: :view do
     let(:current_instructeur) { instructeur }
 
     it { is_expected.to have_css(".fr-header__logo") }
-    it { is_expected.to have_selector(:button, user.email, id: "account-btn") }
+    it { is_expected.to have_selector(:button, user.email, class: "account-btn") }
 
     it 'displays the Help dropdown menu' do
       expect(subject).to have_css(".help-dropdown")

--- a/spec/views/layouts/_header_spec.rb
+++ b/spec/views/layouts/_header_spec.rb
@@ -20,6 +20,7 @@ describe 'layouts/_header.html.haml', type: :view do
     let(:profile) { nil }
 
     it { is_expected.to have_css(".fr-header__logo") }
+    it { is_expected.to_not have_css("button#account-btn") }
 
     it 'displays the Help link' do
       expect(subject).to have_link('Aide', href: FAQ_URL)
@@ -44,6 +45,7 @@ describe 'layouts/_header.html.haml', type: :view do
 
     it { is_expected.to have_css(".fr-header__logo") }
     it { is_expected.to have_link("Dossiers", href: dossiers_path) }
+    it { is_expected.to have_selector(:button, user.email, id: "account-btn") }
 
     it 'displays the Help button' do
       expect(subject).to have_link("Aide", href: FAQ_URL)
@@ -57,6 +59,7 @@ describe 'layouts/_header.html.haml', type: :view do
     let(:current_instructeur) { instructeur }
 
     it { is_expected.to have_css(".fr-header__logo") }
+    it { is_expected.to have_selector(:button, user.email, id: "account-btn") }
 
     it 'displays the Help dropdown menu' do
       expect(subject).to have_css(".help-dropdown")


### PR DESCRIPTION
<img width="1311" alt="Capture d’écran 2022-09-21 à 10 17 59" src="https://user-images.githubusercontent.com/11738628/191452632-c8ad4bb6-98ee-4e1b-b1fb-f9412efe6ec2.png">

- choix de conserver le composant`fr-translate > fr-translate__btn` DSFR  et d'éditer le `::before` via ~~un id~~ une classe spécifique
- autre hypothèse, recréer ce type de composant en css