### PR TITLE
7807 fix améliore la validation sur le libellé de routage

### DIFF
--- a/app/controllers/administrateurs/groupe_instructeurs_controller.rb
+++ b/app/controllers/administrateurs/groupe_instructeurs_controller.rb
@@ -191,10 +191,12 @@ module Administrateurs
     end
 
     def update_routing_criteria_name
-      procedure.update!(routing_criteria_name: routing_criteria_name)
-
-      redirect_to admin_procedure_groupe_instructeurs_path(procedure),
-        notice: "Le libellé est maintenant « #{procedure.routing_criteria_name} »."
+      if procedure.update(routing_criteria_name: routing_criteria_name)
+        flash[:notice] = "Le libellé est maintenant « #{procedure.routing_criteria_name} »."
+      else
+        flash[:alert] = "Le libellé du routage doit être rempli."
+      end
+      redirect_to admin_procedure_groupe_instructeurs_path(procedure)
     end
 
     def update_routing_enabled

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -323,6 +323,7 @@ class Procedure < ApplicationRecord
 
   validates :api_entreprise_token, jwt_token: true, allow_blank: true
   validates :api_particulier_token, format: { with: /\A[A-Za-z0-9\-_=.]{15,}\z/ }, allow_blank: true
+  validates :routing_criteria_name, presence: true, allow_blank: false
 
   before_save :update_juridique_required
   after_initialize :ensure_path_exists


### PR DESCRIPTION
Dans cette PR on se contente d'empêcher l'admin de mettre un espace vide dans le libellé de routage.
Par la suite on fera en sorte que le routage ne soit activé que s'il y a au moins 2 groupes d'instructeurs