### PR TITLE
feat(groupe_instructeur) no select if only one group

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -614,7 +614,7 @@ class Dossier < ApplicationRecord
   end
 
   def show_groupe_instructeur_selector?
-    procedure.routee? && !procedure.feature_enabled?(:procedure_routage_api)
+    procedure.routee? && !procedure.feature_enabled?(:procedure_routage_api) && procedure.groupe_instructeurs.size > 1
   end
 
   def assign_to_groupe_instructeur(groupe_instructeur, author = nil)

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -691,7 +691,7 @@ class Procedure < ApplicationRecord
   end
 
   def defaut_groupe_instructeur_for_new_dossier
-    if !routee? || feature_enabled?(:procedure_routage_api)
+    if !routee? || feature_enabled?(:procedure_routage_api) || (routee? && self.groupe_instructeurs.size == 1)
       defaut_groupe_instructeur
     end
   end

--- a/spec/system/users/brouillon_spec.rb
+++ b/spec/system/users/brouillon_spec.rb
@@ -242,6 +242,29 @@ describe 'The user' do
     expect(page).to have_text('file.pdf')
   end
 
+  context 'with routing activated and one instructor group' do
+    let!(:simple_procedure) { create(:simple_procedure, :published, :with_type_de_champ, :for_individual) }
+    let!(:administrateur) { create(:administrateur, procedures: [simple_procedure]) }
+
+    before do
+      simple_procedure.update(routing_enabled: true)
+      simple_procedure.defaut_groupe_instructeur.instructeurs << administrateur.instructeur
+    end
+
+    it 'sends the dossier without selecting instructor group', js: true do
+      log_in(user, simple_procedure)
+      fill_individual
+      fill_in('Texte obligatoire', with: 'bla bla')
+      wait_for_autosave
+
+      expect(page).not_to have_text('Votre ville')
+
+      click_on 'Déposer le dossier'
+
+      expect(page).to have_text('Merci')
+    end
+  end
+
   context 'with condition' do
     include Logic
 


### PR DESCRIPTION
Voir https://github.com/betagouv/demarches-simplifiees.fr/issues/7807#issuecomment-1271269571

Avec cette PR, en tant qu'usager lorque je remplis mon dossier je ne vois pas le select de groupes d'instructeurs si il n'existe qu'un seul groupe pour la procédure.