### PR TITLE
feat(tags): replace regexp based parser with a parser combinator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ gem 'net-imap', require: false # See https://github.com/mikel/mail/pull/1439
 gem 'net-pop', require: false # same
 gem 'net-smtp', require: false # same
 gem 'openid_connect'
+gem 'parsby'
 gem 'pg'
 gem 'phonelib'
 gem 'prawn-rails' # PDF Generation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -467,6 +467,7 @@ GEM
       webfinger (>= 1.0.1)
     orm_adapter (0.5.0)
     parallel (1.22.1)
+    parsby (1.1.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
     pdf-core (0.9.0)
@@ -877,6 +878,7 @@ DEPENDENCIES
   net-pop
   net-smtp
   openid_connect
+  parsby
   pg
   phonelib
   prawn-rails

--- a/spec/models/concern/tags_substitution_concern_spec.rb
+++ b/spec/models/concern/tags_substitution_concern_spec.rb
@@ -383,13 +383,13 @@ describe TagsSubstitutionConcern, type: :model do
 
     context 'when generating a document for a dossier that is not termine' do
       let(:dossier) { create(:dossier) }
-      let(:template) { '--motivation-- --date de décision--' }
+      let(:template) { 'text --motivation-- --date de décision--' }
       let(:state) { Dossier.states.fetch(:en_instruction) }
 
       subject { template_concern.send(:replace_tags, template, dossier) }
 
       it "does not treat motivation or date de décision as tags" do
-        is_expected.to eq('--motivation-- --date de décision--')
+        is_expected.to eq('text --motivation-- --date de décision--')
       end
     end
 
@@ -494,5 +494,20 @@ describe TagsSubstitutionConcern, type: :model do
     end
 
     it { is_expected.to eq([["public", procedure.draft_revision.types_de_champ.first.stable_id], ['yolo']]) }
+  end
+
+  describe 'parser' do
+    it do
+      tokens = TagsSubstitutionConcern::TagsParser.parse("hello world --public--, --numéro du dossier--, un test--yolo-- encore du text\n---\n encore du text")
+      expect(tokens).to eq([
+        { text: "hello world " },
+        { tag: "public" },
+        { text: ", " },
+        { tag: "numéro du dossier" },
+        { text: ", un test" },
+        { tag: "yolo" },
+        { text: " encore du text\n" + "---\n" + " encore du text" }
+      ])
+    end
   end
 end


### PR DESCRIPTION
Ce changement corrige certains bugs de parse. Il rend aussi la logique un peu plus compréhensible – on ne parse plus le template deux fois pour remplacer les “libelle” par les "id”, mais on annote les token avec les "id”.

(je suis assez confiant sur cette PR car le parsing des tags est bien testé et je n’ai pas changé les interfaces publiques)