### PR TITLE
perf(user dossier): améliore la gestion des conditions coté js

### DIFF
--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -181,7 +181,7 @@ module Users
 
       respond_to do |format|
         format.html { render :brouillon }
-        format.turbo_stream { render layout: false }
+        format.turbo_stream { render(:update, layout: false) }
       end
     end
 

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -181,7 +181,14 @@ module Users
 
       respond_to do |format|
         format.html { render :brouillon }
-        format.turbo_stream { render(:update, layout: false) }
+        format.turbo_stream do
+          @to_shows, @to_hides = @dossier.champs
+            .filter(&:conditional?)
+            .partition(&:visible?)
+            .map { |champs| champs_to_one_selector(champs) }
+
+          render(:update, layout: false)
+        end
       end
     end
 
@@ -205,7 +212,14 @@ module Users
 
       respond_to do |format|
         format.html { render :modifier }
-        format.turbo_stream { render layout: false }
+        format.turbo_stream do
+          @to_shows, @to_hides = @dossier.champs
+            .filter(&:conditional?)
+            .partition(&:visible?)
+            .map { |champs| champs_to_one_selector(champs) }
+
+          render layout: false
+        end
       end
     end
 
@@ -520,6 +534,13 @@ module Users
         { context: :false }
         # rubocop:enable Lint/BooleanSymbol
       end
+    end
+
+    def champs_to_one_selector(champs)
+      champs
+        .map(&:input_group_id)
+        .map { |id| "##{id}" }
+        .join(',')
     end
   end
 end

--- a/app/views/users/dossiers/update.turbo_stream.haml
+++ b/app/views/users/dossiers/update.turbo_stream.haml
@@ -1,5 +1,6 @@
-- @dossier.champs.filter(&:conditional?).each do |champ|
-  - if champ.visible?
-    = turbo_stream.show champ.input_group_id
-  - else
-    = turbo_stream.hide champ.input_group_id
+- to_shows, to_hides = @dossier.champs.filter(&:conditional?).partition(&:visible?)
+
+- if to_shows.present?
+  = turbo_stream.show_all(to_shows.map { "##{_1.input_group_id}" }.join(','))
+- if to_hides.present?
+  = turbo_stream.hide_all(to_hides.map { "##{_1.input_group_id}" }.join(','))

--- a/app/views/users/dossiers/update.turbo_stream.haml
+++ b/app/views/users/dossiers/update.turbo_stream.haml
@@ -1,6 +1,4 @@
-- to_shows, to_hides = @dossier.champs.filter(&:conditional?).partition(&:visible?)
-
-- if to_shows.present?
-  = turbo_stream.show_all(to_shows.map { "##{_1.input_group_id}" }.join(','))
-- if to_hides.present?
-  = turbo_stream.hide_all(to_hides.map { "##{_1.input_group_id}" }.join(','))
+- if @to_shows.present?
+  = turbo_stream.show_all(@to_shows)
+- if @to_hides.present?
+  = turbo_stream.hide_all(@to_hides)

--- a/app/views/users/dossiers/update_brouillon.turbo_stream.haml
+++ b/app/views/users/dossiers/update_brouillon.turbo_stream.haml
@@ -1,5 +1,6 @@
-- @dossier.champs.filter(&:conditional?).each do |champ|
-  - if champ.visible?
-    = turbo_stream.show champ.input_group_id
-  - else
-    = turbo_stream.hide champ.input_group_id
+- to_shows, to_hides = @dossier.champs.filter(&:conditional?).partition(&:visible?)
+
+- if to_shows.present?
+  = turbo_stream.show_all(to_shows.map { "##{_1.input_group_id}" }.join(','))
+- if to_hides.present?
+  = turbo_stream.hide_all(to_hides.map { "##{_1.input_group_id}" }.join(','))

--- a/app/views/users/dossiers/update_brouillon.turbo_stream.haml
+++ b/app/views/users/dossiers/update_brouillon.turbo_stream.haml
@@ -1,6 +1,0 @@
-- to_shows, to_hides = @dossier.champs.filter(&:conditional?).partition(&:visible?)
-
-- if to_shows.present?
-  = turbo_stream.show_all(to_shows.map { "##{_1.input_group_id}" }.join(','))
-- if to_hides.present?
-  = turbo_stream.hide_all(to_hides.map { "##{_1.input_group_id}" }.join(','))


### PR DESCRIPTION
Sur mon poste, on passe environ 16ms par querySelector par champs conditionnel

![sans](https://user-images.githubusercontent.com/907405/195049305-eb202ab7-b3bc-410b-b6a3-c2fbd1572d39.png)

L'idée est de batcher avec querySelectorAll

![avec](https://user-images.githubusercontent.com/907405/195049309-7285fdec-1f0c-40f1-acdf-1b1ca4fc30b7.png)

on passe ici avec 100 champs conditionnés de 500ms de blocage a 100ms