### PR TITLE
feat(procedure.max_duree_conservation_dossiers_dans_ds): make it more flexible

### DIFF
--- a/app/dashboards/procedure_dashboard.rb
+++ b/app/dashboards/procedure_dashboard.rb
@@ -38,7 +38,7 @@ class ProcedureDashboard < Administrate::BaseDashboard
     attestation_template: AttestationTemplateField,
     procedure_expires_when_termine_enabled: Field::Boolean,
     duree_conservation_dossiers_dans_ds: Field::Number,
-    duree_conservation_etendue_par_ds: Field::Boolean
+    max_duree_conservation_dossiers_dans_ds: Field::Number
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -88,7 +88,7 @@ class ProcedureDashboard < Administrate::BaseDashboard
     :attestation_template,
     :procedure_expires_when_termine_enabled,
     :duree_conservation_dossiers_dans_ds,
-    :duree_conservation_etendue_par_ds
+    :max_duree_conservation_dossiers_dans_ds
   ].freeze
 
   # FORM_ATTRIBUTES
@@ -97,7 +97,7 @@ class ProcedureDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = [
     :procedure_expires_when_termine_enabled,
     :duree_conservation_dossiers_dans_ds,
-    :duree_conservation_etendue_par_ds
+    :max_duree_conservation_dossiers_dans_ds
   ].freeze
 
   # Overwrite this method to customize how procedures are displayed

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -32,6 +32,7 @@
 #  lien_dpo                                  :string
 #  lien_notice                               :string
 #  lien_site_web                             :string
+#  max_duree_conservation_dossiers_dans_ds   :integer          default(12)
 #  monavis_embed                             :text
 #  opendata                                  :boolean          default(TRUE)
 #  organisation                              :string
@@ -273,18 +274,15 @@ class Procedure < ApplicationRecord
   validates :duree_conservation_dossiers_dans_ds, allow_nil: false,
                                                   numericality: {
                                                     only_integer: true,
-                                                                  greater_than_or_equal_to: 1,
-                                                                  less_than_or_equal_to: OLD_MAX_DUREE_CONSERVATION
-                                                  },
-                                                  if: :duree_conservation_etendue_par_ds
-
-  validates :duree_conservation_dossiers_dans_ds, allow_nil: false,
-                                                    numericality: {
-                                                      only_integer: true,
-                                                                    greater_than_or_equal_to: 1,
-                                                                    less_than_or_equal_to: NEW_MAX_DUREE_CONSERVATION
-                                                    },
-                                                    unless: :duree_conservation_etendue_par_ds
+                                                    greater_than_or_equal_to: 1,
+                                                    less_than_or_equal_to: :max_duree_conservation_dossiers_dans_ds
+                                                  }
+  validates :max_duree_conservation_dossiers_dans_ds, allow_nil: false,
+                                                  numericality: {
+                                                    only_integer: true,
+                                                    greater_than_or_equal_to: 1,
+                                                    less_than_or_equal_to: 60
+                                                  }
 
   validates :lien_dpo, email_or_link: true, allow_nil: true
   validates_with MonAvisEmbedValidator

--- a/config/locales/models/procedure/fr.yml
+++ b/config/locales/models/procedure/fr.yml
@@ -8,7 +8,8 @@ fr:
       procedure:
         path: Lien public
         organisation: Organisme
-        duree_conservation_dossiers_dans_ds: Durée de conservation des dossiers sur demarches-simplifiees.fr
+        duree_conservation_dossiers_dans_ds: Durée de conservation des dossiers sur demarches-simplifiees.fr (choisi par un usager)
+        max_duree_conservation_dossiers_dans_ds: Durée de conservation des dossiers maximum (autorisé par un super admin de DS)
         aasm_state/brouillon: Brouillon
         aasm_state/publiee: Publiée
         aasm_state/close: Close

