### PR TITLE
fix(dossier): nullify instructeur and expert id on messages when they are deleted

### DIFF
--- a/app/models/commentaire.rb
+++ b/app/models/commentaire.rb
@@ -18,8 +18,8 @@ class Commentaire < ApplicationRecord
   self.ignored_columns = [:user_id]
   belongs_to :dossier, inverse_of: :commentaires, touch: true, optional: false
 
-  belongs_to :instructeur, optional: true
-  belongs_to :expert, optional: true
+  belongs_to :instructeur, inverse_of: :commentaires, optional: true
+  belongs_to :expert, inverse_of: :commentaires, optional: true
 
   validate :messagerie_available?, on: :create, unless: -> { dossier.brouillon? }
 

--- a/app/models/expert.rb
+++ b/app/models/expert.rb
@@ -13,7 +13,7 @@ class Expert < ApplicationRecord
   has_many :procedures, through: :experts_procedures
   has_many :avis, through: :experts_procedures
   has_many :dossiers, through: :avis
-  has_many :commentaires
+  has_many :commentaires, inverse_of: :expert, dependent: :nullify
 
   default_scope { eager_load(:user) }
 

--- a/app/models/instructeur.rb
+++ b/app/models/instructeur.rb
@@ -21,7 +21,7 @@ class Instructeur < ApplicationRecord
   has_many :assign_to_with_email_notifications, -> { with_email_notifications }, class_name: 'AssignTo', inverse_of: :instructeur
   has_many :groupe_instructeur_with_email_notifications, through: :assign_to_with_email_notifications, source: :groupe_instructeur
 
-  has_many :commentaires
+  has_many :commentaires, inverse_of: :instructeur, dependent: :nullify
   has_many :dossiers, -> { state_not_brouillon }, through: :groupe_instructeurs
   has_many :follows, -> { active }, inverse_of: :instructeur
   has_many :previous_follows, -> { inactive }, class_name: 'Follow', inverse_of: :instructeur

--- a/lib/tasks/deployment/20221019094123_nullify_commentaire_deleted_instructeurs.rake
+++ b/lib/tasks/deployment/20221019094123_nullify_commentaire_deleted_instructeurs.rake
@@ -1,0 +1,31 @@
+namespace :after_party do
+  desc 'Deployment task: nullify_commentaire_deleted_instructeurs'
+  task nullify_commentaire_deleted_instructeurs: :environment do
+    puts "Running deploy task 'nullify_commentaire_deleted_instructeurs'"
+
+    commentaires_without_instructeurs = Commentaire.where.missing(:instructeur).where.not(instructeur_id: nil)
+    progress = ProgressReport.new(commentaires_without_instructeurs.count)
+
+    commentaires_without_instructeurs.in_batches do |commentaires|
+      count = commentaires.count
+      commentaires.update_all(instructeur_id: nil)
+      progress.inc(count)
+    end
+    progress.finish
+
+    commentaires_without_experts = Commentaire.where.missing(:expert).where.not(expert_id: nil)
+    progress = ProgressReport.new(commentaires_without_experts.count)
+
+    commentaires_without_experts.in_batches do |commentaires|
+      count = commentaires.count
+      commentaires.update_all(expert_id: nil)
+      progress.inc(count)
+    end
+    progress.finish
+
+    # Update task as completed.  If you remove the line below, the task will
+    # run with every deploy (or every time you call after_party:run).
+    AfterParty::TaskRecord
+      .create version: AfterParty::TaskRecorder.new(__FILE__).timestamp
+  end
+end


### PR DESCRIPTION
L'email est préservé sur le modèle commentaire et utilisé si instructeur ou expert sont vides

https://sentry.io/organizations/demarches-simplifiees/issues/3671240750/?project=1429550&query=is%3Aunresolved
https://sentry.io/organizations/demarches-simplifiees/issues/2845047087/?project=1429550&query=is%3Aunresolved