### PR TITLE
perf: amélioration de la rapidité de la page admin/procedure/show

### DIFF
--- a/app/components/procedure/card/annotations_component.rb
+++ b/app/components/procedure/card/annotations_component.rb
@@ -1,7 +1,6 @@
 class Procedure::Card::AnnotationsComponent < ApplicationComponent
   def initialize(procedure:)
     @procedure = procedure
-    @procedure.validate(:publication)
     @count = @procedure.draft_revision.types_de_champ.private_only.size
   end
 

--- a/app/components/procedure/card/champs_component.rb
+++ b/app/components/procedure/card/champs_component.rb
@@ -1,7 +1,6 @@
 class Procedure::Card::ChampsComponent < ApplicationComponent
   def initialize(procedure:)
     @procedure = procedure
-    @procedure.validate(:publication)
     @count = @procedure.draft_revision.types_de_champ.public_only.size
   end
 

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -98,6 +98,8 @@ module Administrateurs
         )
         .find(params[:id])
 
+      @procedure.validate(:publication)
+
       @current_administrateur = current_administrateur
       @procedure_lien = commencer_url(path: @procedure.path)
       @procedure_lien_test = commencer_test_url(path: @procedure.path)

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -235,6 +235,13 @@ module Administrateurs
     end
 
     def publication
+      @procedure = current_administrateur
+        .procedures
+        .includes(
+          published_revision: :types_de_champ,
+          draft_revision: :types_de_champ
+        ).find(params[:procedure_id])
+
       @procedure_lien = commencer_url(path: @procedure.path)
       @procedure_lien_test = commencer_test_url(path: @procedure.path)
       @procedure.path = @procedure.suggested_path(current_administrateur)

--- a/app/controllers/administrateurs/procedures_controller.rb
+++ b/app/controllers/administrateurs/procedures_controller.rb
@@ -93,8 +93,8 @@ module Administrateurs
       @procedure = current_administrateur
         .procedures
         .includes(
-          published_revision: { revision_types_de_champ: :type_de_champ },
-          draft_revision: { revision_types_de_champ: :type_de_champ }
+          published_revision: :types_de_champ,
+          draft_revision: :types_de_champ
         )
         .find(params[:id])
 

--- a/app/views/administrateurs/procedures/_revision_changes.html.haml
+++ b/app/views/administrateurs/procedures/_revision_changes.html.haml
@@ -4,8 +4,9 @@
   - else
     - changes.filter { |change| change[:model] == :attestation_template }.each do |change|
       = render partial: 'administrateurs/procedures/revision_change_attestation_template', locals: { change: change }
-    - changes.filter { |change| change[:model] == :type_de_champ }.each do |change|
-      = render partial: 'administrateurs/procedures/revision_change_type_de_champ', locals: { change: change }
+    = render partial: "administrateurs/procedures/revision_change_type_de_champ",
+        collection: changes.filter { |change| change[:model] == :type_de_champ },
+        as: :change
     - move_changes, move_private_changes = changes.filter { |change| change[:op] == :move }.partition { |change| !change[:private] }
     - if move_changes.present?
       %li.mb-1= t(:move, scope: [:administrateurs, :revision_changes], count: move_changes.size)


### PR DESCRIPTION
Dans le cas de très grosse procédure ~1 000 champs

Avant

![Screenshot 2022-09-30 at 14-30-29 demarches-simplifiees fr](https://user-images.githubusercontent.com/907405/193270304-c5bee89e-101e-4a76-af6f-026b5d115042.png)

Après

![Screenshot 2022-09-30 at 14-31-01 demarches-simplifiees fr](https://user-images.githubusercontent.com/907405/193270293-a9e7cbc7-06b5-4ac6-afea-06779f380198.png)

Mm ordre de grandeur pour la page publication