--- a/db/migrate/20221005145531_max_column_duree_conservation_dossiers_dans_ds_to_procedure.rb
+++ b/db/migrate/20221005145531_max_column_duree_conservation_dossiers_dans_ds_to_procedure.rb
@@ -1,0 +1,6 @@
+class MaxColumnDureeConservationDossiersDansDsToProcedure < ActiveRecord::Migration[6.1]
+  def change
+    add_column :procedures, :max_duree_conservation_dossiers_dans_ds, :integer
+    change_column_default :procedures, :max_duree_conservation_dossiers_dans_ds, Procedure::NEW_MAX_DUREE_CONSERVATION
+  end
+end

--- a/db/migrate/20221005145646_backfill_procedure_max_duree_conservation_dossiers_dans_ds.rb
+++ b/db/migrate/20221005145646_backfill_procedure_max_duree_conservation_dossiers_dans_ds.rb
@@ -1,0 +1,10 @@
+class BackfillProcedureMaxDureeConservationDossiersDansDs < ActiveRecord::Migration[6.1]
+  def change
+    Procedure.where(duree_conservation_etendue_par_ds: true).in_batches do |batch|
+      batch.update_all(duree_conservation_dossiers_dans_ds: Procedure::OLD_MAX_DUREE_CONSERVATION)
+    end
+    Procedure.where(duree_conservation_etendue_par_ds: false).in_batches do |batch|
+      batch.update_all(duree_conservation_dossiers_dans_ds: Procedure::NEW_MAX_DUREE_CONSERVATION)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_11_134914) do
+ActiveRecord::Schema.define(version: 2022_10_05_145646) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -652,6 +652,7 @@ ActiveRecord::Schema.define(version: 2022_09_11_134914) do
     t.string "lien_dpo"
     t.string "lien_notice"
     t.string "lien_site_web"
+    t.integer "max_duree_conservation_dossiers_dans_ds", default: 12
     t.text "monavis_embed"
     t.boolean "opendata", default: true
     t.string "organisation"

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -283,23 +283,22 @@ describe Procedure do
 
     describe 'duree de conservation dans ds' do
       let(:field_name) { :duree_conservation_dossiers_dans_ds }
-
-      context 'for old procedures, duree_conservation_required it true, the field gets validated' do
-        subject { create(:procedure, duree_conservation_etendue_par_ds: true) }
+      context 'by default is caped to 12' do
+        subject { create(:procedure, duree_conservation_dossiers_dans_ds: 12) }
         it { is_expected.not_to allow_value(nil).for(field_name) }
         it { is_expected.not_to allow_value('').for(field_name) }
         it { is_expected.not_to allow_value('trois').for(field_name) }
         it { is_expected.to allow_value(3).for(field_name) }
-        it { is_expected.to allow_value(36).for(field_name) }
-        it { is_expected.to validate_numericality_of(field_name).is_less_than_or_equal_to(Procedure::OLD_MAX_DUREE_CONSERVATION) }
+        it { is_expected.to validate_numericality_of(field_name).is_less_than_or_equal_to(12) }
       end
-
-      context 'for new procedures, duree_conservation_required it true, the field gets validated' do
-        subject { create(:procedure, duree_conservation_etendue_par_ds: false) }
+      context 'can be over riden' do
+        subject { create(:procedure, duree_conservation_dossiers_dans_ds: 60, max_duree_conservation_dossiers_dans_ds: 60) }
         it { is_expected.not_to allow_value(nil).for(field_name) }
         it { is_expected.not_to allow_value('').for(field_name) }
         it { is_expected.not_to allow_value('trois').for(field_name) }
-        it { is_expected.to validate_numericality_of(field_name).is_less_than_or_equal_to(Procedure::NEW_MAX_DUREE_CONSERVATION) }
+        it { is_expected.to allow_value(3).for(field_name) }
+        it { is_expected.to allow_value(60).for(field_name) }
+        it { is_expected.to validate_numericality_of(field_name).is_less_than_or_equal_to(60) }
       end
     end
 


### PR DESCRIPTION
TODO ap deploiement – virer l'ancienne colunne : `duree_conservation_etendue_par_ds `