### PR TITLE
chore(sentry): regularly notify delayed jobs errors

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -7,5 +7,5 @@ Sentry.init do |config|
   config.enabled_environments = ['production', secrets[:environment].presence].compact
   config.breadcrumbs_logger = [:active_support_logger]
   config.traces_sample_rate = secrets[:enabled] ? 0.001 : nil
-  config.delayed_job.report_after_job_retries = true
+  config.delayed_job.report_after_job_retries = false # don't wait for all attempts before reporting
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -6,6 +6,32 @@ Sentry.init do |config|
   config.environment = secrets[:environment] || Rails.env
   config.enabled_environments = ['production', secrets[:environment].presence].compact
   config.breadcrumbs_logger = [:active_support_logger]
-  config.traces_sample_rate = secrets[:enabled] ? 0.001 : nil
+  config.traces_sampler = lambda do |sampling_context|
+    # if this is the continuation of a trace, just use that decision (rate controlled by the caller)
+    unless sampling_context[:parent_sampled].nil?
+      next sampling_context[:parent_sampled]
+    end
+
+    # transaction_context is the transaction object in hash form
+    # keep in mind that sampling happens right after the transaction is initialized
+    # for example, at the beginning of the request
+    transaction_context = sampling_context[:transaction_context]
+
+    # transaction_context helps you sample transactions with more sophistication
+    # for example, you can provide different sample rates based on the operation or name
+    case transaction_context[:op]
+    when /delayed_job/
+      contexts = Sentry.get_current_scope.contexts
+      job_class = contexts.dig(:"Active-Job", :job_class)
+      attempts = contexts.dig(:"Delayed-Job", :attempts)
+      max_attempts = job_class.safe_constantize&.new&.max_attempts rescue 25
+
+      # Don't trace on all attempts
+      [0, 2, 5, 10, 20, max_attempts].include?(attempts)
+    else # rails requests
+      0.001
+    end
+  end
+
   config.delayed_job.report_after_job_retries = false # don't wait for all attempts before reporting
 end


### PR DESCRIPTION
Auparavant avec `report_after_job_retries = false`on était notifié 1 seule fois au bout des max_attempts atteint.

Maintenant on notifie assez régulièrement Sentry, tout en ignorant les erreurs temporaires (ie. pas au premier au fail)


Doc https://docs.sentry.io/platforms/ruby/configuration/filtering/#using-sampling-to-filter-transaction-events


NB: ça va surement faire remonter des erreurs qu'on voudra ignorer par la suite, comme des erreurs globalid `Error while trying to deserialize arguments: Couldn't find …`, on verra à ce moment là