### PR TITLE
fix zone labels when building a new procedure

### DIFF
--- a/app/helpers/zone_helper.rb
+++ b/app/helpers/zone_helper.rb
@@ -1,5 +1,6 @@
 module ZoneHelper
   def grouped_options_for_zone(date)
+    date ||= Time.zone.now
     collectivite = Zone.find_by(acronym: "COLLECTIVITE")
     {
       "--" => [


### PR DESCRIPTION
Quand une procédure n'a pas encore été sauvegardé, `created_at` ou `published_at` vaut nil.
Avant ce fix, lors de la sélection des zones, les labels étaient calculées en fonction d'une date qui valait donc nil. Alors que celait devrait être la date courante.