### PR TITLE
unschedule export demarches opendata

### DIFF
--- a/app/jobs/cron/datagouv/export_and_publish_demarches_publiques_job.rb
+++ b/app/jobs/cron/datagouv/export_and_publish_demarches_publiques_job.rb
@@ -1,6 +1,9 @@
 class Cron::Datagouv::ExportAndPublishDemarchesPubliquesJob < Cron::CronJob
-  include DatagouvCronSchedulableConcern
   self.schedule_expression = "every month at 3:00"
+
+  def self.schedulable?
+    false
+  end
 
   def perform(*args)
     gzip_filepath = [

--- a/spec/jobs/cron/datagouv/export_and_publish_demarches_publiques_job_spec.rb
+++ b/spec/jobs/cron/datagouv/export_and_publish_demarches_publiques_job_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe Cron::Datagouv::ExportAndPublishDemarchesPubliquesJob, type: :job
 
   describe '#schedulable?' do
     context "when ENV['OPENDATA_ENABLED'] == 'enabled'" do
-      it 'is schedulable' do
+      it 'is not schedulable' do
         ENV['OPENDATA_ENABLED'] = 'enabled'
-        expect(Cron::Datagouv::ExportAndPublishDemarchesPubliquesJob.schedulable?).to be_truthy
+        expect(Cron::Datagouv::ExportAndPublishDemarchesPubliquesJob.schedulable?).to be_falsy
       end
     end
     context "when ENV['OPENDATA_ENABLED'] != 'enabled'" do
-      it 'is schedulable' do
+      it 'is not schedulable' do
         ENV['OPENDATA_ENABLED'] = nil
         expect(Cron::Datagouv::ExportAndPublishDemarchesPubliquesJob.schedulable?).to be_falsy
       end


### PR DESCRIPTION
Cette PR desactive la publication mensuelle des demarches opendata. Nous laissons jusqu'à début novembre les administrateurs de vérifier qu'ils souhaitent ou non publier le descriptif de leurs démarches en opendata.

