### PR TITLE
fix(graphql): PersonneMorale#date_creation may be null

### DIFF
--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -1450,7 +1450,7 @@ type Entreprise {
   """
   capitalSocial: BigInt
   codeEffectifEntreprise: String
-  dateCreation: ISO8601Date!
+  dateCreation: ISO8601Date
 
   """
   effectif moyen d’une année

--- a/app/graphql/types/personne_morale_type.rb
+++ b/app/graphql/types/personne_morale_type.rb
@@ -22,7 +22,7 @@ module Types
       field :code_effectif_entreprise, String, null: true
       field :effectif_mensuel, EffectifType, null: true, description: "effectif pour un mois donné"
       field :effectif_annuel, EffectifType, null: true, description: "effectif moyen d’une année"
-      field :date_creation, GraphQL::Types::ISO8601Date, null: false
+      field :date_creation, GraphQL::Types::ISO8601Date, null: true
       field :etat_administratif, EntrepriseEtatAdministratifType, null: true
       field :nom, String, null: true
       field :prenom, String, null: true

--- a/app/models/entreprise.rb
+++ b/app/models/entreprise.rb
@@ -19,7 +19,7 @@ class Entreprise < Hashie::Dash
   property :effectif_mensuel
   property :effectif_annuel
   property :effectif_annuel_annee
-  property :date_creation
+  property :date_creation, default: nil
   property :nom, default: nil
   property :prenom, default: nil
 

--- a/spec/services/serializer_service_spec.rb
+++ b/spec/services/serializer_service_spec.rb
@@ -1,0 +1,27 @@
+describe SerializerService do
+  let(:dossier) { create(:dossier, :en_construction) }
+
+  describe 'champ' do
+    subject { SerializerService.champ(champ) }
+
+    describe 'type champ is siret' do
+      let(:etablissement) { create(:etablissement) }
+      let(:champ) { create(:champ_siret, etablissement:, dossier:) }
+
+      it {
+        is_expected.to include("stringValue" => etablissement.siret)
+        expect(subject["etablissement"]).to include("siret" => etablissement.siret)
+        expect(subject["etablissement"]["entreprise"]).to include("codeEffectifEntreprise" => etablissement.entreprise_code_effectif_entreprise)
+      }
+
+      context 'with entreprise_date_creation is nil' do
+        let(:etablissement) { create(:etablissement, entreprise_date_creation: nil) }
+
+        it {
+          expect(subject["etablissement"]["entreprise"]).to include("nomCommercial" => etablissement.entreprise_nom_commercial)
+          expect(subject["etablissement"]["entreprise"]["dateCreation"]).to be_nil
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ça fix le passage 'un dossier dans un statut "terminé" pour un dossier dont un champ SIRET correspond à un établissement sans date de création connue.

Ex. de dossier concerné remonté par le support: 9855027