### PR TITLE
Fixe le champ checkbox lorsqu'il est obligatoire et non séléctionné

### DIFF
--- a/app/models/champs/checkbox_champ.rb
+++ b/app/models/champs/checkbox_champ.rb
@@ -27,4 +27,8 @@ class Champs::CheckboxChamp < Champs::YesNoChamp
   def for_export
     true? ? 'on' : 'off'
   end
+
+  def mandatory_blank_and_visible?
+    mandatory? && (blank? || !true?)
+  end
 end


### PR DESCRIPTION
Les usagers peuvent déposer des dossiers même si le champ checkbox obligatoire n'est pas coché. Cette PR fixe ce bug