### PR TITLE
fix(editor champ): ne leve pas d'exception si un type de champ est supprimé 2 fois

### DIFF
--- a/app/controllers/administrateurs/types_de_champ_controller.rb
+++ b/app/controllers/administrateurs/types_de_champ_controller.rb
@@ -72,8 +72,10 @@ module Administrateurs
       reset_procedure
       flash.notice = "Formulaire enregistré"
 
-      @destroyed = @coordinate
-      @morphed = champ_components_starting_at(@coordinate)
+      if @coordinate.present?
+        @destroyed = @coordinate
+        @morphed = champ_components_starting_at(@coordinate)
+      end
     end
 
     private

--- a/app/models/procedure_revision.rb
+++ b/app/models/procedure_revision.rb
@@ -97,6 +97,9 @@ class ProcedureRevision < ApplicationRecord
   def remove_type_de_champ(stable_id)
     coordinate, tdc = coordinate_and_tdc(stable_id)
 
+    # in case of replay
+    return nil if coordinate.nil?
+
     children = children_of(tdc).to_a
     coordinate.destroy
 

--- a/spec/models/procedure_revision_spec.rb
+++ b/spec/models/procedure_revision_spec.rb
@@ -175,9 +175,13 @@ describe ProcedureRevision do
         it 'reorders' do
           expect(draft.revision_types_de_champ_public.pluck(:position)).to eq([0, 1, 2])
 
-          draft.remove_type_de_champ(draft.types_de_champ_public[1].stable_id)
+          first_stable_id = draft.types_de_champ_public[1].stable_id
+
+          draft.remove_type_de_champ(first_stable_id)
 
           expect(draft.revision_types_de_champ_public.pluck(:position)).to eq([0, 1])
+
+          expect { draft.remove_type_de_champ(first_stable_id) }.not_to raise_error
         end
       end
 


### PR DESCRIPTION
https://sentry.io/organizations/demarches-simplifiees/issues/3438516116/?project=1429550&query=is%3Aunresolved