### PR TITLE
fix(drop_down_list): corrige l'apparition de l'option 'non renseigné' dans une liste de choix obligatoire

### DIFF
--- a/app/components/editable_champ/address_component/address_component.html.haml
+++ b/app/components/editable_champ/address_component/address_component.html.haml
@@ -1,6 +1,6 @@
 = @form.hidden_field :value
 = @form.hidden_field :external_id
 = react_component("ComboAdresseSearch",
-  required: @champ.mandatory?,
+  required: @champ.required?,
   id: @champ.input_id,
   describedby: @champ.describedby_id)

--- a/app/components/editable_champ/annuaire_education_component/annuaire_education_component.html.haml
+++ b/app/components/editable_champ/annuaire_education_component/annuaire_education_component.html.haml
@@ -1,6 +1,6 @@
 = @form.hidden_field :value
 = @form.hidden_field :external_id
 = react_component("ComboAnnuaireEducationSearch",
-  required: @champ.mandatory?,
+  required: @champ.required?,
   id: @champ.input_id,
   describedby: @champ.describedby_id)

--- a/app/components/editable_champ/checkbox_component/checkbox_component.html.haml
+++ b/app/components/editable_champ/checkbox_component/checkbox_component.html.haml
@@ -1,4 +1,4 @@
 = @form.check_box :value,
-  { required: @champ.mandatory?, id: @champ.input_id, aria: { describedby: @champ.describedby_id } },
+  { required: @champ.required?, id: @champ.input_id, aria: { describedby: @champ.describedby_id } },
   'on',
   'off'

--- a/app/components/editable_champ/cnaf_component/cnaf_component.html.haml
+++ b/app/components/editable_champ/cnaf_component/cnaf_component.html.haml
@@ -3,7 +3,7 @@
     = @form.label :numero_allocataire, t('.numero_allocataire_label')
     %p.notice= t('.numero_allocataire_notice')
     = @form.text_field :numero_allocataire,
-      required: @champ.mandatory?,
+      required: @champ.required?,
       aria: { describedby: @champ.describedby_id },
       class: "width-33-desktop"
 
@@ -11,6 +11,6 @@
     = @form.label :code_postal, t('.code_postal_label')
     %p.notice= t('.code_postal_notice')
     = @form.text_field :code_postal,
-      required: @champ.mandatory?,
+      required: @champ.required?,
       aria: { describedby: @champ.describedby_id },
       class: "width-33-desktop"

