### PR TITLE
bug(multiple_drop_down_list): when their is a coma in label, comas is splitted as an item

### DIFF
--- a/app/views/shared/champs/multiple_drop_down_list/_show.html.haml
+++ b/app/views/shared/champs/multiple_drop_down_list/_show.html.haml
@@ -1,5 +1,4 @@
-- if champ.to_s.present?
+- if !champ.blank?
   %ul
-    - champ.to_s.split(", ").each do |item|
-      %li
-        = item
+    - champ.selected_options.each do |item|
+      %li= item

--- a/spec/views/shared/champs/multiple_drop_down_list/_show.html.haml_spec.rb
+++ b/spec/views/shared/champs/multiple_drop_down_list/_show.html.haml_spec.rb
@@ -1,0 +1,10 @@
+describe 'views/shared/champs/multiple_drop_down_list/_show.html.haml', type: :view do
+  let(:champ) { build(:champ_multiple_drop_down_list, value: ['abc', '2, 3, 4']) }
+
+  subject { render partial: 'shared/champs/multiple_drop_down_list/show', locals: { champ: champ } }
+
+  it 'renders the view' do
+    subject
+    expect(rendered).to have_selector('li', count: champ.selected_options.size)
+  end
+end


### PR DESCRIPTION
https://github.com/orgs/betagouv/projects/33/views/1