### PR TITLE
fix(instructeur/procedures#show): Procedure presentation filterable state field is in conflict with projected state field. quick fix, maybe will refactor both to align them

### DIFF
--- a/app/models/procedure_presentation.rb
+++ b/app/models/procedure_presentation.rb
@@ -48,7 +48,7 @@ class ProcedurePresentation < ApplicationRecord
       field_hash('self', 'en_construction_since', type: :date, virtual: true),
       field_hash('self', 'en_instruction_since', type: :date, virtual: true),
       field_hash('self', 'processed_since', type: :date, virtual: true),
-      field_hash('self', 'state', type: :enum, scope: 'instructeurs.dossiers.filterable_state')
+      field_hash('self', 'state', type: :enum, scope: 'instructeurs.dossiers.filterable_state', virtual: true)
     ]
   end
 

--- a/spec/models/procedure_presentation_spec.rb
+++ b/spec/models/procedure_presentation_spec.rb
@@ -69,7 +69,7 @@ describe ProcedurePresentation do
           { "label" => "En construction depuis", "table" => "self", "column" => "en_construction_since", "classname" => "", 'virtual' => true, 'type' => :date, 'scope' => '' },
           { "label" => "En instruction depuis", "table" => "self", "column" => "en_instruction_since", "classname" => "", 'virtual' => true, 'type' => :date, 'scope' => '' },
           { "label" => "Terminé depuis", "table" => "self", "column" => "processed_since", "classname" => "", 'virtual' => true, 'type' => :date, 'scope' => '' },
-          { "label" => "Statut", "table" => "self", "column" => "state", "classname" => "", 'virtual' => false, 'scope' => 'instructeurs.dossiers.filterable_state', 'type' => :enum },
+          { "label" => "Statut", "table" => "self", "column" => "state", "classname" => "", 'virtual' => true, 'scope' => 'instructeurs.dossiers.filterable_state', 'type' => :enum },
           { "label" => 'Demandeur', "table" => 'user', "column" => 'email', 'classname' => '', 'virtual' => false, 'type' => :text, "scope" => '' },
           { "label" => 'Email instructeur', "table" => 'followers_instructeurs', "column" => 'email', 'classname' => '', 'virtual' => false, 'type' => :text, "scope" => '' },
           { "label" => 'Groupe instructeur', "table" => 'groupe_instructeur', "column" => 'label', 'classname' => '', 'virtual' => false, 'type' => :text, "scope" => '' },


### PR DESCRIPTION
sentry: https://sentry.io/organizations/demarches-simplifiees/issues/3627673315/?project=1429550&query=is%3Aunresolved
bugreport: https://app.crisp.chat/website/266ba25d-91d1-4774-b01f-a23ba63d662f/inbox/session_a19ceff1-4de8-4b7c-855b-3a880288eb0f/

contexte : sur nos projections nous incluons automatiquement certains champs. on vient d'introduire le filtre par `dossiers.state` ; qui vient en conflit avec cette projection.

C'est un quick fix pour eviter ce conflit

En solution plus pérène, je propose d'extraire [p-e sur `ProcedurePresentation` ; ou sur `DossierProjectionService]` de sorte a les aligner et eviter les surprises. Aussi le systeme de type de procedure presentation eviterait ce 'strftime' sur un champs filtrable/affichable