### PR TITLE
Fix(dossier): don't accept/reject  ith an incomplete etablissement (degraded mode)

### DIFF
--- a/app/controllers/instructeurs/dossiers_controller.rb
+++ b/app/controllers/instructeurs/dossiers_controller.rb
@@ -308,6 +308,8 @@ module Instructeurs
     def aasm_error_message(exception, target_state:)
       if exception.originating_state == target_state
         "Le dossier est déjà #{dossier_display_state(target_state, lower: true)}."
+      elsif exception.failures.include?(:can_terminer?)
+        "Les données relatives au SIRET de ce dossier n’ont pas pu encore être vérifiées : il n’est pas possible de le passer #{dossier_display_state(target_state, lower: true)}."
       else
         "Le dossier est en ce moment #{dossier_display_state(exception.originating_state, lower: true)} : il n’est pas possible de le passer #{dossier_display_state(target_state, lower: true)}."
       end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -170,19 +170,19 @@ class Dossier < ApplicationRecord
     end
 
     event :accepter, after: :after_accepter do
-      transitions from: :en_instruction, to: :accepte
+      transitions from: :en_instruction, to: :accepte, guard: :can_terminer?
     end
 
     event :accepter_automatiquement, after: :after_accepter_automatiquement do
-      transitions from: :en_construction, to: :accepte
+      transitions from: :en_construction, to: :accepte, guard: :can_terminer?
     end
 
     event :refuser, after: :after_refuser do
-      transitions from: :en_instruction, to: :refuse
+      transitions from: :en_instruction, to: :refuse, guard: :can_terminer?
     end
 
     event :classer_sans_suite, after: :after_classer_sans_suite do
-      transitions from: :en_instruction, to: :sans_suite
+      transitions from: :en_instruction, to: :sans_suite, guard: :can_terminer?
     end
 
     event :repasser_en_instruction, after: :after_repasser_en_instruction do
@@ -513,6 +513,12 @@ class Dossier < ApplicationRecord
 
   def can_transition_to_en_construction?
     brouillon? && procedure.dossier_can_transition_to_en_construction? && !for_procedure_preview?
+  end
+
+  def can_terminer?
+    return false if etablissement&.as_degraded_mode?
+
+    true
   end
 
   def can_repasser_en_instruction?

--- a/app/views/instructeurs/dossiers/show.html.haml
+++ b/app/views/instructeurs/dossiers/show.html.haml
@@ -2,4 +2,17 @@
 
 = render partial: "header", locals: { dossier: @dossier }
 
+
+- if @dossier.etablissement&.as_degraded_mode?
+  .container
+    = render Dsfr::CalloutComponent.new(title: "Données de l’entreprise non vérifiées", theme: :warning, icon: "fr-icon-feedback-fill") do |c|
+      - c.with_body do
+        %p
+          Les services de l’INSEE sont indisponibles, nous ne pouvons pas
+          vérifier les informations liées à l’établissement de ce dossier.
+          %strong Il n’est pas possible d’accepter ou de refuser un dossier sans cette étape.
+          %br
+          %br
+          Les informations sur l'entreprise arriveront d’ici quelques heures.
+
 = render partial: "shared/dossiers/demande", locals: { dossier: @dossier, demande_seen_at: @demande_seen_at, profile: 'instructeur' }

--- a/app/views/shared/dossiers/_identite_entreprise.html.haml
+++ b/app/views/shared/dossiers/_identite_entreprise.html.haml
@@ -2,7 +2,7 @@
   %table.table.vertical.dossier-champs
     %tbody
       %tr
-        %td.libelle{ colspan: 2 } ⚠ LʼINSEE est indisponible, les informations sur lʼentreprise arriveront dʼici quelques jours.
+        %td.libelle{ colspan: 2 } ⚠ LʼINSEE est indisponible, les informations sur lʼentreprise arriveront dʼici quelques heures.
       %tr
         %td.libelle SIRET :
         %td= etablissement.siret

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1138,6 +1138,41 @@ describe Dossier do
     it { expect(operation_serialized['executed_at']).to eq(last_operation.executed_at.iso8601) }
   end
 