--- a/app/components/editable_champ/communes_component/communes_component.html.haml
+++ b/app/components/editable_champ/communes_component/communes_component.html.haml
@@ -3,7 +3,7 @@
 = @form.hidden_field :departement
 = @form.hidden_field :code_departement
 = react_component("ComboCommunesSearch",
-  required: @champ.mandatory?,
+  required: @champ.required?,
   id: @champ.input_id,
   classNameDepartement: "width-33-desktop width-100-mobile",
   className: "width-66-desktop width-100-mobile",

--- a/app/components/editable_champ/date_component/date_component.html.haml
+++ b/app/components/editable_champ/date_component/date_component.html.haml
@@ -2,6 +2,6 @@
   id: @champ.input_id,
   aria: { describedby: @champ.describedby_id },
   value: @champ.value,
-  required: @champ.mandatory?,
+  required: @champ.required?,
   placeholder: 'aaaa-mm-jj',
   class: "width-33-desktop"

--- a/app/components/editable_champ/decimal_number_component/decimal_number_component.html.haml
+++ b/app/components/editable_champ/decimal_number_component/decimal_number_component.html.haml
@@ -3,4 +3,4 @@
   aria: { describedby: @champ.describedby_id },
   step: :any,
   placeholder: "3.14",
-  required: @champ.mandatory?
+  required: @champ.required?

--- a/app/components/editable_champ/departements_component/departements_component.html.haml
+++ b/app/components/editable_champ/departements_component/departements_component.html.haml
@@ -1,7 +1,7 @@
 = @form.hidden_field :value
 = @form.hidden_field :external_id
 = react_component("ComboDepartementsSearch",
-  required: @champ.mandatory?,
+  required: @champ.required?,
   id: @champ.input_id,
   className: "width-33-desktop width-100-mobile",
   describedby: @champ.describedby_id)

--- a/app/components/editable_champ/dgfip_component/dgfip_component.html.haml
+++ b/app/components/editable_champ/dgfip_component/dgfip_component.html.haml
@@ -3,7 +3,7 @@
     = @form.label :numero_fiscal, t('.numero_fiscal_label')
     %p.notice= t('.numero_fiscal_notice')
     = @form.text_field :numero_fiscal,
-      required: @champ.mandatory?,
+      required: @champ.required?,
       aria: { describedby: @champ.describedby_id },
       class: "width-33-desktop"
 
@@ -11,6 +11,6 @@
     = @form.label :reference_avis, t('.reference_avis_label')
     %p.notice= t('.reference_avis_notice')
     = @form.text_field :reference_avis,
-      required: @champ.mandatory?,
+      required: @champ.required?,
       aria: { describedby: @champ.describedby_id },
       class: "width-33-desktop"

--- a/app/components/editable_champ/dossier_link_component/dossier_link_component.html.haml
+++ b/app/components/editable_champ/dossier_link_component/dossier_link_component.html.haml
@@ -4,7 +4,7 @@
     aria: { describedby: @champ.describedby_id },
     placeholder: "Numéro de dossier",
     autocomplete: 'off',
-    required: @champ.mandatory?,
+    required: @champ.required?,
     data: { controller: 'turbo-input', turbo_input_url_value: champs_dossier_link_path(@champ.id) },
     class: "width-33-desktop"
 

--- a/app/components/editable_champ/email_component/email_component.html.haml
+++ b/app/components/editable_champ/email_component/email_component.html.haml
@@ -2,4 +2,4 @@
   id: @champ.input_id,
   aria: { describedby: @champ.describedby_id },
   placeholder: t(".placeholder"),
-  required: @champ.mandatory?
+  required: @champ.required?

--- a/app/components/editable_champ/engagement_component/engagement_component.html.haml
+++ b/app/components/editable_champ/engagement_component/engagement_component.html.haml
@@ -1,4 +1,4 @@
 = @form.check_box :value,
-  { required: @champ.mandatory?, id: @champ.input_id, aria: { describedby: @champ.describedby_id } },
+  { required: @champ.required?, id: @champ.input_id, aria: { describedby: @champ.describedby_id } },
   'on',
   'off'

--- a/app/components/editable_champ/iban_component/iban_component.html.haml
+++ b/app/components/editable_champ/iban_component/iban_component.html.haml
@@ -1,7 +1,7 @@
 = @form.text_field :value,
   id: @champ.input_id,
   placeholder: t(".placeholder"),
-  required: @champ.mandatory?,
+  required: @champ.required?,
   aria: { describedby: @champ.describedby_id },
   data: { controller: 'iban-input'},
   class: "width-66-desktop",

--- a/app/components/editable_champ/integer_number_component/integer_number_component.html.haml
+++ b/app/components/editable_champ/integer_number_component/integer_number_component.html.haml
@@ -2,4 +2,4 @@
   id: @champ.input_id,
   aria: { describedby: @champ.describedby_id },
   placeholder: 5,
-  required: @champ.mandatory?
+  required: @champ.required?

--- a/app/components/editable_champ/linked_drop_down_list_component/linked_drop_down_list_component.html.haml
+++ b/app/components/editable_champ/linked_drop_down_list_component/linked_drop_down_list_component.html.haml
@@ -2,7 +2,7 @@
   = @form.select :primary_value,
     @champ.primary_options,
     {},
-    { data: { secondary_options: @champ.secondary_options }, required: @champ.mandatory?, id: @champ.input_id, aria: { describedby: @champ.describedby_id } }
+    { data: { secondary_options: @champ.secondary_options }, required: @champ.required?, id: @champ.input_id, aria: { describedby: @champ.describedby_id } }
 
   .secondary{ class: @champ.has_secondary_options_for_primary? ? '' : 'hidden' }
     = @form.label :secondary_value, for: "#{@champ.input_id}-secondary" do
@@ -14,5 +14,5 @@
     = @form.select :secondary_value,
       @champ.secondary_options[@champ.primary_value],
       {},
-      { data: { secondary: true }, disabled: !@champ.has_secondary_options_for_primary?, required: @champ.mandatory?, id: "#{@champ.input_id}-secondary", aria: { describedby: "#{@champ.describedby_id}-secondary" } }
+      { data: { secondary: true }, disabled: !@champ.has_secondary_options_for_primary?, required: @champ.required?, id: "#{@champ.input_id}-secondary", aria: { describedby: "#{@champ.describedby_id}-secondary" } }
   = @form.hidden_field :secondary_value, value: '', disabled: @champ.has_secondary_options_for_primary?

--- a/app/components/editable_champ/linked_drop_down_list_component/linked_drop_down_list_component.html.haml
+++ b/app/components/editable_champ/linked_drop_down_list_component/linked_drop_down_list_component.html.haml
@@ -7,8 +7,6 @@
   .secondary{ class: @champ.has_secondary_options_for_primary? ? '' : 'hidden' }
     = @form.label :secondary_value, for: "#{@champ.input_id}-secondary" do
       - sanitize((@champ.drop_down_secondary_libelle.presence || "Valeur secondaire dépendant de la première") + (@champ.type_de_champ.mandatory? ? tag.span(' *', class: 'mandatory') : ''))
-      -# - if @champ.type_de_champ.mandatory?
-      -#   %span.mandatory *
     - if @champ.drop_down_secondary_description.present?
       .notice{ id: "#{@champ.describedby_id}-secondary" }= string_to_html(@champ.drop_down_secondary_description)
     = @form.select :secondary_value,

--- a/app/components/editable_champ/mesri_component/mesri_component.html.haml
+++ b/app/components/editable_champ/mesri_component/mesri_component.html.haml
@@ -3,7 +3,7 @@
     = @form.label :ine, t('.ine_label')
     %p.notice= t('.ine_notice')
     = @form.text_field :ine,
-      required: @champ.mandatory?,
+      required: @champ.required?,
       aria: { describedby: @champ.describedby_id },
       class: "width-33-desktop"
 

--- a/app/components/editable_champ/number_component/number_component.html.haml
+++ b/app/components/editable_champ/number_component/number_component.html.haml
@@ -2,4 +2,4 @@
   id: @champ.input_id,
   aria: { describedby: @champ.describedby_id },
   placeholder: @champ.libelle,
-  required: @champ.mandatory?
+  required: @champ.required?

--- a/app/components/editable_champ/pays_component/pays_component.html.haml
+++ b/app/components/editable_champ/pays_component/pays_component.html.haml
@@ -1,7 +1,7 @@
 = @form.hidden_field :value
 = @form.hidden_field :external_id
 = react_component("ComboPaysSearch",
-  required: @champ.mandatory?,
+  required: @champ.required?,
   id: @champ.input_id,
   className: "width-33-desktop width-100-mobile",
   describedby: @champ.describedby_id)

--- a/app/components/editable_champ/phone_component/phone_component.html.haml
+++ b/app/components/editable_champ/phone_component/phone_component.html.haml
@@ -5,5 +5,5 @@
   id: @champ.input_id,
   aria: { describedby: @champ.describedby_id },
   placeholder: t(".placeholder"),
-  required: @champ.mandatory?,
+  required: @champ.required?,
   pattern: "[^a-z^A-Z]+"

--- a/app/components/editable_champ/pole_emploi_component/pole_emploi_component.html.haml
+++ b/app/components/editable_champ/pole_emploi_component/pole_emploi_component.html.haml
@@ -3,6 +3,6 @@
     = @form.label :identifiant, t('.identifiant_label')
     %p.notice= t('.identifiant_notice')
     = @form.text_field :identifiant,
-      required: @champ.mandatory?,
+      required: @champ.required?,
       aria: { describedby: @champ.describedby_id },
       class: "width-33-desktop"

--- a/app/components/editable_champ/regions_component/regions_component.html.haml
+++ b/app/components/editable_champ/regions_component/regions_component.html.haml
@@ -1,7 +1,7 @@
 = @form.hidden_field :value
 = @form.hidden_field :external_id
 = react_component("ComboRegionsSearch",
-  required: @champ.mandatory?,
+  required: @champ.required?,
   id: @champ.input_id,
   className: "width-33-desktop width-100-mobile",
   describedby: @champ.describedby_id)

--- a/app/components/editable_champ/rna_component/rna_component.html.haml
+++ b/app/components/editable_champ/rna_component/rna_component.html.haml
@@ -3,7 +3,7 @@
   aria: { describedby: @champ.describedby_id },
   placeholder: t(".placeholder"),
   data: { controller: 'turbo-input', turbo_input_url_value: champs_rna_path(@champ.id) },
-  required: @champ.mandatory?,
+  required: @champ.required?,
   pattern: "W[0-9]{9}",
   title: t(".title"),
   class: "width-33-desktop",

--- a/app/components/editable_champ/siret_component/siret_component.html.haml
+++ b/app/components/editable_champ/siret_component/siret_component.html.haml
@@ -3,7 +3,7 @@
   aria: { describedby: @champ.describedby_id },
   placeholder: t(".placeholder"),
   data: { controller: 'turbo-input', turbo_input_url_value: champs_siret_path(@champ.id) },
-  required: @champ.mandatory?,
+  required: @champ.required?,
   pattern: "[0-9]{14}",
   title: t(".title"),
   class: "width-33-desktop",

--- a/app/components/editable_champ/text_component/text_component.html.haml
+++ b/app/components/editable_champ/text_component/text_component.html.haml
@@ -1,4 +1,4 @@
 = @form.text_field :value,
   id: @champ.input_id,
-  required: @champ.mandatory?,
+  required: @champ.required?,
   aria: { describedby: @champ.describedby_id }

--- a/app/components/editable_champ/textarea_component/textarea_component.html.haml
+++ b/app/components/editable_champ/textarea_component/textarea_component.html.haml
@@ -2,5 +2,5 @@
   id: @champ.input_id,
   aria: { describedby: @champ.describedby_id },
   rows: 6,
-  required: @champ.mandatory?,
+  required: @champ.required?,
   value: html_to_string(@champ.value)

--- a/app/controllers/users/dossiers_controller.rb
+++ b/app/controllers/users/dossiers_controller.rb
@@ -462,7 +462,7 @@ module Users
       end
 
       if dossier.en_construction?
-        errors += @dossier.check_mandatory_champs
+        errors += @dossier.check_mandatory_and_visible_champs
       end
 
       errors
@@ -473,7 +473,7 @@ module Users
 
       @dossier.valid?(**submit_validation_options)
       errors += @dossier.errors.full_messages
-      errors += @dossier.check_mandatory_champs
+      errors += @dossier.check_mandatory_and_visible_champs
 
       if should_fill_groupe_instructeur?
         @dossier.assign_to_groupe_instructeur(defaut_groupe_instructeur)

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -97,6 +97,13 @@ class Champ < ApplicationRecord
     type_de_champ.mandatory? && visible?
   end
 
+  # used for the `required` html attribute
+  # check visibility to avoid hidden required input
+  # which prevent the form from being sent.
+  def required?
+    type_de_champ.mandatory? && visible?
+  end
+
   def mandatory_blank_and_visible?
     mandatory? && blank?
   end

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -60,6 +60,7 @@ class Champ < ApplicationRecord
     :rna?,
     :siret?,
     :stable_id,
+    :mandatory?,
     to: :type_de_champ
 
   scope :updated_since?, -> (date) { where('champs.updated_at > ?', date) }
@@ -91,10 +92,6 @@ class Champ < ApplicationRecord
 
   def sections
     @sections ||= dossier.sections_for(self)
-  end
-
-  def mandatory?
-    type_de_champ.mandatory? && visible?
   end
 
   # used for the `required` html attribute

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -101,7 +101,7 @@ class Champ < ApplicationRecord
     type_de_champ.mandatory? && visible?
   end
 
-  def mandatory_blank_and_visible?
+  def mandatory_blank?
     mandatory? && blank?
   end
 

--- a/app/models/champs/checkbox_champ.rb
+++ b/app/models/champs/checkbox_champ.rb
@@ -28,7 +28,7 @@ class Champs::CheckboxChamp < Champs::YesNoChamp
     true? ? 'on' : 'off'
   end
 
-  def mandatory_blank_and_visible?
+  def mandatory_blank?
     mandatory? && (blank? || !true?)
   end
 end

--- a/app/models/champs/piece_justificative_champ.rb
+++ b/app/models/champs/piece_justificative_champ.rb
@@ -38,7 +38,7 @@ class Champs::PieceJustificativeChamp < Champ
     # We don’t know how to search inside documents yet
   end
 
-  def mandatory_blank_and_visible?
+  def mandatory_blank?
     mandatory? && !piece_justificative_file.attached?
   end
 

--- a/app/models/champs/siret_champ.rb
+++ b/app/models/champs/siret_champ.rb
@@ -24,7 +24,7 @@ class Champs::SiretChamp < Champ
     etablissement.present? ? etablissement.search_terms : [value]
   end
 
-  def mandatory_blank_and_visible?
+  def mandatory_blank?
     mandatory? && Siret.new(siret: value).invalid?
   end
 end

--- a/app/models/champs/titre_identite_champ.rb
+++ b/app/models/champs/titre_identite_champ.rb
@@ -32,7 +32,7 @@ class Champs::TitreIdentiteChamp < Champ
     # We don’t know how to search inside documents yet
   end
 
-  def mandatory_blank_and_visible?
+  def mandatory_blank?
     mandatory? && !piece_justificative_file.attached?
   end
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -983,7 +983,7 @@ class Dossier < ApplicationRecord
 
   def check_mandatory_champs
     (champs + champs.filter(&:block?).filter(&:visible?).flat_map(&:champs))
-      .filter(&:mandatory_blank_and_visible?)
+      .filter(&:mandatory_blank?)
       .map do |champ|
         "Le champ #{champ.libelle.truncate(200)} doit être rempli."
       end

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -981,8 +981,9 @@ class Dossier < ApplicationRecord
     champs.filter(&:titre_identite?).map(&:piece_justificative_file).each(&:purge_later)
   end
 
-  def check_mandatory_champs
+  def check_mandatory_and_visible_champs
     (champs + champs.filter(&:block?).filter(&:visible?).flat_map(&:champs))
+      .filter(&:visible?)
       .filter(&:mandatory_blank?)
       .map do |champ|
         "Le champ #{champ.libelle.truncate(200)} doit être rempli."

--- a/spec/models/champ_shared_example.rb
+++ b/spec/models/champ_shared_example.rb
@@ -1,26 +1,26 @@
 shared_examples 'champ_spec' do
-  describe 'mandatory_blank_and_visible?' do
+  describe 'mandatory_blank?' do
     let(:type_de_champ) { build(:type_de_champ, mandatory: mandatory) }
     let(:champ) { build(:champ, type_de_champ: type_de_champ, value: value) }
     let(:value) { '' }
     let(:mandatory) { true }
 
     context 'when mandatory and blank' do
-      it { expect(champ.mandatory_blank_and_visible?).to be(true) }
+      it { expect(champ.mandatory_blank?).to be(true) }
     end
 
     context 'when carte mandatory and blank' do
       let(:type_de_champ) { build(:type_de_champ_carte, mandatory: mandatory) }
       let(:champ) { build(:champ_carte, type_de_champ: type_de_champ, value: value) }
       let(:value) { nil }
-      it { expect(champ.mandatory_blank_and_visible?).to be(true) }
+      it { expect(champ.mandatory_blank?).to be(true) }
     end
 
     context 'when multiple_drop_down_list mandatory and blank' do
       let(:type_de_champ) { build(:type_de_champ_multiple_drop_down_list, mandatory: mandatory) }
       let(:champ) { build(:champ_multiple_drop_down_list, type_de_champ: type_de_champ, value: value) }
       let(:value) { '[]' }
-      it { expect(champ.mandatory_blank_and_visible?).to be(true) }
+      it { expect(champ.mandatory_blank?).to be(true) }
     end
 
     context 'when repetition blank' do
@@ -39,18 +39,18 @@ shared_examples 'champ_spec' do
 
     context 'when not blank' do
       let(:value) { 'yop' }
-      it { expect(champ.mandatory_blank_and_visible?).to be(false) }
+      it { expect(champ.mandatory_blank?).to be(false) }
     end
 
     context 'when not mandatory' do
       let(:mandatory) { false }
-      it { expect(champ.mandatory_blank_and_visible?).to be(false) }
+      it { expect(champ.mandatory_blank?).to be(false) }
     end
 
     context 'when not mandatory or blank' do
       let(:value) { 'u' }
       let(:mandatory) { false }
-      it { expect(champ.mandatory_blank_and_visible?).to be(false) }
+      it { expect(champ.mandatory_blank?).to be(false) }
     end
   end
 

--- a/spec/models/champs/linked_drop_down_list_champ_spec.rb
+++ b/spec/models/champs/linked_drop_down_list_champ_spec.rb
@@ -78,7 +78,7 @@ describe Champs::LinkedDropDownListChamp do
       let(:type_de_champ) { build(:type_de_champ_linked_drop_down_list, drop_down_list_value: value) }
 
       it 'blank is fine' do
-        is_expected.not_to be_mandatory_blank_and_visible
+        is_expected.not_to be_mandatory_blank
       end
     end
 
@@ -86,27 +86,27 @@ describe Champs::LinkedDropDownListChamp do
       let(:type_de_champ) { build(:type_de_champ_linked_drop_down_list, mandatory: true, drop_down_list_value: value) }
 
       context 'when there is no value' do
-        it { is_expected.to be_mandatory_blank_and_visible }
+        it { is_expected.to be_mandatory_blank }
       end
 
       context 'when there is a primary value' do
         before { subject.primary_value = 'Primary' }
 
         context 'when there is no secondary value' do
-          it { is_expected.to be_mandatory_blank_and_visible }
+          it { is_expected.to be_mandatory_blank }
         end
 
         context 'when there is a secondary value' do
           before { subject.secondary_value = 'Secondary' }
 
-          it { is_expected.not_to be_mandatory_blank_and_visible }
+          it { is_expected.not_to be_mandatory_blank }
         end
 
         context 'when there is nothing to select for the secondary value' do
           let(:value) { "--A--\nAbbott\nAbelard\n--B--\n--C--\nCynthia" }
           before { subject.primary_value = 'B' }
 
-          it { is_expected.not_to be_mandatory_blank_and_visible }
+          it { is_expected.not_to be_mandatory_blank }
         end
       end
     end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -1172,14 +1172,14 @@ describe Dossier do
     end
   end
 
-  describe "#check_mandatory_champs" do
+  describe "#check_mandatory_and_visible_champs" do
     include Logic
 
     let(:procedure) { create(:procedure, types_de_champ_public: types_de_champ) }
     let(:dossier) { create(:dossier, procedure: procedure) }
     let(:types_de_champ) { [type_de_champ] }
     let(:type_de_champ) { {} }
-    let(:errors) { dossier.check_mandatory_champs }
+    let(:errors) { dossier.check_mandatory_and_visible_champs }
 
     it 'no mandatory champs' do
       expect(errors).to be_empty


### PR DESCRIPTION
Avant : l'option 'non renseigné' était affichée si une liste n'était pas obligatoire (`mandatory?`)

Pb: un champ est obligatoire si sont type de champ est obligatoire && qu'il est visible.
donc si une liste est cachée, elle est non obligatoire, mais elle le devient lorsqu'elle est révélée, sans changement d’élément du dom (turbo ne fait que du hide/show). L'option `non renseigné` est donc invisible.

Maintenant:
- création de la méthode `required?` qui vérifie `type_de_champ.mandatory? && visible?`
- réutilisation de `type_de_champ.mandatory?`, pour ce qui est des asterix et de l'option `non renseigné`
