### PR TITLE
a procedure without zone is finally valid

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -289,7 +289,6 @@ class Procedure < ApplicationRecord
 
   validates :lien_dpo, email_or_link: true, allow_nil: true
   validates_with MonAvisEmbedValidator
-  validates :zones, presence: true, if: -> record { record.publiee? && Flipper.enabled?(:zonage) }
 
   FILE_MAX_SIZE = 20.megabytes
   validates :notice, content_type: [

--- a/spec/controllers/administrateurs/procedures_controller_spec.rb
+++ b/spec/controllers/administrateurs/procedures_controller_spec.rb
@@ -334,19 +334,6 @@ describe Administrateurs::ProceduresController, type: :controller do
 
           it { expect(subject.for_individual).not_to eq procedure_params[:for_individual] }
         end
-
-        context 'when zones are empty' do
-          before do
-            Flipper.enable(:zonage)
-          end
-
-          after do
-            Flipper.disable(:zonage)
-          end
-
-          let(:zone_ids) { [""] }
-          it { is_expected.to render_template :zones }
-        end
       end
     end
   end


### PR DESCRIPTION
Plus de la moitié des procédures en production ne sont pas associées à des zones pour le moment.
Cette PR supprime la validation qui oblige à ce qu'une procédure ait des zones.