### PR TITLE
chore(bundle): update strscan 3.0.3 => 3.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -713,7 +713,7 @@ GEM
     stackprof (0.2.21)
     strong_migrations (0.8.0)
       activerecord (>= 5.2)
-    strscan (3.0.3)
+    strscan (3.0.4)
     swd (1.3.0)
       activesupport (>= 3)
       attr_required (>= 0.0.5)


### PR DESCRIPTION
minor update de la gem

ça va me permettre de lancer `rspec` sans `bundle exec` et éviter un conflit de version dans mon setup