+  describe "can't transition to terminer when etablissement is in degraded mode" do
+    let(:instructeur) { create(:instructeur) }
+    let(:motivation) { 'motivation' }
+
+    context "when dossier is en_instruction" do
+      let(:dossier_incomplete) { create(:dossier, :en_instruction, :with_entreprise, as_degraded_mode: true) }
+      let(:dossier_ok) { create(:dossier, :en_instruction, :with_entreprise, as_degraded_mode: false) }
+
+      it "can't accepter" do
+        expect(dossier_incomplete.may_accepter?(instructeur:, motivation:)).to be_falsey
+        expect(dossier_ok.accepter(instructeur:, motivation:)).to be_truthy
+      end
+
+      it "can't refuser" do
+        expect(dossier_incomplete.may_refuser?(instructeur:, motivation:)).to be_falsey
+        expect(dossier_ok.may_refuser?(instructeur:, motivation:)).to be_truthy
+      end
+
+      it "can't classer_sans_suite" do
+        expect(dossier_incomplete.may_classer_sans_suite?(instructeur:, motivation:)).to be_falsey
+        expect(dossier_ok.may_classer_sans_suite?(instructeur:, motivation:)).to be_truthy
+      end
+    end
+
+    context "when dossier is en_construction" do
+      let(:dossier_incomplete) { create(:dossier, :en_construction, :with_entreprise, as_degraded_mode: true) }
+      let(:dossier_ok) { create(:dossier, :en_construction, :with_entreprise, as_degraded_mode: false) }
+
+      it "can't accepter_automatiquement" do
+        expect(dossier_incomplete.may_accepter_automatiquement?(instructeur:, motivation:)).to be_falsey
+        expect(dossier_ok.accepter_automatiquement(instructeur:, motivation:)).to be_truthy
+      end
+    end
+  end
+
   describe "#check_mandatory_champs" do
     include Logic
 

--- a/spec/views/instructeur/dossiers/show.html.haml_spec.rb
+++ b/spec/views/instructeur/dossiers/show.html.haml_spec.rb
@@ -33,4 +33,22 @@ describe 'instructeurs/dossiers/show.html.haml', type: :view do
       expect(rendered).to have_text("Le dossier a été déposé par le compte de #{france_connect_information.given_name} #{france_connect_information.family_name}, authentifié par France Connect le #{france_connect_information.updated_at.strftime('%d/%m/%Y')}")
     end
   end
+
+  describe 'entreprise degraded mode' do
+    context 'etablissement complete' do
+      let(:dossier) { create(:dossier, :en_construction, :with_entreprise, as_degraded_mode: false) }
+
+      it 'contains no warning' do
+        expect(rendered).not_to have_text("Les services de l’INSEE sont indisponibles")
+      end
+    end
+
+    context 'etablissement in degraded mode' do
+      let(:dossier) { create(:dossier, :en_construction, :with_entreprise, as_degraded_mode: true) }
+
+      it 'warns the instructeur' do
+        expect(rendered).to have_text("Les services de l’INSEE sont indisponibles")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Conséquence de #7770 : des instructeurs tentent de traiter des dossiers créés en mode dégradé et dont l'établissement n'a pas encore été vérifié/consolidé.

En plus d'être un risque métier, ceci provoque des erreurs de transition comme
https://sentry.io/organizations/demarches-simplifiees/issues/2839832517/?project=1429550&query=is%3Aunresolved

Cette PR :
  -  empêche de passer un dossier dans son stade "final"
  - prévient l'instructeur pro-activement
  - prévient l'instructeur s'il tente quand même de changer d'état

![Capture d’écran 2022-09-21 à 15 16 51](https://user-images.githubusercontent.com/150279/191515226-dd96de93-8114-40c9-8d81-646adf9321d3.png)


![Capture d’écran 2022-09-21 à 15 17 15](https://user-images.githubusercontent.com/150279/191515216-c99c05cf-83c1-439d-9d36-c39900b3f22a.png)
