### PR TITLE
fix(api_address): support Adresse BAN without postcode

### DIFF
--- a/app/lib/api_address/address_adapter.rb
+++ b/app/lib/api_address/address_adapter.rb
@@ -22,7 +22,7 @@ class APIAddress::AddressAdapter
           street_address: result.street_address,
           street_number: result.street_number,
           street_name: result.street_name,
-          postal_code: result.postal_code,
+          postal_code: result.postal_code.presence || "",
           city_name: result.city_name,
           city_code: result.city_code,
           department_name: result.department_name,

--- a/app/schemas/adresse-ban.json
+++ b/app/schemas/adresse-ban.json
@@ -19,7 +19,7 @@
           "enum": ["housenumber", "street", "locality", "municipality"]
         }
       },
-      "required": ["label", "type", "name", "postcode", "citycode", "city"]
+      "required": ["label", "type", "name", "citycode", "city"]
     },
     "geometry": {
       "type": "object",

--- a/spec/lib/api_address/address_adapter_spec.rb
+++ b/spec/lib/api_address/address_adapter_spec.rb
@@ -1,6 +1,7 @@
 describe APIAddress::AddressAdapter do
   let(:search_term) { 'Paris' }
   let(:adapter) { described_class.new(search_term) }
+  let(:status) { 200 }
   subject { adapter.to_params }
 
   before do
@@ -15,7 +16,6 @@ describe APIAddress::AddressAdapter do
 
   context "when responds with valid schema" do
     let(:body) { File.read('spec/fixtures/files/api_address/address.json') }
-    let(:status) { 200 }
 
     it '#to_params returns a valid' do
       expect(subject).to be_an_instance_of(Hash)
@@ -26,7 +26,6 @@ describe APIAddress::AddressAdapter do
 
   context "when responds with an address which is not a direct match to search term" do
     let(:body) { File.read('spec/fixtures/files/api_address/address.json') }
-    let(:status) { 200 }
     let(:search_term) { 'Lyon' }
 
     it '#to_params ignores the response' do
@@ -36,10 +35,21 @@ describe APIAddress::AddressAdapter do
 
   context "when responds with invalid schema" do
     let(:body) { File.read('spec/fixtures/files/api_address/address_invalid.json') }
-    let(:status) { 200 }
 
     it '#to_params raise exception' do
       expect { subject }.to raise_exception(APIAddress::AddressAdapter::InvalidSchemaError)
+    end
+  end
+
+  context "when responds without postcode" do
+    let(:body) {
+      json = JSON.parse(File.read('spec/fixtures/files/api_address/address.json'))
+      json["features"][0]["properties"].delete("postcode")
+      json.to_json
+    }
+
+    it "#to_params default to an empty postcode" do
+      expect(subject[:postal_code]).to eq("")
     end
   end
 end


### PR DESCRIPTION
Des adresses n'ont pas de code postal (dans certains TOM par exemple) et faisaient crasher la récupération d'adresse. On fallback sur un string vide plutôt que nil pour limiter les effets de bord, notamment dans l'API.