### PR TITLE
fix(linked_drop_down): corrige l'enregistrement des dropdown liés dans des blocs répétables

### DIFF
--- a/app/javascript/controllers/autosave_controller.ts
+++ b/app/javascript/controllers/autosave_controller.ts
@@ -193,11 +193,13 @@ export class AutosaveController extends ApplicationController {
 
   private get inputs() {
     const element = this.element as HTMLElement;
+
     const inputs = [
       ...element.querySelectorAll<HTMLInputElement>(
         'input:not([type=file]), textarea, select'
       )
-    ];
+    ].filter((element) => !element.disabled);
+
     const parent = this.element.closest('.editable-champ-repetition');
     if (parent) {
       return [
@@ -205,6 +207,6 @@ export class AutosaveController extends ApplicationController {
         ...parent.querySelectorAll<HTMLInputElement>('input[data-id]')
       ];
     }
-    return inputs.filter((element) => !element.disabled);
+    return inputs;
   }
 }


### PR DESCRIPTION
the filter was not applied in repetition block so an additional empty input was send which overrided the real value